### PR TITLE
Collapse per-class asset-terms codecs into one declarative schema; fix projection drift and unify schema-version promotion

### DIFF
--- a/database/manifest/contracts.json
+++ b/database/manifest/contracts.json
@@ -5,7 +5,7 @@
       "directories": [
         "src/Meridian.Contracts"
       ],
-      "fingerprint": "eabdbd739cb85d0e9c00d96a5d70d128768964bf1af2a3c554f9748bd1b2670e",
+      "fingerprint": "0821cc6d1f9ded2a5f28114216e165fe16f4be914727f4a3a076ddb858317e5d",
       "id": "all-contracts",
       "namespace_prefixes": [
         "Meridian.Contracts"
@@ -33,6 +33,8 @@
         "Meridian.Contracts.AccountingSystem.AccountingMigrationRunWorkerPlanDto",
         "Meridian.Contracts.AccountingSystem.AccountingMigrationRunWorkerPlanListDto",
         "Meridian.Contracts.AccountingSystem.AccountingMigrationRunWorkerPlanUpsertRequestDto",
+        "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationEvidenceSubjectTypes",
+        "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationEvidenceValidator",
         "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationProfileDto",
         "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationProfileUpsertRequestDto",
         "Meridian.Contracts.AccountingSystem.AccountingProductionGapDto",
@@ -284,10 +286,28 @@
         "Meridian.Contracts.Archive.VerificationJobStatus",
         "Meridian.Contracts.Archive.VerificationJobType",
         "Meridian.Contracts.Archive.VerificationScheduleConfig",
+        "Meridian.Contracts.AssetOperations.AppendAssetAccountingLifecycleStageRequestDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingCorrectionReferenceDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventKindDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventScopeDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventSpineAppendResultDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventSpineValidator",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventTypeNames",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEvidenceSubjects",
+        "Meridian.Contracts.AssetOperations.AssetAccountingLifecycleStageDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateRequestDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingStageEvidenceDto",
+        "Meridian.Contracts.AssetOperations.AssetAcquisitionLotDto",
         "Meridian.Contracts.AssetOperations.AssetActualActivityDto",
         "Meridian.Contracts.AssetOperations.AssetCashFlowProjectionRunDto",
+        "Meridian.Contracts.AssetOperations.AssetDisposalLotSelectionDto",
         "Meridian.Contracts.AssetOperations.AssetLedgerProjectionDto",
         "Meridian.Contracts.AssetOperations.AssetLifecycleEventDto",
+        "Meridian.Contracts.AssetOperations.AssetLotMutationInstructionDto",
+        "Meridian.Contracts.AssetOperations.AssetLotMutationInstructionValidator",
+        "Meridian.Contracts.AssetOperations.AssetLotMutationIntentDto",
         "Meridian.Contracts.AssetOperations.AssetOperationsDetailDto",
         "Meridian.Contracts.AssetOperations.AssetOperationsOptions",
         "Meridian.Contracts.AssetOperations.AssetOperationsProjectionDto",
@@ -314,6 +334,7 @@
         "Meridian.Contracts.AssetOperations.IPortfolioCashBalanceProvider",
         "Meridian.Contracts.AssetOperations.IPortfolioCashLadderQueryService",
         "Meridian.Contracts.AssetOperations.IPortfolioHoldingsSource",
+        "Meridian.Contracts.AssetOperations.JournalPostingStatusDto",
         "Meridian.Contracts.AssetOperations.PortfolioCapitalActivityDto",
         "Meridian.Contracts.AssetOperations.PortfolioCashBalanceDto",
         "Meridian.Contracts.AssetOperations.PortfolioCashLadderBucketDto",
@@ -325,7 +346,15 @@
         "Meridian.Contracts.AssetOperations.PortfolioCashScenarioDto",
         "Meridian.Contracts.AssetOperations.PortfolioHoldingDto",
         "Meridian.Contracts.AssetOperations.PositionEconomicStateDto",
+        "Meridian.Contracts.AssetOperations.PostedJournalImpactDto",
+        "Meridian.Contracts.AssetOperations.PostedJournalImpactLineDto",
+        "Meridian.Contracts.AssetOperations.PostedJournalImpactValidator",
+        "Meridian.Contracts.AssetOperations.ProjectAssetAccountingEventRequestDto",
+        "Meridian.Contracts.AssetOperations.ProjectedAccountingEffectDto",
+        "Meridian.Contracts.AssetOperations.ProjectedAccountingEffectLineDto",
         "Meridian.Contracts.AssetOperations.ProjectionLineageDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityValidator",
         "Meridian.Contracts.Backfill.BackfillJobStatus",
         "Meridian.Contracts.Backfill.BackfillProgress",
         "Meridian.Contracts.Backfill.BackfillProviderAttemptProgressDto",
@@ -1417,7 +1446,11 @@
         "Meridian.Contracts.SecurityMaster.SecurityAssetProfileTermsDto",
         "Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTerms",
         "Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsUpcasterChain",
+        "Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsUpcasterPipeline",
         "Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsV0ToCurrentUpcaster",
+        "Meridian.Contracts.SecurityMaster.SecurityAssetTermField",
+        "Meridian.Contracts.SecurityMaster.SecurityAssetTermFieldType",
+        "Meridian.Contracts.SecurityMaster.SecurityAssetTermsSchema",
         "Meridian.Contracts.SecurityMaster.SecurityCashFlowSourceDto",
         "Meridian.Contracts.SecurityMaster.SecurityComparisonPriceDto",
         "Meridian.Contracts.SecurityMaster.SecurityDetailDto",
@@ -2126,6 +2159,12 @@
         "Meridian.Contracts.Workstation.RunLotSummary",
         "Meridian.Contracts.Workstation.RunPortfolioDrillInSummary",
         "Meridian.Contracts.Workstation.RunReconciliation",
+        "Meridian.Contracts.Workstation.SampleArtifactDto",
+        "Meridian.Contracts.Workstation.SampleBreakDto",
+        "Meridian.Contracts.Workstation.SampleHighlightDto",
+        "Meridian.Contracts.Workstation.SampleHoldingDto",
+        "Meridian.Contracts.Workstation.SampleMarketHistoryDto",
+        "Meridian.Contracts.Workstation.SampleWorkspaceDto",
         "Meridian.Contracts.Workstation.SecurityClassificationSummaryDto",
         "Meridian.Contracts.Workstation.SecurityEconomicDefinitionSummaryDto",
         "Meridian.Contracts.Workstation.SecurityIdentityDrillInDto",
@@ -2434,16 +2473,34 @@
       "directories": [
         "src/Meridian.Contracts/AssetOperations"
       ],
-      "fingerprint": "8127b935f4c20c2ac25848ea7cff8a54320282d176878fe1235c2f075f52ef3b",
+      "fingerprint": "cca51d49843879e00b4380cc4fc831603ce5e2bb920746dda06ba9bc4490a1a7",
       "id": "asset-operations-contracts",
       "namespace_prefixes": [
         "Meridian.Contracts.AssetOperations"
       ],
       "object_ids": [
+        "Meridian.Contracts.AssetOperations.AppendAssetAccountingLifecycleStageRequestDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingCorrectionReferenceDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventKindDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventScopeDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventSpineAppendResultDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventSpineValidator",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventTypeNames",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEvidenceSubjects",
+        "Meridian.Contracts.AssetOperations.AssetAccountingLifecycleStageDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateRequestDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingStageEvidenceDto",
+        "Meridian.Contracts.AssetOperations.AssetAcquisitionLotDto",
         "Meridian.Contracts.AssetOperations.AssetActualActivityDto",
         "Meridian.Contracts.AssetOperations.AssetCashFlowProjectionRunDto",
+        "Meridian.Contracts.AssetOperations.AssetDisposalLotSelectionDto",
         "Meridian.Contracts.AssetOperations.AssetLedgerProjectionDto",
         "Meridian.Contracts.AssetOperations.AssetLifecycleEventDto",
+        "Meridian.Contracts.AssetOperations.AssetLotMutationInstructionDto",
+        "Meridian.Contracts.AssetOperations.AssetLotMutationInstructionValidator",
+        "Meridian.Contracts.AssetOperations.AssetLotMutationIntentDto",
         "Meridian.Contracts.AssetOperations.AssetOperationsDetailDto",
         "Meridian.Contracts.AssetOperations.AssetOperationsOptions",
         "Meridian.Contracts.AssetOperations.AssetOperationsProjectionDto",
@@ -2470,6 +2527,7 @@
         "Meridian.Contracts.AssetOperations.IPortfolioCashBalanceProvider",
         "Meridian.Contracts.AssetOperations.IPortfolioCashLadderQueryService",
         "Meridian.Contracts.AssetOperations.IPortfolioHoldingsSource",
+        "Meridian.Contracts.AssetOperations.JournalPostingStatusDto",
         "Meridian.Contracts.AssetOperations.PortfolioCapitalActivityDto",
         "Meridian.Contracts.AssetOperations.PortfolioCashBalanceDto",
         "Meridian.Contracts.AssetOperations.PortfolioCashLadderBucketDto",
@@ -2481,7 +2539,15 @@
         "Meridian.Contracts.AssetOperations.PortfolioCashScenarioDto",
         "Meridian.Contracts.AssetOperations.PortfolioHoldingDto",
         "Meridian.Contracts.AssetOperations.PositionEconomicStateDto",
-        "Meridian.Contracts.AssetOperations.ProjectionLineageDto"
+        "Meridian.Contracts.AssetOperations.PostedJournalImpactDto",
+        "Meridian.Contracts.AssetOperations.PostedJournalImpactLineDto",
+        "Meridian.Contracts.AssetOperations.PostedJournalImpactValidator",
+        "Meridian.Contracts.AssetOperations.ProjectAssetAccountingEventRequestDto",
+        "Meridian.Contracts.AssetOperations.ProjectedAccountingEffectDto",
+        "Meridian.Contracts.AssetOperations.ProjectedAccountingEffectLineDto",
+        "Meridian.Contracts.AssetOperations.ProjectionLineageDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityValidator"
       ],
       "schemas": [
         "asset_operations"
@@ -2857,7 +2923,7 @@
         "src/Meridian.Contracts/AccountingSystem",
         "src/Meridian.Contracts/Ledger"
       ],
-      "fingerprint": "85a8f534aed8a11e77c81af6b06171704cdb36036590cb4979910350861ad404",
+      "fingerprint": "3b4de2d6d4c8b2843bf5261e72c702fdbc3b5bc577c0bb050453644c797225cf",
       "id": "ledger-contracts",
       "namespace_prefixes": [
         "Meridian.Contracts.AccountingSystem",
@@ -2886,6 +2952,8 @@
         "Meridian.Contracts.AccountingSystem.AccountingMigrationRunWorkerPlanDto",
         "Meridian.Contracts.AccountingSystem.AccountingMigrationRunWorkerPlanListDto",
         "Meridian.Contracts.AccountingSystem.AccountingMigrationRunWorkerPlanUpsertRequestDto",
+        "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationEvidenceSubjectTypes",
+        "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationEvidenceValidator",
         "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationProfileDto",
         "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationProfileUpsertRequestDto",
         "Meridian.Contracts.AccountingSystem.AccountingProductionGapDto",
@@ -3210,7 +3278,7 @@
       "directories": [
         "src/Meridian.Contracts/SecurityMaster"
       ],
-      "fingerprint": "9b3386b43d1e6d7a74ee9507a16f66d701df23fc753d2b74e333b25c48243fd3",
+      "fingerprint": "0d3ca591a3e8367425f080c95e2991f162c2b6d6d08cce90b71f697303a4794a",
       "id": "security-master-contracts",
       "namespace_prefixes": [
         "Meridian.Contracts.SecurityMaster"
@@ -3323,7 +3391,11 @@
         "Meridian.Contracts.SecurityMaster.SecurityAssetProfileTermsDto",
         "Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTerms",
         "Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsUpcasterChain",
+        "Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsUpcasterPipeline",
         "Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsV0ToCurrentUpcaster",
+        "Meridian.Contracts.SecurityMaster.SecurityAssetTermField",
+        "Meridian.Contracts.SecurityMaster.SecurityAssetTermFieldType",
+        "Meridian.Contracts.SecurityMaster.SecurityAssetTermsSchema",
         "Meridian.Contracts.SecurityMaster.SecurityCashFlowSourceDto",
         "Meridian.Contracts.SecurityMaster.SecurityComparisonPriceDto",
         "Meridian.Contracts.SecurityMaster.SecurityDetailDto",
@@ -3392,7 +3464,7 @@
       ]
     }
   ],
-  "fingerprint": "db843393f523964d8e1c4e1a321420f709d980a71b0bfcf18654767c96c575cd",
+  "fingerprint": "32b87ef173f46b2c9e96302087bc70bb8bba4d473b72c8eeb935dc8804d5b8b8",
   "mapping_policy": {
     "level": "module",
     "note": "Schema associations are module-level only; no DTO-to-table or member-to-column structural equivalence is claimed.",
@@ -3404,7 +3476,7 @@
         "all-contracts",
         "ledger-contracts"
       ],
-      "fingerprint": "9e267a6f7140bd27226c28601e34600168d238b6e52a1b81087435b4198cfc77",
+      "fingerprint": "00990b946e177a806920b5d824dfb110dbad36b5fd3b2188964062a83ec6fd5e",
       "mapped_schemas": [
         "ledger"
       ],
@@ -3432,6 +3504,8 @@
         "Meridian.Contracts.AccountingSystem.AccountingMigrationRunWorkerPlanDto",
         "Meridian.Contracts.AccountingSystem.AccountingMigrationRunWorkerPlanListDto",
         "Meridian.Contracts.AccountingSystem.AccountingMigrationRunWorkerPlanUpsertRequestDto",
+        "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationEvidenceSubjectTypes",
+        "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationEvidenceValidator",
         "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationProfileDto",
         "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationProfileUpsertRequestDto",
         "Meridian.Contracts.AccountingSystem.AccountingProductionGapDto",
@@ -3720,16 +3794,34 @@
         "all-contracts",
         "asset-operations-contracts"
       ],
-      "fingerprint": "67944982824858e54bcb7fb3676afc670571c020072e3ec68147c5a59fe2fca9",
+      "fingerprint": "8ec439c1bf1e1ce6ebeea115237e8737b46dd5fcad3c9a9df4d85ac990c44a59",
       "mapped_schemas": [
         "asset_operations"
       ],
       "namespace": "Meridian.Contracts.AssetOperations",
       "object_ids": [
+        "Meridian.Contracts.AssetOperations.AppendAssetAccountingLifecycleStageRequestDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingCorrectionReferenceDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventKindDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventScopeDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventSpineAppendResultDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventSpineValidator",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventTypeNames",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEvidenceSubjects",
+        "Meridian.Contracts.AssetOperations.AssetAccountingLifecycleStageDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateRequestDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingStageEvidenceDto",
+        "Meridian.Contracts.AssetOperations.AssetAcquisitionLotDto",
         "Meridian.Contracts.AssetOperations.AssetActualActivityDto",
         "Meridian.Contracts.AssetOperations.AssetCashFlowProjectionRunDto",
+        "Meridian.Contracts.AssetOperations.AssetDisposalLotSelectionDto",
         "Meridian.Contracts.AssetOperations.AssetLedgerProjectionDto",
         "Meridian.Contracts.AssetOperations.AssetLifecycleEventDto",
+        "Meridian.Contracts.AssetOperations.AssetLotMutationInstructionDto",
+        "Meridian.Contracts.AssetOperations.AssetLotMutationInstructionValidator",
+        "Meridian.Contracts.AssetOperations.AssetLotMutationIntentDto",
         "Meridian.Contracts.AssetOperations.AssetOperationsDetailDto",
         "Meridian.Contracts.AssetOperations.AssetOperationsOptions",
         "Meridian.Contracts.AssetOperations.AssetOperationsProjectionDto",
@@ -3756,6 +3848,7 @@
         "Meridian.Contracts.AssetOperations.IPortfolioCashBalanceProvider",
         "Meridian.Contracts.AssetOperations.IPortfolioCashLadderQueryService",
         "Meridian.Contracts.AssetOperations.IPortfolioHoldingsSource",
+        "Meridian.Contracts.AssetOperations.JournalPostingStatusDto",
         "Meridian.Contracts.AssetOperations.PortfolioCapitalActivityDto",
         "Meridian.Contracts.AssetOperations.PortfolioCashBalanceDto",
         "Meridian.Contracts.AssetOperations.PortfolioCashLadderBucketDto",
@@ -3767,7 +3860,15 @@
         "Meridian.Contracts.AssetOperations.PortfolioCashScenarioDto",
         "Meridian.Contracts.AssetOperations.PortfolioHoldingDto",
         "Meridian.Contracts.AssetOperations.PositionEconomicStateDto",
-        "Meridian.Contracts.AssetOperations.ProjectionLineageDto"
+        "Meridian.Contracts.AssetOperations.PostedJournalImpactDto",
+        "Meridian.Contracts.AssetOperations.PostedJournalImpactLineDto",
+        "Meridian.Contracts.AssetOperations.PostedJournalImpactValidator",
+        "Meridian.Contracts.AssetOperations.ProjectAssetAccountingEventRequestDto",
+        "Meridian.Contracts.AssetOperations.ProjectedAccountingEffectDto",
+        "Meridian.Contracts.AssetOperations.ProjectedAccountingEffectLineDto",
+        "Meridian.Contracts.AssetOperations.ProjectionLineageDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityValidator"
       ]
     },
     {
@@ -4688,7 +4789,7 @@
         "all-contracts",
         "ledger-contracts"
       ],
-      "fingerprint": "60633605847594ffd21d5b32700e23f0de2bef94cd66733c271f653af66b6cb3",
+      "fingerprint": "6f461d6c93f98d6791b947de92c14dee34353e7000f4b119df8ee7f17b0da792",
       "mapped_schemas": [
         "ledger"
       ],
@@ -5168,7 +5269,7 @@
         "all-contracts",
         "security-master-contracts"
       ],
-      "fingerprint": "35521dae0d11fb74019961c83cf8893ec58578e00c2134d2d9c3b55fe3e7ab21",
+      "fingerprint": "4bdd39e51defef19f331cf95825546bac1a7e4b4b7c54013b670954e61598c14",
       "mapped_schemas": [
         "security_master"
       ],
@@ -5281,7 +5382,11 @@
         "Meridian.Contracts.SecurityMaster.SecurityAssetProfileTermsDto",
         "Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTerms",
         "Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsUpcasterChain",
+        "Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsUpcasterPipeline",
         "Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsV0ToCurrentUpcaster",
+        "Meridian.Contracts.SecurityMaster.SecurityAssetTermField",
+        "Meridian.Contracts.SecurityMaster.SecurityAssetTermFieldType",
+        "Meridian.Contracts.SecurityMaster.SecurityAssetTermsSchema",
         "Meridian.Contracts.SecurityMaster.SecurityCashFlowSourceDto",
         "Meridian.Contracts.SecurityMaster.SecurityComparisonPriceDto",
         "Meridian.Contracts.SecurityMaster.SecurityDetailDto",
@@ -5463,7 +5568,7 @@
       "contract_sets": [
         "all-contracts"
       ],
-      "fingerprint": "8737a7d09d868b167b0019140c42216b3f0878121d6982d546ac126d74cdb31b",
+      "fingerprint": "07564817acc10174a82d5db963399844a64e3a278f811f67faed148c21f0f1f7",
       "mapped_schemas": [],
       "namespace": "Meridian.Contracts.Workstation",
       "object_ids": [
@@ -6060,6 +6165,12 @@
         "Meridian.Contracts.Workstation.RunLotSummary",
         "Meridian.Contracts.Workstation.RunPortfolioDrillInSummary",
         "Meridian.Contracts.Workstation.RunReconciliation",
+        "Meridian.Contracts.Workstation.SampleArtifactDto",
+        "Meridian.Contracts.Workstation.SampleBreakDto",
+        "Meridian.Contracts.Workstation.SampleHighlightDto",
+        "Meridian.Contracts.Workstation.SampleHoldingDto",
+        "Meridian.Contracts.Workstation.SampleMarketHistoryDto",
+        "Meridian.Contracts.Workstation.SampleWorkspaceDto",
         "Meridian.Contracts.Workstation.SecurityClassificationSummaryDto",
         "Meridian.Contracts.Workstation.SecurityEconomicDefinitionSummaryDto",
         "Meridian.Contracts.Workstation.SecurityIdentityDrillInDto",
@@ -6451,7 +6562,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "f7b898a220d3b1a3419867b802506240a0944a70eaca001012e900529e956b21",
+      "fingerprint": "0ee90b2a284b90cd1d9ae8b17ebd8db06d538f5c94d3a7e46d40ac11965d6631",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingApprovalQueueConfigurationDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingApprovalQueueConfigurationDto",
       "kind": "record",
@@ -6470,7 +6581,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 245,
+          "source_line": 246,
           "type": "string"
         },
         {
@@ -6484,7 +6595,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 250,
+          "source_line": 251,
           "type": "string"
         },
         {
@@ -6498,7 +6609,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 244,
+          "source_line": 245,
           "type": "string"
         },
         {
@@ -6512,7 +6623,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "int",
-          "source_line": 248,
+          "source_line": 249,
           "type": "int"
         },
         {
@@ -6526,7 +6637,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 247,
+          "source_line": 248,
           "type": "string"
         },
         {
@@ -6540,7 +6651,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 249,
+          "source_line": 250,
           "type": "string"
         },
         {
@@ -6554,7 +6665,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 246,
+          "source_line": 247,
           "type": "string"
         }
       ],
@@ -6564,12 +6675,12 @@
       "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingApprovalQueueConfigurationDto",
       "references": [],
       "source": {
-        "line": 243,
+        "line": 244,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 243,
+          "line": 244,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -6588,7 +6699,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "5c21b913f846d3403dd0285ceb33badaf4c4fe8bb223b8261bf41e823e5047d2",
+      "fingerprint": "54c91bce00e59fcb24dd49bf317437da70e2477129958a6524861c0723f290e2",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingCertificationArtifactIssueDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingCertificationArtifactIssueDto",
       "kind": "record",
@@ -6607,7 +6718,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 377,
+          "source_line": 378,
           "type": "string"
         },
         {
@@ -6621,7 +6732,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 383,
+          "source_line": 384,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -6635,7 +6746,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 379,
+          "source_line": 380,
           "type": "string"
         },
         {
@@ -6649,7 +6760,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingConfigurationValidationSeverityDto",
-          "source_line": 378,
+          "source_line": 379,
           "type": "AccountingConfigurationValidationSeverityDto"
         },
         {
@@ -6663,7 +6774,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 380,
+          "source_line": 381,
           "type": "string"
         }
       ],
@@ -6675,12 +6786,12 @@
         "Meridian.Contracts.Ledger.AccountingConfigurationValidationSeverityDto"
       ],
       "source": {
-        "line": 376,
+        "line": 377,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 376,
+          "line": 377,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -6702,29 +6813,29 @@
         {
           "explicit_value": false,
           "name": "NotTested",
-          "source_line": 322,
-          "value": null
-        },
-        {
-          "explicit_value": false,
-          "name": "Passed",
           "source_line": 323,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "Warning",
+          "name": "Passed",
           "source_line": 324,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "Failed",
+          "name": "Warning",
           "source_line": 325,
+          "value": null
+        },
+        {
+          "explicit_value": false,
+          "name": "Failed",
+          "source_line": 326,
           "value": null
         }
       ],
-      "fingerprint": "0894b1fa779e65425b3b52b877146d10e58ed266a7e805ced8591238d18edb16",
+      "fingerprint": "ee2c7cf603028f3a1a4ca2e288701ed01cdaf05447388f54bcebb9def4e1c8bd",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingCertificationArtifactLaneStatusDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingCertificationArtifactLaneStatusDto",
       "kind": "enum",
@@ -6738,12 +6849,12 @@
       "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingCertificationArtifactLaneStatusDto",
       "references": [],
       "source": {
-        "line": 320,
+        "line": 321,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 320,
+          "line": 321,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -6765,29 +6876,29 @@
         {
           "explicit_value": false,
           "name": "Draft",
-          "source_line": 314,
-          "value": null
-        },
-        {
-          "explicit_value": false,
-          "name": "Certified",
           "source_line": 315,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "Rejected",
+          "name": "Certified",
           "source_line": 316,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "Superseded",
+          "name": "Rejected",
           "source_line": 317,
+          "value": null
+        },
+        {
+          "explicit_value": false,
+          "name": "Superseded",
+          "source_line": 318,
           "value": null
         }
       ],
-      "fingerprint": "7b72db31d1fe7dbe7f5c61b66ffd1988750db9e157899fde652703128d4ade37",
+      "fingerprint": "e351224275fd3913d6827bd99904067b497d3ec4e1a2571f0cfd0e49b0d39e7b",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingCertificationArtifactStatusDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingCertificationArtifactStatusDto",
       "kind": "enum",
@@ -6801,12 +6912,12 @@
       "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingCertificationArtifactStatusDto",
       "references": [],
       "source": {
-        "line": 312,
+        "line": 313,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 312,
+          "line": 313,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -6825,7 +6936,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "ccee33137e7d24397b759095da94d20e1d9599d4861e5707eb62a37ff116426d",
+      "fingerprint": "8ec04ea2f433de57f12a04854f706f9b5c59d2bbea9479f87e8eacde0926aee3",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingDimensionalCertificationArtifactDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingDimensionalCertificationArtifactDto",
       "kind": "record",
@@ -6844,7 +6955,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 452,
+          "source_line": 453,
           "type": "string"
         },
         {
@@ -6858,7 +6969,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset",
-          "source_line": 460,
+          "source_line": 461,
           "type": "DateTimeOffset"
         },
         {
@@ -6872,7 +6983,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 459,
+          "source_line": 460,
           "type": "string"
         },
         {
@@ -6886,7 +6997,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 455,
+          "source_line": 456,
           "type": "string?"
         },
         {
@@ -6901,7 +7012,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 465,
+          "source_line": 466,
           "type": "string?"
         },
         {
@@ -6915,7 +7026,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 458,
+          "source_line": 459,
           "type": "string"
         },
         {
@@ -6929,7 +7040,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 470,
+          "source_line": 471,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -6943,7 +7054,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 456,
+          "source_line": 457,
           "type": "string"
         },
         {
@@ -6957,7 +7068,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingCertificationArtifactIssueDto>",
-          "source_line": 473,
+          "source_line": 474,
           "type": "IReadOnlyList<AccountingCertificationArtifactIssueDto>"
         },
         {
@@ -6971,7 +7082,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingDimensionalCertificationLaneDto>",
-          "source_line": 467,
+          "source_line": 468,
           "type": "IReadOnlyList<AccountingDimensionalCertificationLaneDto>"
         },
         {
@@ -6985,7 +7096,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 457,
+          "source_line": 458,
           "type": "Guid"
         },
         {
@@ -6999,7 +7110,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 461,
+          "source_line": 462,
           "type": "string"
         },
         {
@@ -7013,7 +7124,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingCertificationArtifactStatusDto",
-          "source_line": 453,
+          "source_line": 454,
           "type": "AccountingCertificationArtifactStatusDto"
         },
         {
@@ -7027,7 +7138,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 454,
+          "source_line": 455,
           "type": "string?"
         }
       ],
@@ -7041,12 +7152,12 @@
         "Meridian.Contracts.AccountingSystem.AccountingDimensionalCertificationLaneDto"
       ],
       "source": {
-        "line": 451,
+        "line": 452,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 451,
+          "line": 452,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -7065,7 +7176,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "0bc7c1a256ac55c37dd447359bb39e892ea3287fb1663edfd1907bcd8f36d4b3",
+      "fingerprint": "b84aed0a7d4acecb955b44f9dac4935f076742cf4de5036519af56007ff9da20",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingDimensionalCertificationLaneDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingDimensionalCertificationLaneDto",
       "kind": "record",
@@ -7084,7 +7195,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 406,
+          "source_line": 407,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -7098,7 +7209,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingCertificationArtifactIssueDto>",
-          "source_line": 409,
+          "source_line": 410,
           "type": "IReadOnlyList<AccountingCertificationArtifactIssueDto>"
         },
         {
@@ -7112,7 +7223,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingDimensionalCertificationLaneKindDto",
-          "source_line": 401,
+          "source_line": 402,
           "type": "AccountingDimensionalCertificationLaneKindDto"
         },
         {
@@ -7126,7 +7237,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingCertificationArtifactLaneStatusDto",
-          "source_line": 402,
+          "source_line": 403,
           "type": "AccountingCertificationArtifactLaneStatusDto"
         }
       ],
@@ -7140,12 +7251,12 @@
         "Meridian.Contracts.AccountingSystem.AccountingDimensionalCertificationLaneKindDto"
       ],
       "source": {
-        "line": 400,
+        "line": 401,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 400,
+          "line": 401,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -7167,47 +7278,47 @@
         {
           "explicit_value": false,
           "name": "LedgerLinePersistence",
-          "source_line": 342,
-          "value": null
-        },
-        {
-          "explicit_value": false,
-          "name": "TrialBalanceFilters",
           "source_line": 343,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "PeriodReports",
+          "name": "TrialBalanceFilters",
           "source_line": 344,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "CrossPeriodReports",
+          "name": "PeriodReports",
           "source_line": 345,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "JournalFilters",
+          "name": "CrossPeriodReports",
           "source_line": 346,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "ReportPackageProvenance",
+          "name": "JournalFilters",
           "source_line": 347,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "ExternalExportMappings",
+          "name": "ReportPackageProvenance",
           "source_line": 348,
+          "value": null
+        },
+        {
+          "explicit_value": false,
+          "name": "ExternalExportMappings",
+          "source_line": 349,
           "value": null
         }
       ],
-      "fingerprint": "7bdfe9ae10fd0107ef84b8697a892fc4a12bc5c3e31fae6d8f5dcf7441a593e3",
+      "fingerprint": "cf47a4feac884ffc2bcf29afbaa1fa83ca7b82dcfc41a7acb5d2d7d9e6aa68c5",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingDimensionalCertificationLaneKindDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingDimensionalCertificationLaneKindDto",
       "kind": "enum",
@@ -7221,12 +7332,12 @@
       "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingDimensionalCertificationLaneKindDto",
       "references": [],
       "source": {
-        "line": 340,
+        "line": 341,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 340,
+          "line": 341,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -7245,7 +7356,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "82e93957af1d351b6c327d64d6b7d5c9bd7701ded9fd9e7d5c2fd3ac75994eec",
+      "fingerprint": "b3fe2913bd82c41e48dd74ae8671a511976fafae354d72c1ace84b749b0a1c63",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingDimensionalReportingReadinessDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingDimensionalReportingReadinessDto",
       "kind": "record",
@@ -7253,6 +7364,35 @@
         "ledger"
       ],
       "members": [
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "AccountingDimensionalCertificationArtifactDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CertificationArtifacts",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<AccountingDimensionalCertificationArtifactDto>",
+          "source_line": 841,
+          "type": "IReadOnlyList<AccountingDimensionalCertificationArtifactDto>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CompanyId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 831,
+          "type": "string?"
+        },
         {
           "collection": false,
           "collection_kind": null,
@@ -7264,7 +7404,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 722,
+          "source_line": 822,
           "type": "bool"
         },
         {
@@ -7278,7 +7418,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 730,
+          "source_line": 835,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -7292,8 +7432,23 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 724,
+          "source_line": 824,
           "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "FundProfileId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 832,
+          "type": "string?"
         },
         {
           "collection": false,
@@ -7306,7 +7461,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 723,
+          "source_line": 823,
           "type": "bool"
         },
         {
@@ -7320,7 +7475,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 720,
+          "source_line": 820,
           "type": "Guid?"
         },
         {
@@ -7335,7 +7490,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 725,
+          "source_line": 825,
           "type": "bool"
         },
         {
@@ -7349,7 +7504,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 721,
+          "source_line": 821,
           "type": "bool"
         },
         {
@@ -7364,8 +7519,37 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 727,
+          "source_line": 827,
           "type": "bool"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 838,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TenantId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 830,
+          "type": "string?"
         },
         {
           "collection": false,
@@ -7379,7 +7563,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 726,
+          "source_line": 826,
           "type": "bool"
         }
       ],
@@ -7387,14 +7571,17 @@
       "namespace": "Meridian.Contracts.AccountingSystem",
       "partial": false,
       "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingDimensionalReportingReadinessDto",
-      "references": [],
+      "references": [
+        "Meridian.Contracts.AccountingSystem.AccountingDimensionalCertificationArtifactDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+      ],
       "source": {
-        "line": 719,
+        "line": 819,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 719,
+          "line": 819,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -7413,7 +7600,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "d3c25c65be71d2b036b303ed528d0b73611f9d7630b71cf1c4049c49d6beaf17",
+      "fingerprint": "a449ee6c3cd5c2fbf22db4ee8da17bcb409addcc0a2fbcde92e0593ac5a0f02b",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingDimensionMappingConfigurationDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingDimensionMappingConfigurationDto",
       "kind": "record",
@@ -7432,7 +7619,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 254,
+          "source_line": 255,
           "type": "string"
         },
         {
@@ -7446,7 +7633,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 258,
+          "source_line": 259,
           "type": "string"
         },
         {
@@ -7460,7 +7647,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 253,
+          "source_line": 254,
           "type": "string"
         },
         {
@@ -7474,7 +7661,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "LedgerDimensionSetDto",
-          "source_line": 256,
+          "source_line": 257,
           "type": "LedgerDimensionSetDto"
         },
         {
@@ -7488,7 +7675,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "LedgerDimensionSetDto",
-          "source_line": 257,
+          "source_line": 258,
           "type": "LedgerDimensionSetDto"
         },
         {
@@ -7502,7 +7689,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 255,
+          "source_line": 256,
           "type": "string"
         }
       ],
@@ -7514,12 +7701,12 @@
         "Meridian.Contracts.Ledger.LedgerDimensionSetDto"
       ],
       "source": {
-        "line": 252,
+        "line": 253,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 252,
+          "line": 253,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -7538,7 +7725,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "579c1bfb544aa44a7deb944b0fde468697f9f3a6cb67b31ad3d33b4c0e67903e",
+      "fingerprint": "079ea29d789b219a598c6473b9597415d670e2902ca15bbee670a7dfb222d595",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingLedgerBookWorkflowReadinessDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingLedgerBookWorkflowReadinessDto",
       "kind": "record",
@@ -7546,6 +7733,20 @@
         "ledger"
       ],
       "members": [
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "AccountingWorkflowCertificationArtifactDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CertificationArtifacts",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<AccountingWorkflowCertificationArtifactDto>",
+          "source_line": 728,
+          "type": "IReadOnlyList<AccountingWorkflowCertificationArtifactDto>"
+        },
         {
           "collection": false,
           "collection_kind": null,
@@ -7557,7 +7758,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 645,
+          "source_line": 710,
           "type": "bool"
         },
         {
@@ -7571,8 +7772,23 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 644,
+          "source_line": 709,
           "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CompanyId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 718,
+          "type": "string?"
         },
         {
           "collection": false,
@@ -7586,7 +7802,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 648,
+          "source_line": 713,
           "type": "bool"
         },
         {
@@ -7600,7 +7816,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 652,
+          "source_line": 722,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -7614,8 +7830,23 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 646,
+          "source_line": 711,
           "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "FundProfileId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 719,
+          "type": "string?"
         },
         {
           "collection": false,
@@ -7628,7 +7859,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 643,
+          "source_line": 708,
           "type": "bool"
         },
         {
@@ -7642,7 +7873,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 641,
+          "source_line": 706,
           "type": "Guid?"
         },
         {
@@ -7656,7 +7887,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 642,
+          "source_line": 707,
           "type": "bool"
         },
         {
@@ -7671,8 +7902,22 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 647,
+          "source_line": 712,
           "type": "bool"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 725,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
         },
         {
           "collection": false,
@@ -7686,22 +7931,40 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 649,
+          "source_line": 714,
           "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TenantId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 717,
+          "type": "string?"
         }
       ],
       "name": "AccountingLedgerBookWorkflowReadinessDto",
       "namespace": "Meridian.Contracts.AccountingSystem",
       "partial": false,
       "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingLedgerBookWorkflowReadinessDto",
-      "references": [],
+      "references": [
+        "Meridian.Contracts.AccountingSystem.AccountingWorkflowCertificationArtifactDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+      ],
       "source": {
-        "line": 640,
+        "line": 705,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 640,
+          "line": 705,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -7720,7 +7983,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "81733961469ab6e21b5260a360e90015080ac96936df2a2d9ac7e7d569bf41cb",
+      "fingerprint": "8b02e6ed38d9a3b05acdf4b963fc6c1142d3c58745f4f9d47b054e3b4c0ef442",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingMigrationRolloutPlanItemDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingMigrationRolloutPlanItemDto",
       "kind": "record",
@@ -7740,7 +8003,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 1053,
+          "source_line": 1168,
           "type": "string?"
         },
         {
@@ -7754,7 +8017,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 1058,
+          "source_line": 1173,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -7768,7 +8031,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 1041,
+          "source_line": 1156,
           "type": "bool"
         },
         {
@@ -7782,7 +8045,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1039,
+          "source_line": 1154,
           "type": "string"
         },
         {
@@ -7796,7 +8059,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 1061,
+          "source_line": 1176,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -7810,7 +8073,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 1055,
+          "source_line": 1170,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -7825,7 +8088,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "int",
-          "source_line": 1048,
+          "source_line": 1163,
           "type": "int"
         },
         {
@@ -7839,7 +8102,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingMigrationRunKindDto",
-          "source_line": 1038,
+          "source_line": 1153,
           "type": "AccountingMigrationRunKindDto"
         },
         {
@@ -7853,7 +8116,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1040,
+          "source_line": 1155,
           "type": "string"
         },
         {
@@ -7868,7 +8131,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 1045,
+          "source_line": 1160,
           "type": "string?"
         },
         {
@@ -7883,7 +8146,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "AccountingMigrationRunStatusDto?",
-          "source_line": 1046,
+          "source_line": 1161,
           "type": "AccountingMigrationRunStatusDto?"
         },
         {
@@ -7898,7 +8161,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "int",
-          "source_line": 1047,
+          "source_line": 1162,
           "type": "int"
         },
         {
@@ -7912,7 +8175,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1044,
+          "source_line": 1159,
           "type": "string"
         },
         {
@@ -7926,7 +8189,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1043,
+          "source_line": 1158,
           "type": "string"
         },
         {
@@ -7941,7 +8204,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "int",
-          "source_line": 1051,
+          "source_line": 1166,
           "type": "int"
         },
         {
@@ -7955,7 +8218,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingProductionReadinessStatusDto",
-          "source_line": 1042,
+          "source_line": 1157,
           "type": "AccountingProductionReadinessStatusDto"
         }
       ],
@@ -7969,12 +8232,12 @@
         "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessStatusDto"
       ],
       "source": {
-        "line": 1037,
+        "line": 1152,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 1037,
+          "line": 1152,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -7993,7 +8256,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "82dceb4cc61017289a79424a5e96d058c846659e589617b83a8a7b42c5cdea8c",
+      "fingerprint": "bfe4095327a8995240f6e25b89cb81a7c1bc0b2b0dac30dc26e2232c8fb34b91",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunArtifactDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunArtifactDto",
       "kind": "record",
@@ -8013,7 +8276,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 129,
+          "source_line": 130,
           "type": "string?"
         },
         {
@@ -8028,7 +8291,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 138,
+          "source_line": 139,
           "type": "string?"
         },
         {
@@ -8043,7 +8306,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset?",
-          "source_line": 128,
+          "source_line": 129,
           "type": "DateTimeOffset?"
         },
         {
@@ -8058,7 +8321,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "LedgerDimensionSetDto?",
-          "source_line": 136,
+          "source_line": 137,
           "type": "LedgerDimensionSetDto?"
         },
         {
@@ -8072,7 +8335,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 142,
+          "source_line": 143,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -8087,7 +8350,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 133,
+          "source_line": 134,
           "type": "string?"
         },
         {
@@ -8102,7 +8365,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "int",
-          "source_line": 131,
+          "source_line": 132,
           "type": "int"
         },
         {
@@ -8116,7 +8379,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingMigrationRunKindDto",
-          "source_line": 125,
+          "source_line": 126,
           "type": "AccountingMigrationRunKindDto"
         },
         {
@@ -8131,7 +8394,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 134,
+          "source_line": 135,
           "type": "Guid?"
         },
         {
@@ -8146,7 +8409,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "int",
-          "source_line": 130,
+          "source_line": 131,
           "type": "int"
         },
         {
@@ -8161,7 +8424,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "bool?",
-          "source_line": 140,
+          "source_line": 141,
           "type": "bool?"
         },
         {
@@ -8175,7 +8438,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 124,
+          "source_line": 125,
           "type": "string"
         },
         {
@@ -8190,7 +8453,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "int?",
-          "source_line": 139,
+          "source_line": 140,
           "type": "int?"
         },
         {
@@ -8204,7 +8467,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset",
-          "source_line": 127,
+          "source_line": 128,
           "type": "DateTimeOffset"
         },
         {
@@ -8218,7 +8481,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingMigrationRunStatusDto",
-          "source_line": 126,
+          "source_line": 127,
           "type": "AccountingMigrationRunStatusDto"
         },
         {
@@ -8233,7 +8496,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 135,
+          "source_line": 136,
           "type": "string?"
         },
         {
@@ -8248,7 +8511,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 137,
+          "source_line": 138,
           "type": "string?"
         }
       ],
@@ -8262,12 +8525,12 @@
         "Meridian.Contracts.Ledger.LedgerDimensionSetDto"
       ],
       "source": {
-        "line": 123,
+        "line": 124,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 123,
+          "line": 124,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -8286,7 +8549,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "95c92b1ca86700477ee7a9eb6f42461c3e09d344c6389ebfde1871062fdf9ca3",
+      "fingerprint": "b0372faaae3cb1343a65ddcb818154ccc5c5a011e7d6128d83ddb49e8a9773ee",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunArtifactListDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunArtifactListDto",
       "kind": "record",
@@ -8305,7 +8568,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingMigrationRunArtifactDto>",
-          "source_line": 153,
+          "source_line": 154,
           "type": "IReadOnlyList<AccountingMigrationRunArtifactDto>"
         },
         {
@@ -8320,7 +8583,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 151,
+          "source_line": 152,
           "type": "string?"
         },
         {
@@ -8335,7 +8598,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 147,
+          "source_line": 148,
           "type": "string?"
         },
         {
@@ -8350,7 +8613,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 148,
+          "source_line": 149,
           "type": "Guid?"
         },
         {
@@ -8365,7 +8628,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 150,
+          "source_line": 151,
           "type": "string?"
         }
       ],
@@ -8377,12 +8640,12 @@
         "Meridian.Contracts.AccountingSystem.AccountingMigrationRunArtifactDto"
       ],
       "source": {
-        "line": 146,
+        "line": 147,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 146,
+          "line": 147,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -8401,7 +8664,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "72bdb6a23e91938272fb7064dc9d4cffff408e7394095f92f8d2ba3621f0cf85",
+      "fingerprint": "7144278ea0b582f0a14319fa64a09b9fe8de7da5dfee103d584a88f2043b9bb2",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunArtifactUpsertRequestDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunArtifactUpsertRequestDto",
       "kind": "record",
@@ -8421,7 +8684,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "OperationsActionOriginDto",
-          "source_line": 162,
+          "source_line": 163,
           "type": "OperationsActionOriginDto"
         },
         {
@@ -8435,7 +8698,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 159,
+          "source_line": 160,
           "type": "string"
         },
         {
@@ -8449,7 +8712,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingMigrationRunArtifactDto",
-          "source_line": 158,
+          "source_line": 159,
           "type": "AccountingMigrationRunArtifactDto"
         },
         {
@@ -8464,7 +8727,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 160,
+          "source_line": 161,
           "type": "string?"
         },
         {
@@ -8478,7 +8741,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 164,
+          "source_line": 165,
           "type": "IReadOnlyList<string>"
         }
       ],
@@ -8491,12 +8754,12 @@
         "Meridian.Contracts.Workstation.OperationsActionOriginDto"
       ],
       "source": {
-        "line": 157,
+        "line": 158,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 157,
+          "line": 158,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -8515,7 +8778,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "b456b56a7f81c6b1e9b63f7672aac3d72c734571d83b339c267e6fe9c0f9661c",
+      "fingerprint": "090a10062c9a4616917bebd473bc09fe4a1fe8570184adef1c1333ac0e08b14b",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunExecutionIssueDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunExecutionIssueDto",
       "kind": "record",
@@ -8534,7 +8797,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 224,
+          "source_line": 225,
           "type": "string"
         },
         {
@@ -8548,7 +8811,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 226,
+          "source_line": 227,
           "type": "string"
         },
         {
@@ -8562,7 +8825,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingConfigurationValidationSeverityDto",
-          "source_line": 225,
+          "source_line": 226,
           "type": "AccountingConfigurationValidationSeverityDto"
         },
         {
@@ -8576,7 +8839,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 227,
+          "source_line": 228,
           "type": "string"
         }
       ],
@@ -8588,12 +8851,12 @@
         "Meridian.Contracts.Ledger.AccountingConfigurationValidationSeverityDto"
       ],
       "source": {
-        "line": 223,
+        "line": 224,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 223,
+          "line": 224,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -8612,7 +8875,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "c145cd0abf32bead086d3aaae7fe2d3646e165ba73c30d2ed82b49ce643b4ffb",
+      "fingerprint": "7f09ef487813279769883a7b07ecc1c3a7609c2343e71d16fb279e483bde5f26",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunExecutionRequestDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunExecutionRequestDto",
       "kind": "record",
@@ -8632,7 +8895,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "OperationsActionOriginDto",
-          "source_line": 182,
+          "source_line": 183,
           "type": "OperationsActionOriginDto"
         },
         {
@@ -8646,7 +8909,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 170,
+          "source_line": 171,
           "type": "string"
         },
         {
@@ -8661,7 +8924,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 174,
+          "source_line": 175,
           "type": "bool"
         },
         {
@@ -8676,7 +8939,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 179,
+          "source_line": 180,
           "type": "string?"
         },
         {
@@ -8691,7 +8954,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 177,
+          "source_line": 178,
           "type": "string?"
         },
         {
@@ -8706,7 +8969,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "LedgerDimensionSetDto?",
-          "source_line": 175,
+          "source_line": 176,
           "type": "LedgerDimensionSetDto?"
         },
         {
@@ -8720,7 +8983,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 185,
+          "source_line": 186,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -8735,7 +8998,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 171,
+          "source_line": 172,
           "type": "string?"
         },
         {
@@ -8749,7 +9012,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingMigrationRunKindDto",
-          "source_line": 169,
+          "source_line": 170,
           "type": "AccountingMigrationRunKindDto"
         },
         {
@@ -8764,7 +9027,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 172,
+          "source_line": 173,
           "type": "Guid?"
         },
         {
@@ -8779,7 +9042,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "int?",
-          "source_line": 181,
+          "source_line": 182,
           "type": "int?"
         },
         {
@@ -8794,7 +9057,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 173,
+          "source_line": 174,
           "type": "string?"
         },
         {
@@ -8809,7 +9072,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "int?",
-          "source_line": 180,
+          "source_line": 181,
           "type": "int?"
         },
         {
@@ -8824,7 +9087,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 178,
+          "source_line": 179,
           "type": "string?"
         },
         {
@@ -8839,7 +9102,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 183,
+          "source_line": 184,
           "type": "string?"
         }
       ],
@@ -8853,12 +9116,12 @@
         "Meridian.Contracts.Workstation.OperationsActionOriginDto"
       ],
       "source": {
-        "line": 168,
+        "line": 169,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 168,
+          "line": 169,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -8877,7 +9140,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "31057614e0f094af862d62e2a15d92659887e4f44549ef7bd0f1af65a4945bd4",
+      "fingerprint": "de9752755be1b2cabae53376ab4ca58fa95d82772b4d6daf60db193245e9b3dd",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunExecutionResultDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunExecutionResultDto",
       "kind": "record",
@@ -8896,7 +9159,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingMigrationRunArtifactDto",
-          "source_line": 230,
+          "source_line": 231,
           "type": "AccountingMigrationRunArtifactDto"
         },
         {
@@ -8910,7 +9173,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 239,
+          "source_line": 240,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -8924,7 +9187,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 232,
+          "source_line": 233,
           "type": "bool"
         },
         {
@@ -8938,7 +9201,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingMigrationRunExecutionIssueDto>",
-          "source_line": 236,
+          "source_line": 237,
           "type": "IReadOnlyList<AccountingMigrationRunExecutionIssueDto>"
         },
         {
@@ -8952,7 +9215,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingMigrationRunStatusDto",
-          "source_line": 231,
+          "source_line": 232,
           "type": "AccountingMigrationRunStatusDto"
         }
       ],
@@ -8966,12 +9229,12 @@
         "Meridian.Contracts.AccountingSystem.AccountingMigrationRunStatusDto"
       ],
       "source": {
-        "line": 229,
+        "line": 230,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 229,
+          "line": 230,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -8993,35 +9256,35 @@
         {
           "explicit_value": true,
           "name": "LedgerBookScope",
-          "source_line": 106,
+          "source_line": 107,
           "value": "0"
         },
         {
           "explicit_value": true,
           "name": "HistoricalJournalBackfill",
-          "source_line": 107,
+          "source_line": 108,
           "value": "1"
         },
         {
           "explicit_value": true,
           "name": "DimensionalBackfill",
-          "source_line": 108,
+          "source_line": 109,
           "value": "2"
         },
         {
           "explicit_value": true,
           "name": "AccountingConfigurationPromotion",
-          "source_line": 109,
+          "source_line": 110,
           "value": "3"
         },
         {
           "explicit_value": true,
           "name": "CloseReportingEvidence",
-          "source_line": 110,
+          "source_line": 111,
           "value": "4"
         }
       ],
-      "fingerprint": "03eb48873048c25edaede81382def18cd54085e5c12494ab22833c18383e83fc",
+      "fingerprint": "f919ec4cefe7118244558c578e580b537b14bd38483832b9fa262a6954f0a45f",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunKindDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunKindDto",
       "kind": "enum",
@@ -9035,12 +9298,12 @@
       "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunKindDto",
       "references": [],
       "source": {
-        "line": 104,
+        "line": 105,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 104,
+          "line": 105,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -9062,35 +9325,35 @@
         {
           "explicit_value": true,
           "name": "Planned",
-          "source_line": 116,
+          "source_line": 117,
           "value": "0"
         },
         {
           "explicit_value": true,
           "name": "Running",
-          "source_line": 117,
+          "source_line": 118,
           "value": "1"
         },
         {
           "explicit_value": true,
           "name": "Completed",
-          "source_line": 118,
+          "source_line": 119,
           "value": "2"
         },
         {
           "explicit_value": true,
           "name": "Failed",
-          "source_line": 119,
+          "source_line": 120,
           "value": "3"
         },
         {
           "explicit_value": true,
           "name": "Certified",
-          "source_line": 120,
+          "source_line": 121,
           "value": "4"
         }
       ],
-      "fingerprint": "d5e15da76a9ad17e5541e9beaf4637224443ae7bb7bdffec3d52bab7e394f205",
+      "fingerprint": "f2c18d57ced755aa3eee9d21a820d84467d7aeb2ceac6f6dd56ad0f79a537e95",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunStatusDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunStatusDto",
       "kind": "enum",
@@ -9104,12 +9367,12 @@
       "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunStatusDto",
       "references": [],
       "source": {
-        "line": 114,
+        "line": 115,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 114,
+          "line": 115,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -9128,7 +9391,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "d7141ed2bec277fe4e1ba0ed2752cf5bdf824b76bca68b04fd8534a0706ce775",
+      "fingerprint": "802c6841cdd2f84a1e7d43e704dda6503af5c74719710062a6b90a66d9e1094c",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunWorkerPlanDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunWorkerPlanDto",
       "kind": "record",
@@ -9148,7 +9411,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 199,
+          "source_line": 200,
           "type": "string?"
         },
         {
@@ -9163,7 +9426,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "LedgerDimensionSetDto?",
-          "source_line": 196,
+          "source_line": 197,
           "type": "LedgerDimensionSetDto?"
         },
         {
@@ -9177,7 +9440,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 202,
+          "source_line": 203,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -9191,7 +9454,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 192,
+          "source_line": 193,
           "type": "string"
         },
         {
@@ -9205,7 +9468,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingMigrationRunKindDto",
-          "source_line": 191,
+          "source_line": 192,
           "type": "AccountingMigrationRunKindDto"
         },
         {
@@ -9219,7 +9482,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 193,
+          "source_line": 194,
           "type": "Guid"
         },
         {
@@ -9233,7 +9496,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "int",
-          "source_line": 195,
+          "source_line": 196,
           "type": "int"
         },
         {
@@ -9247,7 +9510,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 190,
+          "source_line": 191,
           "type": "string"
         },
         {
@@ -9261,7 +9524,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "int",
-          "source_line": 194,
+          "source_line": 195,
           "type": "int"
         },
         {
@@ -9276,7 +9539,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 200,
+          "source_line": 201,
           "type": "string?"
         },
         {
@@ -9291,7 +9554,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 198,
+          "source_line": 199,
           "type": "string?"
         }
       ],
@@ -9304,12 +9567,12 @@
         "Meridian.Contracts.Ledger.LedgerDimensionSetDto"
       ],
       "source": {
-        "line": 189,
+        "line": 190,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 189,
+          "line": 190,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -9328,7 +9591,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "f16aa2eda658af1041acb13e81a5f10b7299c2bfe3864dbd207b7d03bbe83734",
+      "fingerprint": "0ef3b2c7f0fb331951e659caa6b74bf6d3d3e496edea7b93223316507ab80414",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunWorkerPlanListDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunWorkerPlanListDto",
       "kind": "record",
@@ -9348,7 +9611,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 217,
+          "source_line": 218,
           "type": "string?"
         },
         {
@@ -9362,7 +9625,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 212,
+          "source_line": 213,
           "type": "string?"
         },
         {
@@ -9376,7 +9639,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "AccountingMigrationRunKindDto?",
-          "source_line": 214,
+          "source_line": 215,
           "type": "AccountingMigrationRunKindDto?"
         },
         {
@@ -9390,7 +9653,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 213,
+          "source_line": 214,
           "type": "Guid?"
         },
         {
@@ -9404,7 +9667,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingMigrationRunWorkerPlanDto>",
-          "source_line": 219,
+          "source_line": 220,
           "type": "IReadOnlyList<AccountingMigrationRunWorkerPlanDto>"
         },
         {
@@ -9419,7 +9682,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 216,
+          "source_line": 217,
           "type": "string?"
         }
       ],
@@ -9432,12 +9695,12 @@
         "Meridian.Contracts.AccountingSystem.AccountingMigrationRunWorkerPlanDto"
       ],
       "source": {
-        "line": 211,
+        "line": 212,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 211,
+          "line": 212,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -9456,7 +9719,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "2f17fedbf83010566bec8f8a5fbc51e2bacda1650e43115cee896064f3c48a97",
+      "fingerprint": "47b73cdd491a397005a24a45684d9556092eaa9c28d2c238541c173f997434da",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunWorkerPlanUpsertRequestDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunWorkerPlanUpsertRequestDto",
       "kind": "record",
@@ -9476,7 +9739,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "OperationsActionOriginDto",
-          "source_line": 209,
+          "source_line": 210,
           "type": "OperationsActionOriginDto"
         },
         {
@@ -9490,7 +9753,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 208,
+          "source_line": 209,
           "type": "string"
         },
         {
@@ -9504,7 +9767,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingMigrationRunWorkerPlanDto",
-          "source_line": 207,
+          "source_line": 208,
           "type": "AccountingMigrationRunWorkerPlanDto"
         }
       ],
@@ -9517,12 +9780,88 @@
         "Meridian.Contracts.Workstation.OperationsActionOriginDto"
       ],
       "source": {
-        "line": 206,
+        "line": 207,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 206,
+          "line": 207,
+          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "class",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "ledger-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "ledger-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "44cdf581b8b8ad2d1902db56835d6390b67e005440e414df3a3ffefb21ff502a",
+      "full_name": "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationEvidenceSubjectTypes",
+      "id": "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationEvidenceSubjectTypes",
+      "kind": "class",
+      "mapped_schemas": [
+        "ledger"
+      ],
+      "members": [],
+      "name": "AccountingProductionCertificationEvidenceSubjectTypes",
+      "namespace": "Meridian.Contracts.AccountingSystem",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationEvidenceSubjectTypes",
+      "references": [],
+      "source": {
+        "line": 507,
+        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 507,
+          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "class",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "ledger-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "ledger-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "127c68c8118b9f5da3be0ed76d15bdf8cebb5b93886cf6326e1b436992e5052f",
+      "full_name": "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationEvidenceValidator",
+      "id": "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationEvidenceValidator",
+      "kind": "class",
+      "mapped_schemas": [
+        "ledger"
+      ],
+      "members": [],
+      "name": "AccountingProductionCertificationEvidenceValidator",
+      "namespace": "Meridian.Contracts.AccountingSystem",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationEvidenceValidator",
+      "references": [],
+      "source": {
+        "line": 518,
+        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 518,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -9541,7 +9880,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "29272f279b99ff881568591f08c87c176af9c5cd7474ae2d2010107d05c2b79e",
+      "fingerprint": "beb68da033713dc5be05b0645dbecfd63340a02d1ca82759aeaa5769d056354e",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationProfileDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationProfileDto",
       "kind": "record",
@@ -9561,7 +9900,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 525,
+          "source_line": 578,
           "type": "bool"
         },
         {
@@ -9575,7 +9914,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 507,
+          "source_line": 560,
           "type": "bool"
         },
         {
@@ -9590,7 +9929,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 518,
+          "source_line": 571,
           "type": "string?"
         },
         {
@@ -9605,7 +9944,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 516,
+          "source_line": 569,
           "type": "string?"
         },
         {
@@ -9619,7 +9958,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 510,
+          "source_line": 563,
           "type": "bool"
         },
         {
@@ -9633,7 +9972,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingDimensionalCertificationArtifactDto>",
-          "source_line": 536,
+          "source_line": 590,
           "type": "IReadOnlyList<AccountingDimensionalCertificationArtifactDto>"
         },
         {
@@ -9648,7 +9987,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 520,
+          "source_line": 573,
           "type": "bool"
         },
         {
@@ -9662,7 +10001,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 530,
+          "source_line": 584,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -9676,7 +10015,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 512,
+          "source_line": 565,
           "type": "bool"
         },
         {
@@ -9690,7 +10029,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 508,
+          "source_line": 561,
           "type": "bool"
         },
         {
@@ -9704,7 +10043,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 503,
+          "source_line": 556,
           "type": "string"
         },
         {
@@ -9718,7 +10057,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 506,
+          "source_line": 559,
           "type": "bool"
         },
         {
@@ -9732,7 +10071,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 511,
+          "source_line": 564,
           "type": "bool"
         },
         {
@@ -9746,7 +10085,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 504,
+          "source_line": 557,
           "type": "Guid?"
         },
         {
@@ -9761,7 +10100,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 522,
+          "source_line": 575,
           "type": "bool"
         },
         {
@@ -9775,7 +10114,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 509,
+          "source_line": 562,
           "type": "bool"
         },
         {
@@ -9789,7 +10128,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 505,
+          "source_line": 558,
           "type": "bool"
         },
         {
@@ -9804,7 +10143,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 519,
+          "source_line": 572,
           "type": "bool"
         },
         {
@@ -9819,8 +10158,22 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 524,
+          "source_line": 577,
           "type": "bool"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 596,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
         },
         {
           "collection": false,
@@ -9834,7 +10187,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 521,
+          "source_line": 574,
           "type": "bool"
         },
         {
@@ -9848,7 +10201,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingTenantAdminCertificationArtifactDto>",
-          "source_line": 539,
+          "source_line": 593,
           "type": "IReadOnlyList<AccountingTenantAdminCertificationArtifactDto>"
         },
         {
@@ -9863,7 +10216,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 517,
+          "source_line": 570,
           "type": "string?"
         },
         {
@@ -9878,7 +10231,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 523,
+          "source_line": 576,
           "type": "bool"
         },
         {
@@ -9892,7 +10245,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset",
-          "source_line": 513,
+          "source_line": 566,
           "type": "DateTimeOffset"
         },
         {
@@ -9906,7 +10259,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 514,
+          "source_line": 567,
           "type": "string"
         },
         {
@@ -9920,7 +10273,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingWorkflowCertificationArtifactDto>",
-          "source_line": 533,
+          "source_line": 587,
           "type": "IReadOnlyList<AccountingWorkflowCertificationArtifactDto>"
         }
       ],
@@ -9931,15 +10284,16 @@
       "references": [
         "Meridian.Contracts.AccountingSystem.AccountingDimensionalCertificationArtifactDto",
         "Meridian.Contracts.AccountingSystem.AccountingTenantAdminCertificationArtifactDto",
-        "Meridian.Contracts.AccountingSystem.AccountingWorkflowCertificationArtifactDto"
+        "Meridian.Contracts.AccountingSystem.AccountingWorkflowCertificationArtifactDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
       ],
       "source": {
-        "line": 502,
+        "line": 555,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 502,
+          "line": 555,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -9958,7 +10312,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "3883f982bfce474151968778eb3aad45dc713f505dd3991bbaa7c7ac3bbc6555",
+      "fingerprint": "dc2e02a9519edf79adacd7b5fbce5362d0717aad31eba3a046ae3f5ce01b8470",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationProfileUpsertRequestDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationProfileUpsertRequestDto",
       "kind": "record",
@@ -9978,7 +10332,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "OperationsActionOriginDto",
-          "source_line": 548,
+          "source_line": 605,
           "type": "OperationsActionOriginDto"
         },
         {
@@ -9992,7 +10346,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 545,
+          "source_line": 602,
           "type": "string"
         },
         {
@@ -10007,7 +10361,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 546,
+          "source_line": 603,
           "type": "string?"
         },
         {
@@ -10021,7 +10375,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 550,
+          "source_line": 608,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -10035,8 +10389,22 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingProductionCertificationProfileDto",
-          "source_line": 544,
+          "source_line": 601,
           "type": "AccountingProductionCertificationProfileDto"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 611,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
         }
       ],
       "name": "AccountingProductionCertificationProfileUpsertRequestDto",
@@ -10045,15 +10413,16 @@
       "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationProfileUpsertRequestDto",
       "references": [
         "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationProfileDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto",
         "Meridian.Contracts.Workstation.OperationsActionOriginDto"
       ],
       "source": {
-        "line": 543,
+        "line": 600,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 543,
+          "line": 600,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -10072,7 +10441,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "7dca6137307dc381f7c050ed4e0064d51f04d7ebda100845326438034da77ec3",
+      "fingerprint": "8c827126f2a91d8fc6507a613e3d213e64336c5be86627aafbf52ccefff216c5",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingProductionGapDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingProductionGapDto",
       "kind": "record",
@@ -10091,7 +10460,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingProductionReadinessAreaDto>",
-          "source_line": 1077,
+          "source_line": 1192,
           "type": "IReadOnlyList<AccountingProductionReadinessAreaDto>"
         },
         {
@@ -10105,7 +10474,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 1080,
+          "source_line": 1195,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -10119,7 +10488,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1066,
+          "source_line": 1181,
           "type": "string"
         },
         {
@@ -10133,7 +10502,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingConfigurationValidationSeverityDto",
-          "source_line": 1069,
+          "source_line": 1184,
           "type": "AccountingConfigurationValidationSeverityDto"
         },
         {
@@ -10147,7 +10516,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingProductionReadinessIssueDto>",
-          "source_line": 1086,
+          "source_line": 1201,
           "type": "IReadOnlyList<AccountingProductionReadinessIssueDto>"
         },
         {
@@ -10161,7 +10530,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1067,
+          "source_line": 1182,
           "type": "string"
         },
         {
@@ -10175,7 +10544,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1071,
+          "source_line": 1186,
           "type": "string"
         },
         {
@@ -10189,7 +10558,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 1083,
+          "source_line": 1198,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -10203,7 +10572,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingProductionReadinessStatusDto",
-          "source_line": 1068,
+          "source_line": 1183,
           "type": "AccountingProductionReadinessStatusDto"
         },
         {
@@ -10217,7 +10586,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1070,
+          "source_line": 1185,
           "type": "string"
         }
       ],
@@ -10232,12 +10601,12 @@
         "Meridian.Contracts.Ledger.AccountingConfigurationValidationSeverityDto"
       ],
       "source": {
-        "line": 1065,
+        "line": 1180,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 1065,
+          "line": 1180,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -10259,59 +10628,59 @@
         {
           "explicit_value": true,
           "name": "LedgerBooks",
-          "source_line": 92,
+          "source_line": 93,
           "value": "0"
         },
         {
           "explicit_value": true,
           "name": "RulesStudio",
-          "source_line": 93,
+          "source_line": 94,
           "value": "1"
         },
         {
           "explicit_value": true,
           "name": "PostingRules",
-          "source_line": 94,
+          "source_line": 95,
           "value": "2"
         },
         {
           "explicit_value": true,
           "name": "JournalLifecycle",
-          "source_line": 95,
+          "source_line": 96,
           "value": "3"
         },
         {
           "explicit_value": true,
           "name": "DimensionalAccounting",
-          "source_line": 96,
+          "source_line": 97,
           "value": "4"
         },
         {
           "explicit_value": true,
           "name": "ExternalGl",
-          "source_line": 97,
+          "source_line": 98,
           "value": "5"
         },
         {
           "explicit_value": true,
           "name": "CloseReporting",
-          "source_line": 98,
+          "source_line": 99,
           "value": "6"
         },
         {
           "explicit_value": true,
           "name": "TenantAdministration",
-          "source_line": 99,
+          "source_line": 100,
           "value": "7"
         },
         {
           "explicit_value": true,
           "name": "MigrationRollout",
-          "source_line": 100,
+          "source_line": 101,
           "value": "8"
         }
       ],
-      "fingerprint": "e6f435895d74d0fdc8c7b8d77b7f3a2f964d76ad6580109ce64c64542ac5ecd1",
+      "fingerprint": "293f4e5989ce2864f27cdaabd4e02e0988c91af80a8e380a24283e9c732dd929",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessAreaDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessAreaDto",
       "kind": "enum",
@@ -10325,12 +10694,12 @@
       "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessAreaDto",
       "references": [],
       "source": {
-        "line": 90,
+        "line": 91,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 90,
+          "line": 91,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -10349,7 +10718,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "11ffc801783e0b57b09594028eb64c595fc3f0b04976669d6c2903c6a5f0722a",
+      "fingerprint": "daf4314390bb9708ea249dd98855fa988a75698e942e78e2eccd3a1832ea9e56",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessComponentDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessComponentDto",
       "kind": "record",
@@ -10368,7 +10737,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingProductionReadinessAreaDto",
-          "source_line": 1021,
+          "source_line": 1136,
           "type": "AccountingProductionReadinessAreaDto"
         },
         {
@@ -10382,7 +10751,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 1033,
+          "source_line": 1148,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -10396,7 +10765,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingProductionReadinessIssueDto>",
-          "source_line": 1030,
+          "source_line": 1145,
           "type": "IReadOnlyList<AccountingProductionReadinessIssueDto>"
         },
         {
@@ -10410,7 +10779,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1022,
+          "source_line": 1137,
           "type": "string"
         },
         {
@@ -10425,7 +10794,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 1028,
+          "source_line": 1143,
           "type": "string?"
         },
         {
@@ -10439,7 +10808,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "int",
-          "source_line": 1024,
+          "source_line": 1139,
           "type": "int"
         },
         {
@@ -10453,7 +10822,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingProductionReadinessStatusDto",
-          "source_line": 1023,
+          "source_line": 1138,
           "type": "AccountingProductionReadinessStatusDto"
         },
         {
@@ -10467,7 +10836,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1025,
+          "source_line": 1140,
           "type": "string"
         }
       ],
@@ -10481,12 +10850,12 @@
         "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessStatusDto"
       ],
       "source": {
-        "line": 1020,
+        "line": 1135,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 1020,
+          "line": 1135,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -10505,7 +10874,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "bbde66929e822396596ffe23e913fd6b035b1f3e4fa0c595cfd994341ddbce36",
+      "fingerprint": "ddd87c6b81edff4a6a3a74315aaf1e1a48c7646bb4247e21e618eba516221b9e",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessDto",
       "kind": "record",
@@ -10525,7 +10894,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "int",
-          "source_line": 1103,
+          "source_line": 1218,
           "type": "int"
         },
         {
@@ -10539,7 +10908,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingProductionReadinessComponentDto>",
-          "source_line": 1113,
+          "source_line": 1228,
           "type": "IReadOnlyList<AccountingProductionReadinessComponentDto>"
         },
         {
@@ -10553,7 +10922,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingDimensionalCertificationArtifactDto>",
-          "source_line": 1131,
+          "source_line": 1246,
           "type": "IReadOnlyList<AccountingDimensionalCertificationArtifactDto>"
         },
         {
@@ -10568,7 +10937,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "AccountingDimensionalReportingReadinessDto?",
-          "source_line": 1101,
+          "source_line": 1216,
           "type": "AccountingDimensionalReportingReadinessDto?"
         },
         {
@@ -10583,7 +10952,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 1104,
+          "source_line": 1219,
           "type": "bool"
         },
         {
@@ -10598,7 +10967,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "int",
-          "source_line": 1102,
+          "source_line": 1217,
           "type": "int"
         },
         {
@@ -10612,7 +10981,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1092,
+          "source_line": 1207,
           "type": "string"
         },
         {
@@ -10626,7 +10995,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset",
-          "source_line": 1091,
+          "source_line": 1206,
           "type": "DateTimeOffset"
         },
         {
@@ -10640,7 +11009,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingProductionReadinessIssueDto>",
-          "source_line": 1116,
+          "source_line": 1231,
           "type": "IReadOnlyList<AccountingProductionReadinessIssueDto>"
         },
         {
@@ -10654,7 +11023,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 1093,
+          "source_line": 1208,
           "type": "Guid?"
         },
         {
@@ -10669,7 +11038,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "LedgerBookRolloutAssessmentDto?",
-          "source_line": 1098,
+          "source_line": 1213,
           "type": "LedgerBookRolloutAssessmentDto?"
         },
         {
@@ -10684,7 +11053,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "AccountingLedgerBookWorkflowReadinessDto?",
-          "source_line": 1100,
+          "source_line": 1215,
           "type": "AccountingLedgerBookWorkflowReadinessDto?"
         },
         {
@@ -10698,7 +11067,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingMigrationRolloutPlanItemDto>",
-          "source_line": 1122,
+          "source_line": 1237,
           "type": "IReadOnlyList<AccountingMigrationRolloutPlanItemDto>"
         },
         {
@@ -10712,7 +11081,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingMigrationRunArtifactDto>",
-          "source_line": 1119,
+          "source_line": 1234,
           "type": "IReadOnlyList<AccountingMigrationRunArtifactDto>"
         },
         {
@@ -10726,7 +11095,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingProductionGapDto>",
-          "source_line": 1125,
+          "source_line": 1240,
           "type": "IReadOnlyList<AccountingProductionGapDto>"
         },
         {
@@ -10741,7 +11110,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "AccountingRulesStudioSummaryDto?",
-          "source_line": 1099,
+          "source_line": 1214,
           "type": "AccountingRulesStudioSummaryDto?"
         },
         {
@@ -10755,7 +11124,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "int",
-          "source_line": 1095,
+          "source_line": 1210,
           "type": "int"
         },
         {
@@ -10769,7 +11138,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingProductionReadinessStatusDto",
-          "source_line": 1094,
+          "source_line": 1209,
           "type": "AccountingProductionReadinessStatusDto"
         },
         {
@@ -10783,7 +11152,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingTenantAdminCertificationArtifactDto>",
-          "source_line": 1134,
+          "source_line": 1249,
           "type": "IReadOnlyList<AccountingTenantAdminCertificationArtifactDto>"
         },
         {
@@ -10798,7 +11167,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "AccountingTenantAdministrationReadinessDto?",
-          "source_line": 1107,
+          "source_line": 1222,
           "type": "AccountingTenantAdministrationReadinessDto?"
         },
         {
@@ -10812,7 +11181,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingWorkflowCertificationArtifactDto>",
-          "source_line": 1128,
+          "source_line": 1243,
           "type": "IReadOnlyList<AccountingWorkflowCertificationArtifactDto>"
         }
       ],
@@ -10836,3225 +11205,6 @@
         "Meridian.Contracts.Ledger.AccountingRulesStudioSummaryDto",
         "Meridian.Contracts.Ledger.LedgerBookRolloutAssessmentDto"
       ],
-      "source": {
-        "line": 1090,
-        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-      },
-      "sources": [
-        {
-          "line": 1090,
-          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-        }
-      ],
-      "type_parameters": []
-    },
-    {
-      "base_types": [],
-      "classification": "dto",
-      "containing_type": null,
-      "contract_sets": [
-        "all-contracts",
-        "ledger-contracts"
-      ],
-      "diagram": true,
-      "diagram_contract_sets": [
-        "ledger-contracts"
-      ],
-      "enum_members": [],
-      "fingerprint": "f787af280b78dff0fb3b6b1dad110098522e99462a2f806896306c4cfe629d88",
-      "full_name": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessIssueDto",
-      "id": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessIssueDto",
-      "kind": "record",
-      "mapped_schemas": [
-        "ledger"
-      ],
-      "members": [
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Area",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "AccountingProductionReadinessAreaDto",
-          "source_line": 1010,
-          "type": "AccountingProductionReadinessAreaDto"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Code",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1009,
-          "type": "string"
-        },
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "string",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "EvidenceReferences",
-          "nullable": false,
-          "origin": "property",
-          "raw_type": "IReadOnlyList<string>",
-          "source_line": 1016,
-          "type": "IReadOnlyList<string>"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Message",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1012,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Severity",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "AccountingConfigurationValidationSeverityDto",
-          "source_line": 1011,
-          "type": "AccountingConfigurationValidationSeverityDto"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "SuggestedAction",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1013,
-          "type": "string"
-        }
-      ],
-      "name": "AccountingProductionReadinessIssueDto",
-      "namespace": "Meridian.Contracts.AccountingSystem",
-      "partial": false,
-      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessIssueDto",
-      "references": [
-        "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessAreaDto",
-        "Meridian.Contracts.Ledger.AccountingConfigurationValidationSeverityDto"
-      ],
-      "source": {
-        "line": 1008,
-        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-      },
-      "sources": [
-        {
-          "line": 1008,
-          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-        }
-      ],
-      "type_parameters": []
-    },
-    {
-      "base_types": [],
-      "classification": "dto",
-      "containing_type": null,
-      "contract_sets": [
-        "all-contracts",
-        "ledger-contracts"
-      ],
-      "diagram": true,
-      "diagram_contract_sets": [
-        "ledger-contracts"
-      ],
-      "enum_members": [],
-      "fingerprint": "ec60efdb826a5179ccc3f5296ea7a8093e2d732278233b0ef8fed1af158015f2",
-      "full_name": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessRequestDto",
-      "id": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessRequestDto",
-      "kind": "record",
-      "mapped_schemas": [
-        "ledger"
-      ],
-      "members": [
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "AccountingAdminSurfaceConfigured",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 566,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "AccountingBasis",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "AccountingBasisKindDto?",
-          "source_line": 557,
-          "type": "AccountingBasisKindDto?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "AccountingConfigurationPromotionCertified",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 604,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "AdminRoleProfileConfigured",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 563,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ApprovalQueueStudioConfigured",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 580,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "AuditReviewToolingConfigured",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 574,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "BrowserAccountingAdminSurfaceConfigured",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 567,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "BulkImportExportSafeguardsConfigured",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 575,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ChartAdministrationStudioConfigured",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 569,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ClosePlanConfigurationLedgerBookNativeCertified",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 587,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "CloseReportingEvidenceMigrationCertified",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 605,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "CloseReportingLedgerBookNativeCertified",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 586,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "CloseSetupStudioConfigured",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 571,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "CompanyId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 560,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "CrossPeriodReportDimensionQueriesCertified",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 594,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "DimensionalBackfillCertified",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 603,
-          "type": "bool"
-        },
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "AccountingDimensionalCertificationArtifactDto",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "DimensionalCertificationArtifacts",
-          "nullable": false,
-          "origin": "property",
-          "raw_type": "IReadOnlyList<AccountingDimensionalCertificationArtifactDto>",
-          "source_line": 633,
-          "type": "IReadOnlyList<AccountingDimensionalCertificationArtifactDto>"
-        },
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "string",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "DimensionalReportingEvidenceLinks",
-          "nullable": false,
-          "origin": "property",
-          "raw_type": "IReadOnlyList<string>",
-          "source_line": 621,
-          "type": "IReadOnlyList<string>"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "DimensionMappingStudioConfigured",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 581,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "DirectLendingLedgerBookNativeCertified",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 590,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "DisasterRecoveryRunbookConfigured",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 577,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ExternalExportDimensionMappingCertified",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 596,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ExternalGlLedgerBookNativeCertified",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 588,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "FundProfileId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 555,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "HistoricalJournalBackfillCertified",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 602,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ImplementationSandboxConfigured",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 582,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "JournalLifecycleLedgerBookNativeCertified",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 585,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "JournalQueryDimensionFiltersCertified",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 595,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "LedgerBookAdministrationStudioConfigured",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 578,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "LedgerBookId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "Guid?",
-          "source_line": 556,
-          "type": "Guid?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "LedgerBookMigrationCertified",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 601,
-          "type": "bool"
-        },
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "string",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "LedgerBookWorkflowEvidenceLinks",
-          "nullable": false,
-          "origin": "property",
-          "raw_type": "IReadOnlyList<string>",
-          "source_line": 618,
-          "type": "IReadOnlyList<string>"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "LedgerLineDimensionsPersistedCertified",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 597,
-          "type": "bool"
-        },
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "string",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "MigrationEvidenceLinks",
-          "nullable": false,
-          "origin": "property",
-          "raw_type": "IReadOnlyList<string>",
-          "source_line": 624,
-          "type": "IReadOnlyList<string>"
-        },
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "AccountingMigrationRunArtifactDto",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "MigrationRunArtifacts",
-          "nullable": false,
-          "origin": "property",
-          "raw_type": "IReadOnlyList<AccountingMigrationRunArtifactDto>",
-          "source_line": 627,
-          "type": "IReadOnlyList<AccountingMigrationRunArtifactDto>"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "PerformanceValidationConfigured",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 576,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "PeriodReportDimensionQueriesCertified",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 593,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "PostingRuleAuthoringStudioConfigured",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 579,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "PostingRulesLedgerBookNativeCertified",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 584,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ProviderId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 558,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ProviderMappingStudioConfigured",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 572,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ReconciliationLedgerBookNativeCertified",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 589,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ReportingGroupsConfigured",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 565,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ReportPackageDimensionProvenanceCertified",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 599,
-          "type": "bool"
-        },
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "LedgerBookRequiredScopeDto",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "RequiredLedgerBookScopes",
-          "nullable": false,
-          "origin": "property",
-          "raw_type": "IReadOnlyList<LedgerBookRequiredScopeDto>",
-          "source_line": 612,
-          "type": "IReadOnlyList<LedgerBookRequiredScopeDto>"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "RuleTestPromotionStudioConfigured",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 570,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ScopedAccessPoliciesConfigured",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 564,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "StrategyLedgerReadLedgerBookNativeCertified",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 591,
-          "type": "bool"
-        },
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "AccountingTenantAdminCertificationArtifactDto",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "TenantAdminCertificationArtifacts",
-          "nullable": false,
-          "origin": "property",
-          "raw_type": "IReadOnlyList<AccountingTenantAdminCertificationArtifactDto>",
-          "source_line": 636,
-          "type": "IReadOnlyList<AccountingTenantAdminCertificationArtifactDto>"
-        },
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "string",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "TenantAdministrationEvidenceLinks",
-          "nullable": false,
-          "origin": "property",
-          "raw_type": "IReadOnlyList<string>",
-          "source_line": 615,
-          "type": "IReadOnlyList<string>"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "TenantCompanyReportGroupSetupStudioConfigured",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 573,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "TenantId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 559,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "TenantScopeConfigured",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 562,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "TrialBalanceDimensionFiltersCertified",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 598,
-          "type": "bool"
-        },
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "AccountingWorkflowCertificationArtifactDto",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "WorkflowCertificationArtifacts",
-          "nullable": false,
-          "origin": "property",
-          "raw_type": "IReadOnlyList<AccountingWorkflowCertificationArtifactDto>",
-          "source_line": 630,
-          "type": "IReadOnlyList<AccountingWorkflowCertificationArtifactDto>"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "false",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "WpfAccountingAdminSurfaceConfigured",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 568,
-          "type": "bool"
-        }
-      ],
-      "name": "AccountingProductionReadinessRequestDto",
-      "namespace": "Meridian.Contracts.AccountingSystem",
-      "partial": false,
-      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessRequestDto",
-      "references": [
-        "Meridian.Contracts.AccountingSystem.AccountingDimensionalCertificationArtifactDto",
-        "Meridian.Contracts.AccountingSystem.AccountingMigrationRunArtifactDto",
-        "Meridian.Contracts.AccountingSystem.AccountingTenantAdminCertificationArtifactDto",
-        "Meridian.Contracts.AccountingSystem.AccountingWorkflowCertificationArtifactDto",
-        "Meridian.Contracts.Ledger.AccountingBasisKindDto",
-        "Meridian.Contracts.Ledger.LedgerBookRequiredScopeDto"
-      ],
-      "source": {
-        "line": 554,
-        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-      },
-      "sources": [
-        {
-          "line": 554,
-          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-        }
-      ],
-      "type_parameters": []
-    },
-    {
-      "base_types": [],
-      "classification": "enum",
-      "containing_type": null,
-      "contract_sets": [
-        "all-contracts",
-        "ledger-contracts"
-      ],
-      "diagram": true,
-      "diagram_contract_sets": [
-        "ledger-contracts"
-      ],
-      "enum_members": [
-        {
-          "explicit_value": true,
-          "name": "Ready",
-          "source_line": 83,
-          "value": "0"
-        },
-        {
-          "explicit_value": true,
-          "name": "ReviewRequired",
-          "source_line": 84,
-          "value": "1"
-        },
-        {
-          "explicit_value": true,
-          "name": "Blocked",
-          "source_line": 85,
-          "value": "2"
-        },
-        {
-          "explicit_value": true,
-          "name": "Unavailable",
-          "source_line": 86,
-          "value": "3"
-        }
-      ],
-      "fingerprint": "fef2c1b74221a39622381870c64611137311a8c82cd762986a2a87f69bcbde20",
-      "full_name": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessStatusDto",
-      "id": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessStatusDto",
-      "kind": "enum",
-      "mapped_schemas": [
-        "ledger"
-      ],
-      "members": [],
-      "name": "AccountingProductionReadinessStatusDto",
-      "namespace": "Meridian.Contracts.AccountingSystem",
-      "partial": false,
-      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessStatusDto",
-      "references": [],
-      "source": {
-        "line": 81,
-        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-      },
-      "sources": [
-        {
-          "line": 81,
-          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-        }
-      ],
-      "type_parameters": []
-    },
-    {
-      "base_types": [],
-      "classification": "dto",
-      "containing_type": null,
-      "contract_sets": [
-        "all-contracts",
-        "ledger-contracts"
-      ],
-      "diagram": true,
-      "diagram_contract_sets": [
-        "ledger-contracts"
-      ],
-      "enum_members": [],
-      "fingerprint": "91ab8cd54de7021430b6bcbf4d8cffdd72988adda5ba1cd4f2e06f9dd02d6c5a",
-      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemChartAccountDto",
-      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemChartAccountDto",
-      "kind": "record",
-      "mapped_schemas": [
-        "ledger"
-      ],
-      "members": [
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "AccountCode",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1255,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "AccountType",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1257,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Currency",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1258,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "DisplayName",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1256,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "EvidenceRef",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1261,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ExternalAccountId",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1254,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "IsActive",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 1259,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ParentExternalAccountId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1260,
-          "type": "string?"
-        }
-      ],
-      "name": "AccountingSystemChartAccountDto",
-      "namespace": "Meridian.Contracts.AccountingSystem",
-      "partial": false,
-      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemChartAccountDto",
-      "references": [],
-      "source": {
-        "line": 1253,
-        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-      },
-      "sources": [
-        {
-          "line": 1253,
-          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-        }
-      ],
-      "type_parameters": []
-    },
-    {
-      "base_types": [],
-      "classification": "dto",
-      "containing_type": null,
-      "contract_sets": [
-        "all-contracts",
-        "ledger-contracts"
-      ],
-      "diagram": true,
-      "diagram_contract_sets": [
-        "ledger-contracts"
-      ],
-      "enum_members": [],
-      "fingerprint": "aecaf12a7c6a9a2ebe6d240caa1b163f3ad685ddf2146c3e4a500668839c6bba",
-      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemConnectionMetadataDto",
-      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemConnectionMetadataDto",
-      "kind": "record",
-      "mapped_schemas": [
-        "ledger"
-      ],
-      "members": [
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "CompanyId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 71,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "CompanyName",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 72,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Environment",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 70,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "HasLocalConfig",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 73,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "HasRefreshToken",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 74,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "LastConnectedAtUtc",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "DateTimeOffset?",
-          "source_line": 75,
-          "type": "DateTimeOffset?"
-        },
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "string",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "MissingFields",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "IReadOnlyList<string>",
-          "source_line": 78,
-          "type": "IReadOnlyList<string>"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ProviderId",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 69,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "StatusDetail",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 77,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "StatusLabel",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 76,
-          "type": "string"
-        }
-      ],
-      "name": "AccountingSystemConnectionMetadataDto",
-      "namespace": "Meridian.Contracts.AccountingSystem",
-      "partial": false,
-      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemConnectionMetadataDto",
-      "references": [],
-      "source": {
-        "line": 68,
-        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-      },
-      "sources": [
-        {
-          "line": 68,
-          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-        }
-      ],
-      "type_parameters": []
-    },
-    {
-      "base_types": [],
-      "classification": "enum",
-      "containing_type": null,
-      "contract_sets": [
-        "all-contracts",
-        "ledger-contracts"
-      ],
-      "diagram": true,
-      "diagram_contract_sets": [
-        "ledger-contracts"
-      ],
-      "enum_members": [
-        {
-          "explicit_value": false,
-          "name": "Ready",
-          "source_line": 37,
-          "value": null
-        },
-        {
-          "explicit_value": false,
-          "name": "ReviewRequired",
-          "source_line": 38,
-          "value": null
-        },
-        {
-          "explicit_value": false,
-          "name": "Missing",
-          "source_line": 39,
-          "value": null
-        }
-      ],
-      "fingerprint": "2b07f2eb66ba813976bb3d467c5c85905487d0fcb6abc3b72619b8fb2110035c",
-      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemEvidencePackageStatusDto",
-      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemEvidencePackageStatusDto",
-      "kind": "enum",
-      "mapped_schemas": [
-        "ledger"
-      ],
-      "members": [],
-      "name": "AccountingSystemEvidencePackageStatusDto",
-      "namespace": "Meridian.Contracts.AccountingSystem",
-      "partial": false,
-      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemEvidencePackageStatusDto",
-      "references": [],
-      "source": {
-        "line": 35,
-        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-      },
-      "sources": [
-        {
-          "line": 35,
-          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-        }
-      ],
-      "type_parameters": []
-    },
-    {
-      "base_types": [],
-      "classification": "dto",
-      "containing_type": null,
-      "contract_sets": [
-        "all-contracts",
-        "ledger-contracts"
-      ],
-      "diagram": true,
-      "diagram_contract_sets": [
-        "ledger-contracts"
-      ],
-      "enum_members": [],
-      "fingerprint": "42fffbd2126bc2b5966d4eaed7838b27b2b030009cb5147f858ecc171287bfda",
-      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemExportPackageRequestDto",
-      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemExportPackageRequestDto",
-      "kind": "record",
-      "mapped_schemas": [
-        "ledger"
-      ],
-      "members": [
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "OperationsActionOriginDto.HumanOperator",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ActionOrigin",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "OperationsActionOriginDto",
-          "source_line": 1383,
-          "type": "OperationsActionOriginDto"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Actor",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1370,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "CompanyId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1382,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "CorrelationId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1380,
-          "type": "string?"
-        },
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "string",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "EvidenceLinks",
-          "nullable": false,
-          "origin": "property",
-          "raw_type": "IReadOnlyList<string>",
-          "source_line": 1388,
-          "type": "IReadOnlyList<string>"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "FundProfileId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1372,
-          "type": "string?"
-        },
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "Guid",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "JournalEntryIds",
-          "nullable": false,
-          "origin": "property",
-          "raw_type": "IReadOnlyList<Guid>",
-          "source_line": 1385,
-          "type": "IReadOnlyList<Guid>"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "LedgerBookId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "Guid?",
-          "source_line": 1373,
-          "type": "Guid?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "MappingProfileId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1376,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "PeriodEnd",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "DateOnly?",
-          "source_line": 1375,
-          "type": "DateOnly?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "PeriodStart",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "DateOnly?",
-          "source_line": 1374,
-          "type": "DateOnly?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ProviderId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1371,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "true",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "RequireBalancedReconciliation",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 1378,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "TenantId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1381,
-          "type": "string?"
-        }
-      ],
-      "name": "AccountingSystemExportPackageRequestDto",
-      "namespace": "Meridian.Contracts.AccountingSystem",
-      "partial": false,
-      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemExportPackageRequestDto",
-      "references": [
-        "Meridian.Contracts.Workstation.OperationsActionOriginDto"
-      ],
-      "source": {
-        "line": 1369,
-        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-      },
-      "sources": [
-        {
-          "line": 1369,
-          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-        }
-      ],
-      "type_parameters": []
-    },
-    {
-      "base_types": [],
-      "classification": "dto",
-      "containing_type": null,
-      "contract_sets": [
-        "all-contracts",
-        "ledger-contracts"
-      ],
-      "diagram": true,
-      "diagram_contract_sets": [
-        "ledger-contracts"
-      ],
-      "enum_members": [],
-      "fingerprint": "861ed68cebcc127cf8a700346b1c420892f84c0b473b476b5a9a4a7ddfb0139d",
-      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemImportDetailDto",
-      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemImportDetailDto",
-      "kind": "record",
-      "mapped_schemas": [
-        "ledger"
-      ],
-      "members": [
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "AccountingSystemChartAccountDto",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ChartAccounts",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "IReadOnlyList<AccountingSystemChartAccountDto>",
-          "source_line": 1296,
-          "type": "IReadOnlyList<AccountingSystemChartAccountDto>"
-        },
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "AccountingSystemJournalEntryDto",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "JournalEntries",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "IReadOnlyList<AccountingSystemJournalEntryDto>",
-          "source_line": 1297,
-          "type": "IReadOnlyList<AccountingSystemJournalEntryDto>"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Summary",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "AccountingSystemImportSummaryDto",
-          "source_line": 1295,
-          "type": "AccountingSystemImportSummaryDto"
-        },
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "AccountingSystemTrialBalanceLineDto",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "TrialBalance",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "IReadOnlyList<AccountingSystemTrialBalanceLineDto>",
-          "source_line": 1298,
-          "type": "IReadOnlyList<AccountingSystemTrialBalanceLineDto>"
-        }
-      ],
-      "name": "AccountingSystemImportDetailDto",
-      "namespace": "Meridian.Contracts.AccountingSystem",
-      "partial": false,
-      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemImportDetailDto",
-      "references": [
-        "Meridian.Contracts.AccountingSystem.AccountingSystemChartAccountDto",
-        "Meridian.Contracts.AccountingSystem.AccountingSystemImportSummaryDto",
-        "Meridian.Contracts.AccountingSystem.AccountingSystemJournalEntryDto",
-        "Meridian.Contracts.AccountingSystem.AccountingSystemTrialBalanceLineDto"
-      ],
-      "source": {
-        "line": 1294,
-        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-      },
-      "sources": [
-        {
-          "line": 1294,
-          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-        }
-      ],
-      "type_parameters": []
-    },
-    {
-      "base_types": [],
-      "classification": "dto",
-      "containing_type": null,
-      "contract_sets": [
-        "all-contracts",
-        "ledger-contracts"
-      ],
-      "diagram": true,
-      "diagram_contract_sets": [
-        "ledger-contracts"
-      ],
-      "enum_members": [],
-      "fingerprint": "4e53cdf7c210ab3d3e46cf2ace7e75e0ed4caee091e0483bc892c67e8c300c59",
-      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemImportRequestDto",
-      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemImportRequestDto",
-      "kind": "record",
-      "mapped_schemas": [
-        "ledger"
-      ],
-      "members": [
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "CompanyId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1232,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "FundProfileId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1226,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "LedgerBookId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "Guid?",
-          "source_line": 1227,
-          "type": "Guid?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "PeriodEnd",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "DateOnly?",
-          "source_line": 1229,
-          "type": "DateOnly?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "PeriodStart",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "DateOnly?",
-          "source_line": 1228,
-          "type": "DateOnly?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "true",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "PersistPreview",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 1230,
-          "type": "bool"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ProviderId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1225,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "TenantId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1231,
-          "type": "string?"
-        }
-      ],
-      "name": "AccountingSystemImportRequestDto",
-      "namespace": "Meridian.Contracts.AccountingSystem",
-      "partial": false,
-      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemImportRequestDto",
-      "references": [],
-      "source": {
-        "line": 1224,
-        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-      },
-      "sources": [
-        {
-          "line": 1224,
-          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-        }
-      ],
-      "type_parameters": []
-    },
-    {
-      "base_types": [],
-      "classification": "enum",
-      "containing_type": null,
-      "contract_sets": [
-        "all-contracts",
-        "ledger-contracts"
-      ],
-      "diagram": true,
-      "diagram_contract_sets": [
-        "ledger-contracts"
-      ],
-      "enum_members": [
-        {
-          "explicit_value": false,
-          "name": "NotStarted",
-          "source_line": 18,
-          "value": null
-        },
-        {
-          "explicit_value": false,
-          "name": "Previewed",
-          "source_line": 19,
-          "value": null
-        },
-        {
-          "explicit_value": false,
-          "name": "Imported",
-          "source_line": 20,
-          "value": null
-        },
-        {
-          "explicit_value": false,
-          "name": "Failed",
-          "source_line": 21,
-          "value": null
-        }
-      ],
-      "fingerprint": "f2d3bb4edcb67915c5206a87208c6ef3048d95ca610da2a52f90f35ef01747d8",
-      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemImportStateDto",
-      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemImportStateDto",
-      "kind": "enum",
-      "mapped_schemas": [
-        "ledger"
-      ],
-      "members": [],
-      "name": "AccountingSystemImportStateDto",
-      "namespace": "Meridian.Contracts.AccountingSystem",
-      "partial": false,
-      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemImportStateDto",
-      "references": [],
-      "source": {
-        "line": 16,
-        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-      },
-      "sources": [
-        {
-          "line": 16,
-          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-        }
-      ],
-      "type_parameters": []
-    },
-    {
-      "base_types": [],
-      "classification": "dto",
-      "containing_type": null,
-      "contract_sets": [
-        "all-contracts",
-        "ledger-contracts"
-      ],
-      "diagram": true,
-      "diagram_contract_sets": [
-        "ledger-contracts"
-      ],
-      "enum_members": [],
-      "fingerprint": "d826f0320d32a914588ee63164a2fbc14a69225e656010706e9e502ffe121a52",
-      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemImportSummaryDto",
-      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemImportSummaryDto",
-      "kind": "record",
-      "mapped_schemas": [
-        "ledger"
-      ],
-      "members": [
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ChartAccountCount",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "int",
-          "source_line": 1244,
-          "type": "int"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "CompanyId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1250,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ContentHash",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1251,
-          "type": "string?"
-        },
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "string",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "EvidenceReferences",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "IReadOnlyList<string>",
-          "source_line": 1247,
-          "type": "IReadOnlyList<string>"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "FundProfileId",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1238,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ImportedAtUtc",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "DateTimeOffset",
-          "source_line": 1243,
-          "type": "DateTimeOffset"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ImportId",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1235,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "JournalEntryCount",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "int",
-          "source_line": 1245,
-          "type": "int"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "LedgerBookId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "Guid?",
-          "source_line": 1239,
-          "type": "Guid?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "PeriodEnd",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "DateOnly",
-          "source_line": 1242,
-          "type": "DateOnly"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "PeriodStart",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "DateOnly",
-          "source_line": 1241,
-          "type": "DateOnly"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ProviderDisplayName",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1237,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ProviderId",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1236,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "State",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "AccountingSystemImportStateDto",
-          "source_line": 1240,
-          "type": "AccountingSystemImportStateDto"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "TenantId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1249,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "TrialBalanceLineCount",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "int",
-          "source_line": 1246,
-          "type": "int"
-        },
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "string",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Warnings",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "IReadOnlyList<string>",
-          "source_line": 1248,
-          "type": "IReadOnlyList<string>"
-        }
-      ],
-      "name": "AccountingSystemImportSummaryDto",
-      "namespace": "Meridian.Contracts.AccountingSystem",
-      "partial": false,
-      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemImportSummaryDto",
-      "references": [
-        "Meridian.Contracts.AccountingSystem.AccountingSystemImportStateDto"
-      ],
-      "source": {
-        "line": 1234,
-        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-      },
-      "sources": [
-        {
-          "line": 1234,
-          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-        }
-      ],
-      "type_parameters": []
-    },
-    {
-      "base_types": [],
-      "classification": "dto",
-      "containing_type": null,
-      "contract_sets": [
-        "all-contracts",
-        "ledger-contracts"
-      ],
-      "diagram": true,
-      "diagram_contract_sets": [
-        "ledger-contracts"
-      ],
-      "enum_members": [],
-      "fingerprint": "48f176bb3f09201d6f43767c868edb90337898bc8a5ae5af4b6a5573d93e9be4",
-      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemJournalEntryDto",
-      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemJournalEntryDto",
-      "kind": "record",
-      "mapped_schemas": [
-        "ledger"
-      ],
-      "members": [
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "AccountingDate",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "DateOnly",
-          "source_line": 1265,
-          "type": "DateOnly"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Currency",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1267,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Description",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1266,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "EvidenceRef",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1271,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ExternalJournalEntryId",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1264,
-          "type": "string"
-        },
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "AccountingSystemJournalLineDto",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Lines",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "IReadOnlyList<AccountingSystemJournalLineDto>",
-          "source_line": 1270,
-          "type": "IReadOnlyList<AccountingSystemJournalLineDto>"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "TotalCredits",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "decimal",
-          "source_line": 1269,
-          "type": "decimal"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "TotalDebits",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "decimal",
-          "source_line": 1268,
-          "type": "decimal"
-        }
-      ],
-      "name": "AccountingSystemJournalEntryDto",
-      "namespace": "Meridian.Contracts.AccountingSystem",
-      "partial": false,
-      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemJournalEntryDto",
-      "references": [
-        "Meridian.Contracts.AccountingSystem.AccountingSystemJournalLineDto"
-      ],
-      "source": {
-        "line": 1263,
-        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-      },
-      "sources": [
-        {
-          "line": 1263,
-          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-        }
-      ],
-      "type_parameters": []
-    },
-    {
-      "base_types": [],
-      "classification": "dto",
-      "containing_type": null,
-      "contract_sets": [
-        "all-contracts",
-        "ledger-contracts"
-      ],
-      "diagram": true,
-      "diagram_contract_sets": [
-        "ledger-contracts"
-      ],
-      "enum_members": [],
-      "fingerprint": "35bb7929abe1cbe0f5d14adc9a9709e917870f6aa280b225091e5a7276eab531",
-      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemJournalLineDto",
-      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemJournalLineDto",
-      "kind": "record",
-      "mapped_schemas": [
-        "ledger"
-      ],
-      "members": [
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "AccountCode",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1276,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Credit",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "decimal",
-          "source_line": 1279,
-          "type": "decimal"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Currency",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1280,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Debit",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "decimal",
-          "source_line": 1278,
-          "type": "decimal"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Description",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1277,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "EvidenceRef",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1281,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ExternalAccountId",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1275,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ExternalLineId",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1274,
-          "type": "string"
-        }
-      ],
-      "name": "AccountingSystemJournalLineDto",
-      "namespace": "Meridian.Contracts.AccountingSystem",
-      "partial": false,
-      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemJournalLineDto",
-      "references": [],
-      "source": {
-        "line": 1273,
-        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-      },
-      "sources": [
-        {
-          "line": 1273,
-          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-        }
-      ],
-      "type_parameters": []
-    },
-    {
-      "base_types": [],
-      "classification": "dto",
-      "containing_type": null,
-      "contract_sets": [
-        "all-contracts",
-        "ledger-contracts"
-      ],
-      "diagram": true,
-      "diagram_contract_sets": [
-        "ledger-contracts"
-      ],
-      "enum_members": [],
-      "fingerprint": "7b4988d911b357db1ce16403b8962d6a09f67e02b395fd851ff0272302be34ea",
-      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemMappingProfileUpsertRequestDto",
-      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemMappingProfileUpsertRequestDto",
-      "kind": "record",
-      "mapped_schemas": [
-        "ledger"
-      ],
-      "members": [
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "OperationsActionOriginDto.HumanOperator",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ActionOrigin",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "OperationsActionOriginDto",
-          "source_line": 1363,
-          "type": "OperationsActionOriginDto"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Actor",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1355,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "CompanyId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1362,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "CorrelationId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1359,
-          "type": "string?"
-        },
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "string",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "EvidenceLinks",
-          "nullable": false,
-          "origin": "property",
-          "raw_type": "IReadOnlyList<string>",
-          "source_line": 1365,
-          "type": "IReadOnlyList<string>"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "FundProfileId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1357,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "LedgerBookId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "Guid?",
-          "source_line": 1358,
-          "type": "Guid?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Profile",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "ExternalGlMappingProfileDto",
-          "source_line": 1354,
-          "type": "ExternalGlMappingProfileDto"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ProviderId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1356,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "TenantId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1361,
-          "type": "string?"
-        }
-      ],
-      "name": "AccountingSystemMappingProfileUpsertRequestDto",
-      "namespace": "Meridian.Contracts.AccountingSystem",
-      "partial": false,
-      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemMappingProfileUpsertRequestDto",
-      "references": [
-        "Meridian.Contracts.Ledger.ExternalGlMappingProfileDto",
-        "Meridian.Contracts.Workstation.OperationsActionOriginDto"
-      ],
-      "source": {
-        "line": 1353,
-        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-      },
-      "sources": [
-        {
-          "line": 1353,
-          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-        }
-      ],
-      "type_parameters": []
-    },
-    {
-      "base_types": [],
-      "classification": "dto",
-      "containing_type": null,
-      "contract_sets": [
-        "all-contracts",
-        "ledger-contracts"
-      ],
-      "diagram": true,
-      "diagram_contract_sets": [
-        "ledger-contracts"
-      ],
-      "enum_members": [],
-      "fingerprint": "f9ad83e03fc178744fba490c3c407bdc6de75c136d802ae43a1e74331f9718c2",
-      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemOAuthCallbackResultDto",
-      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemOAuthCallbackResultDto",
-      "kind": "record",
-      "mapped_schemas": [
-        "ledger"
-      ],
-      "members": [
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "CompanyId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1218,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "CompanyName",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1219,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "CompletedAtUtc",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "DateTimeOffset",
-          "source_line": 1220,
-          "type": "DateTimeOffset"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "LastError",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1221,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ProviderId",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1216,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Success",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 1217,
-          "type": "bool"
-        },
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "string",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Warnings",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "IReadOnlyList<string>",
-          "source_line": 1222,
-          "type": "IReadOnlyList<string>"
-        }
-      ],
-      "name": "AccountingSystemOAuthCallbackResultDto",
-      "namespace": "Meridian.Contracts.AccountingSystem",
-      "partial": false,
-      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemOAuthCallbackResultDto",
-      "references": [],
-      "source": {
-        "line": 1215,
-        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-      },
-      "sources": [
-        {
-          "line": 1215,
-          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-        }
-      ],
-      "type_parameters": []
-    },
-    {
-      "base_types": [],
-      "classification": "dto",
-      "containing_type": null,
-      "contract_sets": [
-        "all-contracts",
-        "ledger-contracts"
-      ],
-      "diagram": true,
-      "diagram_contract_sets": [
-        "ledger-contracts"
-      ],
-      "enum_members": [],
-      "fingerprint": "1a9e3f4a221d45878b3c225eee8513a161b080a5c7bf4a9f8081493710092406",
-      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemOAuthStartRequestDto",
-      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemOAuthStartRequestDto",
-      "kind": "record",
-      "mapped_schemas": [
-        "ledger"
-      ],
-      "members": [
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ClientId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1198,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ClientSecret",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1199,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "CompanyName",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1202,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Environment",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1201,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "RedirectUri",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1200,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "RequestedBy",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1203,
-          "type": "string?"
-        }
-      ],
-      "name": "AccountingSystemOAuthStartRequestDto",
-      "namespace": "Meridian.Contracts.AccountingSystem",
-      "partial": false,
-      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemOAuthStartRequestDto",
-      "references": [],
-      "source": {
-        "line": 1197,
-        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-      },
-      "sources": [
-        {
-          "line": 1197,
-          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
-        }
-      ],
-      "type_parameters": []
-    },
-    {
-      "base_types": [],
-      "classification": "dto",
-      "containing_type": null,
-      "contract_sets": [
-        "all-contracts",
-        "ledger-contracts"
-      ],
-      "diagram": true,
-      "diagram_contract_sets": [
-        "ledger-contracts"
-      ],
-      "enum_members": [],
-      "fingerprint": "241a0f03b6291dada54aec6295e95b1df92b0716d47bc44b94db82f7858050c7",
-      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemOAuthStartResultDto",
-      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemOAuthStartResultDto",
-      "kind": "record",
-      "mapped_schemas": [
-        "ledger"
-      ],
-      "members": [
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "AuthorizationUrl",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1208,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Environment",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1210,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "LastError",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1212,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ProviderId",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1206,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "RedirectUri",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1211,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "State",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 1209,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Success",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "bool",
-          "source_line": 1207,
-          "type": "bool"
-        },
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "string",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Warnings",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "IReadOnlyList<string>",
-          "source_line": 1213,
-          "type": "IReadOnlyList<string>"
-        }
-      ],
-      "name": "AccountingSystemOAuthStartResultDto",
-      "namespace": "Meridian.Contracts.AccountingSystem",
-      "partial": false,
-      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemOAuthStartResultDto",
-      "references": [],
       "source": {
         "line": 1205,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
@@ -14080,7 +11230,3241 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "c151181427af3ba5b7e17e998a2faae2757559413db01c82e8f0157a69b1e296",
+      "fingerprint": "4a1a2f86d49372c3f857c68e98fc191ee62e0d4ee4971f1a96e0b12b2af4fc3e",
+      "full_name": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessIssueDto",
+      "id": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessIssueDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "ledger"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Area",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "AccountingProductionReadinessAreaDto",
+          "source_line": 1125,
+          "type": "AccountingProductionReadinessAreaDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Code",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1124,
+          "type": "string"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "string",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EvidenceReferences",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<string>",
+          "source_line": 1131,
+          "type": "IReadOnlyList<string>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Message",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1127,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Severity",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "AccountingConfigurationValidationSeverityDto",
+          "source_line": 1126,
+          "type": "AccountingConfigurationValidationSeverityDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "SuggestedAction",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1128,
+          "type": "string"
+        }
+      ],
+      "name": "AccountingProductionReadinessIssueDto",
+      "namespace": "Meridian.Contracts.AccountingSystem",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessIssueDto",
+      "references": [
+        "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessAreaDto",
+        "Meridian.Contracts.Ledger.AccountingConfigurationValidationSeverityDto"
+      ],
+      "source": {
+        "line": 1123,
+        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 1123,
+          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "ledger-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "ledger-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "70cd60f2236e3631cc6f79eede41f5ed3d20ab649f21be4e2fd6f77234733a78",
+      "full_name": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessRequestDto",
+      "id": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessRequestDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "ledger"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AccountingAdminSurfaceConfigured",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 627,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AccountingBasis",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "AccountingBasisKindDto?",
+          "source_line": 618,
+          "type": "AccountingBasisKindDto?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AccountingConfigurationPromotionCertified",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 665,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AdminRoleProfileConfigured",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 624,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ApprovalQueueStudioConfigured",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 641,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AuditReviewToolingConfigured",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 635,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "BrowserAccountingAdminSurfaceConfigured",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 628,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "BulkImportExportSafeguardsConfigured",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 636,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ChartAdministrationStudioConfigured",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 630,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ClosePlanConfigurationLedgerBookNativeCertified",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 648,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CloseReportingEvidenceMigrationCertified",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 666,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CloseReportingLedgerBookNativeCertified",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 647,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CloseSetupStudioConfigured",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 632,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CompanyId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 621,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CrossPeriodReportDimensionQueriesCertified",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 655,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "DimensionalBackfillCertified",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 664,
+          "type": "bool"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "AccountingDimensionalCertificationArtifactDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "DimensionalCertificationArtifacts",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<AccountingDimensionalCertificationArtifactDto>",
+          "source_line": 695,
+          "type": "IReadOnlyList<AccountingDimensionalCertificationArtifactDto>"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "string",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "DimensionalReportingEvidenceLinks",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<string>",
+          "source_line": 683,
+          "type": "IReadOnlyList<string>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "DimensionMappingStudioConfigured",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 642,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "DirectLendingLedgerBookNativeCertified",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 651,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "DisasterRecoveryRunbookConfigured",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 638,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ExternalExportDimensionMappingCertified",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 657,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ExternalGlLedgerBookNativeCertified",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 649,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "FundProfileId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 616,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "HistoricalJournalBackfillCertified",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 663,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ImplementationSandboxConfigured",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 643,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "JournalLifecycleLedgerBookNativeCertified",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 646,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "JournalQueryDimensionFiltersCertified",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 656,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "LedgerBookAdministrationStudioConfigured",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 639,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "LedgerBookId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "Guid?",
+          "source_line": 617,
+          "type": "Guid?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "LedgerBookMigrationCertified",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 662,
+          "type": "bool"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "string",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "LedgerBookWorkflowEvidenceLinks",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<string>",
+          "source_line": 680,
+          "type": "IReadOnlyList<string>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "LedgerLineDimensionsPersistedCertified",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 658,
+          "type": "bool"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "string",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "MigrationEvidenceLinks",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<string>",
+          "source_line": 686,
+          "type": "IReadOnlyList<string>"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "AccountingMigrationRunArtifactDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "MigrationRunArtifacts",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<AccountingMigrationRunArtifactDto>",
+          "source_line": 689,
+          "type": "IReadOnlyList<AccountingMigrationRunArtifactDto>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "PerformanceValidationConfigured",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 637,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "PeriodReportDimensionQueriesCertified",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 654,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "PostingRuleAuthoringStudioConfigured",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 640,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "PostingRulesLedgerBookNativeCertified",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 645,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ProviderId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 619,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ProviderMappingStudioConfigured",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 633,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ReconciliationLedgerBookNativeCertified",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 650,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ReportingGroupsConfigured",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 626,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ReportPackageDimensionProvenanceCertified",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 660,
+          "type": "bool"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "LedgerBookRequiredScopeDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RequiredLedgerBookScopes",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<LedgerBookRequiredScopeDto>",
+          "source_line": 674,
+          "type": "IReadOnlyList<LedgerBookRequiredScopeDto>"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 701,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RuleTestPromotionStudioConfigured",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 631,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ScopedAccessPoliciesConfigured",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 625,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "StrategyLedgerReadLedgerBookNativeCertified",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 652,
+          "type": "bool"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "AccountingTenantAdminCertificationArtifactDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TenantAdminCertificationArtifacts",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<AccountingTenantAdminCertificationArtifactDto>",
+          "source_line": 698,
+          "type": "IReadOnlyList<AccountingTenantAdminCertificationArtifactDto>"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "string",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TenantAdministrationEvidenceLinks",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<string>",
+          "source_line": 677,
+          "type": "IReadOnlyList<string>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TenantCompanyReportGroupSetupStudioConfigured",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 634,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TenantId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 620,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TenantScopeConfigured",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 623,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TrialBalanceDimensionFiltersCertified",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 659,
+          "type": "bool"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "AccountingWorkflowCertificationArtifactDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "WorkflowCertificationArtifacts",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<AccountingWorkflowCertificationArtifactDto>",
+          "source_line": 692,
+          "type": "IReadOnlyList<AccountingWorkflowCertificationArtifactDto>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "false",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "WpfAccountingAdminSurfaceConfigured",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 629,
+          "type": "bool"
+        }
+      ],
+      "name": "AccountingProductionReadinessRequestDto",
+      "namespace": "Meridian.Contracts.AccountingSystem",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessRequestDto",
+      "references": [
+        "Meridian.Contracts.AccountingSystem.AccountingDimensionalCertificationArtifactDto",
+        "Meridian.Contracts.AccountingSystem.AccountingMigrationRunArtifactDto",
+        "Meridian.Contracts.AccountingSystem.AccountingTenantAdminCertificationArtifactDto",
+        "Meridian.Contracts.AccountingSystem.AccountingWorkflowCertificationArtifactDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto",
+        "Meridian.Contracts.Ledger.AccountingBasisKindDto",
+        "Meridian.Contracts.Ledger.LedgerBookRequiredScopeDto"
+      ],
+      "source": {
+        "line": 615,
+        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 615,
+          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "enum",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "ledger-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "ledger-contracts"
+      ],
+      "enum_members": [
+        {
+          "explicit_value": true,
+          "name": "Ready",
+          "source_line": 84,
+          "value": "0"
+        },
+        {
+          "explicit_value": true,
+          "name": "ReviewRequired",
+          "source_line": 85,
+          "value": "1"
+        },
+        {
+          "explicit_value": true,
+          "name": "Blocked",
+          "source_line": 86,
+          "value": "2"
+        },
+        {
+          "explicit_value": true,
+          "name": "Unavailable",
+          "source_line": 87,
+          "value": "3"
+        }
+      ],
+      "fingerprint": "fe1fd8254b5545ddac8d93cfbbc74046a2242d6dc57b217ef3907e086b678057",
+      "full_name": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessStatusDto",
+      "id": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessStatusDto",
+      "kind": "enum",
+      "mapped_schemas": [
+        "ledger"
+      ],
+      "members": [],
+      "name": "AccountingProductionReadinessStatusDto",
+      "namespace": "Meridian.Contracts.AccountingSystem",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingProductionReadinessStatusDto",
+      "references": [],
+      "source": {
+        "line": 82,
+        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 82,
+          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "ledger-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "ledger-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "4838f8de1ee01fb331dcbc061002f7550e8b788d62de4e553760a9ba9c1c1d47",
+      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemChartAccountDto",
+      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemChartAccountDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "ledger"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AccountCode",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1370,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AccountType",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1372,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Currency",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1373,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "DisplayName",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1371,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EvidenceRef",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1376,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ExternalAccountId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1369,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "IsActive",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 1374,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ParentExternalAccountId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1375,
+          "type": "string?"
+        }
+      ],
+      "name": "AccountingSystemChartAccountDto",
+      "namespace": "Meridian.Contracts.AccountingSystem",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemChartAccountDto",
+      "references": [],
+      "source": {
+        "line": 1368,
+        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 1368,
+          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "ledger-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "ledger-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "681ac2547c8ab505a644802b04e6b86ab52031dfaa1da5f92b918a1cf225f0f7",
+      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemConnectionMetadataDto",
+      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemConnectionMetadataDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "ledger"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CompanyId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 72,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CompanyName",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 73,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Environment",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 71,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "HasLocalConfig",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 74,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "HasRefreshToken",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 75,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "LastConnectedAtUtc",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "DateTimeOffset?",
+          "source_line": 76,
+          "type": "DateTimeOffset?"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "string",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "MissingFields",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "IReadOnlyList<string>",
+          "source_line": 79,
+          "type": "IReadOnlyList<string>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ProviderId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 70,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "StatusDetail",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 78,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "StatusLabel",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 77,
+          "type": "string"
+        }
+      ],
+      "name": "AccountingSystemConnectionMetadataDto",
+      "namespace": "Meridian.Contracts.AccountingSystem",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemConnectionMetadataDto",
+      "references": [],
+      "source": {
+        "line": 69,
+        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 69,
+          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "enum",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "ledger-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "ledger-contracts"
+      ],
+      "enum_members": [
+        {
+          "explicit_value": false,
+          "name": "Ready",
+          "source_line": 38,
+          "value": null
+        },
+        {
+          "explicit_value": false,
+          "name": "ReviewRequired",
+          "source_line": 39,
+          "value": null
+        },
+        {
+          "explicit_value": false,
+          "name": "Missing",
+          "source_line": 40,
+          "value": null
+        }
+      ],
+      "fingerprint": "3d941ef82eefe575494a2264f67301f87de9092a588127b3fc0566ff8a509bfe",
+      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemEvidencePackageStatusDto",
+      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemEvidencePackageStatusDto",
+      "kind": "enum",
+      "mapped_schemas": [
+        "ledger"
+      ],
+      "members": [],
+      "name": "AccountingSystemEvidencePackageStatusDto",
+      "namespace": "Meridian.Contracts.AccountingSystem",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemEvidencePackageStatusDto",
+      "references": [],
+      "source": {
+        "line": 36,
+        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 36,
+          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "ledger-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "ledger-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "82c32512751bd1e58afca93eb0bd9bc4e74523c09c6ff71a912af530ca643508",
+      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemExportPackageRequestDto",
+      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemExportPackageRequestDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "ledger"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "OperationsActionOriginDto.HumanOperator",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ActionOrigin",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "OperationsActionOriginDto",
+          "source_line": 1498,
+          "type": "OperationsActionOriginDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Actor",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1485,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CompanyId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1497,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CorrelationId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1495,
+          "type": "string?"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "string",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EvidenceLinks",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<string>",
+          "source_line": 1503,
+          "type": "IReadOnlyList<string>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "FundProfileId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1487,
+          "type": "string?"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "Guid",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "JournalEntryIds",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<Guid>",
+          "source_line": 1500,
+          "type": "IReadOnlyList<Guid>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "LedgerBookId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "Guid?",
+          "source_line": 1488,
+          "type": "Guid?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "MappingProfileId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1491,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "PeriodEnd",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "DateOnly?",
+          "source_line": 1490,
+          "type": "DateOnly?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "PeriodStart",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "DateOnly?",
+          "source_line": 1489,
+          "type": "DateOnly?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ProviderId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1486,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "true",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RequireBalancedReconciliation",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 1493,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TenantId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1496,
+          "type": "string?"
+        }
+      ],
+      "name": "AccountingSystemExportPackageRequestDto",
+      "namespace": "Meridian.Contracts.AccountingSystem",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemExportPackageRequestDto",
+      "references": [
+        "Meridian.Contracts.Workstation.OperationsActionOriginDto"
+      ],
+      "source": {
+        "line": 1484,
+        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 1484,
+          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "ledger-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "ledger-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "06ef56f4d5f11ee40f03d86add9dacc32ad1efe970c1f8ad001d5d09b89e427f",
+      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemImportDetailDto",
+      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemImportDetailDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "ledger"
+      ],
+      "members": [
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "AccountingSystemChartAccountDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ChartAccounts",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "IReadOnlyList<AccountingSystemChartAccountDto>",
+          "source_line": 1411,
+          "type": "IReadOnlyList<AccountingSystemChartAccountDto>"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "AccountingSystemJournalEntryDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "JournalEntries",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "IReadOnlyList<AccountingSystemJournalEntryDto>",
+          "source_line": 1412,
+          "type": "IReadOnlyList<AccountingSystemJournalEntryDto>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Summary",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "AccountingSystemImportSummaryDto",
+          "source_line": 1410,
+          "type": "AccountingSystemImportSummaryDto"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "AccountingSystemTrialBalanceLineDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TrialBalance",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "IReadOnlyList<AccountingSystemTrialBalanceLineDto>",
+          "source_line": 1413,
+          "type": "IReadOnlyList<AccountingSystemTrialBalanceLineDto>"
+        }
+      ],
+      "name": "AccountingSystemImportDetailDto",
+      "namespace": "Meridian.Contracts.AccountingSystem",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemImportDetailDto",
+      "references": [
+        "Meridian.Contracts.AccountingSystem.AccountingSystemChartAccountDto",
+        "Meridian.Contracts.AccountingSystem.AccountingSystemImportSummaryDto",
+        "Meridian.Contracts.AccountingSystem.AccountingSystemJournalEntryDto",
+        "Meridian.Contracts.AccountingSystem.AccountingSystemTrialBalanceLineDto"
+      ],
+      "source": {
+        "line": 1409,
+        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 1409,
+          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "ledger-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "ledger-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "13fe7981bcb68ab0cd39d16393be3fb329a3172209cf78c5b23c3f0d3d14da00",
+      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemImportRequestDto",
+      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemImportRequestDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "ledger"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CompanyId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1347,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "FundProfileId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1341,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "LedgerBookId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "Guid?",
+          "source_line": 1342,
+          "type": "Guid?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "PeriodEnd",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "DateOnly?",
+          "source_line": 1344,
+          "type": "DateOnly?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "PeriodStart",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "DateOnly?",
+          "source_line": 1343,
+          "type": "DateOnly?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "true",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "PersistPreview",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 1345,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ProviderId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1340,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TenantId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1346,
+          "type": "string?"
+        }
+      ],
+      "name": "AccountingSystemImportRequestDto",
+      "namespace": "Meridian.Contracts.AccountingSystem",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemImportRequestDto",
+      "references": [],
+      "source": {
+        "line": 1339,
+        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 1339,
+          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "enum",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "ledger-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "ledger-contracts"
+      ],
+      "enum_members": [
+        {
+          "explicit_value": false,
+          "name": "NotStarted",
+          "source_line": 19,
+          "value": null
+        },
+        {
+          "explicit_value": false,
+          "name": "Previewed",
+          "source_line": 20,
+          "value": null
+        },
+        {
+          "explicit_value": false,
+          "name": "Imported",
+          "source_line": 21,
+          "value": null
+        },
+        {
+          "explicit_value": false,
+          "name": "Failed",
+          "source_line": 22,
+          "value": null
+        }
+      ],
+      "fingerprint": "179307e280ba9e92718819a9e63cc0349143a54c71fe1d1f8e16cf014bf2fe7c",
+      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemImportStateDto",
+      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemImportStateDto",
+      "kind": "enum",
+      "mapped_schemas": [
+        "ledger"
+      ],
+      "members": [],
+      "name": "AccountingSystemImportStateDto",
+      "namespace": "Meridian.Contracts.AccountingSystem",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemImportStateDto",
+      "references": [],
+      "source": {
+        "line": 17,
+        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 17,
+          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "ledger-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "ledger-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "a66ec48d2cfae688fa98b3473e03c81582cdad5b0efe246d9d2df86c33ca9b1c",
+      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemImportSummaryDto",
+      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemImportSummaryDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "ledger"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ChartAccountCount",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "int",
+          "source_line": 1359,
+          "type": "int"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CompanyId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1365,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ContentHash",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1366,
+          "type": "string?"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "string",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EvidenceReferences",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "IReadOnlyList<string>",
+          "source_line": 1362,
+          "type": "IReadOnlyList<string>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "FundProfileId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1353,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ImportedAtUtc",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "DateTimeOffset",
+          "source_line": 1358,
+          "type": "DateTimeOffset"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ImportId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1350,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "JournalEntryCount",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "int",
+          "source_line": 1360,
+          "type": "int"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "LedgerBookId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "Guid?",
+          "source_line": 1354,
+          "type": "Guid?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "PeriodEnd",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "DateOnly",
+          "source_line": 1357,
+          "type": "DateOnly"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "PeriodStart",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "DateOnly",
+          "source_line": 1356,
+          "type": "DateOnly"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ProviderDisplayName",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1352,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ProviderId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1351,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "State",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "AccountingSystemImportStateDto",
+          "source_line": 1355,
+          "type": "AccountingSystemImportStateDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TenantId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1364,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TrialBalanceLineCount",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "int",
+          "source_line": 1361,
+          "type": "int"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "string",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Warnings",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "IReadOnlyList<string>",
+          "source_line": 1363,
+          "type": "IReadOnlyList<string>"
+        }
+      ],
+      "name": "AccountingSystemImportSummaryDto",
+      "namespace": "Meridian.Contracts.AccountingSystem",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemImportSummaryDto",
+      "references": [
+        "Meridian.Contracts.AccountingSystem.AccountingSystemImportStateDto"
+      ],
+      "source": {
+        "line": 1349,
+        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 1349,
+          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "ledger-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "ledger-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "22b4d7078996b0b1fc9054da78d0c006f94564613ef85e75b5be8fd71e8aa222",
+      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemJournalEntryDto",
+      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemJournalEntryDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "ledger"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AccountingDate",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "DateOnly",
+          "source_line": 1380,
+          "type": "DateOnly"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Currency",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1382,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Description",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1381,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EvidenceRef",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1386,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ExternalJournalEntryId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1379,
+          "type": "string"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "AccountingSystemJournalLineDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Lines",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "IReadOnlyList<AccountingSystemJournalLineDto>",
+          "source_line": 1385,
+          "type": "IReadOnlyList<AccountingSystemJournalLineDto>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TotalCredits",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 1384,
+          "type": "decimal"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TotalDebits",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 1383,
+          "type": "decimal"
+        }
+      ],
+      "name": "AccountingSystemJournalEntryDto",
+      "namespace": "Meridian.Contracts.AccountingSystem",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemJournalEntryDto",
+      "references": [
+        "Meridian.Contracts.AccountingSystem.AccountingSystemJournalLineDto"
+      ],
+      "source": {
+        "line": 1378,
+        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 1378,
+          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "ledger-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "ledger-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "e7a1c8ff29a8055b00a2c5811eb42c85b5dc56ffbbb003f7cd72e28110e93efd",
+      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemJournalLineDto",
+      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemJournalLineDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "ledger"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AccountCode",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1391,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Credit",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 1394,
+          "type": "decimal"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Currency",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1395,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Debit",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 1393,
+          "type": "decimal"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Description",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1392,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EvidenceRef",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1396,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ExternalAccountId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1390,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ExternalLineId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1389,
+          "type": "string"
+        }
+      ],
+      "name": "AccountingSystemJournalLineDto",
+      "namespace": "Meridian.Contracts.AccountingSystem",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemJournalLineDto",
+      "references": [],
+      "source": {
+        "line": 1388,
+        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 1388,
+          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "ledger-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "ledger-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "325d7e99c5dae3b8253644495cafe202b64a6ca8fb34de1a5efc348df19cecff",
+      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemMappingProfileUpsertRequestDto",
+      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemMappingProfileUpsertRequestDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "ledger"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "OperationsActionOriginDto.HumanOperator",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ActionOrigin",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "OperationsActionOriginDto",
+          "source_line": 1478,
+          "type": "OperationsActionOriginDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Actor",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1470,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CompanyId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1477,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CorrelationId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1474,
+          "type": "string?"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "string",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EvidenceLinks",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<string>",
+          "source_line": 1480,
+          "type": "IReadOnlyList<string>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "FundProfileId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1472,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "LedgerBookId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "Guid?",
+          "source_line": 1473,
+          "type": "Guid?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Profile",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "ExternalGlMappingProfileDto",
+          "source_line": 1469,
+          "type": "ExternalGlMappingProfileDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ProviderId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1471,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TenantId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1476,
+          "type": "string?"
+        }
+      ],
+      "name": "AccountingSystemMappingProfileUpsertRequestDto",
+      "namespace": "Meridian.Contracts.AccountingSystem",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemMappingProfileUpsertRequestDto",
+      "references": [
+        "Meridian.Contracts.Ledger.ExternalGlMappingProfileDto",
+        "Meridian.Contracts.Workstation.OperationsActionOriginDto"
+      ],
+      "source": {
+        "line": 1468,
+        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 1468,
+          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "ledger-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "ledger-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "f85d0c470555c3355f4f80b7e86af0b2e0343fd1497fa716e65aa1a3662d7fd5",
+      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemOAuthCallbackResultDto",
+      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemOAuthCallbackResultDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "ledger"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CompanyId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1333,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CompanyName",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1334,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CompletedAtUtc",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "DateTimeOffset",
+          "source_line": 1335,
+          "type": "DateTimeOffset"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "LastError",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1336,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ProviderId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1331,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Success",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 1332,
+          "type": "bool"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "string",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Warnings",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "IReadOnlyList<string>",
+          "source_line": 1337,
+          "type": "IReadOnlyList<string>"
+        }
+      ],
+      "name": "AccountingSystemOAuthCallbackResultDto",
+      "namespace": "Meridian.Contracts.AccountingSystem",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemOAuthCallbackResultDto",
+      "references": [],
+      "source": {
+        "line": 1330,
+        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 1330,
+          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "ledger-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "ledger-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "5c37127d6bc925345291278f56618f43d166c9e2dc5a56f6b3e46a54e0eeaaea",
+      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemOAuthStartRequestDto",
+      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemOAuthStartRequestDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "ledger"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ClientId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1313,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ClientSecret",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1314,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CompanyName",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1317,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Environment",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1316,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RedirectUri",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1315,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RequestedBy",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1318,
+          "type": "string?"
+        }
+      ],
+      "name": "AccountingSystemOAuthStartRequestDto",
+      "namespace": "Meridian.Contracts.AccountingSystem",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemOAuthStartRequestDto",
+      "references": [],
+      "source": {
+        "line": 1312,
+        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 1312,
+          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "ledger-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "ledger-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "e8123c1dd3c5bfb48baca827ae631ec0a76e04e77a792ebe84a36a76fa7012e7",
+      "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemOAuthStartResultDto",
+      "id": "Meridian.Contracts.AccountingSystem.AccountingSystemOAuthStartResultDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "ledger"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AuthorizationUrl",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1323,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Environment",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1325,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "LastError",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1327,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ProviderId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1321,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RedirectUri",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1326,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "State",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1324,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Success",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 1322,
+          "type": "bool"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "string",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Warnings",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "IReadOnlyList<string>",
+          "source_line": 1328,
+          "type": "IReadOnlyList<string>"
+        }
+      ],
+      "name": "AccountingSystemOAuthStartResultDto",
+      "namespace": "Meridian.Contracts.AccountingSystem",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemOAuthStartResultDto",
+      "references": [],
+      "source": {
+        "line": 1320,
+        "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 1320,
+          "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "ledger-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "ledger-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "a07523da962f6ed0037a9102a4b172f9c634b75a224924d2d8a957b4815f0873",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemProviderDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingSystemProviderDto",
       "kind": "record",
@@ -14100,7 +14484,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "AccountingSystemConnectionMetadataDto?",
-          "source_line": 54,
+          "source_line": 55,
           "type": "AccountingSystemConnectionMetadataDto?"
         },
         {
@@ -14114,7 +14498,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 44,
+          "source_line": 45,
           "type": "string"
         },
         {
@@ -14128,7 +14512,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 53,
+          "source_line": 54,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -14142,7 +14526,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingSystemProviderMappingRequirementDto>",
-          "source_line": 57,
+          "source_line": 58,
           "type": "IReadOnlyList<AccountingSystemProviderMappingRequirementDto>"
         },
         {
@@ -14156,7 +14540,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 43,
+          "source_line": 44,
           "type": "string"
         },
         {
@@ -14170,7 +14554,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 46,
+          "source_line": 47,
           "type": "bool"
         },
         {
@@ -14184,7 +14568,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingSystemProviderStateDto",
-          "source_line": 45,
+          "source_line": 46,
           "type": "AccountingSystemProviderStateDto"
         },
         {
@@ -14198,7 +14582,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 52,
+          "source_line": 53,
           "type": "string"
         },
         {
@@ -14212,7 +14596,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 51,
+          "source_line": 52,
           "type": "string"
         },
         {
@@ -14226,7 +14610,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 47,
+          "source_line": 48,
           "type": "bool"
         },
         {
@@ -14240,7 +14624,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 48,
+          "source_line": 49,
           "type": "bool"
         },
         {
@@ -14254,7 +14638,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 50,
+          "source_line": 51,
           "type": "bool"
         },
         {
@@ -14268,7 +14652,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 49,
+          "source_line": 50,
           "type": "bool"
         }
       ],
@@ -14282,12 +14666,12 @@
         "Meridian.Contracts.AccountingSystem.AccountingSystemProviderStateDto"
       ],
       "source": {
-        "line": 42,
+        "line": 43,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 42,
+          "line": 43,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -14306,7 +14690,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "5ce0b5070f6bbbebd6218abef350b87c2a521c689b5a02905586ea98a1d52fab",
+      "fingerprint": "964201ac9cabc34e6f281aad15b9f25d6732553137245a76ece1a822aec71c05",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemProviderMappingRequirementDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingSystemProviderMappingRequirementDto",
       "kind": "record",
@@ -14325,7 +14709,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 63,
+          "source_line": 64,
           "type": "string"
         },
         {
@@ -14339,7 +14723,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 65,
+          "source_line": 66,
           "type": "string"
         },
         {
@@ -14353,7 +14737,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 64,
+          "source_line": 65,
           "type": "string"
         },
         {
@@ -14368,7 +14752,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 66,
+          "source_line": 67,
           "type": "bool"
         },
         {
@@ -14382,7 +14766,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 62,
+          "source_line": 63,
           "type": "string"
         }
       ],
@@ -14392,12 +14776,12 @@
       "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemProviderMappingRequirementDto",
       "references": [],
       "source": {
-        "line": 61,
+        "line": 62,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 61,
+          "line": 62,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -14419,23 +14803,23 @@
         {
           "explicit_value": false,
           "name": "Available",
-          "source_line": 10,
-          "value": null
-        },
-        {
-          "explicit_value": false,
-          "name": "Planned",
           "source_line": 11,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "Disabled",
+          "name": "Planned",
           "source_line": 12,
+          "value": null
+        },
+        {
+          "explicit_value": false,
+          "name": "Disabled",
+          "source_line": 13,
           "value": null
         }
       ],
-      "fingerprint": "a6ddf7ef7d0064a948c65caff2d40fb7c14bdb4c65204b3e1cddc562ddd12aa3",
+      "fingerprint": "95e67eb536cb2ff2c5b5fd099d3f1d3c3c12402abb21b0c2858a8d5aca9cda62",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemProviderStateDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingSystemProviderStateDto",
       "kind": "enum",
@@ -14449,12 +14833,12 @@
       "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemProviderStateDto",
       "references": [],
       "source": {
-        "line": 8,
+        "line": 9,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 8,
+          "line": 9,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -14473,7 +14857,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "498870018fb42cae5c9f4c380e4d978438de46d782c65728cada7c74dffeace6",
+      "fingerprint": "4e9d75ad6ca8837ebb284fb235fe414824b84cfe8b2f60865bcedfc3d5e997d6",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemReconciliationEvidencePackageDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingSystemReconciliationEvidencePackageDto",
       "kind": "record",
@@ -14492,7 +14876,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "int",
-          "source_line": 1304,
+          "source_line": 1419,
           "type": "int"
         },
         {
@@ -14506,7 +14890,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 1305,
+          "source_line": 1420,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -14520,7 +14904,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1302,
+          "source_line": 1417,
           "type": "string"
         },
         {
@@ -14534,7 +14918,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1301,
+          "source_line": 1416,
           "type": "string"
         },
         {
@@ -14548,7 +14932,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 1306,
+          "source_line": 1421,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -14562,7 +14946,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingSystemEvidencePackageStatusDto",
-          "source_line": 1303,
+          "source_line": 1418,
           "type": "AccountingSystemEvidencePackageStatusDto"
         }
       ],
@@ -14574,12 +14958,12 @@
         "Meridian.Contracts.AccountingSystem.AccountingSystemEvidencePackageStatusDto"
       ],
       "source": {
-        "line": 1300,
+        "line": 1415,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 1300,
+          "line": 1415,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -14598,7 +14982,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "21fa7e9809fae830eb0533759818bdf0eba8435f5b097c00cca6342b1006df45",
+      "fingerprint": "6137092a3f431b162c58ee62697153e7312213cd65d6649dfe6ebeb56e03c93b",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemReconciliationRowDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingSystemReconciliationRowDto",
       "kind": "record",
@@ -14617,7 +15001,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1334,
+          "source_line": 1449,
           "type": "string"
         },
         {
@@ -14631,7 +15015,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1335,
+          "source_line": 1450,
           "type": "string"
         },
         {
@@ -14645,7 +15029,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1336,
+          "source_line": 1451,
           "type": "string"
         },
         {
@@ -14659,7 +15043,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1343,
+          "source_line": 1458,
           "type": "string"
         },
         {
@@ -14674,7 +15058,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 1344,
+          "source_line": 1459,
           "type": "string?"
         },
         {
@@ -14688,7 +15072,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 1350,
+          "source_line": 1465,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -14702,7 +15086,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "decimal",
-          "source_line": 1339,
+          "source_line": 1454,
           "type": "decimal"
         },
         {
@@ -14716,7 +15100,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "decimal",
-          "source_line": 1338,
+          "source_line": 1453,
           "type": "decimal"
         },
         {
@@ -14730,7 +15114,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 1346,
+          "source_line": 1461,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -14744,7 +15128,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "decimal",
-          "source_line": 1341,
+          "source_line": 1456,
           "type": "decimal"
         },
         {
@@ -14758,7 +15142,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "decimal",
-          "source_line": 1340,
+          "source_line": 1455,
           "type": "decimal"
         },
         {
@@ -14772,7 +15156,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 1348,
+          "source_line": 1463,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -14786,7 +15170,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1333,
+          "source_line": 1448,
           "type": "string"
         },
         {
@@ -14800,7 +15184,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingSystemReconciliationStatusDto",
-          "source_line": 1337,
+          "source_line": 1452,
           "type": "AccountingSystemReconciliationStatusDto"
         },
         {
@@ -14814,7 +15198,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "decimal",
-          "source_line": 1342,
+          "source_line": 1457,
           "type": "decimal"
         }
       ],
@@ -14826,12 +15210,12 @@
         "Meridian.Contracts.AccountingSystem.AccountingSystemReconciliationStatusDto"
       ],
       "source": {
-        "line": 1332,
+        "line": 1447,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 1332,
+          "line": 1447,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -14853,35 +15237,35 @@
         {
           "explicit_value": false,
           "name": "Matched",
-          "source_line": 27,
-          "value": null
-        },
-        {
-          "explicit_value": false,
-          "name": "Variance",
           "source_line": 28,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "MissingExternal",
+          "name": "Variance",
           "source_line": 29,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "MissingMeridian",
+          "name": "MissingExternal",
           "source_line": 30,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "ReviewRequired",
+          "name": "MissingMeridian",
           "source_line": 31,
+          "value": null
+        },
+        {
+          "explicit_value": false,
+          "name": "ReviewRequired",
+          "source_line": 32,
           "value": null
         }
       ],
-      "fingerprint": "e83585215f02d8c55bdd1dfa3e3030f583681eea2b5d30e6f4a46cc1225f682a",
+      "fingerprint": "5eccf3369639f90c66d315fa4619cd4b1c779ef7da5460182406f7fec6d27a7f",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemReconciliationStatusDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingSystemReconciliationStatusDto",
       "kind": "enum",
@@ -14895,12 +15279,12 @@
       "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemReconciliationStatusDto",
       "references": [],
       "source": {
-        "line": 25,
+        "line": 26,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 25,
+          "line": 26,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -14919,7 +15303,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "a9769b363c76eb6d0b8baf23595e65ff5f3ffbe08cf6416e871bbb3830563f86",
+      "fingerprint": "5f7cb7f9ec3c77b82f2a52a180c244af790705f4a9880000f5bafda29fbc1a3c",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemReconciliationSummaryDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingSystemReconciliationSummaryDto",
       "kind": "record",
@@ -14938,7 +15322,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "int",
-          "source_line": 1317,
+          "source_line": 1432,
           "type": "int"
         },
         {
@@ -14952,7 +15336,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingSystemReconciliationEvidencePackageDto>",
-          "source_line": 1329,
+          "source_line": 1444,
           "type": "IReadOnlyList<AccountingSystemReconciliationEvidencePackageDto>"
         },
         {
@@ -14966,7 +15350,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 1325,
+          "source_line": 1440,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -14980,7 +15364,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1312,
+          "source_line": 1427,
           "type": "string"
         },
         {
@@ -14994,7 +15378,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset",
-          "source_line": 1315,
+          "source_line": 1430,
           "type": "DateTimeOffset"
         },
         {
@@ -15009,7 +15393,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 1327,
+          "source_line": 1442,
           "type": "string?"
         },
         {
@@ -15023,7 +15407,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1310,
+          "source_line": 1425,
           "type": "string"
         },
         {
@@ -15038,7 +15422,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 1326,
+          "source_line": 1441,
           "type": "Guid?"
         },
         {
@@ -15052,7 +15436,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "int",
-          "source_line": 1316,
+          "source_line": 1431,
           "type": "int"
         },
         {
@@ -15066,7 +15450,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateOnly",
-          "source_line": 1314,
+          "source_line": 1429,
           "type": "DateOnly"
         },
         {
@@ -15080,7 +15464,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateOnly",
-          "source_line": 1313,
+          "source_line": 1428,
           "type": "DateOnly"
         },
         {
@@ -15094,7 +15478,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1323,
+          "source_line": 1438,
           "type": "string"
         },
         {
@@ -15108,7 +15492,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 1322,
+          "source_line": 1437,
           "type": "bool"
         },
         {
@@ -15122,7 +15506,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1311,
+          "source_line": 1426,
           "type": "string"
         },
         {
@@ -15136,7 +15520,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1309,
+          "source_line": 1424,
           "type": "string"
         },
         {
@@ -15150,7 +15534,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<AccountingSystemReconciliationRowDto>",
-          "source_line": 1324,
+          "source_line": 1439,
           "type": "IReadOnlyList<AccountingSystemReconciliationRowDto>"
         },
         {
@@ -15164,7 +15548,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "decimal",
-          "source_line": 1319,
+          "source_line": 1434,
           "type": "decimal"
         },
         {
@@ -15178,7 +15562,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "decimal",
-          "source_line": 1318,
+          "source_line": 1433,
           "type": "decimal"
         },
         {
@@ -15192,7 +15576,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "decimal",
-          "source_line": 1321,
+          "source_line": 1436,
           "type": "decimal"
         },
         {
@@ -15206,7 +15590,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "decimal",
-          "source_line": 1320,
+          "source_line": 1435,
           "type": "decimal"
         }
       ],
@@ -15219,12 +15603,12 @@
         "Meridian.Contracts.AccountingSystem.AccountingSystemReconciliationRowDto"
       ],
       "source": {
-        "line": 1308,
+        "line": 1423,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 1308,
+          "line": 1423,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -15243,7 +15627,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "0a5dfe038713bae6345b63c348f5badf48de9e493ed008607fa4a20b1f4a2728",
+      "fingerprint": "fb12e4b097fb72012083e0a32bae0f08a3a899bb84ed9ad4f71c62658805d59d",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingSystemTrialBalanceLineDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingSystemTrialBalanceLineDto",
       "kind": "record",
@@ -15262,7 +15646,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1285,
+          "source_line": 1400,
           "type": "string"
         },
         {
@@ -15276,7 +15660,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1286,
+          "source_line": 1401,
           "type": "string"
         },
         {
@@ -15290,7 +15674,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1287,
+          "source_line": 1402,
           "type": "string"
         },
         {
@@ -15304,7 +15688,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateOnly",
-          "source_line": 1291,
+          "source_line": 1406,
           "type": "DateOnly"
         },
         {
@@ -15318,7 +15702,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "decimal",
-          "source_line": 1289,
+          "source_line": 1404,
           "type": "decimal"
         },
         {
@@ -15332,7 +15716,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1290,
+          "source_line": 1405,
           "type": "string"
         },
         {
@@ -15346,7 +15730,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "decimal",
-          "source_line": 1288,
+          "source_line": 1403,
           "type": "decimal"
         },
         {
@@ -15361,7 +15745,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 1292,
+          "source_line": 1407,
           "type": "string?"
         },
         {
@@ -15375,7 +15759,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1284,
+          "source_line": 1399,
           "type": "string"
         }
       ],
@@ -15385,12 +15769,12 @@
       "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingSystemTrialBalanceLineDto",
       "references": [],
       "source": {
-        "line": 1283,
+        "line": 1398,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 1283,
+          "line": 1398,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -15409,7 +15793,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "011096780062fb166392dddc0501b3abdcf1021ea383e8afcf44c4622a6e6a06",
+      "fingerprint": "fc5ec8296f84e24faffcb4f225045d22db14d53997c6d268bf2732511e5bbc58",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingTenantAdminCertificationArtifactDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingTenantAdminCertificationArtifactDto",
       "kind": "record",
@@ -15428,7 +15812,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 478,
+          "source_line": 479,
           "type": "string"
         },
         {
@@ -15442,7 +15826,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset",
-          "source_line": 485,
+          "source_line": 486,
           "type": "DateTimeOffset"
         },
         {
@@ -15456,7 +15840,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 484,
+          "source_line": 485,
           "type": "string"
         },
         {
@@ -15470,7 +15854,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 481,
+          "source_line": 482,
           "type": "string"
         },
         {
@@ -15485,7 +15869,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 490,
+          "source_line": 491,
           "type": "string?"
         },
         {
@@ -15499,7 +15883,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 495,
+          "source_line": 496,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -15513,7 +15897,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 482,
+          "source_line": 483,
           "type": "string"
         },
         {
@@ -15527,7 +15911,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingCertificationArtifactIssueDto>",
-          "source_line": 498,
+          "source_line": 499,
           "type": "IReadOnlyList<AccountingCertificationArtifactIssueDto>"
         },
         {
@@ -15541,7 +15925,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingTenantAdminCertificationLaneDto>",
-          "source_line": 492,
+          "source_line": 493,
           "type": "IReadOnlyList<AccountingTenantAdminCertificationLaneDto>"
         },
         {
@@ -15555,7 +15939,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 483,
+          "source_line": 484,
           "type": "Guid?"
         },
         {
@@ -15569,7 +15953,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 486,
+          "source_line": 487,
           "type": "string"
         },
         {
@@ -15583,7 +15967,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingCertificationArtifactStatusDto",
-          "source_line": 479,
+          "source_line": 480,
           "type": "AccountingCertificationArtifactStatusDto"
         },
         {
@@ -15597,7 +15981,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 480,
+          "source_line": 481,
           "type": "string"
         }
       ],
@@ -15611,12 +15995,12 @@
         "Meridian.Contracts.AccountingSystem.AccountingTenantAdminCertificationLaneDto"
       ],
       "source": {
-        "line": 477,
+        "line": 478,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 477,
+          "line": 478,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -15635,7 +16019,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "601f517260b7fcda7a6072056714654dafecbd490a5f1b419efb09481938f9d2",
+      "fingerprint": "abef9bf8141784d7decab38349ed63f5011e37e4c7de9e8b6dabd930100cc0dd",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingTenantAdminCertificationLaneDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingTenantAdminCertificationLaneDto",
       "kind": "record",
@@ -15654,7 +16038,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 419,
+          "source_line": 420,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -15668,7 +16052,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingCertificationArtifactIssueDto>",
-          "source_line": 422,
+          "source_line": 423,
           "type": "IReadOnlyList<AccountingCertificationArtifactIssueDto>"
         },
         {
@@ -15682,7 +16066,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingTenantAdminCertificationLaneKindDto",
-          "source_line": 414,
+          "source_line": 415,
           "type": "AccountingTenantAdminCertificationLaneKindDto"
         },
         {
@@ -15696,7 +16080,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingCertificationArtifactLaneStatusDto",
-          "source_line": 415,
+          "source_line": 416,
           "type": "AccountingCertificationArtifactLaneStatusDto"
         }
       ],
@@ -15710,12 +16094,12 @@
         "Meridian.Contracts.AccountingSystem.AccountingTenantAdminCertificationLaneKindDto"
       ],
       "source": {
-        "line": 413,
+        "line": 414,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 413,
+          "line": 414,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -15737,131 +16121,131 @@
         {
           "explicit_value": false,
           "name": "TenantScope",
-          "source_line": 353,
-          "value": null
-        },
-        {
-          "explicit_value": false,
-          "name": "AdminRoleProfile",
           "source_line": 354,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "ScopedAccessPolicies",
+          "name": "AdminRoleProfile",
           "source_line": 355,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "ReportingGroups",
+          "name": "ScopedAccessPolicies",
           "source_line": 356,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "AccountingAdminSurface",
+          "name": "ReportingGroups",
           "source_line": 357,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "BrowserAccountingAdminSurface",
+          "name": "AccountingAdminSurface",
           "source_line": 358,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "WpfAccountingAdminSurface",
+          "name": "BrowserAccountingAdminSurface",
           "source_line": 359,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "ChartAdministrationStudio",
+          "name": "WpfAccountingAdminSurface",
           "source_line": 360,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "RuleTestPromotionStudio",
+          "name": "ChartAdministrationStudio",
           "source_line": 361,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "CloseSetupStudio",
+          "name": "RuleTestPromotionStudio",
           "source_line": 362,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "ProviderMappingStudio",
+          "name": "CloseSetupStudio",
           "source_line": 363,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "TenantCompanyReportGroupSetupStudio",
+          "name": "ProviderMappingStudio",
           "source_line": 364,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "AuditReviewTooling",
+          "name": "TenantCompanyReportGroupSetupStudio",
           "source_line": 365,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "BulkImportExportSafeguards",
+          "name": "AuditReviewTooling",
           "source_line": 366,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "PerformanceValidation",
+          "name": "BulkImportExportSafeguards",
           "source_line": 367,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "DisasterRecoveryRunbook",
+          "name": "PerformanceValidation",
           "source_line": 368,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "LedgerBookAdministrationStudio",
+          "name": "DisasterRecoveryRunbook",
           "source_line": 369,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "PostingRuleAuthoringStudio",
+          "name": "LedgerBookAdministrationStudio",
           "source_line": 370,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "ApprovalQueueStudio",
+          "name": "PostingRuleAuthoringStudio",
           "source_line": 371,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "DimensionMappingStudio",
+          "name": "ApprovalQueueStudio",
           "source_line": 372,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "ImplementationSandbox",
+          "name": "DimensionMappingStudio",
           "source_line": 373,
+          "value": null
+        },
+        {
+          "explicit_value": false,
+          "name": "ImplementationSandbox",
+          "source_line": 374,
           "value": null
         }
       ],
-      "fingerprint": "b4501ae61d146086d620430951cabbefc53b5d2c48c88bf4d14152f68d9ecb06",
+      "fingerprint": "80586c11cfa92c6fab926cd4b6243a0805c18c0abafe44dda0d07bdccbb4925f",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingTenantAdminCertificationLaneKindDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingTenantAdminCertificationLaneKindDto",
       "kind": "enum",
@@ -15875,12 +16259,12 @@
       "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingTenantAdminCertificationLaneKindDto",
       "references": [],
       "source": {
-        "line": 351,
+        "line": 352,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 351,
+          "line": 352,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -15899,7 +16283,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "c9cf4d1ee868776c75311654fae8471122e84df750fe5595f3e092f30d6b7b62",
+      "fingerprint": "c2d15273b65c45cc401d26203de152ede5484664d8d0789add36f0a151661195",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingTenantAdministrationProfileDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingTenantAdministrationProfileDto",
       "kind": "record",
@@ -15918,7 +16302,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 267,
+          "source_line": 268,
           "type": "bool"
         },
         {
@@ -15932,7 +16316,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 264,
+          "source_line": 265,
           "type": "bool"
         },
         {
@@ -15946,7 +16330,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingApprovalQueueConfigurationDto>",
-          "source_line": 294,
+          "source_line": 295,
           "type": "IReadOnlyList<AccountingApprovalQueueConfigurationDto>"
         },
         {
@@ -15961,7 +16345,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 285,
+          "source_line": 286,
           "type": "bool"
         },
         {
@@ -15976,7 +16360,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 279,
+          "source_line": 280,
           "type": "bool"
         },
         {
@@ -15991,7 +16375,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 272,
+          "source_line": 273,
           "type": "bool"
         },
         {
@@ -16006,7 +16390,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 280,
+          "source_line": 281,
           "type": "bool"
         },
         {
@@ -16021,7 +16405,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 274,
+          "source_line": 275,
           "type": "bool"
         },
         {
@@ -16036,7 +16420,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 276,
+          "source_line": 277,
           "type": "bool"
         },
         {
@@ -16050,7 +16434,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 262,
+          "source_line": 263,
           "type": "string"
         },
         {
@@ -16065,7 +16449,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 271,
+          "source_line": 272,
           "type": "string?"
         },
         {
@@ -16079,7 +16463,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingDimensionMappingConfigurationDto>",
-          "source_line": 297,
+          "source_line": 298,
           "type": "IReadOnlyList<AccountingDimensionMappingConfigurationDto>"
         },
         {
@@ -16094,7 +16478,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 286,
+          "source_line": 287,
           "type": "bool"
         },
         {
@@ -16109,7 +16493,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 282,
+          "source_line": 283,
           "type": "bool"
         },
         {
@@ -16123,7 +16507,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 291,
+          "source_line": 292,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -16138,7 +16522,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 287,
+          "source_line": 288,
           "type": "bool"
         },
         {
@@ -16153,7 +16537,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 283,
+          "source_line": 284,
           "type": "bool"
         },
         {
@@ -16168,7 +16552,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 281,
+          "source_line": 282,
           "type": "bool"
         },
         {
@@ -16183,7 +16567,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 284,
+          "source_line": 285,
           "type": "bool"
         },
         {
@@ -16198,7 +16582,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 277,
+          "source_line": 278,
           "type": "bool"
         },
         {
@@ -16212,7 +16596,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 266,
+          "source_line": 267,
           "type": "bool"
         },
         {
@@ -16227,7 +16611,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 275,
+          "source_line": 276,
           "type": "bool"
         },
         {
@@ -16241,7 +16625,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 265,
+          "source_line": 266,
           "type": "bool"
         },
         {
@@ -16256,7 +16640,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 278,
+          "source_line": 279,
           "type": "bool"
         },
         {
@@ -16270,7 +16654,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 261,
+          "source_line": 262,
           "type": "string"
         },
         {
@@ -16284,7 +16668,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 263,
+          "source_line": 264,
           "type": "bool"
         },
         {
@@ -16298,7 +16682,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset",
-          "source_line": 268,
+          "source_line": 269,
           "type": "DateTimeOffset"
         },
         {
@@ -16312,7 +16696,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 269,
+          "source_line": 270,
           "type": "string"
         },
         {
@@ -16327,7 +16711,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 273,
+          "source_line": 274,
           "type": "bool"
         }
       ],
@@ -16340,12 +16724,12 @@
         "Meridian.Contracts.AccountingSystem.AccountingDimensionMappingConfigurationDto"
       ],
       "source": {
-        "line": 260,
+        "line": 261,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 260,
+          "line": 261,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -16364,7 +16748,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "e8e67cc18f9a6414721ff79094f5840bc6d18e7d3b144cdefc2d30dce803f9eb",
+      "fingerprint": "ced42d00cd9f52f1650a84a4fd2a022596c53a172d5576a8b3916b0ee479d5cc",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingTenantAdministrationProfileUpsertRequestDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingTenantAdministrationProfileUpsertRequestDto",
       "kind": "record",
@@ -16384,7 +16768,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "OperationsActionOriginDto",
-          "source_line": 306,
+          "source_line": 307,
           "type": "OperationsActionOriginDto"
         },
         {
@@ -16398,7 +16782,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 303,
+          "source_line": 304,
           "type": "string"
         },
         {
@@ -16413,7 +16797,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 304,
+          "source_line": 305,
           "type": "string?"
         },
         {
@@ -16427,7 +16811,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 308,
+          "source_line": 309,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -16441,7 +16825,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingTenantAdministrationProfileDto",
-          "source_line": 302,
+          "source_line": 303,
           "type": "AccountingTenantAdministrationProfileDto"
         }
       ],
@@ -16454,12 +16838,12 @@
         "Meridian.Contracts.Workstation.OperationsActionOriginDto"
       ],
       "source": {
-        "line": 301,
+        "line": 302,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 301,
+          "line": 302,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -16478,7 +16862,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "517eca4d4d74ae422f171a8e6e826140bd650d92ecbcd999002e0d131d3325c4",
+      "fingerprint": "d1d3d625d6652c2f6f67ac2b12578ceef6f8297ca91d2161560ce83c7b8d3b2b",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingTenantAdministrationReadinessDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingTenantAdministrationReadinessDto",
       "kind": "record",
@@ -16497,7 +16881,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 816,
+          "source_line": 949,
           "type": "bool"
         },
         {
@@ -16511,7 +16895,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 813,
+          "source_line": 946,
           "type": "bool"
         },
         {
@@ -16526,7 +16910,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 831,
+          "source_line": 964,
           "type": "bool"
         },
         {
@@ -16541,7 +16925,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 825,
+          "source_line": 958,
           "type": "bool"
         },
         {
@@ -16555,7 +16939,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 817,
+          "source_line": 950,
           "type": "bool"
         },
         {
@@ -16570,8 +16954,22 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 826,
+          "source_line": 959,
           "type": "bool"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "AccountingTenantAdminCertificationArtifactDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CertificationArtifacts",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<AccountingTenantAdminCertificationArtifactDto>",
+          "source_line": 978,
+          "type": "IReadOnlyList<AccountingTenantAdminCertificationArtifactDto>"
         },
         {
           "collection": false,
@@ -16584,7 +16982,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 819,
+          "source_line": 952,
           "type": "bool"
         },
         {
@@ -16598,7 +16996,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 821,
+          "source_line": 954,
           "type": "bool"
         },
         {
@@ -16612,7 +17010,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 811,
+          "source_line": 944,
           "type": "string?"
         },
         {
@@ -16627,7 +17025,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 832,
+          "source_line": 965,
           "type": "bool"
         },
         {
@@ -16642,7 +17040,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 828,
+          "source_line": 961,
           "type": "bool"
         },
         {
@@ -16656,8 +17054,23 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 835,
+          "source_line": 972,
           "type": "IReadOnlyList<string>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "FundProfileId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 968,
+          "type": "string?"
         },
         {
           "collection": false,
@@ -16671,7 +17084,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 833,
+          "source_line": 966,
           "type": "bool"
         },
         {
@@ -16686,8 +17099,23 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 829,
+          "source_line": 962,
           "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "LedgerBookId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "Guid?",
+          "source_line": 969,
+          "type": "Guid?"
         },
         {
           "collection": false,
@@ -16701,7 +17129,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 827,
+          "source_line": 960,
           "type": "bool"
         },
         {
@@ -16716,7 +17144,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 830,
+          "source_line": 963,
           "type": "bool"
         },
         {
@@ -16730,7 +17158,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 822,
+          "source_line": 955,
           "type": "bool"
         },
         {
@@ -16744,8 +17172,22 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 815,
+          "source_line": 948,
           "type": "bool"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 975,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
         },
         {
           "collection": false,
@@ -16758,7 +17200,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 820,
+          "source_line": 953,
           "type": "bool"
         },
         {
@@ -16772,7 +17214,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 814,
+          "source_line": 947,
           "type": "bool"
         },
         {
@@ -16786,7 +17228,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 823,
+          "source_line": 956,
           "type": "bool"
         },
         {
@@ -16800,7 +17242,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 810,
+          "source_line": 943,
           "type": "string?"
         },
         {
@@ -16814,7 +17256,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 812,
+          "source_line": 945,
           "type": "bool"
         },
         {
@@ -16828,7 +17270,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 818,
+          "source_line": 951,
           "type": "bool"
         }
       ],
@@ -16836,14 +17278,17 @@
       "namespace": "Meridian.Contracts.AccountingSystem",
       "partial": false,
       "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingTenantAdministrationReadinessDto",
-      "references": [],
+      "references": [
+        "Meridian.Contracts.AccountingSystem.AccountingTenantAdminCertificationArtifactDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+      ],
       "source": {
-        "line": 809,
+        "line": 942,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 809,
+          "line": 942,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -16862,7 +17307,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "df52de7114fdb5d5a454a8afa95114573a08e37d69e888bc0baf2e5bd03a7fa2",
+      "fingerprint": "439c97c1790106538436479b4a6cd71f4d6c857954de83381e531d6e66434ea9",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingWorkflowCertificationArtifactDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingWorkflowCertificationArtifactDto",
       "kind": "record",
@@ -16881,7 +17326,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 427,
+          "source_line": 428,
           "type": "string"
         },
         {
@@ -16895,7 +17340,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset",
-          "source_line": 434,
+          "source_line": 435,
           "type": "DateTimeOffset"
         },
         {
@@ -16909,7 +17354,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 433,
+          "source_line": 434,
           "type": "string"
         },
         {
@@ -16923,7 +17368,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 430,
+          "source_line": 431,
           "type": "string?"
         },
         {
@@ -16938,7 +17383,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 439,
+          "source_line": 440,
           "type": "string?"
         },
         {
@@ -16952,7 +17397,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 444,
+          "source_line": 445,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -16966,7 +17411,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 431,
+          "source_line": 432,
           "type": "string"
         },
         {
@@ -16980,7 +17425,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingCertificationArtifactIssueDto>",
-          "source_line": 447,
+          "source_line": 448,
           "type": "IReadOnlyList<AccountingCertificationArtifactIssueDto>"
         },
         {
@@ -16994,7 +17439,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingWorkflowCertificationLaneDto>",
-          "source_line": 441,
+          "source_line": 442,
           "type": "IReadOnlyList<AccountingWorkflowCertificationLaneDto>"
         },
         {
@@ -17008,7 +17453,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 432,
+          "source_line": 433,
           "type": "Guid"
         },
         {
@@ -17022,7 +17467,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 435,
+          "source_line": 436,
           "type": "string"
         },
         {
@@ -17036,7 +17481,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingCertificationArtifactStatusDto",
-          "source_line": 428,
+          "source_line": 429,
           "type": "AccountingCertificationArtifactStatusDto"
         },
         {
@@ -17050,7 +17495,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 429,
+          "source_line": 430,
           "type": "string?"
         }
       ],
@@ -17064,12 +17509,12 @@
         "Meridian.Contracts.AccountingSystem.AccountingWorkflowCertificationLaneDto"
       ],
       "source": {
-        "line": 426,
+        "line": 427,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 426,
+          "line": 427,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -17088,7 +17533,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "87e5adda2066ae9cf526a38bbcbfafdb00b9504a9891fed6972f4b1929dcb274",
+      "fingerprint": "a38d144b425d453becc8aa18515dbe50d88de058b8b0bee0de02ae3db85c37d6",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingWorkflowCertificationLaneDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingWorkflowCertificationLaneDto",
       "kind": "record",
@@ -17107,7 +17552,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 393,
+          "source_line": 394,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -17121,7 +17566,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingCertificationArtifactIssueDto>",
-          "source_line": 396,
+          "source_line": 397,
           "type": "IReadOnlyList<AccountingCertificationArtifactIssueDto>"
         },
         {
@@ -17135,7 +17580,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingWorkflowCertificationLaneKindDto",
-          "source_line": 388,
+          "source_line": 389,
           "type": "AccountingWorkflowCertificationLaneKindDto"
         },
         {
@@ -17149,7 +17594,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingCertificationArtifactLaneStatusDto",
-          "source_line": 389,
+          "source_line": 390,
           "type": "AccountingCertificationArtifactLaneStatusDto"
         }
       ],
@@ -17163,12 +17608,12 @@
         "Meridian.Contracts.AccountingSystem.AccountingWorkflowCertificationLaneKindDto"
       ],
       "source": {
-        "line": 387,
+        "line": 388,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 387,
+          "line": 388,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -17190,53 +17635,53 @@
         {
           "explicit_value": false,
           "name": "PostingRules",
-          "source_line": 330,
-          "value": null
-        },
-        {
-          "explicit_value": false,
-          "name": "JournalLifecycle",
           "source_line": 331,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "CloseReporting",
+          "name": "JournalLifecycle",
           "source_line": 332,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "ClosePlanConfiguration",
+          "name": "CloseReporting",
           "source_line": 333,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "ExternalGl",
+          "name": "ClosePlanConfiguration",
           "source_line": 334,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "Reconciliation",
+          "name": "ExternalGl",
           "source_line": 335,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "DirectLendingProjection",
+          "name": "Reconciliation",
           "source_line": 336,
           "value": null
         },
         {
           "explicit_value": false,
-          "name": "StrategyLedgerReads",
+          "name": "DirectLendingProjection",
           "source_line": 337,
+          "value": null
+        },
+        {
+          "explicit_value": false,
+          "name": "StrategyLedgerReads",
+          "source_line": 338,
           "value": null
         }
       ],
-      "fingerprint": "c3dd42aab103c69af2241a9ce68e60bc7fa919d9151b1cf119266608d8cda277",
+      "fingerprint": "df1b32bf99eb190db157f422283270a89bf6d6065104eb812bdce979fa5c511f",
       "full_name": "Meridian.Contracts.AccountingSystem.AccountingWorkflowCertificationLaneKindDto",
       "id": "Meridian.Contracts.AccountingSystem.AccountingWorkflowCertificationLaneKindDto",
       "kind": "enum",
@@ -17250,12 +17695,12 @@
       "qualified_name": "Meridian.Contracts.AccountingSystem.AccountingWorkflowCertificationLaneKindDto",
       "references": [],
       "source": {
-        "line": 328,
+        "line": 329,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 328,
+          "line": 329,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -17274,7 +17719,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "386f8b6192159a89da31cbf98f4a319fd0c977b1f1f446094ad8fa5f9c53180c",
+      "fingerprint": "e6983209f4d1b69793c94f606865d961806ccb13c92d768d294fff2ffa129302",
       "full_name": "Meridian.Contracts.AccountingSystem.CertifyAccountingSystemExportPackageRequestDto",
       "id": "Meridian.Contracts.AccountingSystem.CertifyAccountingSystemExportPackageRequestDto",
       "kind": "record",
@@ -17294,7 +17739,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "OperationsActionOriginDto",
-          "source_line": 1398,
+          "source_line": 1513,
           "type": "OperationsActionOriginDto"
         },
         {
@@ -17308,7 +17753,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1394,
+          "source_line": 1509,
           "type": "string"
         },
         {
@@ -17323,7 +17768,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 1400,
+          "source_line": 1515,
           "type": "string?"
         },
         {
@@ -17338,7 +17783,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 1397,
+          "source_line": 1512,
           "type": "string?"
         },
         {
@@ -17352,7 +17797,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 1402,
+          "source_line": 1517,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -17366,7 +17811,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1393,
+          "source_line": 1508,
           "type": "string"
         },
         {
@@ -17380,7 +17825,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1395,
+          "source_line": 1510,
           "type": "string"
         },
         {
@@ -17395,7 +17840,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 1399,
+          "source_line": 1514,
           "type": "string?"
         }
       ],
@@ -17407,12 +17852,12 @@
         "Meridian.Contracts.Workstation.OperationsActionOriginDto"
       ],
       "source": {
-        "line": 1392,
+        "line": 1507,
         "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
       },
       "sources": [
         {
-          "line": 1392,
+          "line": 1507,
           "path": "src/Meridian.Contracts/AccountingSystem/AccountingSystemDtos.cs"
         }
       ],
@@ -45209,7 +45654,1905 @@
         "asset-operations-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "7990c54c24bc99c70db31d24e8d5e1331146fe1fb709060ead9ec1112ae58160",
+      "fingerprint": "73e67733fb224a522865ef419844e01c95e643c8eb9f0b9e596681ab70936166",
+      "full_name": "Meridian.Contracts.AssetOperations.AppendAssetAccountingLifecycleStageRequestDto",
+      "id": "Meridian.Contracts.AssetOperations.AppendAssetAccountingLifecycleStageRequestDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Actor",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 241,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AttestedAtUtc",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "DateTimeOffset",
+          "source_line": 242,
+          "type": "DateTimeOffset"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CompanyId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 247,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EventId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "Guid",
+          "source_line": 235,
+          "type": "Guid"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EventVersion",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "long",
+          "source_line": 236,
+          "type": "long"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Evidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 249,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ExpectedBookPositionVersion",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "long",
+          "source_line": 239,
+          "type": "long"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ExpectedSpineVersion",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "long",
+          "source_line": 238,
+          "type": "long"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "FundProfileId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 240,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Notes",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 245,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ReferenceId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 243,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Stage",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "AssetAccountingLifecycleStageDto",
+          "source_line": 237,
+          "type": "AssetAccountingLifecycleStageDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TenantId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 246,
+          "type": "string?"
+        }
+      ],
+      "name": "AppendAssetAccountingLifecycleStageRequestDto",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.AppendAssetAccountingLifecycleStageRequestDto",
+      "references": [
+        "Meridian.Contracts.AssetOperations.AssetAccountingLifecycleStageDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+      ],
+      "source": {
+        "line": 234,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 234,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "8f2e6e843a21084c1fd6fe010b651cb30985884c3ca6fe4627ba1ef415c54aea",
+      "full_name": "Meridian.Contracts.AssetOperations.AssetAccountingCorrectionReferenceDto",
+      "id": "Meridian.Contracts.AssetOperations.AssetAccountingCorrectionReferenceDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AccountingBasis",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "AccountingBasisKindDto",
+          "source_line": 171,
+          "type": "AccountingBasisKindDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EventId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "Guid",
+          "source_line": 166,
+          "type": "Guid"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EventVersion",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "long",
+          "source_line": 167,
+          "type": "long"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "LedgerBookId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "Guid",
+          "source_line": 169,
+          "type": "Guid"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "PeriodId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "Guid",
+          "source_line": 170,
+          "type": "Guid"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "PostedJournalEntryId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "Guid",
+          "source_line": 168,
+          "type": "Guid"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TaxLotMutationBatchId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "Guid?",
+          "source_line": 172,
+          "type": "Guid?"
+        }
+      ],
+      "name": "AssetAccountingCorrectionReferenceDto",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.AssetAccountingCorrectionReferenceDto",
+      "references": [
+        "Meridian.Contracts.Ledger.AccountingBasisKindDto"
+      ],
+      "source": {
+        "line": 165,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 165,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "enum",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [
+        {
+          "explicit_value": true,
+          "name": "Acquisition",
+          "source_line": 15,
+          "value": "0"
+        },
+        {
+          "explicit_value": true,
+          "name": "Capitalization",
+          "source_line": 16,
+          "value": "1"
+        },
+        {
+          "explicit_value": true,
+          "name": "Valuation",
+          "source_line": 17,
+          "value": "2"
+        },
+        {
+          "explicit_value": true,
+          "name": "Income",
+          "source_line": 18,
+          "value": "3"
+        },
+        {
+          "explicit_value": true,
+          "name": "CorporateAction",
+          "source_line": 19,
+          "value": "4"
+        },
+        {
+          "explicit_value": true,
+          "name": "Impairment",
+          "source_line": 20,
+          "value": "5"
+        },
+        {
+          "explicit_value": true,
+          "name": "DepreciationAmortization",
+          "source_line": 21,
+          "value": "6"
+        },
+        {
+          "explicit_value": true,
+          "name": "Disposal",
+          "source_line": 22,
+          "value": "7"
+        }
+      ],
+      "fingerprint": "b59785aaf1519d5afb5bb098b7245b7f78b016b3a8b99ce42f5b7252dc0ec6dc",
+      "full_name": "Meridian.Contracts.AssetOperations.AssetAccountingEventKindDto",
+      "id": "Meridian.Contracts.AssetOperations.AssetAccountingEventKindDto",
+      "kind": "enum",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [],
+      "name": "AssetAccountingEventKindDto",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.AssetAccountingEventKindDto",
+      "references": [],
+      "source": {
+        "line": 13,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 13,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "844b740f720933088e72cfee0c78d090ffffd520314d93a184205e2558ada145",
+      "full_name": "Meridian.Contracts.AssetOperations.AssetAccountingEventScopeDto",
+      "id": "Meridian.Contracts.AssetOperations.AssetAccountingEventScopeDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AccountingBasis",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "AccountingBasisKindDto",
+          "source_line": 75,
+          "type": "AccountingBasisKindDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "BookPositionId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "Guid",
+          "source_line": 71,
+          "type": "Guid"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CompanyId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 78,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Dimensions",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "LedgerDimensionSetDto?",
+          "source_line": 79,
+          "type": "LedgerDimensionSetDto?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ExpectedBookPositionVersion",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "long",
+          "source_line": 72,
+          "type": "long"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ExpectedSecurityVersion",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "long",
+          "source_line": 70,
+          "type": "long"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "FundProfileId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 76,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "LedgerBookId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "Guid",
+          "source_line": 73,
+          "type": "Guid"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "PeriodId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "Guid",
+          "source_line": 74,
+          "type": "Guid"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "SecurityId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "Guid",
+          "source_line": 69,
+          "type": "Guid"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TenantId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 77,
+          "type": "string?"
+        }
+      ],
+      "name": "AssetAccountingEventScopeDto",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.AssetAccountingEventScopeDto",
+      "references": [
+        "Meridian.Contracts.Ledger.AccountingBasisKindDto",
+        "Meridian.Contracts.Ledger.LedgerDimensionSetDto"
+      ],
+      "source": {
+        "line": 68,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 68,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "6b7f6cb4bcb9cf8ef65d31b3429568a38131c7f494f14fc397d7858333f17b19",
+      "full_name": "Meridian.Contracts.AssetOperations.AssetAccountingEventSpineAppendResultDto",
+      "id": "Meridian.Contracts.AssetOperations.AssetAccountingEventSpineAppendResultDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Spine",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "AssetAccountingEventSpineDto",
+          "source_line": 253,
+          "type": "AssetAccountingEventSpineDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "WasReplay",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 254,
+          "type": "bool"
+        }
+      ],
+      "name": "AssetAccountingEventSpineAppendResultDto",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.AssetAccountingEventSpineAppendResultDto",
+      "references": [
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto"
+      ],
+      "source": {
+        "line": 252,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 252,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "05a755a4493936104e6acdf719244dd4e5d1c4e4600c9456c82ef9db1d4fd9a7",
+      "full_name": "Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto",
+      "id": "Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Correction",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "AssetAccountingCorrectionReferenceDto?",
+          "source_line": 193,
+          "type": "AssetAccountingCorrectionReferenceDto?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Currency",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 184,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "DraftedCandidate",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "PostingRuleJournalCandidateRequestDto?",
+          "source_line": 194,
+          "type": "PostingRuleJournalCandidateRequestDto?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "DraftedCandidateFingerprint",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 196,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "DraftedCandidateResult",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "PostingRuleJournalCandidateResultDto?",
+          "source_line": 195,
+          "type": "PostingRuleJournalCandidateResultDto?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "DraftedCandidateResultFingerprint",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 197,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "DraftedLotMutation",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "AssetLotMutationInstructionDto?",
+          "source_line": 198,
+          "type": "AssetLotMutationInstructionDto?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "DraftedLotMutationFingerprint",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 199,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EconomicEvent",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "EconomicEventReferenceDto",
+          "source_line": 186,
+          "type": "EconomicEventReferenceDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EffectiveDate",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "DateOnly",
+          "source_line": 182,
+          "type": "DateOnly"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EventAmount",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 183,
+          "type": "decimal"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EventId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "Guid",
+          "source_line": 178,
+          "type": "Guid"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EventKind",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "AssetAccountingEventKindDto",
+          "source_line": 179,
+          "type": "AssetAccountingEventKindDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EventVersion",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "long",
+          "source_line": 180,
+          "type": "long"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "PostedJournalImpact",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "PostedJournalImpactDto?",
+          "source_line": 191,
+          "type": "PostedJournalImpactDto?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ProjectedEffect",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "ProjectedAccountingEffectDto?",
+          "source_line": 190,
+          "type": "ProjectedAccountingEffectDto?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ProjectionLineage",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "ProjectionLineageDto",
+          "source_line": 187,
+          "type": "ProjectionLineageDto"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 201,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Scope",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "AssetAccountingEventScopeDto",
+          "source_line": 185,
+          "type": "AssetAccountingEventScopeDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "SpineVersion",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "long",
+          "source_line": 181,
+          "type": "long"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "AssetAccountingStageEvidenceDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Stages",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<AssetAccountingStageEvidenceDto>",
+          "source_line": 203,
+          "type": "IReadOnlyList<AssetAccountingStageEvidenceDto>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TaxLotMutationBatchId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "Guid?",
+          "source_line": 192,
+          "type": "Guid?"
+        }
+      ],
+      "name": "AssetAccountingEventSpineDto",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto",
+      "references": [
+        "Meridian.Contracts.AssetOperations.AssetAccountingCorrectionReferenceDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventKindDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventScopeDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingStageEvidenceDto",
+        "Meridian.Contracts.AssetOperations.AssetLotMutationInstructionDto",
+        "Meridian.Contracts.AssetOperations.EconomicEventReferenceDto",
+        "Meridian.Contracts.AssetOperations.PostedJournalImpactDto",
+        "Meridian.Contracts.AssetOperations.ProjectedAccountingEffectDto",
+        "Meridian.Contracts.AssetOperations.ProjectionLineageDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto",
+        "Meridian.Contracts.Ledger.PostingRuleJournalCandidateRequestDto",
+        "Meridian.Contracts.Ledger.PostingRuleJournalCandidateResultDto"
+      ],
+      "source": {
+        "line": 177,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 177,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "class",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "a5d2814c3c5123cfe8ad69eacd2e83a57780c2b5c633b93641c4b4c83ef2f51c",
+      "full_name": "Meridian.Contracts.AssetOperations.AssetAccountingEventSpineValidator",
+      "id": "Meridian.Contracts.AssetOperations.AssetAccountingEventSpineValidator",
+      "kind": "class",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [],
+      "name": "AssetAccountingEventSpineValidator",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.AssetAccountingEventSpineValidator",
+      "references": [],
+      "source": {
+        "line": 376,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 376,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "class",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "bbbb0374483b5701d696b4e7ebdabf29950e12fdd7f0e354b4f2f874be2d11f5",
+      "full_name": "Meridian.Contracts.AssetOperations.AssetAccountingEventTypeNames",
+      "id": "Meridian.Contracts.AssetOperations.AssetAccountingEventTypeNames",
+      "kind": "class",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [],
+      "name": "AssetAccountingEventTypeNames",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.AssetAccountingEventTypeNames",
+      "references": [],
+      "source": {
+        "line": 25,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 25,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "class",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "0f3009cf1488050a9677f169d7bbda35c38f26875615df4c5b21d4bcd1597648",
+      "full_name": "Meridian.Contracts.AssetOperations.AssetAccountingEvidenceSubjects",
+      "id": "Meridian.Contracts.AssetOperations.AssetAccountingEvidenceSubjects",
+      "kind": "class",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [],
+      "name": "AssetAccountingEvidenceSubjects",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.AssetAccountingEvidenceSubjects",
+      "references": [],
+      "source": {
+        "line": 27,
+        "path": "src/Meridian.Contracts/AssetOperations/RetainedEvidenceIdentityDto.cs"
+      },
+      "sources": [
+        {
+          "line": 27,
+          "path": "src/Meridian.Contracts/AssetOperations/RetainedEvidenceIdentityDto.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "enum",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [
+        {
+          "explicit_value": true,
+          "name": "Expected",
+          "source_line": 56,
+          "value": "0"
+        },
+        {
+          "explicit_value": true,
+          "name": "Projected",
+          "source_line": 57,
+          "value": "1"
+        },
+        {
+          "explicit_value": true,
+          "name": "Drafted",
+          "source_line": 58,
+          "value": "2"
+        },
+        {
+          "explicit_value": true,
+          "name": "Approved",
+          "source_line": 59,
+          "value": "3"
+        },
+        {
+          "explicit_value": true,
+          "name": "Posted",
+          "source_line": 60,
+          "value": "4"
+        },
+        {
+          "explicit_value": true,
+          "name": "Reconciled",
+          "source_line": 61,
+          "value": "5"
+        },
+        {
+          "explicit_value": true,
+          "name": "Reported",
+          "source_line": 62,
+          "value": "6"
+        }
+      ],
+      "fingerprint": "0aec82207f85bcfa60f78deb449ffea1c3b314b784bece5ccd2051e4bb130e3e",
+      "full_name": "Meridian.Contracts.AssetOperations.AssetAccountingLifecycleStageDto",
+      "id": "Meridian.Contracts.AssetOperations.AssetAccountingLifecycleStageDto",
+      "kind": "enum",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [],
+      "name": "AssetAccountingLifecycleStageDto",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.AssetAccountingLifecycleStageDto",
+      "references": [],
+      "source": {
+        "line": 54,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 54,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "fcd58243364c9c30ea93b91666b50d8fbdc6f3eea70a576af6e7da5938365470",
+      "full_name": "Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateDto",
+      "id": "Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Candidate",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "PostingRuleJournalCandidateResultDto",
+          "source_line": 326,
+          "type": "PostingRuleJournalCandidateResultDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Spine",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "AssetAccountingEventSpineDto",
+          "source_line": 325,
+          "type": "AssetAccountingEventSpineDto"
+        }
+      ],
+      "name": "AssetAccountingPostingCandidateDto",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateDto",
+      "references": [
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto",
+        "Meridian.Contracts.Ledger.PostingRuleJournalCandidateResultDto"
+      ],
+      "source": {
+        "line": 324,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 324,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "20a0c8adfc8338325856d79bb7fc8d2dd408bad0835235993259e1159646c35d",
+      "full_name": "Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateRequestDto",
+      "id": "Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateRequestDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AccountingTimestamp",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "DateTimeOffset",
+          "source_line": 310,
+          "type": "DateTimeOffset"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Actor",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 309,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CorrectionApproval",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "LedgerAdjustmentApprovalMetadataDto?",
+          "source_line": 319,
+          "type": "LedgerAdjustmentApprovalMetadataDto?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CorrelationId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "Guid?",
+          "source_line": 316,
+          "type": "Guid?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CounterpartyId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 317,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Currency",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 308,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Description",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 311,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EconomicEvent",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "EconomicEventReferenceDto",
+          "source_line": 305,
+          "type": "EconomicEventReferenceDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EventAmount",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 307,
+          "type": "decimal"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EventKind",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "AssetAccountingEventKindDto",
+          "source_line": 303,
+          "type": "AssetAccountingEventKindDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ExpectedPeriodVersion",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "long",
+          "source_line": 313,
+          "type": "long"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ExpectedSpineVersion",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "long",
+          "source_line": 312,
+          "type": "long"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "InstrumentSymbol",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 318,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "LotMutation",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "AssetLotMutationInstructionDto?",
+          "source_line": 315,
+          "type": "AssetLotMutationInstructionDto?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ProjectionLineage",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "ProjectionLineageDto",
+          "source_line": 306,
+          "type": "ProjectionLineageDto"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 321,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Scope",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "AssetAccountingEventScopeDto",
+          "source_line": 304,
+          "type": "AssetAccountingEventScopeDto"
+        }
+      ],
+      "name": "AssetAccountingPostingCandidateRequestDto",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateRequestDto",
+      "references": [
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventKindDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventScopeDto",
+        "Meridian.Contracts.AssetOperations.AssetLotMutationInstructionDto",
+        "Meridian.Contracts.AssetOperations.EconomicEventReferenceDto",
+        "Meridian.Contracts.AssetOperations.ProjectionLineageDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto",
+        "Meridian.Contracts.Ledger.LedgerAdjustmentApprovalMetadataDto"
+      ],
+      "source": {
+        "line": 302,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 302,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "c3aa46dcf946fc27646eb15161a6e2f505a3eb5b5ef3c806651515c7cbfd16a7",
+      "full_name": "Meridian.Contracts.AssetOperations.AssetAccountingStageEvidenceDto",
+      "id": "Meridian.Contracts.AssetOperations.AssetAccountingStageEvidenceDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AttestedAtUtc",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "DateTimeOffset",
+          "source_line": 86,
+          "type": "DateTimeOffset"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AttestedBy",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 87,
+          "type": "string"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Evidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 92,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Notes",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 90,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ReferenceId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 89,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Stage",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "AssetAccountingLifecycleStageDto",
+          "source_line": 85,
+          "type": "AssetAccountingLifecycleStageDto"
+        }
+      ],
+      "name": "AssetAccountingStageEvidenceDto",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.AssetAccountingStageEvidenceDto",
+      "references": [
+        "Meridian.Contracts.AssetOperations.AssetAccountingLifecycleStageDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+      ],
+      "source": {
+        "line": 84,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 84,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "1c496a140b50b00942933fdca8f0cd0d3e114a7c7003c555f739e902f48ce71b",
+      "full_name": "Meridian.Contracts.AssetOperations.AssetAcquisitionLotDto",
+      "id": "Meridian.Contracts.AssetOperations.AssetAcquisitionLotDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AccountId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 270,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AcquiredDate",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "DateOnly",
+          "source_line": 267,
+          "type": "DateOnly"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "LotId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 266,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Quantity",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 268,
+          "type": "decimal"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TaxLotRecordId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "Guid",
+          "source_line": 265,
+          "type": "Guid"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "UnitCost",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 269,
+          "type": "decimal"
+        }
+      ],
+      "name": "AssetAcquisitionLotDto",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.AssetAcquisitionLotDto",
+      "references": [],
+      "source": {
+        "line": 264,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 264,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "7d1a47c2ca6b6fa88d56e51080ef8860e9e8617823b026f55073f5a7975ae54b",
       "full_name": "Meridian.Contracts.AssetOperations.AssetActualActivityDto",
       "id": "Meridian.Contracts.AssetOperations.AssetActualActivityDto",
       "kind": "record",
@@ -45228,7 +47571,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 73,
+          "source_line": 85,
           "type": "Guid"
         },
         {
@@ -45242,7 +47585,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 75,
+          "source_line": 87,
           "type": "string"
         },
         {
@@ -45256,7 +47599,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "decimal",
-          "source_line": 78,
+          "source_line": 90,
           "type": "decimal"
         },
         {
@@ -45270,7 +47613,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 79,
+          "source_line": 91,
           "type": "string"
         },
         {
@@ -45284,7 +47627,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateOnly",
-          "source_line": 76,
+          "source_line": 88,
           "type": "DateOnly"
         },
         {
@@ -45298,7 +47641,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 83,
+          "source_line": 95,
           "type": "string?"
         },
         {
@@ -45313,8 +47656,22 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "JsonElement?",
-          "source_line": 84,
+          "source_line": 96,
           "type": "JsonElement?"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 98,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
         },
         {
           "collection": false,
@@ -45327,7 +47684,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 74,
+          "source_line": 86,
           "type": "Guid"
         },
         {
@@ -45341,7 +47698,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "DateOnly?",
-          "source_line": 77,
+          "source_line": 89,
           "type": "DateOnly?"
         },
         {
@@ -45355,7 +47712,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 81,
+          "source_line": 93,
           "type": "string"
         },
         {
@@ -45369,7 +47726,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 82,
+          "source_line": 94,
           "type": "string?"
         },
         {
@@ -45383,7 +47740,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 80,
+          "source_line": 92,
           "type": "string"
         }
       ],
@@ -45391,14 +47748,16 @@
       "namespace": "Meridian.Contracts.AssetOperations",
       "partial": false,
       "qualified_name": "Meridian.Contracts.AssetOperations.AssetActualActivityDto",
-      "references": [],
+      "references": [
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+      ],
       "source": {
-        "line": 72,
+        "line": 84,
         "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
       },
       "sources": [
         {
-          "line": 72,
+          "line": 84,
           "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
         }
       ],
@@ -45417,7 +47776,7 @@
         "asset-operations-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "581a696e0c9411ffa8317b09d8b2fc745d230862a2a553c2addcf22ef6e3c25d",
+      "fingerprint": "036b479d00ac65dfda22916a279053ff3e7d49c54a8674cd34f26288b69f2e94",
       "full_name": "Meridian.Contracts.AssetOperations.AssetCashFlowProjectionRunDto",
       "id": "Meridian.Contracts.AssetOperations.AssetCashFlowProjectionRunDto",
       "kind": "record",
@@ -45436,7 +47795,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 47,
+          "source_line": 53,
           "type": "string"
         },
         {
@@ -45451,7 +47810,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "JsonElement?",
-          "source_line": 52,
+          "source_line": 58,
           "type": "JsonElement?"
         },
         {
@@ -45465,7 +47824,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset",
-          "source_line": 49,
+          "source_line": 55,
           "type": "DateTimeOffset"
         },
         {
@@ -45479,7 +47838,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateOnly",
-          "source_line": 46,
+          "source_line": 52,
           "type": "DateOnly"
         },
         {
@@ -45493,8 +47852,22 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 44,
+          "source_line": 50,
           "type": "Guid"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 60,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
         },
         {
           "collection": false,
@@ -45507,7 +47880,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 45,
+          "source_line": 51,
           "type": "Guid"
         },
         {
@@ -45521,7 +47894,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 50,
+          "source_line": 56,
           "type": "string"
         },
         {
@@ -45535,7 +47908,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 51,
+          "source_line": 57,
           "type": "string?"
         },
         {
@@ -45549,7 +47922,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 48,
+          "source_line": 54,
           "type": "string"
         }
       ],
@@ -45557,14 +47930,16 @@
       "namespace": "Meridian.Contracts.AssetOperations",
       "partial": false,
       "qualified_name": "Meridian.Contracts.AssetOperations.AssetCashFlowProjectionRunDto",
-      "references": [],
+      "references": [
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+      ],
       "source": {
-        "line": 43,
+        "line": 49,
         "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
       },
       "sources": [
         {
-          "line": 43,
+          "line": 49,
           "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
         }
       ],
@@ -45583,7 +47958,174 @@
         "asset-operations-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "298557f4c2309653edccf9ac6755ae1f0e80748a3265042d1c3ca9f1618be486",
+      "fingerprint": "d5ce91e4e1ffa368ac7251596f3e1f370880c179c2ef42d6c6ed2f80eab07d6f",
+      "full_name": "Meridian.Contracts.AssetOperations.AssetDisposalLotSelectionDto",
+      "id": "Meridian.Contracts.AssetOperations.AssetDisposalLotSelectionDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "0m",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ExpectedCostBasis",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 281,
+          "type": "decimal"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ExpectedOpenQuantity",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 276,
+          "type": "decimal"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "0m",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ExpectedUnitCost",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 280,
+          "type": "decimal"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ExpectedVersion",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "long",
+          "source_line": 275,
+          "type": "long"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "LotId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 274,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Quantity",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 277,
+          "type": "decimal"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "SelectionEvidenceId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 279,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "SelectionOrdinal",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "int",
+          "source_line": 278,
+          "type": "int"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TaxLotRecordId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "Guid",
+          "source_line": 273,
+          "type": "Guid"
+        }
+      ],
+      "name": "AssetDisposalLotSelectionDto",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.AssetDisposalLotSelectionDto",
+      "references": [],
+      "source": {
+        "line": 272,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 272,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "3ada00eba2b25eb6ab1f1201bf790268849dc2f53004b2d31d58bae3691b0918",
       "full_name": "Meridian.Contracts.AssetOperations.AssetLedgerProjectionDto",
       "id": "Meridian.Contracts.AssetOperations.AssetLedgerProjectionDto",
       "kind": "record",
@@ -45602,7 +48144,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateOnly",
-          "source_line": 116,
+          "source_line": 137,
           "type": "DateOnly"
         },
         {
@@ -45616,7 +48158,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "decimal?",
-          "source_line": 120,
+          "source_line": 141,
           "type": "decimal?"
         },
         {
@@ -45630,7 +48172,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 121,
+          "source_line": 142,
           "type": "string"
         },
         {
@@ -45644,7 +48186,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "decimal?",
-          "source_line": 119,
+          "source_line": 140,
           "type": "decimal?"
         },
         {
@@ -45659,7 +48201,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "JsonElement?",
-          "source_line": 125,
+          "source_line": 146,
           "type": "JsonElement?"
         },
         {
@@ -45673,7 +48215,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 117,
+          "source_line": 138,
           "type": "string"
         },
         {
@@ -45687,7 +48229,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 113,
+          "source_line": 134,
           "type": "Guid"
         },
         {
@@ -45701,7 +48243,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 124,
+          "source_line": 145,
           "type": "string?"
         },
         {
@@ -45715,8 +48257,22 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 115,
+          "source_line": 136,
           "type": "string"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 148,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
         },
         {
           "collection": false,
@@ -45729,7 +48285,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 114,
+          "source_line": 135,
           "type": "Guid"
         },
         {
@@ -45743,7 +48299,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 122,
+          "source_line": 143,
           "type": "string"
         },
         {
@@ -45757,7 +48313,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 123,
+          "source_line": 144,
           "type": "string?"
         },
         {
@@ -45771,7 +48327,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 118,
+          "source_line": 139,
           "type": "string"
         }
       ],
@@ -45779,14 +48335,16 @@
       "namespace": "Meridian.Contracts.AssetOperations",
       "partial": false,
       "qualified_name": "Meridian.Contracts.AssetOperations.AssetLedgerProjectionDto",
-      "references": [],
+      "references": [
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+      ],
       "source": {
-        "line": 112,
+        "line": 133,
         "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
       },
       "sources": [
         {
-          "line": 112,
+          "line": 133,
           "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
         }
       ],
@@ -45805,7 +48363,7 @@
         "asset-operations-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "e7ff565f5374457e46203e61c232f4994a3416d4ab36d2484b0e894f14327c4a",
+      "fingerprint": "507d02a3e537dc13560172a6269c10fcd5d5af20ea5df8b5900994990ed3a81d",
       "full_name": "Meridian.Contracts.AssetOperations.AssetLifecycleEventDto",
       "id": "Meridian.Contracts.AssetOperations.AssetLifecycleEventDto",
       "kind": "record",
@@ -45824,7 +48382,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateOnly",
-          "source_line": 36,
+          "source_line": 39,
           "type": "DateOnly"
         },
         {
@@ -45838,7 +48396,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 34,
+          "source_line": 37,
           "type": "string"
         },
         {
@@ -45853,7 +48411,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "JsonElement?",
-          "source_line": 41,
+          "source_line": 44,
           "type": "JsonElement?"
         },
         {
@@ -45867,7 +48425,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 32,
+          "source_line": 35,
           "type": "Guid"
         },
         {
@@ -45881,7 +48439,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 35,
+          "source_line": 38,
           "type": "string"
         },
         {
@@ -45895,8 +48453,22 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset",
-          "source_line": 37,
+          "source_line": 40,
           "type": "DateTimeOffset"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 46,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
         },
         {
           "collection": false,
@@ -45909,7 +48481,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 33,
+          "source_line": 36,
           "type": "Guid"
         },
         {
@@ -45923,7 +48495,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 38,
+          "source_line": 41,
           "type": "string"
         },
         {
@@ -45937,7 +48509,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 39,
+          "source_line": 42,
           "type": "string?"
         },
         {
@@ -45951,7 +48523,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 40,
+          "source_line": 43,
           "type": "string"
         }
       ],
@@ -45959,14 +48531,16 @@
       "namespace": "Meridian.Contracts.AssetOperations",
       "partial": false,
       "qualified_name": "Meridian.Contracts.AssetOperations.AssetLifecycleEventDto",
-      "references": [],
+      "references": [
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+      ],
       "source": {
-        "line": 31,
+        "line": 34,
         "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
       },
       "sources": [
         {
-          "line": 31,
+          "line": 34,
           "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
         }
       ],
@@ -45985,7 +48559,279 @@
         "asset-operations-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "2f6ad142e17703acd5e58ee251117ba53fc959e5272b2c67957c1852acfcc29a",
+      "fingerprint": "6d08d8049cf49f4db4f322da2c3d835829b653c3a9ce0881fa23a45ca891b0ad",
+      "full_name": "Meridian.Contracts.AssetOperations.AssetLotMutationInstructionDto",
+      "id": "Meridian.Contracts.AssetOperations.AssetLotMutationInstructionDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Acquisition",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "AssetAcquisitionLotDto?",
+          "source_line": 289,
+          "type": "AssetAcquisitionLotDto?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AssetAccountId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 296,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CorrectionApproval",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "LedgerAdjustmentApprovalMetadataDto?",
+          "source_line": 295,
+          "type": "LedgerAdjustmentApprovalMetadataDto?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CorrectsJournalEntryId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "Guid?",
+          "source_line": 294,
+          "type": "Guid?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CorrectsMutationBatchId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "Guid?",
+          "source_line": 293,
+          "type": "Guid?"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "AssetDisposalLotSelectionDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "DisposalSelections",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<AssetDisposalLotSelectionDto>",
+          "source_line": 298,
+          "type": "IReadOnlyList<AssetDisposalLotSelectionDto>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Intent",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "AssetLotMutationIntentDto",
+          "source_line": 288,
+          "type": "AssetLotMutationIntentDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "PolicyRevision",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 292,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ReliefMethod",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 291,
+          "type": "string?"
+        }
+      ],
+      "name": "AssetLotMutationInstructionDto",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.AssetLotMutationInstructionDto",
+      "references": [
+        "Meridian.Contracts.AssetOperations.AssetAcquisitionLotDto",
+        "Meridian.Contracts.AssetOperations.AssetDisposalLotSelectionDto",
+        "Meridian.Contracts.AssetOperations.AssetLotMutationIntentDto",
+        "Meridian.Contracts.Ledger.LedgerAdjustmentApprovalMetadataDto"
+      ],
+      "source": {
+        "line": 287,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 287,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "class",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "3a29021c349ee3504cb7ebec3ea535c2529ae481dd452700ffe1f2d28ac4f40f",
+      "full_name": "Meridian.Contracts.AssetOperations.AssetLotMutationInstructionValidator",
+      "id": "Meridian.Contracts.AssetOperations.AssetLotMutationInstructionValidator",
+      "kind": "class",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [],
+      "name": "AssetLotMutationInstructionValidator",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.AssetLotMutationInstructionValidator",
+      "references": [],
+      "source": {
+        "line": 792,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 792,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "enum",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [
+        {
+          "explicit_value": true,
+          "name": "None",
+          "source_line": 259,
+          "value": "0"
+        },
+        {
+          "explicit_value": true,
+          "name": "Acquire",
+          "source_line": 260,
+          "value": "1"
+        },
+        {
+          "explicit_value": true,
+          "name": "Dispose",
+          "source_line": 261,
+          "value": "2"
+        }
+      ],
+      "fingerprint": "a40d4ff86665db714155e0e63b231d02afeea30edf67a3a513046baf00783c1e",
+      "full_name": "Meridian.Contracts.AssetOperations.AssetLotMutationIntentDto",
+      "id": "Meridian.Contracts.AssetOperations.AssetLotMutationIntentDto",
+      "kind": "enum",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [],
+      "name": "AssetLotMutationIntentDto",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.AssetLotMutationIntentDto",
+      "references": [],
+      "source": {
+        "line": 257,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 257,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "87370aecf0a071ebfdfa47041ff2fa2307684f1408fc356d4b4ddb2d6f7d5fff",
       "full_name": "Meridian.Contracts.AssetOperations.AssetOperationsDetailDto",
       "id": "Meridian.Contracts.AssetOperations.AssetOperationsDetailDto",
       "kind": "record",
@@ -46004,7 +48850,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<AssetActualActivityDto>",
-          "source_line": 206,
+          "source_line": 240,
           "type": "IReadOnlyList<AssetActualActivityDto>"
         },
         {
@@ -46018,7 +48864,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<BookPositionDto>",
-          "source_line": 217,
+          "source_line": 251,
           "type": "IReadOnlyList<BookPositionDto>"
         },
         {
@@ -46032,7 +48878,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<AssetCashFlowProjectionRunDto>",
-          "source_line": 204,
+          "source_line": 238,
           "type": "IReadOnlyList<AssetCashFlowProjectionRunDto>"
         },
         {
@@ -46046,7 +48892,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<InstrumentRoleDto>",
-          "source_line": 215,
+          "source_line": 249,
           "type": "IReadOnlyList<InstrumentRoleDto>"
         },
         {
@@ -46060,7 +48906,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<AssetLedgerProjectionDto>",
-          "source_line": 209,
+          "source_line": 243,
           "type": "IReadOnlyList<AssetLedgerProjectionDto>"
         },
         {
@@ -46074,7 +48920,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<AssetLifecycleEventDto>",
-          "source_line": 203,
+          "source_line": 237,
           "type": "IReadOnlyList<AssetLifecycleEventDto>"
         },
         {
@@ -46088,7 +48934,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<PositionEconomicStateDto>",
-          "source_line": 219,
+          "source_line": 253,
           "type": "IReadOnlyList<PositionEconomicStateDto>"
         },
         {
@@ -46102,7 +48948,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<AssetProjectedCashFlowDto>",
-          "source_line": 205,
+          "source_line": 239,
           "type": "IReadOnlyList<AssetProjectedCashFlowDto>"
         },
         {
@@ -46116,7 +48962,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<ProjectionLineageDto>",
-          "source_line": 221,
+          "source_line": 255,
           "type": "IReadOnlyList<ProjectionLineageDto>"
         },
         {
@@ -46130,7 +48976,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AssetOperationsReadinessDto",
-          "source_line": 210,
+          "source_line": 244,
           "type": "AssetOperationsReadinessDto"
         },
         {
@@ -46144,7 +48990,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<AssetReconciliationResultDto>",
-          "source_line": 208,
+          "source_line": 242,
           "type": "IReadOnlyList<AssetReconciliationResultDto>"
         },
         {
@@ -46158,8 +49004,22 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<AssetReconciliationRunDto>",
-          "source_line": 207,
+          "source_line": 241,
           "type": "IReadOnlyList<AssetReconciliationRunDto>"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 257,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
         },
         {
           "collection": false,
@@ -46172,7 +49032,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AssetOperationSubjectDto",
-          "source_line": 201,
+          "source_line": 235,
           "type": "AssetOperationSubjectDto"
         },
         {
@@ -46186,7 +49046,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<AssetTermsVersionDto>",
-          "source_line": 202,
+          "source_line": 236,
           "type": "IReadOnlyList<AssetTermsVersionDto>"
         },
         {
@@ -46200,7 +49060,7 @@
           "nullable": true,
           "origin": "property",
           "raw_type": "AssetTermsObligationsTimelineDto?",
-          "source_line": 213,
+          "source_line": 247,
           "type": "AssetTermsObligationsTimelineDto?"
         },
         {
@@ -46214,7 +49074,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<AssetLifecycleEventDto>",
-          "source_line": 211,
+          "source_line": 245,
           "type": "IReadOnlyList<AssetLifecycleEventDto>"
         }
       ],
@@ -46237,15 +49097,16 @@
         "Meridian.Contracts.AssetOperations.BookPositionDto",
         "Meridian.Contracts.AssetOperations.InstrumentRoleDto",
         "Meridian.Contracts.AssetOperations.PositionEconomicStateDto",
-        "Meridian.Contracts.AssetOperations.ProjectionLineageDto"
+        "Meridian.Contracts.AssetOperations.ProjectionLineageDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
       ],
       "source": {
-        "line": 200,
+        "line": 234,
         "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
       },
       "sources": [
         {
-          "line": 200,
+          "line": 234,
           "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
         }
       ],
@@ -46331,7 +49192,7 @@
         "asset-operations-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "a6b4b3faadffd9568a5df8fa53a8214ee44f4bedd07c1ab1c6a0586045184f76",
+      "fingerprint": "b328224f49f439c08240ae4c36229add76be1955af1b4fae37050ae1f2c5cb61",
       "full_name": "Meridian.Contracts.AssetOperations.AssetOperationsProjectionDto",
       "id": "Meridian.Contracts.AssetOperations.AssetOperationsProjectionDto",
       "kind": "record",
@@ -46350,7 +49211,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<AssetActualActivityDto>",
-          "source_line": 230,
+          "source_line": 266,
           "type": "IReadOnlyList<AssetActualActivityDto>"
         },
         {
@@ -46364,7 +49225,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<BookPositionDto>",
-          "source_line": 241,
+          "source_line": 277,
           "type": "IReadOnlyList<BookPositionDto>"
         },
         {
@@ -46378,7 +49239,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<AssetCashFlowProjectionRunDto>",
-          "source_line": 228,
+          "source_line": 264,
           "type": "IReadOnlyList<AssetCashFlowProjectionRunDto>"
         },
         {
@@ -46392,7 +49253,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<InstrumentRoleDto>",
-          "source_line": 239,
+          "source_line": 275,
           "type": "IReadOnlyList<InstrumentRoleDto>"
         },
         {
@@ -46406,7 +49267,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<AssetLedgerProjectionDto>",
-          "source_line": 233,
+          "source_line": 269,
           "type": "IReadOnlyList<AssetLedgerProjectionDto>"
         },
         {
@@ -46420,7 +49281,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<AssetLifecycleEventDto>",
-          "source_line": 227,
+          "source_line": 263,
           "type": "IReadOnlyList<AssetLifecycleEventDto>"
         },
         {
@@ -46434,7 +49295,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<PositionEconomicStateDto>",
-          "source_line": 243,
+          "source_line": 279,
           "type": "IReadOnlyList<PositionEconomicStateDto>"
         },
         {
@@ -46448,7 +49309,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<AssetProjectedCashFlowDto>",
-          "source_line": 229,
+          "source_line": 265,
           "type": "IReadOnlyList<AssetProjectedCashFlowDto>"
         },
         {
@@ -46462,7 +49323,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<ProjectionLineageDto>",
-          "source_line": 245,
+          "source_line": 281,
           "type": "IReadOnlyList<ProjectionLineageDto>"
         },
         {
@@ -46476,7 +49337,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AssetOperationsReadinessDto",
-          "source_line": 234,
+          "source_line": 270,
           "type": "AssetOperationsReadinessDto"
         },
         {
@@ -46490,7 +49351,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<AssetReconciliationResultDto>",
-          "source_line": 232,
+          "source_line": 268,
           "type": "IReadOnlyList<AssetReconciliationResultDto>"
         },
         {
@@ -46504,8 +49365,22 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<AssetReconciliationRunDto>",
-          "source_line": 231,
+          "source_line": 267,
           "type": "IReadOnlyList<AssetReconciliationRunDto>"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 283,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
         },
         {
           "collection": false,
@@ -46518,7 +49393,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AssetOperationSubjectDto",
-          "source_line": 225,
+          "source_line": 261,
           "type": "AssetOperationSubjectDto"
         },
         {
@@ -46532,7 +49407,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<AssetTermsVersionDto>",
-          "source_line": 226,
+          "source_line": 262,
           "type": "IReadOnlyList<AssetTermsVersionDto>"
         },
         {
@@ -46546,7 +49421,7 @@
           "nullable": true,
           "origin": "property",
           "raw_type": "AssetTermsObligationsTimelineDto?",
-          "source_line": 237,
+          "source_line": 273,
           "type": "AssetTermsObligationsTimelineDto?"
         },
         {
@@ -46560,7 +49435,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<AssetLifecycleEventDto>",
-          "source_line": 235,
+          "source_line": 271,
           "type": "IReadOnlyList<AssetLifecycleEventDto>"
         }
       ],
@@ -46583,15 +49458,16 @@
         "Meridian.Contracts.AssetOperations.BookPositionDto",
         "Meridian.Contracts.AssetOperations.InstrumentRoleDto",
         "Meridian.Contracts.AssetOperations.PositionEconomicStateDto",
-        "Meridian.Contracts.AssetOperations.ProjectionLineageDto"
+        "Meridian.Contracts.AssetOperations.ProjectionLineageDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
       ],
       "source": {
-        "line": 224,
+        "line": 260,
         "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
       },
       "sources": [
         {
-          "line": 224,
+          "line": 260,
           "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
         }
       ],
@@ -46610,7 +49486,7 @@
         "asset-operations-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "45da9451fa5ef820f4bffb8c907bd1a8f78af3a4c0c6b63a77696f285ee317a3",
+      "fingerprint": "b7079443ceb6c666a5dfcc7dafcc2ade407d2f412075ab01ddb478daf6f2f6c0",
       "full_name": "Meridian.Contracts.AssetOperations.AssetOperationsReadinessDto",
       "id": "Meridian.Contracts.AssetOperations.AssetOperationsReadinessDto",
       "kind": "record",
@@ -46629,7 +49505,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 191,
+          "source_line": 222,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -46643,7 +49519,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset",
-          "source_line": 195,
+          "source_line": 226,
           "type": "DateTimeOffset"
         },
         {
@@ -46658,7 +49534,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "JsonElement?",
-          "source_line": 198,
+          "source_line": 229,
           "type": "JsonElement?"
         },
         {
@@ -46672,7 +49548,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 193,
+          "source_line": 224,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -46686,8 +49562,22 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 192,
+          "source_line": 223,
           "type": "IReadOnlyList<string>"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 231,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
         },
         {
           "collection": false,
@@ -46700,7 +49590,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 189,
+          "source_line": 220,
           "type": "Guid"
         },
         {
@@ -46714,7 +49604,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 196,
+          "source_line": 227,
           "type": "string"
         },
         {
@@ -46728,7 +49618,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 197,
+          "source_line": 228,
           "type": "string?"
         },
         {
@@ -46742,7 +49632,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 190,
+          "source_line": 221,
           "type": "string"
         },
         {
@@ -46756,7 +49646,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 194,
+          "source_line": 225,
           "type": "IReadOnlyList<string>"
         }
       ],
@@ -46764,14 +49654,16 @@
       "namespace": "Meridian.Contracts.AssetOperations",
       "partial": false,
       "qualified_name": "Meridian.Contracts.AssetOperations.AssetOperationsReadinessDto",
-      "references": [],
+      "references": [
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+      ],
       "source": {
-        "line": 188,
+        "line": 219,
         "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
       },
       "sources": [
         {
-          "line": 188,
+          "line": 219,
           "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
         }
       ],
@@ -46899,7 +49791,7 @@
         "asset-operations-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "2e4a8d93308c3d67745a25e289f831b61229b0167460f8d5a0d8ae4b8a0b80f1",
+      "fingerprint": "f26eb35a86de7a0e7909fbdeb36f3387ce7960354c3249c55869a57cc66ea3e0",
       "full_name": "Meridian.Contracts.AssetOperations.AssetOperationsWriteApprovalDto",
       "id": "Meridian.Contracts.AssetOperations.AssetOperationsWriteApprovalDto",
       "kind": "record",
@@ -46918,7 +49810,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 249,
+          "source_line": 287,
           "type": "string"
         },
         {
@@ -46932,7 +49824,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 250,
+          "source_line": 288,
           "type": "string"
         },
         {
@@ -46946,7 +49838,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset",
-          "source_line": 252,
+          "source_line": 290,
           "type": "DateTimeOffset"
         },
         {
@@ -46960,7 +49852,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 251,
+          "source_line": 289,
           "type": "string"
         }
       ],
@@ -46970,12 +49862,12 @@
       "qualified_name": "Meridian.Contracts.AssetOperations.AssetOperationsWriteApprovalDto",
       "references": [],
       "source": {
-        "line": 248,
+        "line": 286,
         "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
       },
       "sources": [
         {
-          "line": 248,
+          "line": 286,
           "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
         }
       ],
@@ -46994,7 +49886,7 @@
         "asset-operations-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "568a3471e93f9060c264afd6366c46b09a5c0ad0388b513d3624d1b0ce0dbf75",
+      "fingerprint": "364d35a8b7087cf5de21e334f815ee04770c6a67f28d188c8f910828ef2485c9",
       "full_name": "Meridian.Contracts.AssetOperations.AssetProjectedCashFlowDto",
       "id": "Meridian.Contracts.AssetOperations.AssetProjectedCashFlowDto",
       "kind": "record",
@@ -47014,7 +49906,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "DateOnly?",
-          "source_line": 65,
+          "source_line": 74,
           "type": "DateOnly?"
         },
         {
@@ -47029,7 +49921,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "DateOnly?",
-          "source_line": 64,
+          "source_line": 73,
           "type": "DateOnly?"
         },
         {
@@ -47043,7 +49935,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "decimal",
-          "source_line": 61,
+          "source_line": 70,
           "type": "decimal"
         },
         {
@@ -47058,7 +49950,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "decimal?",
-          "source_line": 67,
+          "source_line": 76,
           "type": "decimal?"
         },
         {
@@ -47072,7 +49964,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 62,
+          "source_line": 71,
           "type": "string"
         },
         {
@@ -47086,7 +49978,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateOnly",
-          "source_line": 60,
+          "source_line": 69,
           "type": "DateOnly"
         },
         {
@@ -47101,7 +49993,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "JsonElement?",
-          "source_line": 70,
+          "source_line": 79,
           "type": "JsonElement?"
         },
         {
@@ -47115,7 +50007,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 59,
+          "source_line": 68,
           "type": "string"
         },
         {
@@ -47130,7 +50022,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "decimal?",
-          "source_line": 66,
+          "source_line": 75,
           "type": "decimal?"
         },
         {
@@ -47144,7 +50036,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 55,
+          "source_line": 64,
           "type": "Guid"
         },
         {
@@ -47158,8 +50050,22 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 56,
+          "source_line": 65,
           "type": "Guid"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 81,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
         },
         {
           "collection": false,
@@ -47172,7 +50078,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 57,
+          "source_line": 66,
           "type": "Guid"
         },
         {
@@ -47186,7 +50092,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "int",
-          "source_line": 58,
+          "source_line": 67,
           "type": "int"
         },
         {
@@ -47201,7 +50107,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 68,
+          "source_line": 77,
           "type": "string?"
         },
         {
@@ -47216,7 +50122,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 69,
+          "source_line": 78,
           "type": "string?"
         },
         {
@@ -47230,7 +50136,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 63,
+          "source_line": 72,
           "type": "string"
         }
       ],
@@ -47238,14 +50144,16 @@
       "namespace": "Meridian.Contracts.AssetOperations",
       "partial": false,
       "qualified_name": "Meridian.Contracts.AssetOperations.AssetProjectedCashFlowDto",
-      "references": [],
+      "references": [
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+      ],
       "source": {
-        "line": 54,
+        "line": 63,
         "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
       },
       "sources": [
         {
-          "line": 54,
+          "line": 63,
           "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
         }
       ],
@@ -47264,7 +50172,7 @@
         "asset-operations-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "26cd001725094308885e4adef56a8adb3c175587ac68d4860541f17bfd30fa57",
+      "fingerprint": "41a043e86257f8ecb662ef3167bf944a9f0b5ab858a53448d95e0021fb8f37ad",
       "full_name": "Meridian.Contracts.AssetOperations.AssetReconciliationResultDto",
       "id": "Meridian.Contracts.AssetOperations.AssetReconciliationResultDto",
       "kind": "record",
@@ -47283,7 +50191,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "decimal?",
-          "source_line": 103,
+          "source_line": 121,
           "type": "decimal?"
         },
         {
@@ -47297,7 +50205,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "DateOnly?",
-          "source_line": 106,
+          "source_line": 124,
           "type": "DateOnly?"
         },
         {
@@ -47311,7 +50219,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 109,
+          "source_line": 127,
           "type": "string?"
         },
         {
@@ -47325,7 +50233,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "decimal?",
-          "source_line": 102,
+          "source_line": 120,
           "type": "decimal?"
         },
         {
@@ -47339,8 +50247,190 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "DateOnly?",
-          "source_line": 105,
+          "source_line": 123,
           "type": "DateOnly?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ExtensionPayload",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "JsonElement?",
+          "source_line": 128,
+          "type": "JsonElement?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "MatchStatus",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 119,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ReconciliationResultId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "Guid",
+          "source_line": 116,
+          "type": "Guid"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ReconciliationRunId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "Guid",
+          "source_line": 117,
+          "type": "Guid"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 130,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "SecurityId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "Guid",
+          "source_line": 118,
+          "type": "Guid"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "SourceDomain",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 125,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "SourceEntityId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 126,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "VarianceAmount",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "decimal?",
+          "source_line": 122,
+          "type": "decimal?"
+        }
+      ],
+      "name": "AssetReconciliationResultDto",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.AssetReconciliationResultDto",
+      "references": [
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+      ],
+      "source": {
+        "line": 115,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 115,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "2789a3ec05eb035675283132bbf75f3b5847e059eeb35e7d5ee7c80aa25d937f",
+      "full_name": "Meridian.Contracts.AssetOperations.AssetReconciliationRunDto",
+      "id": "Meridian.Contracts.AssetOperations.AssetReconciliationRunDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CompletedAt",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "DateTimeOffset?",
+          "source_line": 107,
+          "type": "DateTimeOffset?"
         },
         {
           "collection": false,
@@ -47364,177 +50454,11 @@
           "json_ignored": false,
           "json_name": null,
           "key_type": null,
-          "name": "MatchStatus",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 101,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ReconciliationResultId",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "Guid",
-          "source_line": 98,
-          "type": "Guid"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ReconciliationRunId",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "Guid",
-          "source_line": 99,
-          "type": "Guid"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "SecurityId",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "Guid",
-          "source_line": 100,
-          "type": "Guid"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "SourceDomain",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 107,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "SourceEntityId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 108,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "VarianceAmount",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "decimal?",
-          "source_line": 104,
-          "type": "decimal?"
-        }
-      ],
-      "name": "AssetReconciliationResultDto",
-      "namespace": "Meridian.Contracts.AssetOperations",
-      "partial": false,
-      "qualified_name": "Meridian.Contracts.AssetOperations.AssetReconciliationResultDto",
-      "references": [],
-      "source": {
-        "line": 97,
-        "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
-      },
-      "sources": [
-        {
-          "line": 97,
-          "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
-        }
-      ],
-      "type_parameters": []
-    },
-    {
-      "base_types": [],
-      "classification": "dto",
-      "containing_type": null,
-      "contract_sets": [
-        "all-contracts",
-        "asset-operations-contracts"
-      ],
-      "diagram": true,
-      "diagram_contract_sets": [
-        "asset-operations-contracts"
-      ],
-      "enum_members": [],
-      "fingerprint": "4e6e798d96f2585321696a479ebfd0272a37a0e63faa9bae3e5733ed30ba2e47",
-      "full_name": "Meridian.Contracts.AssetOperations.AssetReconciliationRunDto",
-      "id": "Meridian.Contracts.AssetOperations.AssetReconciliationRunDto",
-      "kind": "record",
-      "mapped_schemas": [
-        "asset_operations"
-      ],
-      "members": [
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "CompletedAt",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "DateTimeOffset?",
-          "source_line": 92,
-          "type": "DateTimeOffset?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ExtensionPayload",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "JsonElement?",
-          "source_line": 95,
-          "type": "JsonElement?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
           "name": "ProjectionRunId",
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 89,
+          "source_line": 104,
           "type": "Guid?"
         },
         {
@@ -47548,7 +50472,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 87,
+          "source_line": 102,
           "type": "Guid"
         },
         {
@@ -47562,8 +50486,22 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset",
-          "source_line": 91,
+          "source_line": 106,
           "type": "DateTimeOffset"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 112,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
         },
         {
           "collection": false,
@@ -47576,7 +50514,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 88,
+          "source_line": 103,
           "type": "Guid"
         },
         {
@@ -47590,7 +50528,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 93,
+          "source_line": 108,
           "type": "string"
         },
         {
@@ -47604,7 +50542,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 94,
+          "source_line": 109,
           "type": "string?"
         },
         {
@@ -47618,7 +50556,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 90,
+          "source_line": 105,
           "type": "string"
         }
       ],
@@ -47626,14 +50564,16 @@
       "namespace": "Meridian.Contracts.AssetOperations",
       "partial": false,
       "qualified_name": "Meridian.Contracts.AssetOperations.AssetReconciliationRunDto",
-      "references": [],
+      "references": [
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+      ],
       "source": {
-        "line": 86,
+        "line": 101,
         "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
       },
       "sources": [
         {
-          "line": 86,
+          "line": 101,
           "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
         }
       ],
@@ -47652,7 +50592,7 @@
         "asset-operations-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "086648b5c52227de615a8066ad332ac3cae3b343be5416b449be64402cc387bc",
+      "fingerprint": "57f1b373471b98856ac64f4b206546222e4b98c6fffa1725918e4632480b6bc5",
       "full_name": "Meridian.Contracts.AssetOperations.AssetTermsObligationsTimelineDto",
       "id": "Meridian.Contracts.AssetOperations.AssetTermsObligationsTimelineDto",
       "kind": "record",
@@ -47671,7 +50611,7 @@
           "nullable": true,
           "origin": "property",
           "raw_type": "string?",
-          "source_line": 183,
+          "source_line": 212,
           "type": "string?"
         },
         {
@@ -47685,7 +50625,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 174,
+          "source_line": 203,
           "type": "string"
         },
         {
@@ -47699,7 +50639,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<AssetTermsObligationTimelineEventDto>",
-          "source_line": 176,
+          "source_line": 205,
           "type": "IReadOnlyList<AssetTermsObligationTimelineEventDto>"
         },
         {
@@ -47714,7 +50654,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "JsonElement?",
-          "source_line": 181,
+          "source_line": 210,
           "type": "JsonElement?"
         },
         {
@@ -47728,7 +50668,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset",
-          "source_line": 178,
+          "source_line": 207,
           "type": "DateTimeOffset"
         },
         {
@@ -47742,8 +50682,22 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateOnly",
-          "source_line": 173,
+          "source_line": 202,
           "type": "DateOnly"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 216,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
         },
         {
           "collection": false,
@@ -47756,7 +50710,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 172,
+          "source_line": 201,
           "type": "Guid"
         },
         {
@@ -47770,7 +50724,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 179,
+          "source_line": 208,
           "type": "string"
         },
         {
@@ -47784,7 +50738,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 180,
+          "source_line": 209,
           "type": "string?"
         },
         {
@@ -47798,7 +50752,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 175,
+          "source_line": 204,
           "type": "string"
         },
         {
@@ -47812,7 +50766,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AssetTimelineVarianceDto>",
-          "source_line": 185,
+          "source_line": 214,
           "type": "IReadOnlyList<AssetTimelineVarianceDto>"
         },
         {
@@ -47826,7 +50780,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 177,
+          "source_line": 206,
           "type": "IReadOnlyList<string>"
         }
       ],
@@ -47836,15 +50790,16 @@
       "qualified_name": "Meridian.Contracts.AssetOperations.AssetTermsObligationsTimelineDto",
       "references": [
         "Meridian.Contracts.AssetOperations.AssetTermsObligationTimelineEventDto",
-        "Meridian.Contracts.AssetOperations.AssetTimelineVarianceDto"
+        "Meridian.Contracts.AssetOperations.AssetTimelineVarianceDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
       ],
       "source": {
-        "line": 171,
+        "line": 200,
         "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
       },
       "sources": [
         {
-          "line": 171,
+          "line": 200,
           "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
         }
       ],
@@ -47863,7 +50818,7 @@
         "asset-operations-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "aadd53113481d78b3c1fb00a3b2322ff5c7ce14ddb62f9a7600b30f7d530e29d",
+      "fingerprint": "51e1af94714e1d2e5f05020db9f238b5640bbbb520c0047a25420c34ec37a104",
       "full_name": "Meridian.Contracts.AssetOperations.AssetTermsObligationTimelineEventDto",
       "id": "Meridian.Contracts.AssetOperations.AssetTermsObligationTimelineEventDto",
       "kind": "record",
@@ -47882,7 +50837,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "DateOnly?",
-          "source_line": 135,
+          "source_line": 159,
           "type": "DateOnly?"
         },
         {
@@ -47896,7 +50851,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "DateOnly?",
-          "source_line": 134,
+          "source_line": 158,
           "type": "DateOnly?"
         },
         {
@@ -47910,7 +50865,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "decimal?",
-          "source_line": 137,
+          "source_line": 161,
           "type": "decimal?"
         },
         {
@@ -47924,7 +50879,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 139,
+          "source_line": 163,
           "type": "string"
         },
         {
@@ -47938,7 +50893,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateOnly",
-          "source_line": 132,
+          "source_line": 156,
           "type": "DateOnly"
         },
         {
@@ -47952,7 +50907,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 130,
+          "source_line": 154,
           "type": "string"
         },
         {
@@ -47966,7 +50921,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 131,
+          "source_line": 155,
           "type": "string"
         },
         {
@@ -47980,7 +50935,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 143,
+          "source_line": 167,
           "type": "string?"
         },
         {
@@ -47994,7 +50949,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "decimal?",
-          "source_line": 136,
+          "source_line": 160,
           "type": "decimal?"
         },
         {
@@ -48009,7 +50964,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "JsonElement?",
-          "source_line": 146,
+          "source_line": 170,
           "type": "JsonElement?"
         },
         {
@@ -48023,7 +50978,7 @@
           "nullable": true,
           "origin": "property",
           "raw_type": "string?",
-          "source_line": 148,
+          "source_line": 172,
           "type": "string?"
         },
         {
@@ -48037,7 +50992,7 @@
           "nullable": true,
           "origin": "property",
           "raw_type": "string?",
-          "source_line": 150,
+          "source_line": 174,
           "type": "string?"
         },
         {
@@ -48051,7 +51006,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 144,
+          "source_line": 168,
           "type": "string?"
         },
         {
@@ -48065,7 +51020,7 @@
           "nullable": true,
           "origin": "property",
           "raw_type": "string?",
-          "source_line": 152,
+          "source_line": 176,
           "type": "string?"
         },
         {
@@ -48079,8 +51034,22 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "DateOnly?",
-          "source_line": 133,
+          "source_line": 157,
           "type": "DateOnly?"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 178,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
         },
         {
           "collection": false,
@@ -48093,7 +51062,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 129,
+          "source_line": 153,
           "type": "Guid"
         },
         {
@@ -48107,7 +51076,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 141,
+          "source_line": 165,
           "type": "string"
         },
         {
@@ -48121,7 +51090,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 142,
+          "source_line": 166,
           "type": "string?"
         },
         {
@@ -48135,7 +51104,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 140,
+          "source_line": 164,
           "type": "string"
         },
         {
@@ -48149,7 +51118,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 145,
+          "source_line": 169,
           "type": "string"
         },
         {
@@ -48163,7 +51132,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 128,
+          "source_line": 152,
           "type": "Guid"
         },
         {
@@ -48177,7 +51146,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "decimal?",
-          "source_line": 138,
+          "source_line": 162,
           "type": "decimal?"
         }
       ],
@@ -48185,14 +51154,16 @@
       "namespace": "Meridian.Contracts.AssetOperations",
       "partial": false,
       "qualified_name": "Meridian.Contracts.AssetOperations.AssetTermsObligationTimelineEventDto",
-      "references": [],
+      "references": [
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+      ],
       "source": {
-        "line": 127,
+        "line": 151,
         "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
       },
       "sources": [
         {
-          "line": 127,
+          "line": 151,
           "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
         }
       ],
@@ -48211,7 +51182,7 @@
         "asset-operations-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "4c0d15f91d32bfd9d76ac02dbd1566c5c15746fb2fac61f50417f0d49a3db42d",
+      "fingerprint": "d1ab21c577474cf43f763eccf8817787d9ec9dc6c5e71049a0bc51d3e8f4a9ca",
       "full_name": "Meridian.Contracts.AssetOperations.AssetTermsVersionDto",
       "id": "Meridian.Contracts.AssetOperations.AssetTermsVersionDto",
       "kind": "record",
@@ -48261,6 +51232,20 @@
           "raw_type": "DateTimeOffset",
           "source_line": 25,
           "type": "DateTimeOffset"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 31,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
         },
         {
           "collection": false,
@@ -48365,7 +51350,9 @@
       "namespace": "Meridian.Contracts.AssetOperations",
       "partial": false,
       "qualified_name": "Meridian.Contracts.AssetOperations.AssetTermsVersionDto",
-      "references": [],
+      "references": [
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+      ],
       "source": {
         "line": 19,
         "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
@@ -48391,7 +51378,7 @@
         "asset-operations-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "d88bcfa7324dc4ed263e06ded1ee6da3b9c87691a3679436d80c6a75371dbd72",
+      "fingerprint": "5eaf22b6494084de57f15d050811087241987ea49a48c22d11309812e1fdaa7b",
       "full_name": "Meridian.Contracts.AssetOperations.AssetTimelineVarianceDto",
       "id": "Meridian.Contracts.AssetOperations.AssetTimelineVarianceDto",
       "kind": "record",
@@ -48410,7 +51397,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "decimal?",
-          "source_line": 162,
+          "source_line": 188,
           "type": "decimal?"
         },
         {
@@ -48424,7 +51411,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "DateOnly?",
-          "source_line": 160,
+          "source_line": 186,
           "type": "DateOnly?"
         },
         {
@@ -48438,7 +51425,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 164,
+          "source_line": 190,
           "type": "string"
         },
         {
@@ -48452,7 +51439,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 158,
+          "source_line": 184,
           "type": "string"
         },
         {
@@ -48467,7 +51454,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 169,
+          "source_line": 195,
           "type": "string?"
         },
         {
@@ -48481,7 +51468,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "decimal?",
-          "source_line": 161,
+          "source_line": 187,
           "type": "decimal?"
         },
         {
@@ -48495,8 +51482,22 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateOnly",
-          "source_line": 159,
+          "source_line": 185,
           "type": "DateOnly"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 197,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
         },
         {
           "collection": false,
@@ -48509,7 +51510,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 157,
+          "source_line": 183,
           "type": "Guid"
         },
         {
@@ -48523,7 +51524,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 166,
+          "source_line": 192,
           "type": "string"
         },
         {
@@ -48537,7 +51538,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 167,
+          "source_line": 193,
           "type": "string?"
         },
         {
@@ -48551,7 +51552,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 165,
+          "source_line": 191,
           "type": "string"
         },
         {
@@ -48565,7 +51566,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 168,
+          "source_line": 194,
           "type": "string"
         },
         {
@@ -48579,7 +51580,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "decimal?",
-          "source_line": 163,
+          "source_line": 189,
           "type": "decimal?"
         },
         {
@@ -48593,7 +51594,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 156,
+          "source_line": 182,
           "type": "Guid"
         }
       ],
@@ -48601,14 +51602,16 @@
       "namespace": "Meridian.Contracts.AssetOperations",
       "partial": false,
       "qualified_name": "Meridian.Contracts.AssetOperations.AssetTimelineVarianceDto",
-      "references": [],
+      "references": [
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+      ],
       "source": {
-        "line": 155,
+        "line": 181,
         "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
       },
       "sources": [
         {
-          "line": 155,
+          "line": 181,
           "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
         }
       ],
@@ -48627,7 +51630,7 @@
         "asset-operations-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "470887fb6b14aa1fc1399220991cb9c6fae9f053cea7aa8defe801f3c6881fdb",
+      "fingerprint": "dc0780aba45d6b1ab3ac4d468a461dcc202e235f5a7081741ad7be25591014c6",
       "full_name": "Meridian.Contracts.AssetOperations.BookPositionDto",
       "id": "Meridian.Contracts.AssetOperations.BookPositionDto",
       "kind": "record",
@@ -48646,7 +51649,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingBookContextDto",
-          "source_line": 62,
+          "source_line": 64,
           "type": "AccountingBookContextDto"
         },
         {
@@ -48661,7 +51664,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "PositionEconomicStateDto?",
-          "source_line": 69,
+          "source_line": 71,
           "type": "PositionEconomicStateDto?"
         },
         {
@@ -48675,7 +51678,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateOnly",
-          "source_line": 65,
+          "source_line": 67,
           "type": "DateOnly"
         },
         {
@@ -48690,7 +51693,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "DateOnly?",
-          "source_line": 66,
+          "source_line": 68,
           "type": "DateOnly?"
         },
         {
@@ -48704,7 +51707,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 75,
+          "source_line": 77,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -48719,7 +51722,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "JsonElement?",
-          "source_line": 73,
+          "source_line": 75,
           "type": "JsonElement?"
         },
         {
@@ -48734,7 +51737,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "EconomicEventReferenceDto?",
-          "source_line": 70,
+          "source_line": 72,
           "type": "EconomicEventReferenceDto?"
         },
         {
@@ -48748,7 +51751,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 59,
+          "source_line": 61,
           "type": "Guid"
         },
         {
@@ -48762,7 +51765,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 63,
+          "source_line": 65,
           "type": "string"
         },
         {
@@ -48777,7 +51780,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 68,
+          "source_line": 70,
           "type": "string?"
         },
         {
@@ -48792,8 +51795,22 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "ProjectionLineageDto?",
-          "source_line": 71,
+          "source_line": 73,
           "type": "ProjectionLineageDto?"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 79,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
         },
         {
           "collection": false,
@@ -48806,7 +51823,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 61,
+          "source_line": 63,
           "type": "Guid"
         },
         {
@@ -48820,7 +51837,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 60,
+          "source_line": 62,
           "type": "Guid"
         },
         {
@@ -48834,7 +51851,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 64,
+          "source_line": 66,
           "type": "string"
         },
         {
@@ -48849,7 +51866,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "long",
-          "source_line": 67,
+          "source_line": 69,
           "type": "long"
         }
       ],
@@ -48861,15 +51878,16 @@
         "Meridian.Contracts.AssetOperations.EconomicEventReferenceDto",
         "Meridian.Contracts.AssetOperations.PositionEconomicStateDto",
         "Meridian.Contracts.AssetOperations.ProjectionLineageDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto",
         "Meridian.Contracts.Ledger.AccountingBookContextDto"
       ],
       "source": {
-        "line": 58,
+        "line": 60,
         "path": "src/Meridian.Contracts/AssetOperations/InstrumentPositionDtos.cs"
       },
       "sources": [
         {
-          "line": 58,
+          "line": 60,
           "path": "src/Meridian.Contracts/AssetOperations/InstrumentPositionDtos.cs"
         }
       ],
@@ -48926,7 +51944,7 @@
         "asset-operations-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "1b6cd9e92e59a0c80bd38dfa7e240aaa1a3d8fda8a16567ee31b96ac86626d60",
+      "fingerprint": "f7a7dd7554cdaf658eaf25ecf65e95c745d6ae2f89703ff0bf257e9c8c3c00fa",
       "full_name": "Meridian.Contracts.AssetOperations.EconomicEventReferenceDto",
       "id": "Meridian.Contracts.AssetOperations.EconomicEventReferenceDto",
       "kind": "record",
@@ -48945,7 +51963,7 @@
           "nullable": true,
           "origin": "property",
           "raw_type": "Guid?",
-          "source_line": 123,
+          "source_line": 129,
           "type": "Guid?"
         },
         {
@@ -48960,7 +51978,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 115,
+          "source_line": 121,
           "type": "Guid?"
         },
         {
@@ -48975,7 +51993,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 114,
+          "source_line": 120,
           "type": "Guid?"
         },
         {
@@ -48989,7 +52007,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateOnly",
-          "source_line": 110,
+          "source_line": 116,
           "type": "DateOnly"
         },
         {
@@ -49003,7 +52021,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 107,
+          "source_line": 113,
           "type": "Guid"
         },
         {
@@ -49017,7 +52035,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 108,
+          "source_line": 114,
           "type": "string"
         },
         {
@@ -49031,7 +52049,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "long",
-          "source_line": 109,
+          "source_line": 115,
           "type": "long"
         },
         {
@@ -49045,7 +52063,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 119,
+          "source_line": 125,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -49059,8 +52077,22 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset",
-          "source_line": 111,
+          "source_line": 117,
           "type": "DateTimeOffset"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 131,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
         },
         {
           "collection": false,
@@ -49073,7 +52105,7 @@
           "nullable": true,
           "origin": "property",
           "raw_type": "Guid?",
-          "source_line": 121,
+          "source_line": 127,
           "type": "Guid?"
         },
         {
@@ -49088,7 +52120,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 116,
+          "source_line": 122,
           "type": "string?"
         },
         {
@@ -49102,7 +52134,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 112,
+          "source_line": 118,
           "type": "string"
         },
         {
@@ -49117,7 +52149,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 113,
+          "source_line": 119,
           "type": "string?"
         }
       ],
@@ -49125,14 +52157,16 @@
       "namespace": "Meridian.Contracts.AssetOperations",
       "partial": false,
       "qualified_name": "Meridian.Contracts.AssetOperations.EconomicEventReferenceDto",
-      "references": [],
+      "references": [
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+      ],
       "source": {
-        "line": 106,
+        "line": 112,
         "path": "src/Meridian.Contracts/AssetOperations/InstrumentPositionDtos.cs"
       },
       "sources": [
         {
-          "line": 106,
+          "line": 112,
           "path": "src/Meridian.Contracts/AssetOperations/InstrumentPositionDtos.cs"
         }
       ],
@@ -49151,7 +52185,7 @@
         "asset-operations-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "ae3361e723cb6bbbde3c21ee4c07e40672b046945a07215b7ff46244eaf955d4",
+      "fingerprint": "7719476dbcae732fb0fd981ee550be92e95bee951f42e4340402f1170e49ba07",
       "full_name": "Meridian.Contracts.AssetOperations.IAssetOperationsCommandService",
       "id": "Meridian.Contracts.AssetOperations.IAssetOperationsCommandService",
       "kind": "interface",
@@ -49165,12 +52199,12 @@
       "qualified_name": "Meridian.Contracts.AssetOperations.IAssetOperationsCommandService",
       "references": [],
       "source": {
-        "line": 261,
+        "line": 299,
         "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
       },
       "sources": [
         {
-          "line": 261,
+          "line": 299,
           "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
         }
       ],
@@ -49189,7 +52223,7 @@
         "asset-operations-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "1337cd2198b4122587edf3c36457500d4ce0fe5f755db0148d5aec849fa109fb",
+      "fingerprint": "6a545ae9f1343e7331049c6e10b7af7337b6f23fd19f358db0b00d6ce07ea3f5",
       "full_name": "Meridian.Contracts.AssetOperations.IAssetOperationsQueryService",
       "id": "Meridian.Contracts.AssetOperations.IAssetOperationsQueryService",
       "kind": "interface",
@@ -49203,12 +52237,12 @@
       "qualified_name": "Meridian.Contracts.AssetOperations.IAssetOperationsQueryService",
       "references": [],
       "source": {
-        "line": 254,
+        "line": 292,
         "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
       },
       "sources": [
         {
-          "line": 254,
+          "line": 292,
           "path": "src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs"
         }
       ],
@@ -49303,7 +52337,7 @@
         "asset-operations-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "d969277c86c413c5a369dd2b3f3b8bacc99b4323d9eb9da7c7ed6fee87b8ef19",
+      "fingerprint": "d45f1dc1922852b6fa7bf0bd61375c7e752b1768c98a753132fce4483bef2f16",
       "full_name": "Meridian.Contracts.AssetOperations.InstrumentRoleDto",
       "id": "Meridian.Contracts.AssetOperations.InstrumentRoleDto",
       "kind": "record",
@@ -49471,6 +52505,20 @@
           "type": "string"
         },
         {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 57,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
+        },
+        {
           "collection": false,
           "collection_kind": null,
           "element_type": null,
@@ -49533,7 +52581,8 @@
       "partial": false,
       "qualified_name": "Meridian.Contracts.AssetOperations.InstrumentRoleDto",
       "references": [
-        "Meridian.Contracts.AssetOperations.EconomicEventReferenceDto"
+        "Meridian.Contracts.AssetOperations.EconomicEventReferenceDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
       ],
       "source": {
         "line": 38,
@@ -49733,6 +52782,57 @@
         {
           "line": 139,
           "path": "src/Meridian.Contracts/AssetOperations/PortfolioCashLadderDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "enum",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [
+        {
+          "explicit_value": true,
+          "name": "Unknown",
+          "source_line": 139,
+          "value": "0"
+        },
+        {
+          "explicit_value": true,
+          "name": "Posted",
+          "source_line": 140,
+          "value": "1"
+        }
+      ],
+      "fingerprint": "9fe61aca1715f882f9755d9fe43177b4f9722501e57d8d4f92a9ef34b2ac4110",
+      "full_name": "Meridian.Contracts.AssetOperations.JournalPostingStatusDto",
+      "id": "Meridian.Contracts.AssetOperations.JournalPostingStatusDto",
+      "kind": "enum",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [],
+      "name": "JournalPostingStatusDto",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.JournalPostingStatusDto",
+      "references": [],
+      "source": {
+        "line": 137,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 137,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
         }
       ],
       "type_parameters": []
@@ -51176,7 +54276,7 @@
         "asset-operations-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "1d40a1a50e4be8238ae1395272902f90d29866e731423cc49fb35361b1ade34a",
+      "fingerprint": "9750b74e0181719a2565f964b1483491e02bbabd711132c3ed119678e6a01bd8",
       "full_name": "Meridian.Contracts.AssetOperations.PositionEconomicStateDto",
       "id": "Meridian.Contracts.AssetOperations.PositionEconomicStateDto",
       "kind": "record",
@@ -51195,7 +54295,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateOnly",
-          "source_line": 81,
+          "source_line": 85,
           "type": "DateOnly"
         },
         {
@@ -51210,7 +54310,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "decimal?",
-          "source_line": 90,
+          "source_line": 94,
           "type": "decimal?"
         },
         {
@@ -51224,7 +54324,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 82,
+          "source_line": 86,
           "type": "string"
         },
         {
@@ -51239,7 +54339,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "decimal?",
-          "source_line": 88,
+          "source_line": 92,
           "type": "decimal?"
         },
         {
@@ -51254,7 +54354,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "decimal?",
-          "source_line": 96,
+          "source_line": 100,
           "type": "decimal?"
         },
         {
@@ -51268,7 +54368,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 79,
+          "source_line": 83,
           "type": "Guid"
         },
         {
@@ -51282,7 +54382,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 101,
+          "source_line": 105,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -51297,7 +54397,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "JsonElement?",
-          "source_line": 99,
+          "source_line": 103,
           "type": "JsonElement?"
         },
         {
@@ -51312,7 +54412,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "decimal?",
-          "source_line": 86,
+          "source_line": 90,
           "type": "decimal?"
         },
         {
@@ -51327,7 +54427,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "decimal?",
-          "source_line": 87,
+          "source_line": 91,
           "type": "decimal?"
         },
         {
@@ -51342,7 +54442,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "decimal?",
-          "source_line": 85,
+          "source_line": 89,
           "type": "decimal?"
         },
         {
@@ -51356,7 +54456,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 80,
+          "source_line": 84,
           "type": "Guid"
         },
         {
@@ -51371,7 +54471,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "decimal?",
-          "source_line": 95,
+          "source_line": 99,
           "type": "decimal?"
         },
         {
@@ -51385,7 +54485,7 @@
           "nullable": true,
           "origin": "property",
           "raw_type": "ProjectionLineageDto?",
-          "source_line": 103,
+          "source_line": 107,
           "type": "ProjectionLineageDto?"
         },
         {
@@ -51400,7 +54500,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "decimal?",
-          "source_line": 91,
+          "source_line": 95,
           "type": "decimal?"
         },
         {
@@ -51415,7 +54515,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "decimal?",
-          "source_line": 84,
+          "source_line": 88,
           "type": "decimal?"
         },
         {
@@ -51430,8 +54530,22 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "decimal?",
-          "source_line": 94,
+          "source_line": 98,
           "type": "decimal?"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 109,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
         },
         {
           "collection": false,
@@ -51445,7 +54559,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "DateOnly?",
-          "source_line": 93,
+          "source_line": 97,
           "type": "DateOnly?"
         },
         {
@@ -51460,7 +54574,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "EconomicEventReferenceDto?",
-          "source_line": 97,
+          "source_line": 101,
           "type": "EconomicEventReferenceDto?"
         },
         {
@@ -51475,7 +54589,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "DateOnly?",
-          "source_line": 92,
+          "source_line": 96,
           "type": "DateOnly?"
         },
         {
@@ -51490,7 +54604,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "decimal?",
-          "source_line": 89,
+          "source_line": 93,
           "type": "decimal?"
         },
         {
@@ -51504,7 +54618,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "long",
-          "source_line": 83,
+          "source_line": 87,
           "type": "long"
         }
       ],
@@ -51514,15 +54628,16 @@
       "qualified_name": "Meridian.Contracts.AssetOperations.PositionEconomicStateDto",
       "references": [
         "Meridian.Contracts.AssetOperations.EconomicEventReferenceDto",
-        "Meridian.Contracts.AssetOperations.ProjectionLineageDto"
+        "Meridian.Contracts.AssetOperations.ProjectionLineageDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
       ],
       "source": {
-        "line": 78,
+        "line": 82,
         "path": "src/Meridian.Contracts/AssetOperations/InstrumentPositionDtos.cs"
       },
       "sources": [
         {
-          "line": 78,
+          "line": 82,
           "path": "src/Meridian.Contracts/AssetOperations/InstrumentPositionDtos.cs"
         }
       ],
@@ -51541,7 +54656,880 @@
         "asset-operations-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "056dba30dd3c82e79c792322e22173ea097ede2cd52ad4bfd2d0c01252f14856",
+      "fingerprint": "e2f4a0013fc50f437bcaf5f6e871e8b268742c5131e76acfcfee1be9a1e5bc40",
+      "full_name": "Meridian.Contracts.AssetOperations.PostedJournalImpactDto",
+      "id": "Meridian.Contracts.AssetOperations.PostedJournalImpactDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AccountingBasis",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "AccountingBasisKindDto",
+          "source_line": 151,
+          "type": "AccountingBasisKindDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Currency",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 154,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "JournalEntryId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "Guid",
+          "source_line": 148,
+          "type": "Guid"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "LedgerBookId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "Guid",
+          "source_line": 149,
+          "type": "Guid"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "PostedJournalImpactLineDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Lines",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<PostedJournalImpactLineDto>",
+          "source_line": 159,
+          "type": "IReadOnlyList<PostedJournalImpactLineDto>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "PeriodId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "Guid",
+          "source_line": 150,
+          "type": "Guid"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "PostedAtUtc",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "DateTimeOffset",
+          "source_line": 152,
+          "type": "DateTimeOffset"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "PostingStatus",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "JournalPostingStatusDto",
+          "source_line": 153,
+          "type": "JournalPostingStatusDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TotalCredits",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 156,
+          "type": "decimal"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TotalDebits",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 155,
+          "type": "decimal"
+        }
+      ],
+      "name": "PostedJournalImpactDto",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.PostedJournalImpactDto",
+      "references": [
+        "Meridian.Contracts.AssetOperations.JournalPostingStatusDto",
+        "Meridian.Contracts.AssetOperations.PostedJournalImpactLineDto",
+        "Meridian.Contracts.Ledger.AccountingBasisKindDto"
+      ],
+      "source": {
+        "line": 147,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 147,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "20c028dc07f30a5ec4784a64482cbcb7167ab84f92f4322a2db50047dab19a89",
+      "full_name": "Meridian.Contracts.AssetOperations.PostedJournalImpactLineDto",
+      "id": "Meridian.Contracts.AssetOperations.PostedJournalImpactLineDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AccountId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 129,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Credit",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 131,
+          "type": "decimal"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Currency",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 132,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Debit",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 130,
+          "type": "decimal"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Description",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 133,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Dimensions",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "LedgerDimensionSetDto?",
+          "source_line": 134,
+          "type": "LedgerDimensionSetDto?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "LineId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "Guid",
+          "source_line": 128,
+          "type": "Guid"
+        }
+      ],
+      "name": "PostedJournalImpactLineDto",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.PostedJournalImpactLineDto",
+      "references": [
+        "Meridian.Contracts.Ledger.LedgerDimensionSetDto"
+      ],
+      "source": {
+        "line": 127,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 127,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "class",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "ed89892dedcfd567b0f228e3259278473b6d04e9272174b146322e03b77ca574",
+      "full_name": "Meridian.Contracts.AssetOperations.PostedJournalImpactValidator",
+      "id": "Meridian.Contracts.AssetOperations.PostedJournalImpactValidator",
+      "kind": "class",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [],
+      "name": "PostedJournalImpactValidator",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.PostedJournalImpactValidator",
+      "references": [],
+      "source": {
+        "line": 328,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 328,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "0bd1471f02246ff6017101aa4a97123b5375856ced549f7100f6cac4dafe4365",
+      "full_name": "Meridian.Contracts.AssetOperations.ProjectAssetAccountingEventRequestDto",
+      "id": "Meridian.Contracts.AssetOperations.ProjectAssetAccountingEventRequestDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Actor",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 220,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Correction",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "AssetAccountingCorrectionReferenceDto?",
+          "source_line": 224,
+          "type": "AssetAccountingCorrectionReferenceDto?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Currency",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 218,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EconomicEvent",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "EconomicEventReferenceDto",
+          "source_line": 214,
+          "type": "EconomicEventReferenceDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EventAmount",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 217,
+          "type": "decimal"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EventKind",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "AssetAccountingEventKindDto",
+          "source_line": 212,
+          "type": "AssetAccountingEventKindDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ExpectedPeriodVersion",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "long",
+          "source_line": 219,
+          "type": "long"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Notes",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 223,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ProjectedAtUtc",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "DateTimeOffset",
+          "source_line": 221,
+          "type": "DateTimeOffset"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ProjectedEffect",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "ProjectedAccountingEffectDto",
+          "source_line": 216,
+          "type": "ProjectedAccountingEffectDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ProjectionLineage",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "ProjectionLineageDto",
+          "source_line": 215,
+          "type": "ProjectionLineageDto"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 226,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Scope",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "AssetAccountingEventScopeDto",
+          "source_line": 213,
+          "type": "AssetAccountingEventScopeDto"
+        }
+      ],
+      "name": "ProjectAssetAccountingEventRequestDto",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.ProjectAssetAccountingEventRequestDto",
+      "references": [
+        "Meridian.Contracts.AssetOperations.AssetAccountingCorrectionReferenceDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventKindDto",
+        "Meridian.Contracts.AssetOperations.AssetAccountingEventScopeDto",
+        "Meridian.Contracts.AssetOperations.EconomicEventReferenceDto",
+        "Meridian.Contracts.AssetOperations.ProjectedAccountingEffectDto",
+        "Meridian.Contracts.AssetOperations.ProjectionLineageDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+      ],
+      "source": {
+        "line": 211,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 211,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "8aa0e8c3f200e1e7c827f43fb33475e972676934c44ed64c6397bdffb839d39b",
+      "full_name": "Meridian.Contracts.AssetOperations.ProjectedAccountingEffectDto",
+      "id": "Meridian.Contracts.AssetOperations.ProjectedAccountingEffectDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Currency",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 116,
+          "type": "string"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "ProjectedAccountingEffectLineDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Lines",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<ProjectedAccountingEffectLineDto>",
+          "source_line": 119,
+          "type": "IReadOnlyList<ProjectedAccountingEffectLineDto>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ModelKey",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 111,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ModelVersion",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 112,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ProjectionAsOfDate",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "DateOnly",
+          "source_line": 113,
+          "type": "DateOnly"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ProjectionRunId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "Guid",
+          "source_line": 110,
+          "type": "Guid"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TotalCredits",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 115,
+          "type": "decimal"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TotalDebits",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 114,
+          "type": "decimal"
+        }
+      ],
+      "name": "ProjectedAccountingEffectDto",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.ProjectedAccountingEffectDto",
+      "references": [
+        "Meridian.Contracts.AssetOperations.ProjectedAccountingEffectLineDto"
+      ],
+      "source": {
+        "line": 109,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 109,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "72b43bcc38e170a9e5d2ee3e73fb86e561462bab643880de43ee3575b004f10e",
+      "full_name": "Meridian.Contracts.AssetOperations.ProjectedAccountingEffectLineDto",
+      "id": "Meridian.Contracts.AssetOperations.ProjectedAccountingEffectLineDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AccountId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 99,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Credit",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 101,
+          "type": "decimal"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Currency",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 102,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Debit",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 100,
+          "type": "decimal"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Description",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 103,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Dimensions",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "LedgerDimensionSetDto?",
+          "source_line": 104,
+          "type": "LedgerDimensionSetDto?"
+        }
+      ],
+      "name": "ProjectedAccountingEffectLineDto",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.ProjectedAccountingEffectLineDto",
+      "references": [
+        "Meridian.Contracts.Ledger.LedgerDimensionSetDto"
+      ],
+      "source": {
+        "line": 98,
+        "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 98,
+          "path": "src/Meridian.Contracts/AssetOperations/AssetAccountingEventDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "00f801de5b5aba23dc01ed760270da65f0207494ea63bdb0bee69ed1e3b0a509",
       "full_name": "Meridian.Contracts.AssetOperations.ProjectionLineageDto",
       "id": "Meridian.Contracts.AssetOperations.ProjectionLineageDto",
       "kind": "record",
@@ -51560,7 +55548,7 @@
           "nullable": true,
           "origin": "property",
           "raw_type": "Guid?",
-          "source_line": 145,
+          "source_line": 153,
           "type": "Guid?"
         },
         {
@@ -51574,7 +55562,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 131,
+          "source_line": 139,
           "type": "string"
         },
         {
@@ -51588,7 +55576,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 143,
+          "source_line": 151,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -51602,7 +55590,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset",
-          "source_line": 134,
+          "source_line": 142,
           "type": "DateTimeOffset"
         },
         {
@@ -51616,7 +55604,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 129,
+          "source_line": 137,
           "type": "string"
         },
         {
@@ -51630,7 +55618,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 130,
+          "source_line": 138,
           "type": "string"
         },
         {
@@ -51644,7 +55632,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateOnly",
-          "source_line": 133,
+          "source_line": 141,
           "type": "DateOnly"
         },
         {
@@ -51658,7 +55646,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 128,
+          "source_line": 136,
           "type": "Guid?"
         },
         {
@@ -51672,8 +55660,22 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 127,
+          "source_line": 135,
           "type": "Guid"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 155,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
         },
         {
           "collection": false,
@@ -51686,7 +55688,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 132,
+          "source_line": 140,
           "type": "string"
         },
         {
@@ -51700,7 +55702,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 135,
+          "source_line": 143,
           "type": "string"
         },
         {
@@ -51714,7 +55716,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 136,
+          "source_line": 144,
           "type": "string?"
         },
         {
@@ -51729,7 +55731,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 140,
+          "source_line": 148,
           "type": "Guid?"
         },
         {
@@ -51744,7 +55746,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 139,
+          "source_line": 147,
           "type": "string?"
         },
         {
@@ -51759,7 +55761,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 138,
+          "source_line": 146,
           "type": "string?"
         },
         {
@@ -51773,7 +55775,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "EconomicEventReferenceDto",
-          "source_line": 137,
+          "source_line": 145,
           "type": "EconomicEventReferenceDto"
         }
       ],
@@ -51782,16 +55784,290 @@
       "partial": false,
       "qualified_name": "Meridian.Contracts.AssetOperations.ProjectionLineageDto",
       "references": [
-        "Meridian.Contracts.AssetOperations.EconomicEventReferenceDto"
+        "Meridian.Contracts.AssetOperations.EconomicEventReferenceDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
       ],
       "source": {
-        "line": 126,
+        "line": 134,
         "path": "src/Meridian.Contracts/AssetOperations/InstrumentPositionDtos.cs"
       },
       "sources": [
         {
-          "line": 126,
+          "line": 134,
           "path": "src/Meridian.Contracts/AssetOperations/InstrumentPositionDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "b7a16a27e5cffda5e8201745168d1d183590970d954cb5fae451b8b3a9756009",
+      "full_name": "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto",
+      "id": "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ContentHashSha256",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 13,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EffectiveDate",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "DateOnly",
+          "source_line": 19,
+          "type": "DateOnly"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EvidenceId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 11,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EvidenceUri",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 12,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EvidenceVersion",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "long",
+          "source_line": 20,
+          "type": "long"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedAtUtc",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "DateTimeOffset",
+          "source_line": 21,
+          "type": "DateTimeOffset"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedBy",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 22,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ReviewedAtUtc",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "DateTimeOffset",
+          "source_line": 18,
+          "type": "DateTimeOffset"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ReviewedBy",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 17,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ReviewStatus",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 16,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "SourceReference",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 15,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "SourceSystem",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 14,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "SubjectId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 24,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "SubjectType",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 23,
+          "type": "string"
+        }
+      ],
+      "name": "RetainedEvidenceIdentityDto",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto",
+      "references": [],
+      "source": {
+        "line": 10,
+        "path": "src/Meridian.Contracts/AssetOperations/RetainedEvidenceIdentityDto.cs"
+      },
+      "sources": [
+        {
+          "line": 10,
+          "path": "src/Meridian.Contracts/AssetOperations/RetainedEvidenceIdentityDto.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "class",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "asset-operations-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "asset-operations-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "bd12fe5afca5d3d50d23d4e65704ccc8032f3e77410e9aba9e4bc4e6f343a947",
+      "full_name": "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityValidator",
+      "id": "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityValidator",
+      "kind": "class",
+      "mapped_schemas": [
+        "asset_operations"
+      ],
+      "members": [],
+      "name": "RetainedEvidenceIdentityValidator",
+      "namespace": "Meridian.Contracts.AssetOperations",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityValidator",
+      "references": [],
+      "source": {
+        "line": 141,
+        "path": "src/Meridian.Contracts/AssetOperations/RetainedEvidenceIdentityDto.cs"
+      },
+      "sources": [
+        {
+          "line": 141,
+          "path": "src/Meridian.Contracts/AssetOperations/RetainedEvidenceIdentityDto.cs"
         }
       ],
       "type_parameters": []
@@ -135528,7 +139804,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "9997133a9864019ea483944327f9a6ded4b4febfef68af9600e8e20922f09c0e",
+      "fingerprint": "854f3046c248e26a3e0f32d2e5571230752c0f0d71673ddb6f55a791afb8e22d",
       "full_name": "Meridian.Contracts.Ledger.AccountingBasisProjectionItemDto",
       "id": "Meridian.Contracts.Ledger.AccountingBasisProjectionItemDto",
       "kind": "record",
@@ -135547,7 +139823,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingBasisKindDto",
-          "source_line": 990,
+          "source_line": 1016,
           "type": "AccountingBasisKindDto"
         },
         {
@@ -135561,7 +139837,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "PostingRuleJournalCandidateResultDto",
-          "source_line": 993,
+          "source_line": 1019,
           "type": "PostingRuleJournalCandidateResultDto"
         },
         {
@@ -135576,7 +139852,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 995,
+          "source_line": 1021,
           "type": "string?"
         },
         {
@@ -135590,7 +139866,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 991,
+          "source_line": 1017,
           "type": "Guid"
         },
         {
@@ -135604,7 +139880,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 992,
+          "source_line": 1018,
           "type": "Guid"
         },
         {
@@ -135618,7 +139894,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 994,
+          "source_line": 1020,
           "type": "string"
         }
       ],
@@ -135629,6 +139905,445 @@
       "references": [
         "Meridian.Contracts.Ledger.AccountingBasisKindDto",
         "Meridian.Contracts.Ledger.PostingRuleJournalCandidateResultDto"
+      ],
+      "source": {
+        "line": 1015,
+        "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 1015,
+          "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "ledger-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "ledger-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "967a6b6eb39aae7f5f979938da8a3bed686a80f102d08a714f248dedcc3754d8",
+      "full_name": "Meridian.Contracts.Ledger.AccountingBasisProjectionSetDto",
+      "id": "Meridian.Contracts.Ledger.AccountingBasisProjectionSetDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "ledger"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Currency",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1029,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EffectiveDate",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "DateOnly",
+          "source_line": 1027,
+          "type": "DateOnly"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EventAmount",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 1028,
+          "type": "decimal"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "FundProfileId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1025,
+          "type": "string"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "AccountingBasisProjectionItemDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Items",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<AccountingBasisProjectionItemDto>",
+          "source_line": 1033,
+          "type": "IReadOnlyList<AccountingBasisProjectionItemDto>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ProjectedAtUtc",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "DateTimeOffset",
+          "source_line": 1030,
+          "type": "DateTimeOffset"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "SourceEventId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "Guid",
+          "source_line": 1024,
+          "type": "Guid"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "SourceEventType",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 1026,
+          "type": "string"
+        }
+      ],
+      "name": "AccountingBasisProjectionSetDto",
+      "namespace": "Meridian.Contracts.Ledger",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.Ledger.AccountingBasisProjectionSetDto",
+      "references": [
+        "Meridian.Contracts.Ledger.AccountingBasisProjectionItemDto"
+      ],
+      "source": {
+        "line": 1023,
+        "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 1023,
+          "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "ledger-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "ledger-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "70c5d47c80492b4a8fc14d77dbe357612188b8f8176ee950c440d63f2931717e",
+      "full_name": "Meridian.Contracts.Ledger.AccountingBasisProjectionSetRequestDto",
+      "id": "Meridian.Contracts.Ledger.AccountingBasisProjectionSetRequestDto",
+      "kind": "record",
+      "mapped_schemas": [
+        "ledger"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AccountingTimestamp",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "DateTimeOffset",
+          "source_line": 997,
+          "type": "DateTimeOffset"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Actor",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 995,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CompanyId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1006,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CorrelationId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "Guid?",
+          "source_line": 1000,
+          "type": "Guid?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "CounterpartyId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1001,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Currency",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 993,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Description",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 998,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EffectiveDate",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "DateOnly",
+          "source_line": 994,
+          "type": "DateOnly"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EventAmount",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 992,
+          "type": "decimal"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "string",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EvidenceLinks",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<string>",
+          "source_line": 1011,
+          "type": "IReadOnlyList<string>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "FundProfileId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 990,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "InstrumentSymbol",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1002,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "SourceEventId",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "Guid",
+          "source_line": 996,
+          "type": "Guid"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "SourceEventType",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 991,
+          "type": "string"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "AccountingBasisProjectionTargetDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Targets",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<AccountingBasisProjectionTargetDto>",
+          "source_line": 1008,
+          "type": "IReadOnlyList<AccountingBasisProjectionTargetDto>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TenantId",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 1005,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TreasuryContext",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "TreasuryLedgerContextDto?",
+          "source_line": 1003,
+          "type": "TreasuryLedgerContextDto?"
+        }
+      ],
+      "name": "AccountingBasisProjectionSetRequestDto",
+      "namespace": "Meridian.Contracts.Ledger",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.Ledger.AccountingBasisProjectionSetRequestDto",
+      "references": [
+        "Meridian.Contracts.Ledger.AccountingBasisProjectionTargetDto",
+        "Meridian.Contracts.Ledger.TreasuryLedgerContextDto"
       ],
       "source": {
         "line": 989,
@@ -135655,446 +140370,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "115abbb860022d9e32bb2827dfdfd6865b064a75dde330f9b1589bf0ce367919",
-      "full_name": "Meridian.Contracts.Ledger.AccountingBasisProjectionSetDto",
-      "id": "Meridian.Contracts.Ledger.AccountingBasisProjectionSetDto",
-      "kind": "record",
-      "mapped_schemas": [
-        "ledger"
-      ],
-      "members": [
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Currency",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1003,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "EffectiveDate",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "DateOnly",
-          "source_line": 1001,
-          "type": "DateOnly"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "EventAmount",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "decimal",
-          "source_line": 1002,
-          "type": "decimal"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "FundProfileId",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 999,
-          "type": "string"
-        },
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "AccountingBasisProjectionItemDto",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Items",
-          "nullable": false,
-          "origin": "property",
-          "raw_type": "IReadOnlyList<AccountingBasisProjectionItemDto>",
-          "source_line": 1007,
-          "type": "IReadOnlyList<AccountingBasisProjectionItemDto>"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "ProjectedAtUtc",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "DateTimeOffset",
-          "source_line": 1004,
-          "type": "DateTimeOffset"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "SourceEventId",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "Guid",
-          "source_line": 998,
-          "type": "Guid"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "SourceEventType",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 1000,
-          "type": "string"
-        }
-      ],
-      "name": "AccountingBasisProjectionSetDto",
-      "namespace": "Meridian.Contracts.Ledger",
-      "partial": false,
-      "qualified_name": "Meridian.Contracts.Ledger.AccountingBasisProjectionSetDto",
-      "references": [
-        "Meridian.Contracts.Ledger.AccountingBasisProjectionItemDto"
-      ],
-      "source": {
-        "line": 997,
-        "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
-      },
-      "sources": [
-        {
-          "line": 997,
-          "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
-        }
-      ],
-      "type_parameters": []
-    },
-    {
-      "base_types": [],
-      "classification": "dto",
-      "containing_type": null,
-      "contract_sets": [
-        "all-contracts",
-        "ledger-contracts"
-      ],
-      "diagram": true,
-      "diagram_contract_sets": [
-        "ledger-contracts"
-      ],
-      "enum_members": [],
-      "fingerprint": "8d149aef8a051d24075d4e4e5efcc84c9b565e7072ddfd540c27d43e05fa5e4a",
-      "full_name": "Meridian.Contracts.Ledger.AccountingBasisProjectionSetRequestDto",
-      "id": "Meridian.Contracts.Ledger.AccountingBasisProjectionSetRequestDto",
-      "kind": "record",
-      "mapped_schemas": [
-        "ledger"
-      ],
-      "members": [
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "AccountingTimestamp",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "DateTimeOffset",
-          "source_line": 971,
-          "type": "DateTimeOffset"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Actor",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 969,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "CompanyId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 980,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "CorrelationId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "Guid?",
-          "source_line": 974,
-          "type": "Guid?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "CounterpartyId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 975,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Currency",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 967,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Description",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 972,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "EffectiveDate",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "DateOnly",
-          "source_line": 968,
-          "type": "DateOnly"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "EventAmount",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "decimal",
-          "source_line": 966,
-          "type": "decimal"
-        },
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "string",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "EvidenceLinks",
-          "nullable": false,
-          "origin": "property",
-          "raw_type": "IReadOnlyList<string>",
-          "source_line": 985,
-          "type": "IReadOnlyList<string>"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "FundProfileId",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 964,
-          "type": "string"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "InstrumentSymbol",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 976,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "SourceEventId",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "Guid",
-          "source_line": 970,
-          "type": "Guid"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "SourceEventType",
-          "nullable": false,
-          "origin": "positional_parameter",
-          "raw_type": "string",
-          "source_line": 965,
-          "type": "string"
-        },
-        {
-          "collection": true,
-          "collection_kind": "IReadOnlyList",
-          "element_type": "AccountingBasisProjectionTargetDto",
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "Targets",
-          "nullable": false,
-          "origin": "property",
-          "raw_type": "IReadOnlyList<AccountingBasisProjectionTargetDto>",
-          "source_line": 982,
-          "type": "IReadOnlyList<AccountingBasisProjectionTargetDto>"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "TenantId",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "string?",
-          "source_line": 979,
-          "type": "string?"
-        },
-        {
-          "collection": false,
-          "collection_kind": null,
-          "default": "null",
-          "element_type": null,
-          "json_ignored": false,
-          "json_name": null,
-          "key_type": null,
-          "name": "TreasuryContext",
-          "nullable": true,
-          "origin": "positional_parameter",
-          "raw_type": "TreasuryLedgerContextDto?",
-          "source_line": 977,
-          "type": "TreasuryLedgerContextDto?"
-        }
-      ],
-      "name": "AccountingBasisProjectionSetRequestDto",
-      "namespace": "Meridian.Contracts.Ledger",
-      "partial": false,
-      "qualified_name": "Meridian.Contracts.Ledger.AccountingBasisProjectionSetRequestDto",
-      "references": [
-        "Meridian.Contracts.Ledger.AccountingBasisProjectionTargetDto",
-        "Meridian.Contracts.Ledger.TreasuryLedgerContextDto"
-      ],
-      "source": {
-        "line": 963,
-        "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
-      },
-      "sources": [
-        {
-          "line": 963,
-          "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
-        }
-      ],
-      "type_parameters": []
-    },
-    {
-      "base_types": [],
-      "classification": "dto",
-      "containing_type": null,
-      "contract_sets": [
-        "all-contracts",
-        "ledger-contracts"
-      ],
-      "diagram": true,
-      "diagram_contract_sets": [
-        "ledger-contracts"
-      ],
-      "enum_members": [],
-      "fingerprint": "9f3b554629038d46212fcbc478d98e300bde6ae9bddb55964c582772de26b0ec",
+      "fingerprint": "b67e346fedc97f62979f5f543b68cf83b4dceba9c0d71a7fb8755534ed98d6fe",
       "full_name": "Meridian.Contracts.Ledger.AccountingBasisProjectionTargetDto",
       "id": "Meridian.Contracts.Ledger.AccountingBasisProjectionTargetDto",
       "kind": "record",
@@ -136113,7 +140389,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingBasisKindDto",
-          "source_line": 956,
+          "source_line": 982,
           "type": "AccountingBasisKindDto"
         },
         {
@@ -136128,7 +140404,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "LedgerDimensionSetDto?",
-          "source_line": 961,
+          "source_line": 987,
           "type": "LedgerDimensionSetDto?"
         },
         {
@@ -136142,7 +140418,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 957,
+          "source_line": 983,
           "type": "Guid"
         },
         {
@@ -136156,7 +140432,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 958,
+          "source_line": 984,
           "type": "Guid"
         },
         {
@@ -136171,7 +140447,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 959,
+          "source_line": 985,
           "type": "string?"
         },
         {
@@ -136186,7 +140462,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "AccountingTreatmentKindDto?",
-          "source_line": 960,
+          "source_line": 986,
           "type": "AccountingTreatmentKindDto?"
         }
       ],
@@ -136200,12 +140476,12 @@
         "Meridian.Contracts.Ledger.LedgerDimensionSetDto"
       ],
       "source": {
-        "line": 955,
+        "line": 981,
         "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
       },
       "sources": [
         {
-          "line": 955,
+          "line": 981,
           "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
         }
       ],
@@ -138200,7 +142476,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "318e999f34037c4f743213c4d0ddc98738a851e4c590e5f9482c33e8a7acf36d",
+      "fingerprint": "a53ccc953574f7833c2fe860f63c23d0d785ccd6d5ce7dfe68184c25b1ad06aa",
       "full_name": "Meridian.Contracts.Ledger.AccountingPostingCommandDto",
       "id": "Meridian.Contracts.Ledger.AccountingPostingCommandDto",
       "kind": "record",
@@ -138220,7 +142496,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "OperationsActionOriginDto",
-          "source_line": 71,
+          "source_line": 78,
           "type": "OperationsActionOriginDto"
         },
         {
@@ -138234,7 +142510,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 54,
+          "source_line": 61,
           "type": "Guid"
         },
         {
@@ -138249,7 +142525,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 68,
+          "source_line": 75,
           "type": "string?"
         },
         {
@@ -138264,7 +142540,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingPostingApprovalStateDto",
-          "source_line": 67,
+          "source_line": 74,
           "type": "AccountingPostingApprovalStateDto"
         },
         {
@@ -138278,7 +142554,7 @@
           "nullable": true,
           "origin": "property",
           "raw_type": "AccountingBookContextDto?",
-          "source_line": 77,
+          "source_line": 84,
           "type": "AccountingBookContextDto?"
         },
         {
@@ -138292,7 +142568,7 @@
           "nullable": true,
           "origin": "property",
           "raw_type": "Guid?",
-          "source_line": 79,
+          "source_line": 86,
           "type": "Guid?"
         },
         {
@@ -138307,7 +142583,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 62,
+          "source_line": 69,
           "type": "Guid?"
         },
         {
@@ -138321,7 +142597,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 53,
+          "source_line": 60,
           "type": "Guid"
         },
         {
@@ -138336,7 +142612,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 61,
+          "source_line": 68,
           "type": "Guid?"
         },
         {
@@ -138350,7 +142626,7 @@
           "nullable": true,
           "origin": "property",
           "raw_type": "EconomicEventReferenceDto?",
-          "source_line": 81,
+          "source_line": 88,
           "type": "EconomicEventReferenceDto?"
         },
         {
@@ -138364,7 +142640,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateOnly",
-          "source_line": 56,
+          "source_line": 63,
           "type": "DateOnly"
         },
         {
@@ -138378,7 +142654,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingPostingEvidenceReferenceDto>",
-          "source_line": 74,
+          "source_line": 81,
           "type": "IReadOnlyList<AccountingPostingEvidenceReferenceDto>"
         },
         {
@@ -138393,7 +142669,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "long?",
-          "source_line": 64,
+          "source_line": 71,
           "type": "long?"
         },
         {
@@ -138407,7 +142683,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 58,
+          "source_line": 65,
           "type": "string"
         },
         {
@@ -138422,7 +142698,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingPostingIntentDto",
-          "source_line": 59,
+          "source_line": 66,
           "type": "AccountingPostingIntentDto"
         },
         {
@@ -138437,7 +142713,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 72,
+          "source_line": 79,
           "type": "Guid?"
         },
         {
@@ -138452,7 +142728,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 69,
+          "source_line": 76,
           "type": "string?"
         },
         {
@@ -138466,7 +142742,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 55,
+          "source_line": 62,
           "type": "Guid"
         },
         {
@@ -138480,7 +142756,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset",
-          "source_line": 57,
+          "source_line": 64,
           "type": "DateTimeOffset"
         },
         {
@@ -138494,7 +142770,7 @@
           "nullable": true,
           "origin": "property",
           "raw_type": "ProjectionLineageDto?",
-          "source_line": 83,
+          "source_line": 90,
           "type": "ProjectionLineageDto?"
         },
         {
@@ -138508,7 +142784,7 @@
           "nullable": true,
           "origin": "property",
           "raw_type": "AccountingRulePackReferenceDto?",
-          "source_line": 85,
+          "source_line": 92,
           "type": "AccountingRulePackReferenceDto?"
         },
         {
@@ -138523,7 +142799,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 60,
+          "source_line": 67,
           "type": "Guid?"
         },
         {
@@ -138538,7 +142814,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 65,
+          "source_line": 72,
           "type": "string?"
         },
         {
@@ -138553,7 +142829,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 63,
+          "source_line": 70,
           "type": "Guid?"
         },
         {
@@ -138568,7 +142844,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "TreasuryLedgerContextDto?",
-          "source_line": 66,
+          "source_line": 73,
           "type": "TreasuryLedgerContextDto?"
         }
       ],
@@ -138588,12 +142864,12 @@
         "Meridian.Contracts.Workstation.OperationsActionOriginDto"
       ],
       "source": {
-        "line": 52,
+        "line": 59,
         "path": "src/Meridian.Contracts/Ledger/AccountingPostingCommandDtos.cs"
       },
       "sources": [
         {
-          "line": 52,
+          "line": 59,
           "path": "src/Meridian.Contracts/Ledger/AccountingPostingCommandDtos.cs"
         }
       ],
@@ -138705,7 +142981,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "e51ad921b956129f2a6ca0d10b9771345275947d842520ed33dc6345c7b01811",
+      "fingerprint": "19c0ffa56d2f8c31769bb0c410ed6776906275ae859d5331f95059a986ce8a90",
       "full_name": "Meridian.Contracts.Ledger.AccountingPostingEvidenceReferenceDto",
       "id": "Meridian.Contracts.Ledger.AccountingPostingEvidenceReferenceDto",
       "kind": "record",
@@ -138746,6 +143022,21 @@
         {
           "collection": false,
           "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EffectiveDate",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "DateOnly?",
+          "source_line": 54,
+          "type": "DateOnly?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
           "element_type": null,
           "json_ignored": false,
           "json_name": null,
@@ -138756,6 +143047,21 @@
           "raw_type": "string",
           "source_line": 42,
           "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "EvidenceVersion",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "long?",
+          "source_line": 55,
+          "type": "long?"
         },
         {
           "collection": false,
@@ -138802,6 +143108,66 @@
         {
           "collection": false,
           "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ReviewedAtUtc",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "DateTimeOffset?",
+          "source_line": 53,
+          "type": "DateTimeOffset?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Reviewer",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 52,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ReviewStatus",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 56,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "SourceReference",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 51,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
           "element_type": null,
           "json_ignored": false,
           "json_name": null,
@@ -138826,6 +143192,21 @@
           "origin": "positional_parameter",
           "raw_type": "string?",
           "source_line": 48,
+          "type": "string?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "SubjectType",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 57,
           "type": "string?"
         },
         {
@@ -141721,7 +146102,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "78be83fa95ba0606eccb6d3076cc520406d95f1f77c64db99f08f986c9a1640e",
+      "fingerprint": "8810d6b18fab268880066fe21656b4e2fd255c16092672d993242e6b8ab2b393",
       "full_name": "Meridian.Contracts.Ledger.AccountingRuleTestCaseDto",
       "id": "Meridian.Contracts.Ledger.AccountingRuleTestCaseDto",
       "kind": "record",
@@ -141740,7 +146121,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1013,
+          "source_line": 1039,
           "type": "string"
         },
         {
@@ -141754,7 +146135,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 1028,
+          "source_line": 1054,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -141769,7 +146150,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 1017,
+          "source_line": 1043,
           "type": "bool"
         },
         {
@@ -141783,7 +146164,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<GeneratedPostingLineDto>",
-          "source_line": 1025,
+          "source_line": 1051,
           "type": "IReadOnlyList<GeneratedPostingLineDto>"
         },
         {
@@ -141797,7 +146178,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 1022,
+          "source_line": 1048,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -141812,7 +146193,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 1015,
+          "source_line": 1041,
           "type": "string?"
         },
         {
@@ -141827,7 +146208,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 1016,
+          "source_line": 1042,
           "type": "string?"
         },
         {
@@ -141841,7 +146222,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "RuleDryRunRequestDto",
-          "source_line": 1014,
+          "source_line": 1040,
           "type": "RuleDryRunRequestDto"
         },
         {
@@ -141855,7 +146236,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1012,
+          "source_line": 1038,
           "type": "string"
         }
       ],
@@ -141868,12 +146249,12 @@
         "Meridian.Contracts.Ledger.RuleDryRunRequestDto"
       ],
       "source": {
-        "line": 1011,
+        "line": 1037,
         "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
       },
       "sources": [
         {
-          "line": 1011,
+          "line": 1037,
           "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
         }
       ],
@@ -141892,7 +146273,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "1906f0a94e74034bfc74d3caa71fa400fa0acec74d9097d4a6c57f5a592d8ea4",
+      "fingerprint": "c57817a55db559170951b0364eb3aa06f5f04320f4206253d8d18e26a139684e",
       "full_name": "Meridian.Contracts.Ledger.AccountingRuleTestCaseResultDto",
       "id": "Meridian.Contracts.Ledger.AccountingRuleTestCaseResultDto",
       "kind": "record",
@@ -141911,7 +146292,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<AccountingConfigurationValidationIssueDto>",
-          "source_line": 1037,
+          "source_line": 1063,
           "type": "IReadOnlyList<AccountingConfigurationValidationIssueDto>"
         },
         {
@@ -141925,7 +146306,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1034,
+          "source_line": 1060,
           "type": "string"
         },
         {
@@ -141939,7 +146320,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "RuleDryRunResultDto",
-          "source_line": 1036,
+          "source_line": 1062,
           "type": "RuleDryRunResultDto"
         },
         {
@@ -141953,7 +146334,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 1035,
+          "source_line": 1061,
           "type": "bool"
         },
         {
@@ -141967,7 +146348,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1033,
+          "source_line": 1059,
           "type": "string"
         }
       ],
@@ -141980,12 +146361,12 @@
         "Meridian.Contracts.Ledger.RuleDryRunResultDto"
       ],
       "source": {
-        "line": 1032,
+        "line": 1058,
         "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
       },
       "sources": [
         {
-          "line": 1032,
+          "line": 1058,
           "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
         }
       ],
@@ -142004,7 +146385,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "0f6cc5b7b5e74e6bd258fc15e8956e546f560ca701f6b5cd90fc88d16a4b38f9",
+      "fingerprint": "1f5421948f1d2b5852786db4c149b6615936632cb425ab0c9bdb5612954ad31c",
       "full_name": "Meridian.Contracts.Ledger.AccountingRuleTestSuiteResultDto",
       "id": "Meridian.Contracts.Ledger.AccountingRuleTestSuiteResultDto",
       "kind": "record",
@@ -142023,7 +146404,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1043,
+          "source_line": 1069,
           "type": "string"
         },
         {
@@ -142037,7 +146418,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset",
-          "source_line": 1042,
+          "source_line": 1068,
           "type": "DateTimeOffset"
         },
         {
@@ -142051,7 +146432,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "int",
-          "source_line": 1046,
+          "source_line": 1072,
           "type": "int"
         },
         {
@@ -142065,7 +146446,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1040,
+          "source_line": 1066,
           "type": "string"
         },
         {
@@ -142079,7 +146460,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 1041,
+          "source_line": 1067,
           "type": "Guid?"
         },
         {
@@ -142093,7 +146474,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "int",
-          "source_line": 1045,
+          "source_line": 1071,
           "type": "int"
         },
         {
@@ -142107,7 +146488,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<AccountingRuleTestCaseResultDto>",
-          "source_line": 1047,
+          "source_line": 1073,
           "type": "IReadOnlyList<AccountingRuleTestCaseResultDto>"
         },
         {
@@ -142121,7 +146502,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "int",
-          "source_line": 1044,
+          "source_line": 1070,
           "type": "int"
         }
       ],
@@ -142133,12 +146514,12 @@
         "Meridian.Contracts.Ledger.AccountingRuleTestCaseResultDto"
       ],
       "source": {
-        "line": 1039,
+        "line": 1065,
         "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
       },
       "sources": [
         {
-          "line": 1039,
+          "line": 1065,
           "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
         }
       ],
@@ -149476,7 +153857,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "5b6b37d22c9c4cf559d0a2f84d27378deefe3a4ba558b64ce58133ce964e4a93",
+      "fingerprint": "1f61d9157ebdaf562f91192fb4050dc56c5e4723a1d794d22a1ff00115f77fd6",
       "full_name": "Meridian.Contracts.Ledger.ExecuteAccountingRuleTestCasesRequestDto",
       "id": "Meridian.Contracts.Ledger.ExecuteAccountingRuleTestCasesRequestDto",
       "kind": "record",
@@ -149495,7 +153876,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1051,
+          "source_line": 1077,
           "type": "string"
         },
         {
@@ -149510,7 +153891,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 1056,
+          "source_line": 1082,
           "type": "string?"
         },
         {
@@ -149525,7 +153906,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 1054,
+          "source_line": 1080,
           "type": "string?"
         },
         {
@@ -149539,7 +153920,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1050,
+          "source_line": 1076,
           "type": "string"
         },
         {
@@ -149554,7 +153935,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 1053,
+          "source_line": 1079,
           "type": "Guid?"
         },
         {
@@ -149569,7 +153950,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 1055,
+          "source_line": 1081,
           "type": "string?"
         },
         {
@@ -149583,7 +153964,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<AccountingRuleTestCaseDto>",
-          "source_line": 1058,
+          "source_line": 1084,
           "type": "IReadOnlyList<AccountingRuleTestCaseDto>"
         }
       ],
@@ -149595,12 +153976,12 @@
         "Meridian.Contracts.Ledger.AccountingRuleTestCaseDto"
       ],
       "source": {
-        "line": 1049,
+        "line": 1075,
         "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
       },
       "sources": [
         {
-          "line": 1049,
+          "line": 1075,
           "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
         }
       ],
@@ -151988,7 +156369,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "a3ccacd0bf34c024297aff029e2c0664b6db2b696aa89be2e2084311505a28a3",
+      "fingerprint": "1883b4bd8bb29c5a0e23bd606e5fed7148d7e43534c26fd45b527b2bd0114551",
       "full_name": "Meridian.Contracts.Ledger.JournalEntryLifecycleActionRequestDto",
       "id": "Meridian.Contracts.Ledger.JournalEntryLifecycleActionRequestDto",
       "kind": "record",
@@ -152007,7 +156388,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "JournalEntryLifecycleActionDto",
-          "source_line": 1080,
+          "source_line": 1106,
           "type": "JournalEntryLifecycleActionDto"
         },
         {
@@ -152022,7 +156403,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "OperationsActionOriginDto",
-          "source_line": 1086,
+          "source_line": 1112,
           "type": "OperationsActionOriginDto"
         },
         {
@@ -152036,7 +156417,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1081,
+          "source_line": 1107,
           "type": "string"
         },
         {
@@ -152051,7 +156432,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 1091,
+          "source_line": 1117,
           "type": "string?"
         },
         {
@@ -152066,7 +156447,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 1084,
+          "source_line": 1110,
           "type": "string?"
         },
         {
@@ -152080,7 +156461,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 1094,
+          "source_line": 1120,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -152094,7 +156475,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1079,
+          "source_line": 1105,
           "type": "string"
         },
         {
@@ -152108,7 +156489,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 1078,
+          "source_line": 1104,
           "type": "Guid"
         },
         {
@@ -152123,7 +156504,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 1089,
+          "source_line": 1115,
           "type": "Guid?"
         },
         {
@@ -152138,7 +156519,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 1083,
+          "source_line": 1109,
           "type": "string?"
         },
         {
@@ -152153,7 +156534,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 1087,
+          "source_line": 1113,
           "type": "bool"
         },
         {
@@ -152167,7 +156548,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<ManualJournalEntryLineDto>",
-          "source_line": 1097,
+          "source_line": 1123,
           "type": "IReadOnlyList<ManualJournalEntryLineDto>"
         },
         {
@@ -152182,7 +156563,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "IReadOnlyList<string>?",
-          "source_line": 1092,
+          "source_line": 1118,
           "type": "IReadOnlyList<string>?"
         },
         {
@@ -152197,7 +156578,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 1090,
+          "source_line": 1116,
           "type": "string?"
         },
         {
@@ -152211,7 +156592,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "int",
-          "source_line": 1082,
+          "source_line": 1108,
           "type": "int"
         }
       ],
@@ -152225,12 +156606,12 @@
         "Meridian.Contracts.Workstation.OperationsActionOriginDto"
       ],
       "source": {
-        "line": 1077,
+        "line": 1103,
         "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
       },
       "sources": [
         {
-          "line": 1077,
+          "line": 1103,
           "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
         }
       ],
@@ -152249,7 +156630,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "9b4ed3d52166f71ff47856552b5d2371da0aeda1155aa0d74c0ae21ca541c268",
+      "fingerprint": "74dbb18c197a65ded3bf0826e2008880af18252dad69eab30b9cab94a05531ec",
       "full_name": "Meridian.Contracts.Ledger.JournalEntryLifecycleActionResultDto",
       "id": "Meridian.Contracts.Ledger.JournalEntryLifecycleActionResultDto",
       "kind": "record",
@@ -152268,7 +156649,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<ManualJournalEntryDraftDto>",
-          "source_line": 1134,
+          "source_line": 1160,
           "type": "IReadOnlyList<ManualJournalEntryDraftDto>"
         },
         {
@@ -152282,7 +156663,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "ManualJournalEntryDraftDto",
-          "source_line": 1129,
+          "source_line": 1155,
           "type": "ManualJournalEntryDraftDto"
         },
         {
@@ -152297,7 +156678,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "PostedLedgerJournalEntryResultDto?",
-          "source_line": 1132,
+          "source_line": 1158,
           "type": "PostedLedgerJournalEntryResultDto?"
         },
         {
@@ -152311,7 +156692,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "JournalEntryLifecycleTransitionDto",
-          "source_line": 1130,
+          "source_line": 1156,
           "type": "JournalEntryLifecycleTransitionDto"
         }
       ],
@@ -152325,12 +156706,12 @@
         "Meridian.Contracts.Ledger.PostedLedgerJournalEntryResultDto"
       ],
       "source": {
-        "line": 1128,
+        "line": 1154,
         "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
       },
       "sources": [
         {
-          "line": 1128,
+          "line": 1154,
           "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
         }
       ],
@@ -152349,7 +156730,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "3c5549072b6969b8a01f4b448b6ea5acf1c150d2cdb689e751fd0469b04b7d7a",
+      "fingerprint": "0d95f5eee7c0911ac405f7e1424eb54a115c539b1014e2b2fb194707d87ce908",
       "full_name": "Meridian.Contracts.Ledger.JournalEntryLifecycleTransitionDto",
       "id": "Meridian.Contracts.Ledger.JournalEntryLifecycleTransitionDto",
       "kind": "record",
@@ -152368,7 +156749,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "JournalEntryLifecycleActionDto",
-          "source_line": 1066,
+          "source_line": 1092,
           "type": "JournalEntryLifecycleActionDto"
         },
         {
@@ -152382,7 +156763,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1067,
+          "source_line": 1093,
           "type": "string"
         },
         {
@@ -152397,7 +156778,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 1070,
+          "source_line": 1096,
           "type": "string?"
         },
         {
@@ -152411,7 +156792,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 1073,
+          "source_line": 1099,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -152425,7 +156806,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "ManualJournalEntryStatusDto",
-          "source_line": 1064,
+          "source_line": 1090,
           "type": "ManualJournalEntryStatusDto"
         },
         {
@@ -152440,7 +156821,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 1069,
+          "source_line": 1095,
           "type": "string?"
         },
         {
@@ -152454,7 +156835,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset",
-          "source_line": 1068,
+          "source_line": 1094,
           "type": "DateTimeOffset"
         },
         {
@@ -152468,7 +156849,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "ManualJournalEntryStatusDto",
-          "source_line": 1065,
+          "source_line": 1091,
           "type": "ManualJournalEntryStatusDto"
         },
         {
@@ -152482,7 +156863,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1063,
+          "source_line": 1089,
           "type": "string"
         }
       ],
@@ -152495,12 +156876,12 @@
         "Meridian.Contracts.Ledger.ManualJournalEntryStatusDto"
       ],
       "source": {
-        "line": 1062,
+        "line": 1088,
         "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
       },
       "sources": [
         {
-          "line": 1062,
+          "line": 1088,
           "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
         }
       ],
@@ -152519,7 +156900,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "412b20a4ec98e495b48ebf6c00573b250460018789533cc6b5eb1843f8b2ae30",
+      "fingerprint": "3bef2aa84551b5b778342b42dd68dc55ba4858f201c7d7649c716ccb4d6ca80d",
       "full_name": "Meridian.Contracts.Ledger.JournalEntryRebookDto",
       "id": "Meridian.Contracts.Ledger.JournalEntryRebookDto",
       "kind": "record",
@@ -152538,7 +156919,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset",
-          "source_line": 1112,
+          "source_line": 1138,
           "type": "DateTimeOffset"
         },
         {
@@ -152552,7 +156933,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1113,
+          "source_line": 1139,
           "type": "string"
         },
         {
@@ -152566,7 +156947,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 1109,
+          "source_line": 1135,
           "type": "Guid"
         },
         {
@@ -152580,7 +156961,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1111,
+          "source_line": 1137,
           "type": "string"
         },
         {
@@ -152594,7 +156975,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 1110,
+          "source_line": 1136,
           "type": "Guid"
         }
       ],
@@ -152604,12 +156985,12 @@
       "qualified_name": "Meridian.Contracts.Ledger.JournalEntryRebookDto",
       "references": [],
       "source": {
-        "line": 1108,
+        "line": 1134,
         "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
       },
       "sources": [
         {
-          "line": 1108,
+          "line": 1134,
           "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
         }
       ],
@@ -152628,7 +157009,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "09b3e4bd370e7f3dbb09165d4b5746b84131d91ab7984c72e200c94677bb29f2",
+      "fingerprint": "5353eb243c7bea8f1169b9e1f56f23e83b52fe0eb8fa07c02ca5f7315edb0906",
       "full_name": "Meridian.Contracts.Ledger.JournalEntryReversalDto",
       "id": "Meridian.Contracts.Ledger.JournalEntryReversalDto",
       "kind": "record",
@@ -152647,7 +157028,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset",
-          "source_line": 1105,
+          "source_line": 1131,
           "type": "DateTimeOffset"
         },
         {
@@ -152661,7 +157042,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1106,
+          "source_line": 1132,
           "type": "string"
         },
         {
@@ -152675,7 +157056,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 1102,
+          "source_line": 1128,
           "type": "Guid"
         },
         {
@@ -152689,7 +157070,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 1104,
+          "source_line": 1130,
           "type": "string"
         },
         {
@@ -152703,7 +157084,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 1103,
+          "source_line": 1129,
           "type": "Guid"
         }
       ],
@@ -152713,12 +157094,12 @@
       "qualified_name": "Meridian.Contracts.Ledger.JournalEntryReversalDto",
       "references": [],
       "source": {
-        "line": 1101,
+        "line": 1127,
         "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
       },
       "sources": [
         {
-          "line": 1101,
+          "line": 1127,
           "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
         }
       ],
@@ -162840,7 +167221,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "ccfe583ae8c148ad8ba257f4a4b428cd7803609c93bc31537f96924635342855",
+      "fingerprint": "43b3b184febde65d47a39653e9a45a9ea088925a87ca92b59eb7f2e1331bbeb1",
       "full_name": "Meridian.Contracts.Ledger.PostedLedgerJournalEntryResultDto",
       "id": "Meridian.Contracts.Ledger.PostedLedgerJournalEntryResultDto",
       "kind": "record",
@@ -162859,7 +167240,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingBasisKindDto",
-          "source_line": 1118,
+          "source_line": 1144,
           "type": "AccountingBasisKindDto"
         },
         {
@@ -162873,7 +167254,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 1120,
+          "source_line": 1146,
           "type": "Guid"
         },
         {
@@ -162887,7 +167268,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 1121,
+          "source_line": 1147,
           "type": "Guid?"
         },
         {
@@ -162901,7 +167282,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 1123,
+          "source_line": 1149,
           "type": "Guid?"
         },
         {
@@ -162916,7 +167297,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "long?",
-          "source_line": 1124,
+          "source_line": 1150,
           "type": "long?"
         },
         {
@@ -162931,7 +167312,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 1126,
+          "source_line": 1152,
           "type": "string?"
         },
         {
@@ -162945,7 +167326,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 1116,
+          "source_line": 1142,
           "type": "Guid"
         },
         {
@@ -162959,7 +167340,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 1117,
+          "source_line": 1143,
           "type": "Guid"
         },
         {
@@ -162973,7 +167354,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "Guid",
-          "source_line": 1119,
+          "source_line": 1145,
           "type": "Guid"
         },
         {
@@ -162988,7 +167369,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset?",
-          "source_line": 1125,
+          "source_line": 1151,
           "type": "DateTimeOffset?"
         },
         {
@@ -163002,7 +167383,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 1122,
+          "source_line": 1148,
           "type": "Guid?"
         }
       ],
@@ -163014,12 +167395,12 @@
         "Meridian.Contracts.Ledger.AccountingBasisKindDto"
       ],
       "source": {
-        "line": 1115,
+        "line": 1141,
         "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
       },
       "sources": [
         {
-          "line": 1115,
+          "line": 1141,
           "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
         }
       ],
@@ -163038,7 +167419,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "5fcbd0cfa94918fd615f952e1b7f2e6a4ac1a345ff49a6af2b964e13ed9cfaae",
+      "fingerprint": "4d462caaf000d3c69d7b7eefa8b1fd1d0830370574c78f86a2cdafa5e4eeec6f",
       "full_name": "Meridian.Contracts.Ledger.PostedPostingRuleJournalCandidateResultDto",
       "id": "Meridian.Contracts.Ledger.PostedPostingRuleJournalCandidateResultDto",
       "kind": "record",
@@ -163057,8 +167438,36 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "PostingRuleJournalCandidateResultDto",
-          "source_line": 951,
+          "source_line": 970,
           "type": "PostingRuleJournalCandidateResultDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "JournalImpact",
+          "nullable": true,
+          "origin": "property",
+          "raw_type": "PostedJournalImpactDto?",
+          "source_line": 974,
+          "type": "PostedJournalImpactDto?"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "AssetAccountingStageEvidenceDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "LifecycleStages",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<AssetAccountingStageEvidenceDto>",
+          "source_line": 978,
+          "type": "IReadOnlyList<AssetAccountingStageEvidenceDto>"
         },
         {
           "collection": false,
@@ -163071,8 +167480,22 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "PostedLedgerJournalEntryResultDto",
-          "source_line": 952,
+          "source_line": 971,
           "type": "PostedLedgerJournalEntryResultDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "TaxLotMutationBatchId",
+          "nullable": true,
+          "origin": "property",
+          "raw_type": "Guid?",
+          "source_line": 976,
+          "type": "Guid?"
         },
         {
           "collection": false,
@@ -163086,7 +167509,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 953,
+          "source_line": 972,
           "type": "bool"
         }
       ],
@@ -163095,16 +167518,18 @@
       "partial": false,
       "qualified_name": "Meridian.Contracts.Ledger.PostedPostingRuleJournalCandidateResultDto",
       "references": [
+        "Meridian.Contracts.AssetOperations.AssetAccountingStageEvidenceDto",
+        "Meridian.Contracts.AssetOperations.PostedJournalImpactDto",
         "Meridian.Contracts.Ledger.PostedLedgerJournalEntryResultDto",
         "Meridian.Contracts.Ledger.PostingRuleJournalCandidateResultDto"
       ],
       "source": {
-        "line": 950,
+        "line": 969,
         "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
       },
       "sources": [
         {
-          "line": 950,
+          "line": 969,
           "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
         }
       ],
@@ -163446,7 +167871,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "63244e12c7d62d82761c1bbe603dbf465442713c279317517f6160fdebe186d4",
+      "fingerprint": "793ecc2df7018b373f0d8c8e28ca63bd2f61d6ccaf8b5db665b91fac2ee5b7d7",
       "full_name": "Meridian.Contracts.Ledger.PostingRuleJournalCandidateIssueDto",
       "id": "Meridian.Contracts.Ledger.PostingRuleJournalCandidateIssueDto",
       "kind": "record",
@@ -163465,7 +167890,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 894,
+          "source_line": 908,
           "type": "bool"
         },
         {
@@ -163479,7 +167904,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 891,
+          "source_line": 905,
           "type": "string"
         },
         {
@@ -163493,7 +167918,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 893,
+          "source_line": 907,
           "type": "string"
         },
         {
@@ -163507,7 +167932,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "AccountingConfigurationValidationSeverityDto",
-          "source_line": 892,
+          "source_line": 906,
           "type": "AccountingConfigurationValidationSeverityDto"
         },
         {
@@ -163522,7 +167947,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 896,
+          "source_line": 910,
           "type": "string?"
         },
         {
@@ -163537,7 +167962,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 895,
+          "source_line": 909,
           "type": "string?"
         }
       ],
@@ -163549,12 +167974,12 @@
         "Meridian.Contracts.Ledger.AccountingConfigurationValidationSeverityDto"
       ],
       "source": {
-        "line": 890,
+        "line": 904,
         "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
       },
       "sources": [
         {
-          "line": 890,
+          "line": 904,
           "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
         }
       ],
@@ -163573,7 +167998,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "1b7ca735ee21ae9eaabb5084e91069aae7792608948be957f0fc489f14d7bbe5",
+      "fingerprint": "9265017ebd6a15ac474efe6dd9db05055e239db8de6a56cbea6f00781aa6e967",
       "full_name": "Meridian.Contracts.Ledger.PostingRuleJournalCandidateRequestDto",
       "id": "Meridian.Contracts.Ledger.PostingRuleJournalCandidateRequestDto",
       "kind": "record",
@@ -163660,11 +168085,25 @@
           "json_ignored": false,
           "json_name": null,
           "key_type": null,
+          "name": "AssetLotMutation",
+          "nullable": true,
+          "origin": "property",
+          "raw_type": "AssetLotMutationInstructionDto?",
+          "source_line": 899,
+          "type": "AssetLotMutationInstructionDto?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
           "name": "BookContext",
           "nullable": true,
           "origin": "property",
           "raw_type": "AccountingBookContextDto?",
-          "source_line": 879,
+          "source_line": 885,
           "type": "AccountingBookContextDto?"
         },
         {
@@ -163678,7 +168117,7 @@
           "nullable": true,
           "origin": "property",
           "raw_type": "Guid?",
-          "source_line": 881,
+          "source_line": 887,
           "type": "Guid?"
         },
         {
@@ -163780,7 +168219,7 @@
           "nullable": true,
           "origin": "property",
           "raw_type": "EconomicEventReferenceDto?",
-          "source_line": 883,
+          "source_line": 889,
           "type": "EconomicEventReferenceDto?"
         },
         {
@@ -163824,6 +168263,20 @@
           "raw_type": "IReadOnlyList<string>",
           "source_line": 876,
           "type": "IReadOnlyList<string>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ExpectedPeriodVersion",
+          "nullable": true,
+          "origin": "property",
+          "raw_type": "long?",
+          "source_line": 901,
+          "type": "long?"
         },
         {
           "collection": false,
@@ -163924,8 +168377,22 @@
           "nullable": true,
           "origin": "property",
           "raw_type": "ProjectionLineageDto?",
-          "source_line": 885,
+          "source_line": 891,
           "type": "ProjectionLineageDto?"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "RetainedEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 883,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
         },
         {
           "collection": false,
@@ -163938,7 +168405,7 @@
           "nullable": true,
           "origin": "property",
           "raw_type": "AccountingRulePackReferenceDto?",
-          "source_line": 887,
+          "source_line": 893,
           "type": "AccountingRulePackReferenceDto?"
         },
         {
@@ -164036,8 +168503,10 @@
       "partial": false,
       "qualified_name": "Meridian.Contracts.Ledger.PostingRuleJournalCandidateRequestDto",
       "references": [
+        "Meridian.Contracts.AssetOperations.AssetLotMutationInstructionDto",
         "Meridian.Contracts.AssetOperations.EconomicEventReferenceDto",
         "Meridian.Contracts.AssetOperations.ProjectionLineageDto",
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto",
         "Meridian.Contracts.Ledger.AccountingBasisKindDto",
         "Meridian.Contracts.Ledger.AccountingBookContextDto",
         "Meridian.Contracts.Ledger.AccountingRulePackReferenceDto",
@@ -164072,7 +168541,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "ec61830f170fac300b04ccfb5268d2d47ad48abca4de07d817c609bce800d4be",
+      "fingerprint": "ab2b12d8c71a20c233e4b2f7948cea673fec29957bbaeae0f839271fe351177e",
       "full_name": "Meridian.Contracts.Ledger.PostingRuleJournalCandidateResultDto",
       "id": "Meridian.Contracts.Ledger.PostingRuleJournalCandidateResultDto",
       "kind": "record",
@@ -164091,7 +168560,7 @@
           "nullable": true,
           "origin": "property",
           "raw_type": "AccountingBookContextDto?",
-          "source_line": 924,
+          "source_line": 938,
           "type": "AccountingBookContextDto?"
         },
         {
@@ -164105,7 +168574,7 @@
           "nullable": true,
           "origin": "property",
           "raw_type": "Guid?",
-          "source_line": 926,
+          "source_line": 940,
           "type": "Guid?"
         },
         {
@@ -164119,7 +168588,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 911,
+          "source_line": 925,
           "type": "bool"
         },
         {
@@ -164133,7 +168602,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 910,
+          "source_line": 924,
           "type": "bool"
         },
         {
@@ -164147,7 +168616,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "RuleDryRunResultDto",
-          "source_line": 899,
+          "source_line": 913,
           "type": "RuleDryRunResultDto"
         },
         {
@@ -164161,7 +168630,7 @@
           "nullable": true,
           "origin": "property",
           "raw_type": "EconomicEventReferenceDto?",
-          "source_line": 928,
+          "source_line": 942,
           "type": "EconomicEventReferenceDto?"
         },
         {
@@ -164175,7 +168644,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 918,
+          "source_line": 932,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -164189,7 +168658,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<GeneratedPostingLineDto>",
-          "source_line": 915,
+          "source_line": 929,
           "type": "IReadOnlyList<GeneratedPostingLineDto>"
         },
         {
@@ -164203,7 +168672,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 909,
+          "source_line": 923,
           "type": "bool"
         },
         {
@@ -164217,7 +168686,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "decimal",
-          "source_line": 907,
+          "source_line": 921,
           "type": "decimal"
         },
         {
@@ -164231,7 +168700,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 908,
+          "source_line": 922,
           "type": "bool"
         },
         {
@@ -164245,7 +168714,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<PostingRuleJournalCandidateIssueDto>",
-          "source_line": 921,
+          "source_line": 935,
           "type": "IReadOnlyList<PostingRuleJournalCandidateIssueDto>"
         },
         {
@@ -164259,7 +168728,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "Guid?",
-          "source_line": 904,
+          "source_line": 918,
           "type": "Guid?"
         },
         {
@@ -164273,7 +168742,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "AccountingPostingCommandDto?",
-          "source_line": 903,
+          "source_line": 917,
           "type": "AccountingPostingCommandDto?"
         },
         {
@@ -164287,7 +168756,7 @@
           "nullable": true,
           "origin": "property",
           "raw_type": "ProjectionLineageDto?",
-          "source_line": 930,
+          "source_line": 944,
           "type": "ProjectionLineageDto?"
         },
         {
@@ -164301,7 +168770,7 @@
           "nullable": true,
           "origin": "property",
           "raw_type": "AccountingRulePackReferenceDto?",
-          "source_line": 932,
+          "source_line": 946,
           "type": "AccountingRulePackReferenceDto?"
         },
         {
@@ -164315,7 +168784,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 900,
+          "source_line": 914,
           "type": "string?"
         },
         {
@@ -164329,7 +168798,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 901,
+          "source_line": 915,
           "type": "string?"
         },
         {
@@ -164343,7 +168812,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "decimal",
-          "source_line": 906,
+          "source_line": 920,
           "type": "decimal"
         },
         {
@@ -164357,7 +168826,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "decimal",
-          "source_line": 905,
+          "source_line": 919,
           "type": "decimal"
         }
       ],
@@ -164376,12 +168845,12 @@
         "Meridian.Contracts.Ledger.RuleDryRunResultDto"
       ],
       "source": {
-        "line": 898,
+        "line": 912,
         "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
       },
       "sources": [
         {
-          "line": 898,
+          "line": 912,
           "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
         }
       ],
@@ -164400,7 +168869,7 @@
         "ledger-contracts"
       ],
       "enum_members": [],
-      "fingerprint": "3a2d51fd1f68c1e9e944a07580a6c1b0818a058e3bd940fe744389a01640b14b",
+      "fingerprint": "0ca492b81f7b47657e2b9011a4358269c6aca71c772402cab15e7768f7d7b945",
       "full_name": "Meridian.Contracts.Ledger.PostPostingRuleJournalCandidateRequestDto",
       "id": "Meridian.Contracts.Ledger.PostPostingRuleJournalCandidateRequestDto",
       "kind": "record",
@@ -164420,7 +168889,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "OperationsActionOriginDto",
-          "source_line": 942,
+          "source_line": 956,
           "type": "OperationsActionOriginDto"
         },
         {
@@ -164434,8 +168903,22 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 937,
+          "source_line": 951,
           "type": "string"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "RetainedEvidenceIdentityDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ApprovalEvidence",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyList<RetainedEvidenceIdentityDto>",
+          "source_line": 966,
+          "type": "IReadOnlyList<RetainedEvidenceIdentityDto>"
         },
         {
           "collection": false,
@@ -164448,7 +168931,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 938,
+          "source_line": 952,
           "type": "string"
         },
         {
@@ -164463,7 +168946,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 939,
+          "source_line": 953,
           "type": "string?"
         },
         {
@@ -164477,7 +168960,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "PostingRuleJournalCandidateRequestDto",
-          "source_line": 936,
+          "source_line": 950,
           "type": "PostingRuleJournalCandidateRequestDto"
         },
         {
@@ -164492,7 +168975,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 944,
+          "source_line": 958,
           "type": "string?"
         },
         {
@@ -164507,7 +168990,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 941,
+          "source_line": 955,
           "type": "string?"
         },
         {
@@ -164521,7 +169004,7 @@
           "nullable": false,
           "origin": "property",
           "raw_type": "IReadOnlyList<string>",
-          "source_line": 946,
+          "source_line": 960,
           "type": "IReadOnlyList<string>"
         },
         {
@@ -164536,7 +169019,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 943,
+          "source_line": 957,
           "type": "string?"
         }
       ],
@@ -164545,16 +169028,17 @@
       "partial": false,
       "qualified_name": "Meridian.Contracts.Ledger.PostPostingRuleJournalCandidateRequestDto",
       "references": [
+        "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto",
         "Meridian.Contracts.Ledger.PostingRuleJournalCandidateRequestDto",
         "Meridian.Contracts.Workstation.OperationsActionOriginDto"
       ],
       "source": {
-        "line": 935,
+        "line": 949,
         "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
       },
       "sources": [
         {
-          "line": 935,
+          "line": 949,
           "path": "src/Meridian.Contracts/Ledger/AccountingConfigurationDtos.cs"
         }
       ],
@@ -202210,6 +206694,64 @@
         "security-master-contracts"
       ],
       "enum_members": [],
+      "fingerprint": "ac2001d98a7ba69c22f67440c82baae5330a3b475e5db39d8450fcd3cf04cb02",
+      "full_name": "Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsUpcasterPipeline",
+      "id": "Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsUpcasterPipeline",
+      "kind": "class",
+      "mapped_schemas": [
+        "security_master"
+      ],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Instance",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "SecurityAssetSpecificTermsUpcasterPipeline",
+          "source_line": 170,
+          "type": "SecurityAssetSpecificTermsUpcasterPipeline"
+        }
+      ],
+      "name": "SecurityAssetSpecificTermsUpcasterPipeline",
+      "namespace": "Meridian.Contracts.SecurityMaster",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsUpcasterPipeline",
+      "references": [
+        "Meridian.Contracts.Schema.ISchemaUpcaster",
+        "Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTerms"
+      ],
+      "source": {
+        "line": 167,
+        "path": "src/Meridian.Contracts/SecurityMaster/SecurityAssetSpecificTermsUpcasterChain.cs"
+      },
+      "sources": [
+        {
+          "line": 167,
+          "path": "src/Meridian.Contracts/SecurityMaster/SecurityAssetSpecificTermsUpcasterChain.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [
+        "ISchemaUpcaster<SecurityAssetSpecificTerms>"
+      ],
+      "classification": "class",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "security-master-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "security-master-contracts"
+      ],
+      "enum_members": [],
       "fingerprint": "d09da90564df6618b9bd0262b635062d632924146a1fe067ffdedb761beb4bd6",
       "full_name": "Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsV0ToCurrentUpcaster",
       "id": "Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsV0ToCurrentUpcaster",
@@ -202249,6 +206791,243 @@
         {
           "line": 22,
           "path": "src/Meridian.Contracts/SecurityMaster/SecurityAssetSpecificTermsUpcaster.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "record",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "security-master-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "security-master-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "b0ebcbb46aaf09acfc6897257d813d42609f4aedd45adcfb677edea70f564be3",
+      "full_name": "Meridian.Contracts.SecurityMaster.SecurityAssetTermField",
+      "id": "Meridian.Contracts.SecurityMaster.SecurityAssetTermField",
+      "kind": "record",
+      "mapped_schemas": [
+        "security_master"
+      ],
+      "members": [
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "string",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Aliases",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "IReadOnlyList<string>",
+          "source_line": 44,
+          "type": "IReadOnlyList<string>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Key",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 41,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Required",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "bool",
+          "source_line": 43,
+          "type": "bool"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Type",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "SecurityAssetTermFieldType",
+          "source_line": 42,
+          "type": "SecurityAssetTermFieldType"
+        }
+      ],
+      "name": "SecurityAssetTermField",
+      "namespace": "Meridian.Contracts.SecurityMaster",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.SecurityMaster.SecurityAssetTermField",
+      "references": [
+        "Meridian.Contracts.SecurityMaster.SecurityAssetTermFieldType"
+      ],
+      "source": {
+        "line": 40,
+        "path": "src/Meridian.Contracts/SecurityMaster/SecurityAssetTermsSchema.cs"
+      },
+      "sources": [
+        {
+          "line": 40,
+          "path": "src/Meridian.Contracts/SecurityMaster/SecurityAssetTermsSchema.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "enum",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "security-master-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "security-master-contracts"
+      ],
+      "enum_members": [
+        {
+          "explicit_value": false,
+          "name": "String",
+          "source_line": 11,
+          "value": null
+        },
+        {
+          "explicit_value": false,
+          "name": "Decimal",
+          "source_line": 14,
+          "value": null
+        },
+        {
+          "explicit_value": false,
+          "name": "Integer",
+          "source_line": 17,
+          "value": null
+        },
+        {
+          "explicit_value": false,
+          "name": "Boolean",
+          "source_line": 20,
+          "value": null
+        },
+        {
+          "explicit_value": false,
+          "name": "Date",
+          "source_line": 23,
+          "value": null
+        },
+        {
+          "explicit_value": false,
+          "name": "Guid",
+          "source_line": 26,
+          "value": null
+        },
+        {
+          "explicit_value": false,
+          "name": "Array",
+          "source_line": 29,
+          "value": null
+        },
+        {
+          "explicit_value": false,
+          "name": "Object",
+          "source_line": 32,
+          "value": null
+        }
+      ],
+      "fingerprint": "f976f11638e170f8a6e347a2974da74474c3b77fe5d73a5eb519343823dd9c05",
+      "full_name": "Meridian.Contracts.SecurityMaster.SecurityAssetTermFieldType",
+      "id": "Meridian.Contracts.SecurityMaster.SecurityAssetTermFieldType",
+      "kind": "enum",
+      "mapped_schemas": [
+        "security_master"
+      ],
+      "members": [],
+      "name": "SecurityAssetTermFieldType",
+      "namespace": "Meridian.Contracts.SecurityMaster",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.SecurityMaster.SecurityAssetTermFieldType",
+      "references": [],
+      "source": {
+        "line": 8,
+        "path": "src/Meridian.Contracts/SecurityMaster/SecurityAssetTermsSchema.cs"
+      },
+      "sources": [
+        {
+          "line": 8,
+          "path": "src/Meridian.Contracts/SecurityMaster/SecurityAssetTermsSchema.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "class",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts",
+        "security-master-contracts"
+      ],
+      "diagram": true,
+      "diagram_contract_sets": [
+        "security-master-contracts"
+      ],
+      "enum_members": [],
+      "fingerprint": "3f5a9b0f9b06659785ccfb468ff1bb065d047a855e4012b9a675f8d3f53514d0",
+      "full_name": "Meridian.Contracts.SecurityMaster.SecurityAssetTermsSchema",
+      "id": "Meridian.Contracts.SecurityMaster.SecurityAssetTermsSchema",
+      "kind": "class",
+      "mapped_schemas": [
+        "security_master"
+      ],
+      "members": [
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyCollection",
+          "element_type": "string",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AssetClasses",
+          "nullable": false,
+          "origin": "property",
+          "raw_type": "IReadOnlyCollection<string>",
+          "source_line": 327,
+          "type": "IReadOnlyCollection<string>"
+        }
+      ],
+      "name": "SecurityAssetTermsSchema",
+      "namespace": "Meridian.Contracts.SecurityMaster",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.SecurityMaster.SecurityAssetTermsSchema",
+      "references": [],
+      "source": {
+        "line": 70,
+        "path": "src/Meridian.Contracts/SecurityMaster/SecurityAssetTermsSchema.cs"
+      },
+      "sources": [
+        {
+          "line": 70,
+          "path": "src/Meridian.Contracts/SecurityMaster/SecurityAssetTermsSchema.cs"
         }
       ],
       "type_parameters": []
@@ -215177,7 +219956,7 @@
       "diagram": false,
       "diagram_contract_sets": [],
       "enum_members": [],
-      "fingerprint": "b18831499a11b71d71e36743f3826965b85b923a345d72cfb799316532c6a5e4",
+      "fingerprint": "809b118737e32982ee180d69c6c0011e44474211c58461d5564c1b8b6ca10f31",
       "full_name": "Meridian.Contracts.Workstation.ActivationOutcomeDto",
       "id": "Meridian.Contracts.Workstation.ActivationOutcomeDto",
       "kind": "record",
@@ -215194,7 +219973,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 31,
+          "source_line": 75,
           "type": "string"
         },
         {
@@ -215208,7 +219987,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset?",
-          "source_line": 34,
+          "source_line": 78,
           "type": "DateTimeOffset?"
         },
         {
@@ -215222,7 +220001,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 33,
+          "source_line": 77,
           "type": "bool"
         },
         {
@@ -215236,7 +220015,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 29,
+          "source_line": 73,
           "type": "string"
         },
         {
@@ -215250,7 +220029,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 30,
+          "source_line": 74,
           "type": "string"
         },
         {
@@ -215264,7 +220043,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 32,
+          "source_line": 76,
           "type": "string"
         }
       ],
@@ -215274,12 +220053,12 @@
       "qualified_name": "Meridian.Contracts.Workstation.ActivationOutcomeDto",
       "references": [],
       "source": {
-        "line": 28,
+        "line": 72,
         "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
       },
       "sources": [
         {
-          "line": 28,
+          "line": 72,
           "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
         }
       ],
@@ -221978,7 +226757,7 @@
       "diagram": false,
       "diagram_contract_sets": [],
       "enum_members": [],
-      "fingerprint": "75a3bdc49675df26b3ad7b229b38c613892b848b3498b0a59e8aa59e7ea74794",
+      "fingerprint": "1b5ce4930ac400223a660ed3459a406ac9e03b8cb64cf9caa55f6aa93344ff47",
       "full_name": "Meridian.Contracts.Workstation.CompleteActivationOutcomeRequestDto",
       "id": "Meridian.Contracts.Workstation.CompleteActivationOutcomeRequestDto",
       "kind": "record",
@@ -221995,7 +226774,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 44,
+          "source_line": 88,
           "type": "string"
         }
       ],
@@ -222005,12 +226784,12 @@
       "qualified_name": "Meridian.Contracts.Workstation.CompleteActivationOutcomeRequestDto",
       "references": [],
       "source": {
-        "line": 44,
+        "line": 88,
         "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
       },
       "sources": [
         {
-          "line": 44,
+          "line": 88,
           "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
         }
       ],
@@ -222026,7 +226805,7 @@
       "diagram": false,
       "diagram_contract_sets": [],
       "enum_members": [],
-      "fingerprint": "5f8ac756d92aefbcd46d70b9cf04c03fc41d3d0a7f4a81821935a5c028b46e87",
+      "fingerprint": "35c4cdc2998ae01e78f6412cc58c58dc7aa42c220a2c1074164b92c75d8c6da0",
       "full_name": "Meridian.Contracts.Workstation.CompleteFirstRunRequestDto",
       "id": "Meridian.Contracts.Workstation.CompleteFirstRunRequestDto",
       "kind": "record",
@@ -222043,7 +226822,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 41,
+          "source_line": 85,
           "type": "string"
         },
         {
@@ -222057,7 +226836,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 39,
+          "source_line": 83,
           "type": "string"
         },
         {
@@ -222071,7 +226850,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 40,
+          "source_line": 84,
           "type": "string"
         },
         {
@@ -222085,7 +226864,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 42,
+          "source_line": 86,
           "type": "bool"
         }
       ],
@@ -222095,12 +226874,12 @@
       "qualified_name": "Meridian.Contracts.Workstation.CompleteFirstRunRequestDto",
       "references": [],
       "source": {
-        "line": 38,
+        "line": 82,
         "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
       },
       "sources": [
         {
-          "line": 38,
+          "line": 82,
           "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
         }
       ],
@@ -225084,7 +229863,7 @@
       "diagram": false,
       "diagram_contract_sets": [],
       "enum_members": [],
-      "fingerprint": "ba8c53e941345979df25641477f2633b8a11dd1f2742519698f3f0fe4d48feb6",
+      "fingerprint": "cc72ba1493cc32733e5439ee0ec260c866126dc74da65f997d52bad845c82895",
       "full_name": "Meridian.Contracts.Workstation.DesktopLaunchTicketRedemptionDto",
       "id": "Meridian.Contracts.Workstation.DesktopLaunchTicketRedemptionDto",
       "kind": "record",
@@ -225101,7 +229880,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DateTimeOffset",
-          "source_line": 49,
+          "source_line": 93,
           "type": "DateTimeOffset"
         },
         {
@@ -225115,7 +229894,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 48,
+          "source_line": 92,
           "type": "string"
         },
         {
@@ -225129,7 +229908,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 47,
+          "source_line": 91,
           "type": "string"
         }
       ],
@@ -225139,12 +229918,12 @@
       "qualified_name": "Meridian.Contracts.Workstation.DesktopLaunchTicketRedemptionDto",
       "references": [],
       "source": {
-        "line": 46,
+        "line": 90,
         "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
       },
       "sources": [
         {
-          "line": 46,
+          "line": 90,
           "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
         }
       ],
@@ -238271,7 +243050,7 @@
       "diagram": false,
       "diagram_contract_sets": [],
       "enum_members": [],
-      "fingerprint": "27de409715fceea38856c2b95bed42c071fea497987acbd1cba5edbbf06609b4",
+      "fingerprint": "a9bfe8b418d06984401072cbd24c24fe9f76e720a4e606f489dd86709f6edd4e",
       "full_name": "Meridian.Contracts.Workstation.FirstRunStatusDto",
       "id": "Meridian.Contracts.Workstation.FirstRunStatusDto",
       "kind": "record",
@@ -238350,6 +243129,21 @@
         {
           "collection": false,
           "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "SampleWorkspace",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "SampleWorkspaceDto?",
+          "source_line": 12,
+          "type": "SampleWorkspaceDto?"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
           "element_type": null,
           "json_ignored": false,
           "json_name": null,
@@ -238397,6 +243191,7 @@
       "references": [
         "Meridian.Contracts.Workstation.ActivationOutcomeDto",
         "Meridian.Contracts.Workstation.RecommendedActionDto",
+        "Meridian.Contracts.Workstation.SampleWorkspaceDto",
         "Meridian.Contracts.Workstation.StarterWorkspaceDto",
         "Meridian.Contracts.Workstation.WorkspaceModeDto"
       ],
@@ -279965,7 +284760,7 @@
       "diagram": false,
       "diagram_contract_sets": [],
       "enum_members": [],
-      "fingerprint": "5e9c0b0271687705631cbe073c25f974049527b2eaccc7b54e61d644ef5796d2",
+      "fingerprint": "3f2dfae296e1e594b5e53acd6a55f1b77a9e081cfce1ee835a99808139748632",
       "full_name": "Meridian.Contracts.Workstation.RecommendedActionDto",
       "id": "Meridian.Contracts.Workstation.RecommendedActionDto",
       "kind": "record",
@@ -279982,7 +284777,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 36,
+          "source_line": 80,
           "type": "string"
         },
         {
@@ -279996,7 +284791,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 36,
+          "source_line": 80,
           "type": "string"
         },
         {
@@ -280010,7 +284805,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 36,
+          "source_line": 80,
           "type": "string"
         }
       ],
@@ -280020,12 +284815,12 @@
       "qualified_name": "Meridian.Contracts.Workstation.RecommendedActionDto",
       "references": [],
       "source": {
-        "line": 36,
+        "line": 80,
         "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
       },
       "sources": [
         {
-          "line": 36,
+          "line": 80,
           "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
         }
       ],
@@ -305279,6 +310074,734 @@
       "diagram": false,
       "diagram_contract_sets": [],
       "enum_members": [],
+      "fingerprint": "8f3ce4afdcb11a823157033dcc2e030f23cc0ca848ea6b67790e23173cfef8a5",
+      "full_name": "Meridian.Contracts.Workstation.SampleArtifactDto",
+      "id": "Meridian.Contracts.Workstation.SampleArtifactDto",
+      "kind": "record",
+      "mapped_schemas": [],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Detail",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 51,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Name",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 51,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Route",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 51,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Status",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 51,
+          "type": "string"
+        }
+      ],
+      "name": "SampleArtifactDto",
+      "namespace": "Meridian.Contracts.Workstation",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.Workstation.SampleArtifactDto",
+      "references": [],
+      "source": {
+        "line": 51,
+        "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 51,
+          "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts"
+      ],
+      "diagram": false,
+      "diagram_contract_sets": [],
+      "enum_members": [],
+      "fingerprint": "550d30545b188d54f255eda91b6d6c18c7ca97b560f046992782e1f7fdb14829",
+      "full_name": "Meridian.Contracts.Workstation.SampleBreakDto",
+      "id": "Meridian.Contracts.Workstation.SampleBreakDto",
+      "kind": "record",
+      "mapped_schemas": [],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Category",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 45,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Id",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 43,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Route",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 49,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Severity",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 46,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Summary",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 48,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Title",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 44,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Variance",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 47,
+          "type": "decimal"
+        }
+      ],
+      "name": "SampleBreakDto",
+      "namespace": "Meridian.Contracts.Workstation",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.Workstation.SampleBreakDto",
+      "references": [],
+      "source": {
+        "line": 42,
+        "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 42,
+          "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts"
+      ],
+      "diagram": false,
+      "diagram_contract_sets": [],
+      "enum_members": [],
+      "fingerprint": "7e56ba3f81695aca9ae7ba97688b0d13012dd332c34900a33d9d1e1b5a54e62c",
+      "full_name": "Meridian.Contracts.Workstation.SampleHighlightDto",
+      "id": "Meridian.Contracts.Workstation.SampleHighlightDto",
+      "kind": "record",
+      "mapped_schemas": [],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Detail",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 55,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Label",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 55,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Route",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 55,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Value",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 55,
+          "type": "string"
+        }
+      ],
+      "name": "SampleHighlightDto",
+      "namespace": "Meridian.Contracts.Workstation",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.Workstation.SampleHighlightDto",
+      "references": [],
+      "source": {
+        "line": 55,
+        "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 55,
+          "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts"
+      ],
+      "diagram": false,
+      "diagram_contract_sets": [],
+      "enum_members": [],
+      "fingerprint": "d6fcd806138c7192cf1bdcbb32edc701495f1ee6f3265f12640dc2b664ff3792",
+      "full_name": "Meridian.Contracts.Workstation.SampleHoldingDto",
+      "id": "Meridian.Contracts.Workstation.SampleHoldingDto",
+      "kind": "record",
+      "mapped_schemas": [],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "AveragePrice",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 37,
+          "type": "decimal"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "LastPrice",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 38,
+          "type": "decimal"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "MarketValue",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 39,
+          "type": "decimal"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Quantity",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 36,
+          "type": "decimal"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Symbol",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 35,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "UnrealizedPnl",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 40,
+          "type": "decimal"
+        }
+      ],
+      "name": "SampleHoldingDto",
+      "namespace": "Meridian.Contracts.Workstation",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.Workstation.SampleHoldingDto",
+      "references": [],
+      "source": {
+        "line": 34,
+        "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 34,
+          "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts"
+      ],
+      "diagram": false,
+      "diagram_contract_sets": [],
+      "enum_members": [],
+      "fingerprint": "9b5fe9ba5d89b506d46b92bce5aa6e240a9ec877bb260ceaf3c99d3959b14e3e",
+      "full_name": "Meridian.Contracts.Workstation.SampleMarketHistoryDto",
+      "id": "Meridian.Contracts.Workstation.SampleMarketHistoryDto",
+      "kind": "record",
+      "mapped_schemas": [],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Route",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 53,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Sessions",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "int",
+          "source_line": 53,
+          "type": "int"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "string",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Symbols",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "IReadOnlyList<string>",
+          "source_line": 53,
+          "type": "IReadOnlyList<string>"
+        }
+      ],
+      "name": "SampleMarketHistoryDto",
+      "namespace": "Meridian.Contracts.Workstation",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.Workstation.SampleMarketHistoryDto",
+      "references": [],
+      "source": {
+        "line": 53,
+        "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 53,
+          "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts"
+      ],
+      "diagram": false,
+      "diagram_contract_sets": [],
+      "enum_members": [],
+      "fingerprint": "2585c0d4084437b711df7c612bc863778368c1a9a1de9b429736e0d6f3e5b768",
+      "full_name": "Meridian.Contracts.Workstation.SampleWorkspaceDto",
+      "id": "Meridian.Contracts.Workstation.SampleWorkspaceDto",
+      "kind": "record",
+      "mapped_schemas": [],
+      "members": [
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Cash",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 24,
+          "type": "decimal"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Headline",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 20,
+          "type": "string"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "SampleHighlightDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Highlights",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "IReadOnlyList<SampleHighlightDto>",
+          "source_line": 32,
+          "type": "IReadOnlyList<SampleHighlightDto>"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "SampleHoldingDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Holdings",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "IReadOnlyList<SampleHoldingDto>",
+          "source_line": 26,
+          "type": "IReadOnlyList<SampleHoldingDto>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "MarketHistory",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "SampleMarketHistoryDto",
+          "source_line": 31,
+          "type": "SampleMarketHistoryDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "PortfolioName",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 22,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "PortfolioValue",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 23,
+          "type": "decimal"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "SampleBreakDto",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "ReconciliationBreaks",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "IReadOnlyList<SampleBreakDto>",
+          "source_line": 28,
+          "type": "IReadOnlyList<SampleBreakDto>"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Report",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "SampleArtifactDto",
+          "source_line": 29,
+          "type": "SampleArtifactDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Strategy",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "SampleArtifactDto",
+          "source_line": 30,
+          "type": "SampleArtifactDto"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Summary",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 21,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "UnrealizedPnl",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "decimal",
+          "source_line": 25,
+          "type": "decimal"
+        },
+        {
+          "collection": true,
+          "collection_kind": "IReadOnlyList",
+          "element_type": "string",
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "Watchlist",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "IReadOnlyList<string>",
+          "source_line": 27,
+          "type": "IReadOnlyList<string>"
+        }
+      ],
+      "name": "SampleWorkspaceDto",
+      "namespace": "Meridian.Contracts.Workstation",
+      "partial": false,
+      "qualified_name": "Meridian.Contracts.Workstation.SampleWorkspaceDto",
+      "references": [
+        "Meridian.Contracts.Workstation.SampleArtifactDto",
+        "Meridian.Contracts.Workstation.SampleBreakDto",
+        "Meridian.Contracts.Workstation.SampleHighlightDto",
+        "Meridian.Contracts.Workstation.SampleHoldingDto",
+        "Meridian.Contracts.Workstation.SampleMarketHistoryDto"
+      ],
+      "source": {
+        "line": 19,
+        "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
+      },
+      "sources": [
+        {
+          "line": 19,
+          "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
+        }
+      ],
+      "type_parameters": []
+    },
+    {
+      "base_types": [],
+      "classification": "dto",
+      "containing_type": null,
+      "contract_sets": [
+        "all-contracts"
+      ],
+      "diagram": false,
+      "diagram_contract_sets": [],
+      "enum_members": [],
       "fingerprint": "c526e58f23d49ae26c78debc26ee428f3c45857b44bd2e40678e5222d36e4081",
       "full_name": "Meridian.Contracts.Workstation.SecurityClassificationSummaryDto",
       "id": "Meridian.Contracts.Workstation.SecurityClassificationSummaryDto",
@@ -312527,7 +318050,7 @@
       "diagram": false,
       "diagram_contract_sets": [],
       "enum_members": [],
-      "fingerprint": "25c002f8aa79e7bd2feedd8ac2f1e384f66a3fc057f78015edb3f59ecac0658d",
+      "fingerprint": "0ceb034947d11dbf66206c807f517bf934a506eabf380271efe43e5cdcab993e",
       "full_name": "Meridian.Contracts.Workstation.StarterWorkspaceDto",
       "id": "Meridian.Contracts.Workstation.StarterWorkspaceDto",
       "kind": "record",
@@ -312544,7 +318067,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 26,
+          "source_line": 70,
           "type": "string"
         },
         {
@@ -312558,7 +318081,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 25,
+          "source_line": 69,
           "type": "string"
         },
         {
@@ -312572,7 +318095,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 24,
+          "source_line": 68,
           "type": "string"
         },
         {
@@ -312586,7 +318109,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 22,
+          "source_line": 66,
           "type": "string"
         },
         {
@@ -312600,7 +318123,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 23,
+          "source_line": 67,
           "type": "string"
         }
       ],
@@ -312610,12 +318133,12 @@
       "qualified_name": "Meridian.Contracts.Workstation.StarterWorkspaceDto",
       "references": [],
       "source": {
-        "line": 21,
+        "line": 65,
         "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
       },
       "sources": [
         {
-          "line": 21,
+          "line": 65,
           "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
         }
       ],
@@ -336340,7 +341863,7 @@
       "diagram": false,
       "diagram_contract_sets": [],
       "enum_members": [],
-      "fingerprint": "5f6b254110843672df384cf207818aa413392cb0e2081ba2bd07a1a192727c28",
+      "fingerprint": "36c4e18782438fa321e0837beb75d26e963eec8b39d1fbe4ed5083fcf709cff8",
       "full_name": "Meridian.Contracts.Workstation.WorkspaceModeDto",
       "id": "Meridian.Contracts.Workstation.WorkspaceModeDto",
       "kind": "record",
@@ -336357,7 +341880,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 17,
+          "source_line": 61,
           "type": "string"
         },
         {
@@ -336371,7 +341894,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 14,
+          "source_line": 58,
           "type": "string"
         },
         {
@@ -336385,7 +341908,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 16,
+          "source_line": 60,
           "type": "bool"
         },
         {
@@ -336399,7 +341922,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 15,
+          "source_line": 59,
           "type": "string"
         },
         {
@@ -336413,7 +341936,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 18,
+          "source_line": 62,
           "type": "string"
         },
         {
@@ -336427,7 +341950,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 19,
+          "source_line": 63,
           "type": "string"
         }
       ],
@@ -336437,12 +341960,12 @@
       "qualified_name": "Meridian.Contracts.Workstation.WorkspaceModeDto",
       "references": [],
       "source": {
-        "line": 13,
+        "line": 57,
         "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
       },
       "sources": [
         {
-          "line": 13,
+          "line": 57,
           "path": "src/Meridian.Contracts/Workstation/FirstRunDtos.cs"
         }
       ],

--- a/database/manifest/dependencies.json
+++ b/database/manifest/dependencies.json
@@ -136,6 +136,18 @@
       "kind": "contract-set-member",
       "label": "",
       "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AccountingSystem.AccountingProductionCertificationEvidenceSubjectTypes"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AccountingSystem.AccountingProductionCertificationEvidenceValidator"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
       "target": "contract:Meridian.Contracts.AccountingSystem.AccountingProductionCertificationProfileDto"
     },
     {
@@ -1642,6 +1654,90 @@
       "kind": "contract-set-member",
       "label": "",
       "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AppendAssetAccountingLifecycleStageRequestDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingCorrectionReferenceDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventKindDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventScopeDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventSpineAppendResultDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventSpineValidator"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventTypeNames"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEvidenceSubjects"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingLifecycleStageDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateRequestDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingStageEvidenceDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAcquisitionLotDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
       "target": "contract:Meridian.Contracts.AssetOperations.AssetActualActivityDto"
     },
     {
@@ -1654,6 +1750,12 @@
       "kind": "contract-set-member",
       "label": "",
       "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetDisposalLotSelectionDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
       "target": "contract:Meridian.Contracts.AssetOperations.AssetLedgerProjectionDto"
     },
     {
@@ -1661,6 +1763,24 @@
       "label": "",
       "source": "contract-set:all-contracts",
       "target": "contract:Meridian.Contracts.AssetOperations.AssetLifecycleEventDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetLotMutationInstructionDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetLotMutationInstructionValidator"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetLotMutationIntentDto"
     },
     {
       "kind": "contract-set-member",
@@ -1822,6 +1942,12 @@
       "kind": "contract-set-member",
       "label": "",
       "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.JournalPostingStatusDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
       "target": "contract:Meridian.Contracts.AssetOperations.PortfolioCapitalActivityDto"
     },
     {
@@ -1888,7 +2014,55 @@
       "kind": "contract-set-member",
       "label": "",
       "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.PostedJournalImpactDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.PostedJournalImpactLineDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.PostedJournalImpactValidator"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.ProjectAssetAccountingEventRequestDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.ProjectedAccountingEffectDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.ProjectedAccountingEffectLineDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
       "target": "contract:Meridian.Contracts.AssetOperations.ProjectionLineageDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityValidator"
     },
     {
       "kind": "contract-set-member",
@@ -8440,7 +8614,31 @@
       "kind": "contract-set-member",
       "label": "",
       "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsUpcasterPipeline"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
       "target": "contract:Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsV0ToCurrentUpcaster"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.SecurityMaster.SecurityAssetTermField"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.SecurityMaster.SecurityAssetTermFieldType"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.SecurityMaster.SecurityAssetTermsSchema"
     },
     {
       "kind": "contract-set-member",
@@ -12694,6 +12892,42 @@
       "kind": "contract-set-member",
       "label": "",
       "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.Workstation.SampleArtifactDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.Workstation.SampleBreakDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.Workstation.SampleHighlightDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.Workstation.SampleHoldingDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.Workstation.SampleMarketHistoryDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
+      "target": "contract:Meridian.Contracts.Workstation.SampleWorkspaceDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:all-contracts",
       "target": "contract:Meridian.Contracts.Workstation.SecurityClassificationSummaryDto"
     },
     {
@@ -14494,6 +14728,90 @@
       "kind": "contract-set-member",
       "label": "",
       "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AppendAssetAccountingLifecycleStageRequestDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingCorrectionReferenceDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventKindDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventScopeDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventSpineAppendResultDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventSpineValidator"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventTypeNames"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEvidenceSubjects"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingLifecycleStageDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateRequestDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingStageEvidenceDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAcquisitionLotDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
       "target": "contract:Meridian.Contracts.AssetOperations.AssetActualActivityDto"
     },
     {
@@ -14506,6 +14824,12 @@
       "kind": "contract-set-member",
       "label": "",
       "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetDisposalLotSelectionDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
       "target": "contract:Meridian.Contracts.AssetOperations.AssetLedgerProjectionDto"
     },
     {
@@ -14513,6 +14837,24 @@
       "label": "",
       "source": "contract-set:asset-operations-contracts",
       "target": "contract:Meridian.Contracts.AssetOperations.AssetLifecycleEventDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetLotMutationInstructionDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetLotMutationInstructionValidator"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetLotMutationIntentDto"
     },
     {
       "kind": "contract-set-member",
@@ -14674,6 +15016,12 @@
       "kind": "contract-set-member",
       "label": "",
       "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.JournalPostingStatusDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
       "target": "contract:Meridian.Contracts.AssetOperations.PortfolioCapitalActivityDto"
     },
     {
@@ -14740,7 +15088,55 @@
       "kind": "contract-set-member",
       "label": "",
       "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.PostedJournalImpactDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.PostedJournalImpactLineDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.PostedJournalImpactValidator"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.ProjectAssetAccountingEventRequestDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.ProjectedAccountingEffectDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.ProjectedAccountingEffectLineDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
       "target": "contract:Meridian.Contracts.AssetOperations.ProjectionLineageDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:asset-operations-contracts",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityValidator"
     },
     {
       "kind": "contract-set-member",
@@ -16667,6 +17063,18 @@
       "label": "",
       "source": "contract-set:ledger-contracts",
       "target": "contract:Meridian.Contracts.AccountingSystem.AccountingMigrationRunWorkerPlanUpsertRequestDto"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:ledger-contracts",
+      "target": "contract:Meridian.Contracts.AccountingSystem.AccountingProductionCertificationEvidenceSubjectTypes"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:ledger-contracts",
+      "target": "contract:Meridian.Contracts.AccountingSystem.AccountingProductionCertificationEvidenceValidator"
     },
     {
       "kind": "contract-set-member",
@@ -19006,7 +19414,31 @@
       "kind": "contract-set-member",
       "label": "",
       "source": "contract-set:security-master-contracts",
+      "target": "contract:Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsUpcasterPipeline"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:security-master-contracts",
       "target": "contract:Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsV0ToCurrentUpcaster"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:security-master-contracts",
+      "target": "contract:Meridian.Contracts.SecurityMaster.SecurityAssetTermField"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:security-master-contracts",
+      "target": "contract:Meridian.Contracts.SecurityMaster.SecurityAssetTermFieldType"
+    },
+    {
+      "kind": "contract-set-member",
+      "label": "",
+      "source": "contract-set:security-master-contracts",
+      "target": "contract:Meridian.Contracts.SecurityMaster.SecurityAssetTermsSchema"
     },
     {
       "kind": "contract-set-member",
@@ -19431,6 +19863,30 @@
     {
       "kind": "contract-reference",
       "label": "",
+      "source": "contract:Meridian.Contracts.AccountingSystem.AccountingDimensionalReportingReadinessDto",
+      "target": "contract:Meridian.Contracts.AccountingSystem.AccountingDimensionalCertificationArtifactDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AccountingSystem.AccountingDimensionalReportingReadinessDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AccountingSystem.AccountingLedgerBookWorkflowReadinessDto",
+      "target": "contract:Meridian.Contracts.AccountingSystem.AccountingWorkflowCertificationArtifactDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AccountingSystem.AccountingLedgerBookWorkflowReadinessDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
       "source": "contract:Meridian.Contracts.AccountingSystem.AccountingMigrationRolloutPlanItemDto",
       "target": "contract:Meridian.Contracts.AccountingSystem.AccountingMigrationRunKindDto"
     },
@@ -19581,8 +20037,20 @@
     {
       "kind": "contract-reference",
       "label": "",
+      "source": "contract:Meridian.Contracts.AccountingSystem.AccountingProductionCertificationProfileDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
       "source": "contract:Meridian.Contracts.AccountingSystem.AccountingProductionCertificationProfileUpsertRequestDto",
       "target": "contract:Meridian.Contracts.AccountingSystem.AccountingProductionCertificationProfileDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AccountingSystem.AccountingProductionCertificationProfileUpsertRequestDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
     },
     {
       "kind": "contract-reference",
@@ -19756,6 +20224,12 @@
       "kind": "contract-reference",
       "label": "",
       "source": "contract:Meridian.Contracts.AccountingSystem.AccountingProductionReadinessRequestDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AccountingSystem.AccountingProductionReadinessRequestDto",
       "target": "contract:Meridian.Contracts.Ledger.AccountingBasisKindDto"
     },
     {
@@ -19919,6 +20393,18 @@
       "label": "",
       "source": "contract:Meridian.Contracts.AccountingSystem.AccountingTenantAdministrationProfileUpsertRequestDto",
       "target": "contract:Meridian.Contracts.Workstation.OperationsActionOriginDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AccountingSystem.AccountingTenantAdministrationReadinessDto",
+      "target": "contract:Meridian.Contracts.AccountingSystem.AccountingTenantAdminCertificationArtifactDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AccountingSystem.AccountingTenantAdministrationReadinessDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
     },
     {
       "kind": "contract-reference",
@@ -20661,6 +21147,228 @@
     {
       "kind": "contract-reference",
       "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AppendAssetAccountingLifecycleStageRequestDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingLifecycleStageDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AppendAssetAccountingLifecycleStageRequestDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingCorrectionReferenceDto",
+      "target": "contract:Meridian.Contracts.Ledger.AccountingBasisKindDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventScopeDto",
+      "target": "contract:Meridian.Contracts.Ledger.AccountingBasisKindDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventScopeDto",
+      "target": "contract:Meridian.Contracts.Ledger.LedgerDimensionSetDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventSpineAppendResultDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingCorrectionReferenceDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventKindDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventScopeDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingStageEvidenceDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetLotMutationInstructionDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.EconomicEventReferenceDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.PostedJournalImpactDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.ProjectedAccountingEffectDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.ProjectionLineageDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto",
+      "target": "contract:Meridian.Contracts.Ledger.PostingRuleJournalCandidateRequestDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto",
+      "target": "contract:Meridian.Contracts.Ledger.PostingRuleJournalCandidateResultDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateDto",
+      "target": "contract:Meridian.Contracts.Ledger.PostingRuleJournalCandidateResultDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateRequestDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventKindDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateRequestDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventScopeDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateRequestDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetLotMutationInstructionDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateRequestDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.EconomicEventReferenceDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateRequestDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.ProjectionLineageDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateRequestDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateRequestDto",
+      "target": "contract:Meridian.Contracts.Ledger.LedgerAdjustmentApprovalMetadataDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingStageEvidenceDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingLifecycleStageDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetAccountingStageEvidenceDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetActualActivityDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetCashFlowProjectionRunDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetLedgerProjectionDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetLifecycleEventDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetLotMutationInstructionDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAcquisitionLotDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetLotMutationInstructionDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetDisposalLotSelectionDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetLotMutationInstructionDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetLotMutationIntentDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetLotMutationInstructionDto",
+      "target": "contract:Meridian.Contracts.Ledger.LedgerAdjustmentApprovalMetadataDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
       "source": "contract:Meridian.Contracts.AssetOperations.AssetOperationsDetailDto",
       "target": "contract:Meridian.Contracts.AssetOperations.AssetActualActivityDto"
     },
@@ -20751,6 +21459,12 @@
     {
       "kind": "contract-reference",
       "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetOperationsDetailDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
       "source": "contract:Meridian.Contracts.AssetOperations.AssetOperationsProjectionDto",
       "target": "contract:Meridian.Contracts.AssetOperations.AssetActualActivityDto"
     },
@@ -20837,6 +21551,42 @@
       "label": "",
       "source": "contract:Meridian.Contracts.AssetOperations.AssetOperationsProjectionDto",
       "target": "contract:Meridian.Contracts.AssetOperations.ProjectionLineageDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetOperationsProjectionDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetOperationsReadinessDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetProjectedCashFlowDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetReconciliationResultDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetReconciliationRunDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetTermsObligationTimelineEventDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
     },
     {
       "kind": "contract-reference",
@@ -20853,6 +21603,24 @@
     {
       "kind": "contract-reference",
       "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetTermsObligationsTimelineDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetTermsVersionDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.AssetTimelineVarianceDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
       "source": "contract:Meridian.Contracts.AssetOperations.BookPositionDto",
       "target": "contract:Meridian.Contracts.AssetOperations.EconomicEventReferenceDto"
     },
@@ -20872,13 +21640,31 @@
       "kind": "contract-reference",
       "label": "",
       "source": "contract:Meridian.Contracts.AssetOperations.BookPositionDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.BookPositionDto",
       "target": "contract:Meridian.Contracts.Ledger.AccountingBookContextDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.EconomicEventReferenceDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
     },
     {
       "kind": "contract-reference",
       "label": "",
       "source": "contract:Meridian.Contracts.AssetOperations.InstrumentRoleDto",
       "target": "contract:Meridian.Contracts.AssetOperations.EconomicEventReferenceDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.InstrumentRoleDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
     },
     {
       "kind": "contract-reference",
@@ -20925,8 +21711,98 @@
     {
       "kind": "contract-reference",
       "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.PositionEconomicStateDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.PostedJournalImpactDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.JournalPostingStatusDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.PostedJournalImpactDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.PostedJournalImpactLineDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.PostedJournalImpactDto",
+      "target": "contract:Meridian.Contracts.Ledger.AccountingBasisKindDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.PostedJournalImpactLineDto",
+      "target": "contract:Meridian.Contracts.Ledger.LedgerDimensionSetDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.ProjectAssetAccountingEventRequestDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingCorrectionReferenceDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.ProjectAssetAccountingEventRequestDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventKindDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.ProjectAssetAccountingEventRequestDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventScopeDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.ProjectAssetAccountingEventRequestDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.EconomicEventReferenceDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.ProjectAssetAccountingEventRequestDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.ProjectedAccountingEffectDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.ProjectAssetAccountingEventRequestDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.ProjectionLineageDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.ProjectAssetAccountingEventRequestDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.ProjectedAccountingEffectDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.ProjectedAccountingEffectLineDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.ProjectedAccountingEffectLineDto",
+      "target": "contract:Meridian.Contracts.Ledger.LedgerDimensionSetDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
       "source": "contract:Meridian.Contracts.AssetOperations.ProjectionLineageDto",
       "target": "contract:Meridian.Contracts.AssetOperations.EconomicEventReferenceDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.AssetOperations.ProjectionLineageDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
     },
     {
       "kind": "contract-reference",
@@ -26332,6 +27208,12 @@
       "kind": "contract-reference",
       "label": "",
       "source": "contract:Meridian.Contracts.Ledger.PostPostingRuleJournalCandidateRequestDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.Ledger.PostPostingRuleJournalCandidateRequestDto",
       "target": "contract:Meridian.Contracts.Ledger.PostingRuleJournalCandidateRequestDto"
     },
     {
@@ -26345,6 +27227,18 @@
       "label": "",
       "source": "contract:Meridian.Contracts.Ledger.PostedLedgerJournalEntryResultDto",
       "target": "contract:Meridian.Contracts.Ledger.AccountingBasisKindDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.Ledger.PostedPostingRuleJournalCandidateResultDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetAccountingStageEvidenceDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.Ledger.PostedPostingRuleJournalCandidateResultDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.PostedJournalImpactDto"
     },
     {
       "kind": "contract-reference",
@@ -26416,6 +27310,12 @@
       "kind": "contract-reference",
       "label": "",
       "source": "contract:Meridian.Contracts.Ledger.PostingRuleJournalCandidateRequestDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.AssetLotMutationInstructionDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.Ledger.PostingRuleJournalCandidateRequestDto",
       "target": "contract:Meridian.Contracts.AssetOperations.EconomicEventReferenceDto"
     },
     {
@@ -26423,6 +27323,12 @@
       "label": "",
       "source": "contract:Meridian.Contracts.Ledger.PostingRuleJournalCandidateRequestDto",
       "target": "contract:Meridian.Contracts.AssetOperations.ProjectionLineageDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.Ledger.PostingRuleJournalCandidateRequestDto",
+      "target": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
     },
     {
       "kind": "contract-reference",
@@ -28041,6 +28947,18 @@
     {
       "kind": "contract-reference",
       "label": "",
+      "source": "contract:Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsUpcasterPipeline",
+      "target": "contract:Meridian.Contracts.Schema.ISchemaUpcaster"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsUpcasterPipeline",
+      "target": "contract:Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTerms"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
       "source": "contract:Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsV0ToCurrentUpcaster",
       "target": "contract:Meridian.Contracts.Schema.ISchemaUpcaster"
     },
@@ -28049,6 +28967,12 @@
       "label": "",
       "source": "contract:Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsV0ToCurrentUpcaster",
       "target": "contract:Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTerms"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.SecurityMaster.SecurityAssetTermField",
+      "target": "contract:Meridian.Contracts.SecurityMaster.SecurityAssetTermFieldType"
     },
     {
       "kind": "contract-reference",
@@ -29639,6 +30563,12 @@
       "label": "",
       "source": "contract:Meridian.Contracts.Workstation.FirstRunStatusDto",
       "target": "contract:Meridian.Contracts.Workstation.RecommendedActionDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.Workstation.FirstRunStatusDto",
+      "target": "contract:Meridian.Contracts.Workstation.SampleWorkspaceDto"
     },
     {
       "kind": "contract-reference",
@@ -33725,6 +34655,36 @@
       "label": "",
       "source": "contract:Meridian.Contracts.Workstation.RunReconciliation",
       "target": "contract:Meridian.Contracts.Workstation.FundWorkflowCommandMetadata"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.Workstation.SampleWorkspaceDto",
+      "target": "contract:Meridian.Contracts.Workstation.SampleArtifactDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.Workstation.SampleWorkspaceDto",
+      "target": "contract:Meridian.Contracts.Workstation.SampleBreakDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.Workstation.SampleWorkspaceDto",
+      "target": "contract:Meridian.Contracts.Workstation.SampleHighlightDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.Workstation.SampleWorkspaceDto",
+      "target": "contract:Meridian.Contracts.Workstation.SampleHoldingDto"
+    },
+    {
+      "kind": "contract-reference",
+      "label": "",
+      "source": "contract:Meridian.Contracts.Workstation.SampleWorkspaceDto",
+      "target": "contract:Meridian.Contracts.Workstation.SampleMarketHistoryDto"
     },
     {
       "kind": "contract-reference",
@@ -39850,7 +40810,7 @@
       "target": "migration-module:security-master"
     }
   ],
-  "fingerprint": "52bfb73c7d5db9d87cb245136e68bf2a20ab9a61155080f37926564b04b34b29",
+  "fingerprint": "f620816e46e8dfbd58ea1994bf99b0caf769364a87c0c54dba0403cd9cf74078",
   "format": "meridian.schema-dependencies.v1",
   "nodes": [
     {
@@ -40034,6 +40994,18 @@
       "id": "contract:Meridian.Contracts.AccountingSystem.AccountingMigrationRunWorkerPlanUpsertRequestDto",
       "kind": "contract-type",
       "label": "Meridian.Contracts.AccountingSystem.AccountingMigrationRunWorkerPlanUpsertRequestDto"
+    },
+    {
+      "classification": "class",
+      "id": "contract:Meridian.Contracts.AccountingSystem.AccountingProductionCertificationEvidenceSubjectTypes",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationEvidenceSubjectTypes"
+    },
+    {
+      "classification": "class",
+      "id": "contract:Meridian.Contracts.AccountingSystem.AccountingProductionCertificationEvidenceValidator",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AccountingSystem.AccountingProductionCertificationEvidenceValidator"
     },
     {
       "classification": "dto",
@@ -41543,6 +42515,90 @@
     },
     {
       "classification": "dto",
+      "id": "contract:Meridian.Contracts.AssetOperations.AppendAssetAccountingLifecycleStageRequestDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.AppendAssetAccountingLifecycleStageRequestDto"
+    },
+    {
+      "classification": "dto",
+      "id": "contract:Meridian.Contracts.AssetOperations.AssetAccountingCorrectionReferenceDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.AssetAccountingCorrectionReferenceDto"
+    },
+    {
+      "classification": "enum",
+      "id": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventKindDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.AssetAccountingEventKindDto"
+    },
+    {
+      "classification": "dto",
+      "id": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventScopeDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.AssetAccountingEventScopeDto"
+    },
+    {
+      "classification": "dto",
+      "id": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventSpineAppendResultDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.AssetAccountingEventSpineAppendResultDto"
+    },
+    {
+      "classification": "dto",
+      "id": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.AssetAccountingEventSpineDto"
+    },
+    {
+      "classification": "class",
+      "id": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventSpineValidator",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.AssetAccountingEventSpineValidator"
+    },
+    {
+      "classification": "class",
+      "id": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEventTypeNames",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.AssetAccountingEventTypeNames"
+    },
+    {
+      "classification": "class",
+      "id": "contract:Meridian.Contracts.AssetOperations.AssetAccountingEvidenceSubjects",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.AssetAccountingEvidenceSubjects"
+    },
+    {
+      "classification": "enum",
+      "id": "contract:Meridian.Contracts.AssetOperations.AssetAccountingLifecycleStageDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.AssetAccountingLifecycleStageDto"
+    },
+    {
+      "classification": "dto",
+      "id": "contract:Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateDto"
+    },
+    {
+      "classification": "dto",
+      "id": "contract:Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateRequestDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.AssetAccountingPostingCandidateRequestDto"
+    },
+    {
+      "classification": "dto",
+      "id": "contract:Meridian.Contracts.AssetOperations.AssetAccountingStageEvidenceDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.AssetAccountingStageEvidenceDto"
+    },
+    {
+      "classification": "dto",
+      "id": "contract:Meridian.Contracts.AssetOperations.AssetAcquisitionLotDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.AssetAcquisitionLotDto"
+    },
+    {
+      "classification": "dto",
       "id": "contract:Meridian.Contracts.AssetOperations.AssetActualActivityDto",
       "kind": "contract-type",
       "label": "Meridian.Contracts.AssetOperations.AssetActualActivityDto"
@@ -41555,6 +42611,12 @@
     },
     {
       "classification": "dto",
+      "id": "contract:Meridian.Contracts.AssetOperations.AssetDisposalLotSelectionDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.AssetDisposalLotSelectionDto"
+    },
+    {
+      "classification": "dto",
       "id": "contract:Meridian.Contracts.AssetOperations.AssetLedgerProjectionDto",
       "kind": "contract-type",
       "label": "Meridian.Contracts.AssetOperations.AssetLedgerProjectionDto"
@@ -41564,6 +42626,24 @@
       "id": "contract:Meridian.Contracts.AssetOperations.AssetLifecycleEventDto",
       "kind": "contract-type",
       "label": "Meridian.Contracts.AssetOperations.AssetLifecycleEventDto"
+    },
+    {
+      "classification": "dto",
+      "id": "contract:Meridian.Contracts.AssetOperations.AssetLotMutationInstructionDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.AssetLotMutationInstructionDto"
+    },
+    {
+      "classification": "class",
+      "id": "contract:Meridian.Contracts.AssetOperations.AssetLotMutationInstructionValidator",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.AssetLotMutationInstructionValidator"
+    },
+    {
+      "classification": "enum",
+      "id": "contract:Meridian.Contracts.AssetOperations.AssetLotMutationIntentDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.AssetLotMutationIntentDto"
     },
     {
       "classification": "dto",
@@ -41722,6 +42802,12 @@
       "label": "Meridian.Contracts.AssetOperations.InstrumentRoleKinds"
     },
     {
+      "classification": "enum",
+      "id": "contract:Meridian.Contracts.AssetOperations.JournalPostingStatusDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.JournalPostingStatusDto"
+    },
+    {
       "classification": "dto",
       "id": "contract:Meridian.Contracts.AssetOperations.PortfolioCapitalActivityDto",
       "kind": "contract-type",
@@ -41789,9 +42875,57 @@
     },
     {
       "classification": "dto",
+      "id": "contract:Meridian.Contracts.AssetOperations.PostedJournalImpactDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.PostedJournalImpactDto"
+    },
+    {
+      "classification": "dto",
+      "id": "contract:Meridian.Contracts.AssetOperations.PostedJournalImpactLineDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.PostedJournalImpactLineDto"
+    },
+    {
+      "classification": "class",
+      "id": "contract:Meridian.Contracts.AssetOperations.PostedJournalImpactValidator",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.PostedJournalImpactValidator"
+    },
+    {
+      "classification": "dto",
+      "id": "contract:Meridian.Contracts.AssetOperations.ProjectAssetAccountingEventRequestDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.ProjectAssetAccountingEventRequestDto"
+    },
+    {
+      "classification": "dto",
+      "id": "contract:Meridian.Contracts.AssetOperations.ProjectedAccountingEffectDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.ProjectedAccountingEffectDto"
+    },
+    {
+      "classification": "dto",
+      "id": "contract:Meridian.Contracts.AssetOperations.ProjectedAccountingEffectLineDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.ProjectedAccountingEffectLineDto"
+    },
+    {
+      "classification": "dto",
       "id": "contract:Meridian.Contracts.AssetOperations.ProjectionLineageDto",
       "kind": "contract-type",
       "label": "Meridian.Contracts.AssetOperations.ProjectionLineageDto"
+    },
+    {
+      "classification": "dto",
+      "id": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityDto"
+    },
+    {
+      "classification": "class",
+      "id": "contract:Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityValidator",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.AssetOperations.RetainedEvidenceIdentityValidator"
     },
     {
       "classification": "class",
@@ -48341,9 +49475,33 @@
     },
     {
       "classification": "class",
+      "id": "contract:Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsUpcasterPipeline",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsUpcasterPipeline"
+    },
+    {
+      "classification": "class",
       "id": "contract:Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsV0ToCurrentUpcaster",
       "kind": "contract-type",
       "label": "Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsV0ToCurrentUpcaster"
+    },
+    {
+      "classification": "record",
+      "id": "contract:Meridian.Contracts.SecurityMaster.SecurityAssetTermField",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.SecurityMaster.SecurityAssetTermField"
+    },
+    {
+      "classification": "enum",
+      "id": "contract:Meridian.Contracts.SecurityMaster.SecurityAssetTermFieldType",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.SecurityMaster.SecurityAssetTermFieldType"
+    },
+    {
+      "classification": "class",
+      "id": "contract:Meridian.Contracts.SecurityMaster.SecurityAssetTermsSchema",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.SecurityMaster.SecurityAssetTermsSchema"
     },
     {
       "classification": "dto",
@@ -52592,6 +53750,42 @@
       "id": "contract:Meridian.Contracts.Workstation.RunReconciliation",
       "kind": "contract-type",
       "label": "Meridian.Contracts.Workstation.RunReconciliation"
+    },
+    {
+      "classification": "dto",
+      "id": "contract:Meridian.Contracts.Workstation.SampleArtifactDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.Workstation.SampleArtifactDto"
+    },
+    {
+      "classification": "dto",
+      "id": "contract:Meridian.Contracts.Workstation.SampleBreakDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.Workstation.SampleBreakDto"
+    },
+    {
+      "classification": "dto",
+      "id": "contract:Meridian.Contracts.Workstation.SampleHighlightDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.Workstation.SampleHighlightDto"
+    },
+    {
+      "classification": "dto",
+      "id": "contract:Meridian.Contracts.Workstation.SampleHoldingDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.Workstation.SampleHoldingDto"
+    },
+    {
+      "classification": "dto",
+      "id": "contract:Meridian.Contracts.Workstation.SampleMarketHistoryDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.Workstation.SampleMarketHistoryDto"
+    },
+    {
+      "classification": "dto",
+      "id": "contract:Meridian.Contracts.Workstation.SampleWorkspaceDto",
+      "kind": "contract-type",
+      "label": "Meridian.Contracts.Workstation.SampleWorkspaceDto"
     },
     {
       "classification": "dto",
@@ -57745,11 +58939,11 @@
     }
   ],
   "summary": {
-    "contract_references": 2801,
-    "contract_set_memberships": 3230,
-    "edges": 6626,
+    "contract_references": 2889,
+    "contract_set_memberships": 3302,
+    "edges": 6786,
     "foreign_keys": 77,
     "logical_references": 6,
-    "nodes": 3055
+    "nodes": 3094
   }
 }

--- a/docs/generated/database/contracts/asset-operations-contracts.md
+++ b/docs/generated/database/contracts/asset-operations-contracts.md
@@ -5,11 +5,109 @@
 This is an explicit module association, not a claim that a DTO is identical to a table.
 
 Mapped physical schemas: `asset_operations`.
-Catalogued objects: 42.
+Catalogued objects: 69.
 
 ```mermaid
 classDiagram
     %% asset-operations-contracts: module mapping, not DTO/table equivalence
+    class Meridian_Contracts_AssetOperations_AppendAssetAccountingLifecycleStageRequestDto["AppendAssetAccountingLifecycleStageRequestDto"] {
+        +string Actor
+        +DateTimeOffset AttestedAtUtc
+        +string? CompanyId
+        +Guid EventId
+        +long EventVersion
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ Evidence
+        +long ExpectedBookPositionVersion
+        +long ExpectedSpineVersion
+        +string FundProfileId
+        +string? Notes
+        +string ReferenceId
+        +AssetAccountingLifecycleStageDto Stage
+    }
+    class Meridian_Contracts_AssetOperations_AssetAccountingCorrectionReferenceDto["AssetAccountingCorrectionReferenceDto"] {
+        +AccountingBasisKindDto AccountingBasis
+        +Guid EventId
+        +long EventVersion
+        +Guid LedgerBookId
+        +Guid PeriodId
+        +Guid PostedJournalEntryId
+        +Guid? TaxLotMutationBatchId
+    }
+    class Meridian_Contracts_AssetOperations_AssetAccountingEventKindDto["AssetAccountingEventKindDto"] {
+    }
+    class Meridian_Contracts_AssetOperations_AssetAccountingEventScopeDto["AssetAccountingEventScopeDto"] {
+        +AccountingBasisKindDto AccountingBasis
+        +Guid BookPositionId
+        +string? CompanyId
+        +LedgerDimensionSetDto? Dimensions
+        +long ExpectedBookPositionVersion
+        +long ExpectedSecurityVersion
+        +string FundProfileId
+        +Guid LedgerBookId
+        +Guid PeriodId
+        +Guid SecurityId
+        +string? TenantId
+    }
+    class Meridian_Contracts_AssetOperations_AssetAccountingEventSpineAppendResultDto["AssetAccountingEventSpineAppendResultDto"] {
+        +AssetAccountingEventSpineDto Spine
+        +bool WasReplay
+    }
+    class Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto["AssetAccountingEventSpineDto"] {
+        +AssetAccountingCorrectionReferenceDto? Correction
+        +string Currency
+        +PostingRuleJournalCandidateRequestDto? DraftedCandidate
+        +string? DraftedCandidateFingerprint
+        +PostingRuleJournalCandidateResultDto? DraftedCandidateResult
+        +string? DraftedCandidateResultFingerprint
+        +AssetLotMutationInstructionDto? DraftedLotMutation
+        +string? DraftedLotMutationFingerprint
+        +EconomicEventReferenceDto EconomicEvent
+        +DateOnly EffectiveDate
+        +decimal EventAmount
+        +Guid EventId
+    }
+    class Meridian_Contracts_AssetOperations_AssetAccountingEventSpineValidator["AssetAccountingEventSpineValidator"] {
+    }
+    class Meridian_Contracts_AssetOperations_AssetAccountingEventTypeNames["AssetAccountingEventTypeNames"] {
+    }
+    class Meridian_Contracts_AssetOperations_AssetAccountingEvidenceSubjects["AssetAccountingEvidenceSubjects"] {
+    }
+    class Meridian_Contracts_AssetOperations_AssetAccountingLifecycleStageDto["AssetAccountingLifecycleStageDto"] {
+    }
+    class Meridian_Contracts_AssetOperations_AssetAccountingPostingCandidateDto["AssetAccountingPostingCandidateDto"] {
+        +PostingRuleJournalCandidateResultDto Candidate
+        +AssetAccountingEventSpineDto Spine
+    }
+    class Meridian_Contracts_AssetOperations_AssetAccountingPostingCandidateRequestDto["AssetAccountingPostingCandidateRequestDto"] {
+        +DateTimeOffset AccountingTimestamp
+        +string Actor
+        +LedgerAdjustmentApprovalMetadataDto? CorrectionApproval
+        +Guid? CorrelationId
+        +string? CounterpartyId
+        +string Currency
+        +string Description
+        +EconomicEventReferenceDto EconomicEvent
+        +decimal EventAmount
+        +AssetAccountingEventKindDto EventKind
+        +long ExpectedPeriodVersion
+        +long ExpectedSpineVersion
+    }
+    class Meridian_Contracts_AssetOperations_AssetAccountingStageEvidenceDto["AssetAccountingStageEvidenceDto"] {
+        +DateTimeOffset AttestedAtUtc
+        +string AttestedBy
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ Evidence
+        +string? Notes
+        +string? ReferenceId
+        +AssetAccountingLifecycleStageDto Stage
+    }
+    class Meridian_Contracts_AssetOperations_AssetAcquisitionLotDto["AssetAcquisitionLotDto"] {
+        +string AccountId
+        +DateOnly AcquiredDate
+        +string LotId
+        +decimal Quantity
+        +Guid TaxLotRecordId
+        +decimal UnitCost
+    }
     class Meridian_Contracts_AssetOperations_AssetActualActivityDto["AssetActualActivityDto"] {
         +Guid ActivityId
         +string ActivityType
@@ -18,11 +116,11 @@ classDiagram
         +DateOnly EffectiveDate
         +string? EvidenceLink
         +JsonElement? ExtensionPayload
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
         +Guid SecurityId
         +DateOnly? SettlementDate
         +string SourceDomain
         +string? SourceEntityId
-        +string Status
     }
     class Meridian_Contracts_AssetOperations_AssetCashFlowProjectionRunDto["AssetCashFlowProjectionRunDto"] {
         +string EngineVersion
@@ -30,10 +128,22 @@ classDiagram
         +DateTimeOffset GeneratedAt
         +DateOnly ProjectionAsOf
         +Guid ProjectionRunId
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
         +Guid SecurityId
         +string SourceDomain
         +string? SourceEntityId
         +string Status
+    }
+    class Meridian_Contracts_AssetOperations_AssetDisposalLotSelectionDto["AssetDisposalLotSelectionDto"] {
+        +decimal ExpectedCostBasis
+        +decimal ExpectedOpenQuantity
+        +decimal ExpectedUnitCost
+        +long ExpectedVersion
+        +string LotId
+        +decimal Quantity
+        +string SelectionEvidenceId
+        +int SelectionOrdinal
+        +Guid TaxLotRecordId
     }
     class Meridian_Contracts_AssetOperations_AssetLedgerProjectionDto["AssetLedgerProjectionDto"] {
         +DateOnly AccountingDate
@@ -45,9 +155,9 @@ classDiagram
         +Guid LedgerProjectionId
         +string? LedgerReferenceId
         +string ProjectionType
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
         +Guid SecurityId
         +string SourceDomain
-        +string? SourceEntityId
     }
     class Meridian_Contracts_AssetOperations_AssetLifecycleEventDto["AssetLifecycleEventDto"] {
         +DateOnly EffectiveDate
@@ -56,10 +166,26 @@ classDiagram
         +Guid LifecycleEventId
         +string LifecycleState
         +DateTimeOffset RecordedAt
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
         +Guid SecurityId
         +string SourceDomain
         +string? SourceEntityId
         +string Summary
+    }
+    class Meridian_Contracts_AssetOperations_AssetLotMutationInstructionDto["AssetLotMutationInstructionDto"] {
+        +AssetAcquisitionLotDto? Acquisition
+        +string? AssetAccountId
+        +LedgerAdjustmentApprovalMetadataDto? CorrectionApproval
+        +Guid? CorrectsJournalEntryId
+        +Guid? CorrectsMutationBatchId
+        +IReadOnlyList~AssetDisposalLotSelectionDto~ DisposalSelections
+        +AssetLotMutationIntentDto Intent
+        +string? PolicyRevision
+        +string? ReliefMethod
+    }
+    class Meridian_Contracts_AssetOperations_AssetLotMutationInstructionValidator["AssetLotMutationInstructionValidator"] {
+    }
+    class Meridian_Contracts_AssetOperations_AssetLotMutationIntentDto["AssetLotMutationIntentDto"] {
     }
     class Meridian_Contracts_AssetOperations_AssetOperationSubjectDto["AssetOperationSubjectDto"] {
         +string AssetClass
@@ -106,6 +232,7 @@ classDiagram
         +JsonElement? ExtensionPayload
         +IReadOnlyList~string~ MissingCapabilities
         +IReadOnlyList~string~ ReadyCapabilities
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
         +Guid SecurityId
         +string SourceDomain
         +string? SourceEntityId
@@ -130,7 +257,7 @@ classDiagram
         +decimal? PrincipalBasis
         +Guid ProjectedCashFlowId
         +Guid ProjectionRunId
-        +Guid SecurityId
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
     }
     class Meridian_Contracts_AssetOperations_AssetReconciliationResultDto["AssetReconciliationResultDto"] {
         +decimal? ActualAmount
@@ -142,9 +269,9 @@ classDiagram
         +string MatchStatus
         +Guid ReconciliationResultId
         +Guid ReconciliationRunId
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
         +Guid SecurityId
         +string SourceDomain
-        +string? SourceEntityId
     }
     class Meridian_Contracts_AssetOperations_AssetReconciliationRunDto["AssetReconciliationRunDto"] {
         +DateTimeOffset? CompletedAt
@@ -152,6 +279,7 @@ classDiagram
         +Guid? ProjectionRunId
         +Guid ReconciliationRunId
         +DateTimeOffset RequestedAt
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
         +Guid SecurityId
         +string SourceDomain
         +string? SourceEntityId
@@ -178,17 +306,18 @@ classDiagram
         +JsonElement? ExtensionPayload
         +DateTimeOffset GeneratedAt
         +DateOnly ProjectionAsOf
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
         +Guid SecurityId
         +string SourceDomain
         +string? SourceEntityId
         +string Status
         +IReadOnlyList~AssetTimelineVarianceDto~ Variances
-        +IReadOnlyList~string~ Warnings
     }
     class Meridian_Contracts_AssetOperations_AssetTermsVersionDto["AssetTermsVersionDto"] {
         +DateOnly EffectiveDate
         +JsonElement? ExtensionPayload
         +DateTimeOffset RecordedAt
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
         +Guid SecurityId
         +string SourceDomain
         +string? SourceEntityId
@@ -205,11 +334,11 @@ classDiagram
         +string? EvidenceLink
         +decimal? ExpectedAmount
         +DateOnly ExpectedDate
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
         +Guid SecurityId
         +string SourceDomain
         +string? SourceEntityId
         +string Status
-        +string Summary
     }
     class Meridian_Contracts_AssetOperations_BookPositionDto["BookPositionDto"] {
         +AccountingBookContextDto BookContext
@@ -223,7 +352,7 @@ classDiagram
         +string PositionSide
         +string? PrimaryAccountId
         +ProjectionLineageDto? ProjectionLineage
-        +Guid RoleId
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
     }
     class Meridian_Contracts_AssetOperations_BookPositionSides["BookPositionSides"] {
     }
@@ -237,9 +366,9 @@ classDiagram
         +long EventVersion
         +IReadOnlyList~string~ EvidenceLinks
         +DateTimeOffset OccurredAtUtc
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
         +Guid? SecurityId
         +string? SourceContentHash
-        +string SourceDomain
     }
     class Meridian_Contracts_AssetOperations_IAssetOperationsCommandService["IAssetOperationsCommandService"] {
     }
@@ -269,9 +398,11 @@ classDiagram
         +EconomicEventReferenceDto? OriginEvent
         +string OwnerScopeId
         +string OwnerScopeKind
-        +Guid RoleId
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
     }
     class Meridian_Contracts_AssetOperations_InstrumentRoleKinds["InstrumentRoleKinds"] {
+    }
+    class Meridian_Contracts_AssetOperations_JournalPostingStatusDto["JournalPostingStatusDto"] {
     }
     class Meridian_Contracts_AssetOperations_PortfolioCapitalActivityDto["PortfolioCapitalActivityDto"] {
         +Guid ActivityId
@@ -371,6 +502,61 @@ classDiagram
         +decimal? ParAmount
         +Guid PositionId
     }
+    class Meridian_Contracts_AssetOperations_PostedJournalImpactDto["PostedJournalImpactDto"] {
+        +AccountingBasisKindDto AccountingBasis
+        +string Currency
+        +Guid JournalEntryId
+        +Guid LedgerBookId
+        +IReadOnlyList~PostedJournalImpactLineDto~ Lines
+        +Guid PeriodId
+        +DateTimeOffset PostedAtUtc
+        +JournalPostingStatusDto PostingStatus
+        +decimal TotalCredits
+        +decimal TotalDebits
+    }
+    class Meridian_Contracts_AssetOperations_PostedJournalImpactLineDto["PostedJournalImpactLineDto"] {
+        +string AccountId
+        +decimal Credit
+        +string Currency
+        +decimal Debit
+        +string? Description
+        +LedgerDimensionSetDto? Dimensions
+        +Guid LineId
+    }
+    class Meridian_Contracts_AssetOperations_PostedJournalImpactValidator["PostedJournalImpactValidator"] {
+    }
+    class Meridian_Contracts_AssetOperations_ProjectAssetAccountingEventRequestDto["ProjectAssetAccountingEventRequestDto"] {
+        +string Actor
+        +AssetAccountingCorrectionReferenceDto? Correction
+        +string Currency
+        +EconomicEventReferenceDto EconomicEvent
+        +decimal EventAmount
+        +AssetAccountingEventKindDto EventKind
+        +long ExpectedPeriodVersion
+        +string? Notes
+        +DateTimeOffset ProjectedAtUtc
+        +ProjectedAccountingEffectDto ProjectedEffect
+        +ProjectionLineageDto ProjectionLineage
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
+    }
+    class Meridian_Contracts_AssetOperations_ProjectedAccountingEffectDto["ProjectedAccountingEffectDto"] {
+        +string Currency
+        +IReadOnlyList~ProjectedAccountingEffectLineDto~ Lines
+        +string ModelKey
+        +string ModelVersion
+        +DateOnly ProjectionAsOfDate
+        +Guid ProjectionRunId
+        +decimal TotalCredits
+        +decimal TotalDebits
+    }
+    class Meridian_Contracts_AssetOperations_ProjectedAccountingEffectLineDto["ProjectedAccountingEffectLineDto"] {
+        +string AccountId
+        +decimal Credit
+        +string Currency
+        +decimal Debit
+        +string? Description
+        +LedgerDimensionSetDto? Dimensions
+    }
     class Meridian_Contracts_AssetOperations_ProjectionLineageDto["ProjectionLineageDto"] {
         +Guid? BookPositionId
         +string EngineVersion
@@ -381,10 +567,55 @@ classDiagram
         +DateOnly ProjectionAsOfDate
         +Guid? ProjectionEventId
         +Guid ProjectionRunId
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
         +string Scenario
         +string SourceDomain
-        +string? SourceEntityId
     }
+    class Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto["RetainedEvidenceIdentityDto"] {
+        +string ContentHashSha256
+        +DateOnly EffectiveDate
+        +string EvidenceId
+        +string EvidenceUri
+        +long EvidenceVersion
+        +DateTimeOffset RetainedAtUtc
+        +string RetainedBy
+        +DateTimeOffset ReviewedAtUtc
+        +string ReviewedBy
+        +string ReviewStatus
+        +string SourceReference
+        +string SourceSystem
+    }
+    class Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityValidator["RetainedEvidenceIdentityValidator"] {
+    }
+    Meridian_Contracts_AssetOperations_AppendAssetAccountingLifecycleStageRequestDto --> Meridian_Contracts_AssetOperations_AssetAccountingLifecycleStageDto
+    Meridian_Contracts_AssetOperations_AppendAssetAccountingLifecycleStageRequestDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetAccountingEventSpineAppendResultDto --> Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto
+    Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto --> Meridian_Contracts_AssetOperations_AssetAccountingCorrectionReferenceDto
+    Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto --> Meridian_Contracts_AssetOperations_AssetAccountingEventKindDto
+    Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto --> Meridian_Contracts_AssetOperations_AssetAccountingEventScopeDto
+    Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto --> Meridian_Contracts_AssetOperations_AssetAccountingStageEvidenceDto
+    Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto --> Meridian_Contracts_AssetOperations_AssetLotMutationInstructionDto
+    Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto --> Meridian_Contracts_AssetOperations_EconomicEventReferenceDto
+    Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto --> Meridian_Contracts_AssetOperations_PostedJournalImpactDto
+    Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto --> Meridian_Contracts_AssetOperations_ProjectedAccountingEffectDto
+    Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto --> Meridian_Contracts_AssetOperations_ProjectionLineageDto
+    Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetAccountingPostingCandidateDto --> Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto
+    Meridian_Contracts_AssetOperations_AssetAccountingPostingCandidateRequestDto --> Meridian_Contracts_AssetOperations_AssetAccountingEventKindDto
+    Meridian_Contracts_AssetOperations_AssetAccountingPostingCandidateRequestDto --> Meridian_Contracts_AssetOperations_AssetAccountingEventScopeDto
+    Meridian_Contracts_AssetOperations_AssetAccountingPostingCandidateRequestDto --> Meridian_Contracts_AssetOperations_AssetLotMutationInstructionDto
+    Meridian_Contracts_AssetOperations_AssetAccountingPostingCandidateRequestDto --> Meridian_Contracts_AssetOperations_EconomicEventReferenceDto
+    Meridian_Contracts_AssetOperations_AssetAccountingPostingCandidateRequestDto --> Meridian_Contracts_AssetOperations_ProjectionLineageDto
+    Meridian_Contracts_AssetOperations_AssetAccountingPostingCandidateRequestDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetAccountingStageEvidenceDto --> Meridian_Contracts_AssetOperations_AssetAccountingLifecycleStageDto
+    Meridian_Contracts_AssetOperations_AssetAccountingStageEvidenceDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetActualActivityDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetCashFlowProjectionRunDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetLedgerProjectionDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetLifecycleEventDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetLotMutationInstructionDto --> Meridian_Contracts_AssetOperations_AssetAcquisitionLotDto
+    Meridian_Contracts_AssetOperations_AssetLotMutationInstructionDto --> Meridian_Contracts_AssetOperations_AssetDisposalLotSelectionDto
+    Meridian_Contracts_AssetOperations_AssetLotMutationInstructionDto --> Meridian_Contracts_AssetOperations_AssetLotMutationIntentDto
     Meridian_Contracts_AssetOperations_AssetOperationsDetailDto --> Meridian_Contracts_AssetOperations_AssetActualActivityDto
     Meridian_Contracts_AssetOperations_AssetOperationsDetailDto --> Meridian_Contracts_AssetOperations_AssetCashFlowProjectionRunDto
     Meridian_Contracts_AssetOperations_AssetOperationsDetailDto --> Meridian_Contracts_AssetOperations_AssetLedgerProjectionDto
@@ -400,6 +631,7 @@ classDiagram
     Meridian_Contracts_AssetOperations_AssetOperationsDetailDto --> Meridian_Contracts_AssetOperations_InstrumentRoleDto
     Meridian_Contracts_AssetOperations_AssetOperationsDetailDto --> Meridian_Contracts_AssetOperations_PositionEconomicStateDto
     Meridian_Contracts_AssetOperations_AssetOperationsDetailDto --> Meridian_Contracts_AssetOperations_ProjectionLineageDto
+    Meridian_Contracts_AssetOperations_AssetOperationsDetailDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
     Meridian_Contracts_AssetOperations_AssetOperationsProjectionDto --> Meridian_Contracts_AssetOperations_AssetActualActivityDto
     Meridian_Contracts_AssetOperations_AssetOperationsProjectionDto --> Meridian_Contracts_AssetOperations_AssetCashFlowProjectionRunDto
     Meridian_Contracts_AssetOperations_AssetOperationsProjectionDto --> Meridian_Contracts_AssetOperations_AssetLedgerProjectionDto
@@ -415,12 +647,24 @@ classDiagram
     Meridian_Contracts_AssetOperations_AssetOperationsProjectionDto --> Meridian_Contracts_AssetOperations_InstrumentRoleDto
     Meridian_Contracts_AssetOperations_AssetOperationsProjectionDto --> Meridian_Contracts_AssetOperations_PositionEconomicStateDto
     Meridian_Contracts_AssetOperations_AssetOperationsProjectionDto --> Meridian_Contracts_AssetOperations_ProjectionLineageDto
+    Meridian_Contracts_AssetOperations_AssetOperationsProjectionDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetOperationsReadinessDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetProjectedCashFlowDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetReconciliationResultDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetReconciliationRunDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetTermsObligationTimelineEventDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
     Meridian_Contracts_AssetOperations_AssetTermsObligationsTimelineDto --> Meridian_Contracts_AssetOperations_AssetTermsObligationTimelineEventDto
     Meridian_Contracts_AssetOperations_AssetTermsObligationsTimelineDto --> Meridian_Contracts_AssetOperations_AssetTimelineVarianceDto
+    Meridian_Contracts_AssetOperations_AssetTermsObligationsTimelineDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetTermsVersionDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetTimelineVarianceDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
     Meridian_Contracts_AssetOperations_BookPositionDto --> Meridian_Contracts_AssetOperations_EconomicEventReferenceDto
     Meridian_Contracts_AssetOperations_BookPositionDto --> Meridian_Contracts_AssetOperations_PositionEconomicStateDto
     Meridian_Contracts_AssetOperations_BookPositionDto --> Meridian_Contracts_AssetOperations_ProjectionLineageDto
+    Meridian_Contracts_AssetOperations_BookPositionDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_EconomicEventReferenceDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
     Meridian_Contracts_AssetOperations_InstrumentRoleDto --> Meridian_Contracts_AssetOperations_EconomicEventReferenceDto
+    Meridian_Contracts_AssetOperations_InstrumentRoleDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
     Meridian_Contracts_AssetOperations_PortfolioCashLadderBucketDto --> Meridian_Contracts_AssetOperations_PortfolioCashLadderSourceSliceDto
     Meridian_Contracts_AssetOperations_PortfolioCashLadderDto --> Meridian_Contracts_AssetOperations_PortfolioCashLadderBucketDto
     Meridian_Contracts_AssetOperations_PortfolioCashLadderDto --> Meridian_Contracts_AssetOperations_PortfolioCashLadderContributionDto
@@ -428,5 +672,17 @@ classDiagram
     Meridian_Contracts_AssetOperations_PortfolioCashLadderPositionDto --> Meridian_Contracts_AssetOperations_AssetOperationsDetailDto
     Meridian_Contracts_AssetOperations_PositionEconomicStateDto --> Meridian_Contracts_AssetOperations_EconomicEventReferenceDto
     Meridian_Contracts_AssetOperations_PositionEconomicStateDto --> Meridian_Contracts_AssetOperations_ProjectionLineageDto
+    Meridian_Contracts_AssetOperations_PositionEconomicStateDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_PostedJournalImpactDto --> Meridian_Contracts_AssetOperations_JournalPostingStatusDto
+    Meridian_Contracts_AssetOperations_PostedJournalImpactDto --> Meridian_Contracts_AssetOperations_PostedJournalImpactLineDto
+    Meridian_Contracts_AssetOperations_ProjectAssetAccountingEventRequestDto --> Meridian_Contracts_AssetOperations_AssetAccountingCorrectionReferenceDto
+    Meridian_Contracts_AssetOperations_ProjectAssetAccountingEventRequestDto --> Meridian_Contracts_AssetOperations_AssetAccountingEventKindDto
+    Meridian_Contracts_AssetOperations_ProjectAssetAccountingEventRequestDto --> Meridian_Contracts_AssetOperations_AssetAccountingEventScopeDto
+    Meridian_Contracts_AssetOperations_ProjectAssetAccountingEventRequestDto --> Meridian_Contracts_AssetOperations_EconomicEventReferenceDto
+    Meridian_Contracts_AssetOperations_ProjectAssetAccountingEventRequestDto --> Meridian_Contracts_AssetOperations_ProjectedAccountingEffectDto
+    Meridian_Contracts_AssetOperations_ProjectAssetAccountingEventRequestDto --> Meridian_Contracts_AssetOperations_ProjectionLineageDto
+    Meridian_Contracts_AssetOperations_ProjectAssetAccountingEventRequestDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_ProjectedAccountingEffectDto --> Meridian_Contracts_AssetOperations_ProjectedAccountingEffectLineDto
     Meridian_Contracts_AssetOperations_ProjectionLineageDto --> Meridian_Contracts_AssetOperations_EconomicEventReferenceDto
+    Meridian_Contracts_AssetOperations_ProjectionLineageDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
 ```

--- a/docs/generated/database/contracts/ledger-contracts-page-01.md
+++ b/docs/generated/database/contracts/ledger-contracts-page-01.md
@@ -2,7 +2,7 @@
 
 # `ledger-contracts` data objects - page 1 of 4
 
-Objects 1-80 of 281. References crossing pages remain available in the dependency manifest.
+Objects 1-80 of 283. References crossing pages remain available in the dependency manifest.
 
 ```mermaid
 classDiagram
@@ -58,27 +58,32 @@ classDiagram
     class Meridian_Contracts_AccountingSystem_AccountingDimensionalCertificationLaneKindDto["AccountingDimensionalCertificationLaneKindDto"] {
     }
     class Meridian_Contracts_AccountingSystem_AccountingDimensionalReportingReadinessDto["AccountingDimensionalReportingReadinessDto"] {
+        +IReadOnlyList~AccountingDimensionalCertificationArtifactDto~ CertificationArtifacts
+        +string? CompanyId
         +bool CrossPeriodReportDimensionQueriesCertified
         +IReadOnlyList~string~ EvidenceReferences
         +bool ExternalExportDimensionMappingCertified
+        +string? FundProfileId
         +bool JournalQueryDimensionFiltersCertified
         +Guid? LedgerBookId
         +bool LedgerLineDimensionsPersistedCertified
         +bool PeriodReportDimensionQueriesCertified
         +bool ReportPackageDimensionProvenanceCertified
-        +bool TrialBalanceDimensionFiltersCertified
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
     }
     class Meridian_Contracts_AccountingSystem_AccountingLedgerBookWorkflowReadinessDto["AccountingLedgerBookWorkflowReadinessDto"] {
+        +IReadOnlyList~AccountingWorkflowCertificationArtifactDto~ CertificationArtifacts
         +bool ClosePlanConfigurationLedgerBookNativeCertified
         +bool CloseReportingLedgerBookNativeCertified
+        +string? CompanyId
         +bool DirectLendingLedgerBookNativeCertified
         +IReadOnlyList~string~ EvidenceReferences
         +bool ExternalGlLedgerBookNativeCertified
+        +string? FundProfileId
         +bool JournalLifecycleLedgerBookNativeCertified
         +Guid? LedgerBookId
         +bool PostingRulesLedgerBookNativeCertified
         +bool ReconciliationLedgerBookNativeCertified
-        +bool StrategyLedgerReadLedgerBookNativeCertified
     }
     class Meridian_Contracts_AccountingSystem_AccountingMigrationRolloutPlanItemDto["AccountingMigrationRolloutPlanItemDto"] {
         +string? ActionRoute
@@ -179,6 +184,10 @@ classDiagram
         +string Actor
         +AccountingMigrationRunWorkerPlanDto Plan
     }
+    class Meridian_Contracts_AccountingSystem_AccountingProductionCertificationEvidenceSubjectTypes["AccountingProductionCertificationEvidenceSubjectTypes"] {
+    }
+    class Meridian_Contracts_AccountingSystem_AccountingProductionCertificationEvidenceValidator["AccountingProductionCertificationEvidenceValidator"] {
+    }
     class Meridian_Contracts_AccountingSystem_AccountingProductionCertificationProfileDto["AccountingProductionCertificationProfileDto"] {
         +bool ClosePlanConfigurationLedgerBookNativeCertified
         +bool CloseReportingLedgerBookNativeCertified
@@ -199,6 +208,7 @@ classDiagram
         +string? CorrelationId
         +IReadOnlyList~string~ EvidenceLinks
         +AccountingProductionCertificationProfileDto Profile
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
     }
     class Meridian_Contracts_AccountingSystem_AccountingProductionGapDto["AccountingProductionGapDto"] {
         +IReadOnlyList~AccountingProductionReadinessAreaDto~ Areas
@@ -513,12 +523,12 @@ classDiagram
         +bool AuditReviewToolingConfigured
         +bool BrowserAccountingAdminSurfaceConfigured
         +bool BulkImportExportSafeguardsConfigured
+        +IReadOnlyList~AccountingTenantAdminCertificationArtifactDto~ CertificationArtifacts
         +bool ChartAdministrationStudioConfigured
         +bool CloseSetupStudioConfigured
         +string? CompanyId
         +bool DimensionMappingStudioConfigured
         +bool DisasterRecoveryRunbookConfigured
-        +IReadOnlyList~string~ EvidenceReferences
     }
     class Meridian_Contracts_AccountingSystem_AccountingWorkflowCertificationArtifactDto["AccountingWorkflowCertificationArtifactDto"] {
         +string CertificationId
@@ -678,29 +688,6 @@ classDiagram
         +decimal TotalDebits
         +IReadOnlyList~AccountingConfigurationValidationIssueDto~ ValidationIssues
     }
-    class Meridian_Contracts_Ledger_AccountingPolicyDto["AccountingPolicyDto"] {
-        +AccountingBasisKindDto AccountingBasis
-        +DateTimeOffset CreatedAt
-        +string DisplayName
-        +DateOnly EffectiveFrom
-        +DateOnly? EffectiveTo
-        +string? FundProfileId
-        +Guid? FundStructureNodeId
-        +string? InstrumentId
-        +bool IsDefault
-        +string PolicyId
-        +AccountingPolicyRulePackDto? RulePack
-        +string RulesJson
-    }
-    class Meridian_Contracts_Ledger_AccountingPolicyQuery["AccountingPolicyQuery"] {
-        +AccountingBasisKindDto AccountingBasis
-        +DateOnly? EffectiveDate
-        +string? FundProfileId
-        +Guid? FundStructureNodeId
-        +string? InstrumentId
-        +string? PolicyId
-        +Guid? SourceEventId
-    }
     Meridian_Contracts_AccountingSystem_AccountingCertificationArtifactIssueDto --> Meridian_Contracts_Ledger_AccountingConfigurationValidationSeverityDto
     Meridian_Contracts_AccountingSystem_AccountingDimensionalCertificationArtifactDto --> Meridian_Contracts_AccountingSystem_AccountingCertificationArtifactIssueDto
     Meridian_Contracts_AccountingSystem_AccountingDimensionalCertificationArtifactDto --> Meridian_Contracts_AccountingSystem_AccountingCertificationArtifactStatusDto
@@ -708,6 +695,8 @@ classDiagram
     Meridian_Contracts_AccountingSystem_AccountingDimensionalCertificationLaneDto --> Meridian_Contracts_AccountingSystem_AccountingCertificationArtifactIssueDto
     Meridian_Contracts_AccountingSystem_AccountingDimensionalCertificationLaneDto --> Meridian_Contracts_AccountingSystem_AccountingCertificationArtifactLaneStatusDto
     Meridian_Contracts_AccountingSystem_AccountingDimensionalCertificationLaneDto --> Meridian_Contracts_AccountingSystem_AccountingDimensionalCertificationLaneKindDto
+    Meridian_Contracts_AccountingSystem_AccountingDimensionalReportingReadinessDto --> Meridian_Contracts_AccountingSystem_AccountingDimensionalCertificationArtifactDto
+    Meridian_Contracts_AccountingSystem_AccountingLedgerBookWorkflowReadinessDto --> Meridian_Contracts_AccountingSystem_AccountingWorkflowCertificationArtifactDto
     Meridian_Contracts_AccountingSystem_AccountingMigrationRolloutPlanItemDto --> Meridian_Contracts_AccountingSystem_AccountingMigrationRunKindDto
     Meridian_Contracts_AccountingSystem_AccountingMigrationRolloutPlanItemDto --> Meridian_Contracts_AccountingSystem_AccountingMigrationRunStatusDto
     Meridian_Contracts_AccountingSystem_AccountingMigrationRolloutPlanItemDto --> Meridian_Contracts_AccountingSystem_AccountingProductionReadinessStatusDto
@@ -776,6 +765,7 @@ classDiagram
     Meridian_Contracts_AccountingSystem_AccountingTenantAdministrationProfileDto --> Meridian_Contracts_AccountingSystem_AccountingApprovalQueueConfigurationDto
     Meridian_Contracts_AccountingSystem_AccountingTenantAdministrationProfileDto --> Meridian_Contracts_AccountingSystem_AccountingDimensionMappingConfigurationDto
     Meridian_Contracts_AccountingSystem_AccountingTenantAdministrationProfileUpsertRequestDto --> Meridian_Contracts_AccountingSystem_AccountingTenantAdministrationProfileDto
+    Meridian_Contracts_AccountingSystem_AccountingTenantAdministrationReadinessDto --> Meridian_Contracts_AccountingSystem_AccountingTenantAdminCertificationArtifactDto
     Meridian_Contracts_AccountingSystem_AccountingWorkflowCertificationArtifactDto --> Meridian_Contracts_AccountingSystem_AccountingCertificationArtifactIssueDto
     Meridian_Contracts_AccountingSystem_AccountingWorkflowCertificationArtifactDto --> Meridian_Contracts_AccountingSystem_AccountingCertificationArtifactStatusDto
     Meridian_Contracts_AccountingSystem_AccountingWorkflowCertificationArtifactDto --> Meridian_Contracts_AccountingSystem_AccountingWorkflowCertificationLaneDto
@@ -795,6 +785,4 @@ classDiagram
     Meridian_Contracts_Ledger_AccountingConfigurationWorkspaceDto --> Meridian_Contracts_Ledger_AccountingConfigurationValidationIssueDto
     Meridian_Contracts_Ledger_AccountingJournalTemplatePreviewDto --> Meridian_Contracts_Ledger_AccountingConfigurationValidationIssueDto
     Meridian_Contracts_Ledger_AccountingJournalTemplatePreviewDto --> Meridian_Contracts_Ledger_AccountingJournalPreviewLineDto
-    Meridian_Contracts_Ledger_AccountingPolicyDto --> Meridian_Contracts_Ledger_AccountingBasisKindDto
-    Meridian_Contracts_Ledger_AccountingPolicyQuery --> Meridian_Contracts_Ledger_AccountingBasisKindDto
 ```

--- a/docs/generated/database/contracts/ledger-contracts-page-02.md
+++ b/docs/generated/database/contracts/ledger-contracts-page-02.md
@@ -2,11 +2,34 @@
 
 # `ledger-contracts` data objects - page 2 of 4
 
-Objects 81-160 of 281. References crossing pages remain available in the dependency manifest.
+Objects 81-160 of 283. References crossing pages remain available in the dependency manifest.
 
 ```mermaid
 classDiagram
     %% ledger-contracts: module mapping, not DTO/table equivalence
+    class Meridian_Contracts_Ledger_AccountingPolicyDto["AccountingPolicyDto"] {
+        +AccountingBasisKindDto AccountingBasis
+        +DateTimeOffset CreatedAt
+        +string DisplayName
+        +DateOnly EffectiveFrom
+        +DateOnly? EffectiveTo
+        +string? FundProfileId
+        +Guid? FundStructureNodeId
+        +string? InstrumentId
+        +bool IsDefault
+        +string PolicyId
+        +AccountingPolicyRulePackDto? RulePack
+        +string RulesJson
+    }
+    class Meridian_Contracts_Ledger_AccountingPolicyQuery["AccountingPolicyQuery"] {
+        +AccountingBasisKindDto AccountingBasis
+        +DateOnly? EffectiveDate
+        +string? FundProfileId
+        +Guid? FundStructureNodeId
+        +string? InstrumentId
+        +string? PolicyId
+        +Guid? SourceEventId
+    }
     class Meridian_Contracts_Ledger_AccountingPolicyRuleDto["AccountingPolicyRuleDto"] {
         +bool AllowsAutoPosting
         +string? Description
@@ -46,13 +69,16 @@ classDiagram
     class Meridian_Contracts_Ledger_AccountingPostingEvidenceReferenceDto["AccountingPostingEvidenceReferenceDto"] {
         +string? ContentHash
         +string? Description
+        +DateOnly? EffectiveDate
         +string EvidenceId
+        +long? EvidenceVersion
         +AccountingPostingEvidenceKindDto Kind
         +DateTimeOffset RetainedAtUtc
         +string RetainedBy
-        +string SourceSystem
-        +string? SubjectId
-        +string Uri
+        +DateTimeOffset? ReviewedAtUtc
+        +string? Reviewer
+        +string? ReviewStatus
+        +string? SourceReference
     }
     class Meridian_Contracts_Ledger_AccountingPostingIntentDto["AccountingPostingIntentDto"] {
     }
@@ -698,10 +724,7 @@ classDiagram
         +string LineId
         +AccountingTemplateLineSideDto Side
     }
-    class Meridian_Contracts_Ledger_IAccountingActionAuditStore["IAccountingActionAuditStore"] {
-    }
-    class Meridian_Contracts_Ledger_IAccountingConfigurationService["IAccountingConfigurationService"] {
-    }
+    Meridian_Contracts_Ledger_AccountingPolicyDto --> Meridian_Contracts_Ledger_AccountingPolicyRulePackDto
     Meridian_Contracts_Ledger_AccountingPolicyRuleDto --> Meridian_Contracts_Ledger_AccountingTreatmentKindDto
     Meridian_Contracts_Ledger_AccountingPolicyRulePackDto --> Meridian_Contracts_Ledger_AccountingPolicyRuleDto
     Meridian_Contracts_Ledger_AccountingPostingCommandDto --> Meridian_Contracts_Ledger_AccountingPostingApprovalStateDto

--- a/docs/generated/database/contracts/ledger-contracts-page-03.md
+++ b/docs/generated/database/contracts/ledger-contracts-page-03.md
@@ -2,11 +2,15 @@
 
 # `ledger-contracts` data objects - page 3 of 4
 
-Objects 161-240 of 281. References crossing pages remain available in the dependency manifest.
+Objects 161-240 of 283. References crossing pages remain available in the dependency manifest.
 
 ```mermaid
 classDiagram
     %% ledger-contracts: module mapping, not DTO/table equivalence
+    class Meridian_Contracts_Ledger_IAccountingActionAuditStore["IAccountingActionAuditStore"] {
+    }
+    class Meridian_Contracts_Ledger_IAccountingConfigurationService["IAccountingConfigurationService"] {
+    }
     class Meridian_Contracts_Ledger_IAccountingConfigurationStore["IAccountingConfigurationStore"] {
     }
     class Meridian_Contracts_Ledger_ICapitalAccountWorkbenchService["ICapitalAccountWorkbenchService"] {
@@ -603,6 +607,7 @@ classDiagram
     class Meridian_Contracts_Ledger_PostPostingRuleJournalCandidateRequestDto["PostPostingRuleJournalCandidateRequestDto"] {
         +OperationsActionOriginDto ActionOrigin
         +string Actor
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ ApprovalEvidence
         +string ApprovalId
         +string? ApprovalNotes
         +PostingRuleJournalCandidateRequestDto Candidate
@@ -626,7 +631,10 @@ classDiagram
     }
     class Meridian_Contracts_Ledger_PostedPostingRuleJournalCandidateResultDto["PostedPostingRuleJournalCandidateResultDto"] {
         +PostingRuleJournalCandidateResultDto Candidate
+        +PostedJournalImpactDto? JournalImpact
+        +IReadOnlyList~AssetAccountingStageEvidenceDto~ LifecycleStages
         +PostedLedgerJournalEntryResultDto PostedJournal
+        +Guid? TaxLotMutationBatchId
         +bool WasReplay
     }
     class Meridian_Contracts_Ledger_PostingRuleDto["PostingRuleDto"] {
@@ -657,36 +665,13 @@ classDiagram
         +string Actor
         +LedgerAdjustmentApprovalMetadataDto? AdjustmentApproval
         +Guid AggregateId
+        +AssetLotMutationInstructionDto? AssetLotMutation
         +AccountingBookContextDto? BookContext
         +Guid? BookPositionId
         +string? CompanyId
         +Guid? CorrelationId
         +string? CounterpartyId
         +string Currency
-        +string Description
-    }
-    class Meridian_Contracts_Ledger_PostingRuleJournalCandidateResultDto["PostingRuleJournalCandidateResultDto"] {
-        +AccountingBookContextDto? BookContext
-        +Guid? BookPositionId
-        +bool CanPostWithoutAdditionalApproval
-        +bool CanSubmitForApproval
-        +RuleDryRunResultDto DryRunResult
-        +EconomicEventReferenceDto? EconomicEvent
-        +IReadOnlyList~string~ EvidenceLinks
-        +IReadOnlyList~GeneratedPostingLineDto~ GeneratedPostingLines
-        +bool HasBlockingIssues
-        +decimal Imbalance
-        +bool IsBalanced
-        +IReadOnlyList~PostingRuleJournalCandidateIssueDto~ Issues
-    }
-    class Meridian_Contracts_Ledger_PreviewJournalTemplateRequest["PreviewJournalTemplateRequest"] {
-        +string Actor
-        +string? CompanyId
-        +string? CorrelationId
-        +string FundProfileId
-        +Guid? LedgerBookId
-        +string TemplateId
-        +string? TenantId
     }
     Meridian_Contracts_Ledger_InvestorCapitalStatementDto --> Meridian_Contracts_Ledger_LedgerDimensionSetDto
     Meridian_Contracts_Ledger_JournalEntryLifecycleActionRequestDto --> Meridian_Contracts_Ledger_JournalEntryLifecycleActionDto
@@ -754,10 +739,8 @@ classDiagram
     Meridian_Contracts_Ledger_PaymentIntentWorkflowDto --> Meridian_Contracts_Ledger_PaymentIntentWorkflowStatusDto
     Meridian_Contracts_Ledger_PostPostingRuleJournalCandidateRequestDto --> Meridian_Contracts_Ledger_PostingRuleJournalCandidateRequestDto
     Meridian_Contracts_Ledger_PostedPostingRuleJournalCandidateResultDto --> Meridian_Contracts_Ledger_PostedLedgerJournalEntryResultDto
-    Meridian_Contracts_Ledger_PostedPostingRuleJournalCandidateResultDto --> Meridian_Contracts_Ledger_PostingRuleJournalCandidateResultDto
     Meridian_Contracts_Ledger_PostingRuleDto --> Meridian_Contracts_Ledger_LedgerDimensionSetDto
     Meridian_Contracts_Ledger_PostingRuleJournalCandidateRequestDto --> Meridian_Contracts_Ledger_LedgerAdjustmentApprovalMetadataDto
     Meridian_Contracts_Ledger_PostingRuleJournalCandidateRequestDto --> Meridian_Contracts_Ledger_LedgerDimensionSetDto
     Meridian_Contracts_Ledger_PostingRuleJournalCandidateRequestDto --> Meridian_Contracts_Ledger_LedgerPostingKindDto
-    Meridian_Contracts_Ledger_PostingRuleJournalCandidateResultDto --> Meridian_Contracts_Ledger_PostingRuleJournalCandidateIssueDto
 ```

--- a/docs/generated/database/contracts/ledger-contracts-page-04.md
+++ b/docs/generated/database/contracts/ledger-contracts-page-04.md
@@ -2,11 +2,34 @@
 
 # `ledger-contracts` data objects - page 4 of 4
 
-Objects 241-281 of 281. References crossing pages remain available in the dependency manifest.
+Objects 241-283 of 283. References crossing pages remain available in the dependency manifest.
 
 ```mermaid
 classDiagram
     %% ledger-contracts: module mapping, not DTO/table equivalence
+    class Meridian_Contracts_Ledger_PostingRuleJournalCandidateResultDto["PostingRuleJournalCandidateResultDto"] {
+        +AccountingBookContextDto? BookContext
+        +Guid? BookPositionId
+        +bool CanPostWithoutAdditionalApproval
+        +bool CanSubmitForApproval
+        +RuleDryRunResultDto DryRunResult
+        +EconomicEventReferenceDto? EconomicEvent
+        +IReadOnlyList~string~ EvidenceLinks
+        +IReadOnlyList~GeneratedPostingLineDto~ GeneratedPostingLines
+        +bool HasBlockingIssues
+        +decimal Imbalance
+        +bool IsBalanced
+        +IReadOnlyList~PostingRuleJournalCandidateIssueDto~ Issues
+    }
+    class Meridian_Contracts_Ledger_PreviewJournalTemplateRequest["PreviewJournalTemplateRequest"] {
+        +string Actor
+        +string? CompanyId
+        +string? CorrelationId
+        +string FundProfileId
+        +Guid? LedgerBookId
+        +string TemplateId
+        +string? TenantId
+    }
     class Meridian_Contracts_Ledger_PrivateCapitalActivityProjectionDto["PrivateCapitalActivityProjectionDto"] {
         +int ApprovalQueueCount
         +int CapitalAccountCount
@@ -457,6 +480,7 @@ classDiagram
         +bool PeriodIsLocked
         +string? TenantId
     }
+    Meridian_Contracts_Ledger_PostingRuleJournalCandidateResultDto --> Meridian_Contracts_Ledger_RuleDryRunResultDto
     Meridian_Contracts_Ledger_PrivateCapitalActivityProjectionDto --> Meridian_Contracts_Ledger_PrivateCapitalCapitalAccountActivityDto
     Meridian_Contracts_Ledger_PrivateCapitalActivityProjectionDto --> Meridian_Contracts_Ledger_PrivateCapitalCapitalAccountSubledgerDto
     Meridian_Contracts_Ledger_PrivateCapitalActivityProjectionDto --> Meridian_Contracts_Ledger_PrivateCapitalCapitalAccountSubledgerEntryDto

--- a/docs/generated/database/contracts/ledger-contracts.md
+++ b/docs/generated/database/contracts/ledger-contracts.md
@@ -5,11 +5,11 @@
 This is an explicit module association, not a claim that a DTO is identical to a table.
 
 Mapped physical schemas: `ledger`.
-Catalogued objects: 281.
+Catalogued objects: 283.
 
 The catalog is split into 4 reviewable diagrams; no objects are omitted.
 
 - [Page 1: objects 1-80](ledger-contracts-page-01.md)
 - [Page 2: objects 81-160](ledger-contracts-page-02.md)
 - [Page 3: objects 161-240](ledger-contracts-page-03.md)
-- [Page 4: objects 241-281](ledger-contracts-page-04.md)
+- [Page 4: objects 241-283](ledger-contracts-page-04.md)

--- a/docs/generated/database/contracts/security-master-contracts-page-01.md
+++ b/docs/generated/database/contracts/security-master-contracts-page-01.md
@@ -2,7 +2,7 @@
 
 # `security-master-contracts` data objects - page 1 of 3
 
-Objects 1-80 of 170. References crossing pages remain available in the dependency manifest.
+Objects 1-80 of 174. References crossing pages remain available in the dependency manifest.
 
 ```mermaid
 classDiagram

--- a/docs/generated/database/contracts/security-master-contracts-page-02.md
+++ b/docs/generated/database/contracts/security-master-contracts-page-02.md
@@ -2,7 +2,7 @@
 
 # `security-master-contracts` data objects - page 2 of 3
 
-Objects 81-160 of 170. References crossing pages remain available in the dependency manifest.
+Objects 81-160 of 174. References crossing pages remain available in the dependency manifest.
 
 ```mermaid
 classDiagram
@@ -194,8 +194,22 @@ classDiagram
     }
     class Meridian_Contracts_SecurityMaster_SecurityAssetSpecificTermsUpcasterChain["SecurityAssetSpecificTermsUpcasterChain"] {
     }
+    class Meridian_Contracts_SecurityMaster_SecurityAssetSpecificTermsUpcasterPipeline["SecurityAssetSpecificTermsUpcasterPipeline"] {
+        +SecurityAssetSpecificTermsUpcasterPipeline Instance
+    }
     class Meridian_Contracts_SecurityMaster_SecurityAssetSpecificTermsV0ToCurrentUpcaster["SecurityAssetSpecificTermsV0ToCurrentUpcaster"] {
         +SecurityAssetSpecificTermsV0ToCurrentUpcaster Instance
+    }
+    class Meridian_Contracts_SecurityMaster_SecurityAssetTermField["SecurityAssetTermField"] {
+        +IReadOnlyList~string~ Aliases
+        +string Key
+        +bool Required
+        +SecurityAssetTermFieldType Type
+    }
+    class Meridian_Contracts_SecurityMaster_SecurityAssetTermFieldType["SecurityAssetTermFieldType"] {
+    }
+    class Meridian_Contracts_SecurityMaster_SecurityAssetTermsSchema["SecurityAssetTermsSchema"] {
+        +IReadOnlyCollection~string~ AssetClasses
     }
     class Meridian_Contracts_SecurityMaster_SecurityCashFlowSourceDto["SecurityCashFlowSourceDto"] {
         +DateTimeOffset? ClientConfirmedAt
@@ -521,39 +535,6 @@ classDiagram
         +IReadOnlyList~StructuredCashFlowLedgerPosting~ Postings
         +Guid SecurityId
     }
-    class Meridian_Contracts_SecurityMaster_StructuredCashFlowLeg["StructuredCashFlowLeg"] {
-        +decimal? CurrentIndexRate
-        +string? DayCountConvention
-        +CashFlowLegDirection? Direction
-        +bool ExchangesPrincipal
-        +decimal? FixedRate
-        +string? IndexName
-        +string LegId
-        +decimal? Notional
-        +string? PaymentFrequency
-        +CashFlowLegRateKind RateKind
-        +decimal? SpreadBps
-    }
-    class Meridian_Contracts_SecurityMaster_StructuredCashFlowLegSchedule["StructuredCashFlowLegSchedule"] {
-        +CashFlowLegDirection? Direction
-        +string LegId
-        +CashFlowLegRateKind RateKind
-        +IReadOnlyList~StructuredCashFlowScheduleEntry~ Schedule
-    }
-    class Meridian_Contracts_SecurityMaster_StructuredCashFlowProjectionDto["StructuredCashFlowProjectionDto"] {
-        +DateTimeOffset AsOf
-        +IReadOnlyList~StructuredFactorScheduleEntry~? FactorSchedule
-        +IReadOnlyList~StructuredCashFlowLegSchedule~? LegSchedules
-        +StructuredCashFlowScenario Scenario
-        +IReadOnlyList~StructuredCashFlowScheduleEntry~ Schedule
-        +Guid SecurityId
-        +StructuredCashFlowSourceKind SourceKind
-        +DateTimeOffset? SourceLastUpdatedUtc
-        +StructuredCashFlowStaleness Staleness
-        +StructuredCashFlowTerms? TermsUsed
-    }
-    class Meridian_Contracts_SecurityMaster_StructuredCashFlowScenario["StructuredCashFlowScenario"] {
-    }
     Meridian_Contracts_SecurityMaster_SecurityAliasDto --> Meridian_Contracts_SecurityMaster_SecurityAliasScope
     Meridian_Contracts_SecurityMaster_SecurityAssetClassDescriptor --> Meridian_Contracts_SecurityMaster_SecurityIdentifierKind
     Meridian_Contracts_SecurityMaster_SecurityAssetProfileDefinitionDto --> Meridian_Contracts_SecurityMaster_SecurityAssetProfileAccountingImpactHintDto
@@ -578,7 +559,9 @@ classDiagram
     Meridian_Contracts_SecurityMaster_SecurityAssetProfilePromotionSignalDto --> Meridian_Contracts_SecurityMaster_SecurityAssetProfilePromotionSignalSeverityDto
     Meridian_Contracts_SecurityMaster_SecurityAssetProfileTermsDto --> Meridian_Contracts_SecurityMaster_SecurityAssetProfileApprovalMetadataDto
     Meridian_Contracts_SecurityMaster_SecurityAssetProfileTermsDto --> Meridian_Contracts_SecurityMaster_SecurityEvidenceLinkDto
+    Meridian_Contracts_SecurityMaster_SecurityAssetSpecificTermsUpcasterPipeline --> Meridian_Contracts_SecurityMaster_SecurityAssetSpecificTerms
     Meridian_Contracts_SecurityMaster_SecurityAssetSpecificTermsV0ToCurrentUpcaster --> Meridian_Contracts_SecurityMaster_SecurityAssetSpecificTerms
+    Meridian_Contracts_SecurityMaster_SecurityAssetTermField --> Meridian_Contracts_SecurityMaster_SecurityAssetTermFieldType
     Meridian_Contracts_SecurityMaster_SecurityDetailDto --> Meridian_Contracts_SecurityMaster_SecurityAliasDto
     Meridian_Contracts_SecurityMaster_SecurityDetailDto --> Meridian_Contracts_SecurityMaster_SecurityIdentifierDto
     Meridian_Contracts_SecurityMaster_SecurityDetailDto --> Meridian_Contracts_SecurityMaster_SecurityStatusDto
@@ -611,6 +594,4 @@ classDiagram
     Meridian_Contracts_SecurityMaster_SecurityValidationSnapshotRequestDto --> Meridian_Contracts_SecurityMaster_SecurityValidationWorkflowDto
     Meridian_Contracts_SecurityMaster_StructuredCashFlowLedgerPosting --> Meridian_Contracts_SecurityMaster_StructuredCashFlowLedgerLine
     Meridian_Contracts_SecurityMaster_StructuredCashFlowLedgerPostingResult --> Meridian_Contracts_SecurityMaster_StructuredCashFlowLedgerPosting
-    Meridian_Contracts_SecurityMaster_StructuredCashFlowProjectionDto --> Meridian_Contracts_SecurityMaster_StructuredCashFlowLegSchedule
-    Meridian_Contracts_SecurityMaster_StructuredCashFlowProjectionDto --> Meridian_Contracts_SecurityMaster_StructuredCashFlowScenario
 ```

--- a/docs/generated/database/contracts/security-master-contracts-page-03.md
+++ b/docs/generated/database/contracts/security-master-contracts-page-03.md
@@ -2,11 +2,44 @@
 
 # `security-master-contracts` data objects - page 3 of 3
 
-Objects 161-170 of 170. References crossing pages remain available in the dependency manifest.
+Objects 161-174 of 174. References crossing pages remain available in the dependency manifest.
 
 ```mermaid
 classDiagram
     %% security-master-contracts: module mapping, not DTO/table equivalence
+    class Meridian_Contracts_SecurityMaster_StructuredCashFlowLeg["StructuredCashFlowLeg"] {
+        +decimal? CurrentIndexRate
+        +string? DayCountConvention
+        +CashFlowLegDirection? Direction
+        +bool ExchangesPrincipal
+        +decimal? FixedRate
+        +string? IndexName
+        +string LegId
+        +decimal? Notional
+        +string? PaymentFrequency
+        +CashFlowLegRateKind RateKind
+        +decimal? SpreadBps
+    }
+    class Meridian_Contracts_SecurityMaster_StructuredCashFlowLegSchedule["StructuredCashFlowLegSchedule"] {
+        +CashFlowLegDirection? Direction
+        +string LegId
+        +CashFlowLegRateKind RateKind
+        +IReadOnlyList~StructuredCashFlowScheduleEntry~ Schedule
+    }
+    class Meridian_Contracts_SecurityMaster_StructuredCashFlowProjectionDto["StructuredCashFlowProjectionDto"] {
+        +DateTimeOffset AsOf
+        +IReadOnlyList~StructuredFactorScheduleEntry~? FactorSchedule
+        +IReadOnlyList~StructuredCashFlowLegSchedule~? LegSchedules
+        +StructuredCashFlowScenario Scenario
+        +IReadOnlyList~StructuredCashFlowScheduleEntry~ Schedule
+        +Guid SecurityId
+        +StructuredCashFlowSourceKind SourceKind
+        +DateTimeOffset? SourceLastUpdatedUtc
+        +StructuredCashFlowStaleness Staleness
+        +StructuredCashFlowTerms? TermsUsed
+    }
+    class Meridian_Contracts_SecurityMaster_StructuredCashFlowScenario["StructuredCashFlowScenario"] {
+    }
     class Meridian_Contracts_SecurityMaster_StructuredCashFlowScheduleEntry["StructuredCashFlowScheduleEntry"] {
         +decimal Factor
         +decimal InterestAmount
@@ -79,6 +112,15 @@ classDiagram
         +DateTimeOffset ValidFrom
         +DateTimeOffset? ValidTo
     }
+    Meridian_Contracts_SecurityMaster_StructuredCashFlowLegSchedule --> Meridian_Contracts_SecurityMaster_StructuredCashFlowScheduleEntry
+    Meridian_Contracts_SecurityMaster_StructuredCashFlowProjectionDto --> Meridian_Contracts_SecurityMaster_StructuredCashFlowLegSchedule
+    Meridian_Contracts_SecurityMaster_StructuredCashFlowProjectionDto --> Meridian_Contracts_SecurityMaster_StructuredCashFlowScenario
+    Meridian_Contracts_SecurityMaster_StructuredCashFlowProjectionDto --> Meridian_Contracts_SecurityMaster_StructuredCashFlowScheduleEntry
+    Meridian_Contracts_SecurityMaster_StructuredCashFlowProjectionDto --> Meridian_Contracts_SecurityMaster_StructuredCashFlowSourceKind
+    Meridian_Contracts_SecurityMaster_StructuredCashFlowProjectionDto --> Meridian_Contracts_SecurityMaster_StructuredCashFlowStaleness
+    Meridian_Contracts_SecurityMaster_StructuredCashFlowProjectionDto --> Meridian_Contracts_SecurityMaster_StructuredCashFlowTerms
+    Meridian_Contracts_SecurityMaster_StructuredCashFlowProjectionDto --> Meridian_Contracts_SecurityMaster_StructuredFactorScheduleEntry
+    Meridian_Contracts_SecurityMaster_StructuredCashFlowTerms --> Meridian_Contracts_SecurityMaster_StructuredCashFlowLeg
     Meridian_Contracts_SecurityMaster_StructuredCashFlowTerms --> Meridian_Contracts_SecurityMaster_StructuredFactorScheduleEntry
     Meridian_Contracts_SecurityMaster_UpsertCashFlowSourceRequest --> Meridian_Contracts_SecurityMaster_StructuredCashFlowSourceKind
 ```

--- a/docs/generated/database/contracts/security-master-contracts.md
+++ b/docs/generated/database/contracts/security-master-contracts.md
@@ -5,10 +5,10 @@
 This is an explicit module association, not a claim that a DTO is identical to a table.
 
 Mapped physical schemas: `security_master`.
-Catalogued objects: 170.
+Catalogued objects: 174.
 
 The catalog is split into 3 reviewable diagrams; no objects are omitted.
 
 - [Page 1: objects 1-80](security-master-contracts-page-01.md)
 - [Page 2: objects 81-160](security-master-contracts-page-02.md)
-- [Page 3: objects 161-170](security-master-contracts-page-03.md)
+- [Page 3: objects 161-174](security-master-contracts-page-03.md)

--- a/docs/generated/database/data-object-catalog.md
+++ b/docs/generated/database/data-object-catalog.md
@@ -4,7 +4,7 @@
 
 This is a source inventory of public DTOs and related contract objects. Database-to-contract links are explicit module associations; they do not assert one-to-one structural equivalence.
 
-- Public contract objects: 2465
+- Public contract objects: 2504
 - Namespaces: 54
 
 ## Classifications
@@ -12,13 +12,13 @@ This is a source inventory of public DTOs and related contract objects. Database
 | Classification | Count |
 | --- | ---: |
 | `catalog` | 10 |
-| `class` | 162 |
+| `class` | 172 |
 | `configuration` | 19 |
-| `dto` | 1205 |
-| `enum` | 340 |
+| `dto` | 1228 |
+| `enum` | 345 |
 | `event` | 5 |
 | `payload` | 60 |
-| `record` | 301 |
+| `record` | 302 |
 | `record_struct` | 3 |
 | `request` | 144 |
 | `response` | 87 |
@@ -28,10 +28,10 @@ This is a source inventory of public DTOs and related contract objects. Database
 
 ## Database-adjacent diagrams
 
-- [`ledger-contracts`](contracts/ledger-contracts.md): 281 objects; mapped schemas: `ledger`.
-- [`security-master-contracts`](contracts/security-master-contracts.md): 170 objects; mapped schemas: `security_master`.
+- [`ledger-contracts`](contracts/ledger-contracts.md): 283 objects; mapped schemas: `ledger`.
+- [`security-master-contracts`](contracts/security-master-contracts.md): 174 objects; mapped schemas: `security_master`.
 - [`direct-lending-contracts`](contracts/direct-lending-contracts.md): 98 objects; mapped schemas: `security_master`.
-- [`asset-operations-contracts`](contracts/asset-operations-contracts.md): 42 objects; mapped schemas: `asset_operations`.
+- [`asset-operations-contracts`](contracts/asset-operations-contracts.md): 69 objects; mapped schemas: `asset_operations`.
 - [`fund-governance-contracts`](contracts/fund-governance-contracts.md): 141 objects; mapped schemas: `fund_accounts`, `fund_structure`.
 - [`banking-contracts`](contracts/banking-contracts.md): 10 objects; mapped schemas: `banking`.
 - [`money-market-contracts`](contracts/money-market-contracts.md): 1 objects; mapped schemas: `money_market`.

--- a/docs/generated/database/diagrams/contracts-asset-operations-contracts.mmd
+++ b/docs/generated/database/diagrams/contracts-asset-operations-contracts.mmd
@@ -1,5 +1,103 @@
 classDiagram
     %% asset-operations-contracts: module mapping, not DTO/table equivalence
+    class Meridian_Contracts_AssetOperations_AppendAssetAccountingLifecycleStageRequestDto["AppendAssetAccountingLifecycleStageRequestDto"] {
+        +string Actor
+        +DateTimeOffset AttestedAtUtc
+        +string? CompanyId
+        +Guid EventId
+        +long EventVersion
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ Evidence
+        +long ExpectedBookPositionVersion
+        +long ExpectedSpineVersion
+        +string FundProfileId
+        +string? Notes
+        +string ReferenceId
+        +AssetAccountingLifecycleStageDto Stage
+    }
+    class Meridian_Contracts_AssetOperations_AssetAccountingCorrectionReferenceDto["AssetAccountingCorrectionReferenceDto"] {
+        +AccountingBasisKindDto AccountingBasis
+        +Guid EventId
+        +long EventVersion
+        +Guid LedgerBookId
+        +Guid PeriodId
+        +Guid PostedJournalEntryId
+        +Guid? TaxLotMutationBatchId
+    }
+    class Meridian_Contracts_AssetOperations_AssetAccountingEventKindDto["AssetAccountingEventKindDto"] {
+    }
+    class Meridian_Contracts_AssetOperations_AssetAccountingEventScopeDto["AssetAccountingEventScopeDto"] {
+        +AccountingBasisKindDto AccountingBasis
+        +Guid BookPositionId
+        +string? CompanyId
+        +LedgerDimensionSetDto? Dimensions
+        +long ExpectedBookPositionVersion
+        +long ExpectedSecurityVersion
+        +string FundProfileId
+        +Guid LedgerBookId
+        +Guid PeriodId
+        +Guid SecurityId
+        +string? TenantId
+    }
+    class Meridian_Contracts_AssetOperations_AssetAccountingEventSpineAppendResultDto["AssetAccountingEventSpineAppendResultDto"] {
+        +AssetAccountingEventSpineDto Spine
+        +bool WasReplay
+    }
+    class Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto["AssetAccountingEventSpineDto"] {
+        +AssetAccountingCorrectionReferenceDto? Correction
+        +string Currency
+        +PostingRuleJournalCandidateRequestDto? DraftedCandidate
+        +string? DraftedCandidateFingerprint
+        +PostingRuleJournalCandidateResultDto? DraftedCandidateResult
+        +string? DraftedCandidateResultFingerprint
+        +AssetLotMutationInstructionDto? DraftedLotMutation
+        +string? DraftedLotMutationFingerprint
+        +EconomicEventReferenceDto EconomicEvent
+        +DateOnly EffectiveDate
+        +decimal EventAmount
+        +Guid EventId
+    }
+    class Meridian_Contracts_AssetOperations_AssetAccountingEventSpineValidator["AssetAccountingEventSpineValidator"] {
+    }
+    class Meridian_Contracts_AssetOperations_AssetAccountingEventTypeNames["AssetAccountingEventTypeNames"] {
+    }
+    class Meridian_Contracts_AssetOperations_AssetAccountingEvidenceSubjects["AssetAccountingEvidenceSubjects"] {
+    }
+    class Meridian_Contracts_AssetOperations_AssetAccountingLifecycleStageDto["AssetAccountingLifecycleStageDto"] {
+    }
+    class Meridian_Contracts_AssetOperations_AssetAccountingPostingCandidateDto["AssetAccountingPostingCandidateDto"] {
+        +PostingRuleJournalCandidateResultDto Candidate
+        +AssetAccountingEventSpineDto Spine
+    }
+    class Meridian_Contracts_AssetOperations_AssetAccountingPostingCandidateRequestDto["AssetAccountingPostingCandidateRequestDto"] {
+        +DateTimeOffset AccountingTimestamp
+        +string Actor
+        +LedgerAdjustmentApprovalMetadataDto? CorrectionApproval
+        +Guid? CorrelationId
+        +string? CounterpartyId
+        +string Currency
+        +string Description
+        +EconomicEventReferenceDto EconomicEvent
+        +decimal EventAmount
+        +AssetAccountingEventKindDto EventKind
+        +long ExpectedPeriodVersion
+        +long ExpectedSpineVersion
+    }
+    class Meridian_Contracts_AssetOperations_AssetAccountingStageEvidenceDto["AssetAccountingStageEvidenceDto"] {
+        +DateTimeOffset AttestedAtUtc
+        +string AttestedBy
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ Evidence
+        +string? Notes
+        +string? ReferenceId
+        +AssetAccountingLifecycleStageDto Stage
+    }
+    class Meridian_Contracts_AssetOperations_AssetAcquisitionLotDto["AssetAcquisitionLotDto"] {
+        +string AccountId
+        +DateOnly AcquiredDate
+        +string LotId
+        +decimal Quantity
+        +Guid TaxLotRecordId
+        +decimal UnitCost
+    }
     class Meridian_Contracts_AssetOperations_AssetActualActivityDto["AssetActualActivityDto"] {
         +Guid ActivityId
         +string ActivityType
@@ -8,11 +106,11 @@ classDiagram
         +DateOnly EffectiveDate
         +string? EvidenceLink
         +JsonElement? ExtensionPayload
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
         +Guid SecurityId
         +DateOnly? SettlementDate
         +string SourceDomain
         +string? SourceEntityId
-        +string Status
     }
     class Meridian_Contracts_AssetOperations_AssetCashFlowProjectionRunDto["AssetCashFlowProjectionRunDto"] {
         +string EngineVersion
@@ -20,10 +118,22 @@ classDiagram
         +DateTimeOffset GeneratedAt
         +DateOnly ProjectionAsOf
         +Guid ProjectionRunId
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
         +Guid SecurityId
         +string SourceDomain
         +string? SourceEntityId
         +string Status
+    }
+    class Meridian_Contracts_AssetOperations_AssetDisposalLotSelectionDto["AssetDisposalLotSelectionDto"] {
+        +decimal ExpectedCostBasis
+        +decimal ExpectedOpenQuantity
+        +decimal ExpectedUnitCost
+        +long ExpectedVersion
+        +string LotId
+        +decimal Quantity
+        +string SelectionEvidenceId
+        +int SelectionOrdinal
+        +Guid TaxLotRecordId
     }
     class Meridian_Contracts_AssetOperations_AssetLedgerProjectionDto["AssetLedgerProjectionDto"] {
         +DateOnly AccountingDate
@@ -35,9 +145,9 @@ classDiagram
         +Guid LedgerProjectionId
         +string? LedgerReferenceId
         +string ProjectionType
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
         +Guid SecurityId
         +string SourceDomain
-        +string? SourceEntityId
     }
     class Meridian_Contracts_AssetOperations_AssetLifecycleEventDto["AssetLifecycleEventDto"] {
         +DateOnly EffectiveDate
@@ -46,10 +156,26 @@ classDiagram
         +Guid LifecycleEventId
         +string LifecycleState
         +DateTimeOffset RecordedAt
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
         +Guid SecurityId
         +string SourceDomain
         +string? SourceEntityId
         +string Summary
+    }
+    class Meridian_Contracts_AssetOperations_AssetLotMutationInstructionDto["AssetLotMutationInstructionDto"] {
+        +AssetAcquisitionLotDto? Acquisition
+        +string? AssetAccountId
+        +LedgerAdjustmentApprovalMetadataDto? CorrectionApproval
+        +Guid? CorrectsJournalEntryId
+        +Guid? CorrectsMutationBatchId
+        +IReadOnlyList~AssetDisposalLotSelectionDto~ DisposalSelections
+        +AssetLotMutationIntentDto Intent
+        +string? PolicyRevision
+        +string? ReliefMethod
+    }
+    class Meridian_Contracts_AssetOperations_AssetLotMutationInstructionValidator["AssetLotMutationInstructionValidator"] {
+    }
+    class Meridian_Contracts_AssetOperations_AssetLotMutationIntentDto["AssetLotMutationIntentDto"] {
     }
     class Meridian_Contracts_AssetOperations_AssetOperationSubjectDto["AssetOperationSubjectDto"] {
         +string AssetClass
@@ -96,6 +222,7 @@ classDiagram
         +JsonElement? ExtensionPayload
         +IReadOnlyList~string~ MissingCapabilities
         +IReadOnlyList~string~ ReadyCapabilities
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
         +Guid SecurityId
         +string SourceDomain
         +string? SourceEntityId
@@ -120,7 +247,7 @@ classDiagram
         +decimal? PrincipalBasis
         +Guid ProjectedCashFlowId
         +Guid ProjectionRunId
-        +Guid SecurityId
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
     }
     class Meridian_Contracts_AssetOperations_AssetReconciliationResultDto["AssetReconciliationResultDto"] {
         +decimal? ActualAmount
@@ -132,9 +259,9 @@ classDiagram
         +string MatchStatus
         +Guid ReconciliationResultId
         +Guid ReconciliationRunId
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
         +Guid SecurityId
         +string SourceDomain
-        +string? SourceEntityId
     }
     class Meridian_Contracts_AssetOperations_AssetReconciliationRunDto["AssetReconciliationRunDto"] {
         +DateTimeOffset? CompletedAt
@@ -142,6 +269,7 @@ classDiagram
         +Guid? ProjectionRunId
         +Guid ReconciliationRunId
         +DateTimeOffset RequestedAt
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
         +Guid SecurityId
         +string SourceDomain
         +string? SourceEntityId
@@ -168,17 +296,18 @@ classDiagram
         +JsonElement? ExtensionPayload
         +DateTimeOffset GeneratedAt
         +DateOnly ProjectionAsOf
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
         +Guid SecurityId
         +string SourceDomain
         +string? SourceEntityId
         +string Status
         +IReadOnlyList~AssetTimelineVarianceDto~ Variances
-        +IReadOnlyList~string~ Warnings
     }
     class Meridian_Contracts_AssetOperations_AssetTermsVersionDto["AssetTermsVersionDto"] {
         +DateOnly EffectiveDate
         +JsonElement? ExtensionPayload
         +DateTimeOffset RecordedAt
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
         +Guid SecurityId
         +string SourceDomain
         +string? SourceEntityId
@@ -195,11 +324,11 @@ classDiagram
         +string? EvidenceLink
         +decimal? ExpectedAmount
         +DateOnly ExpectedDate
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
         +Guid SecurityId
         +string SourceDomain
         +string? SourceEntityId
         +string Status
-        +string Summary
     }
     class Meridian_Contracts_AssetOperations_BookPositionDto["BookPositionDto"] {
         +AccountingBookContextDto BookContext
@@ -213,7 +342,7 @@ classDiagram
         +string PositionSide
         +string? PrimaryAccountId
         +ProjectionLineageDto? ProjectionLineage
-        +Guid RoleId
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
     }
     class Meridian_Contracts_AssetOperations_BookPositionSides["BookPositionSides"] {
     }
@@ -227,9 +356,9 @@ classDiagram
         +long EventVersion
         +IReadOnlyList~string~ EvidenceLinks
         +DateTimeOffset OccurredAtUtc
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
         +Guid? SecurityId
         +string? SourceContentHash
-        +string SourceDomain
     }
     class Meridian_Contracts_AssetOperations_IAssetOperationsCommandService["IAssetOperationsCommandService"] {
     }
@@ -259,9 +388,11 @@ classDiagram
         +EconomicEventReferenceDto? OriginEvent
         +string OwnerScopeId
         +string OwnerScopeKind
-        +Guid RoleId
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
     }
     class Meridian_Contracts_AssetOperations_InstrumentRoleKinds["InstrumentRoleKinds"] {
+    }
+    class Meridian_Contracts_AssetOperations_JournalPostingStatusDto["JournalPostingStatusDto"] {
     }
     class Meridian_Contracts_AssetOperations_PortfolioCapitalActivityDto["PortfolioCapitalActivityDto"] {
         +Guid ActivityId
@@ -361,6 +492,61 @@ classDiagram
         +decimal? ParAmount
         +Guid PositionId
     }
+    class Meridian_Contracts_AssetOperations_PostedJournalImpactDto["PostedJournalImpactDto"] {
+        +AccountingBasisKindDto AccountingBasis
+        +string Currency
+        +Guid JournalEntryId
+        +Guid LedgerBookId
+        +IReadOnlyList~PostedJournalImpactLineDto~ Lines
+        +Guid PeriodId
+        +DateTimeOffset PostedAtUtc
+        +JournalPostingStatusDto PostingStatus
+        +decimal TotalCredits
+        +decimal TotalDebits
+    }
+    class Meridian_Contracts_AssetOperations_PostedJournalImpactLineDto["PostedJournalImpactLineDto"] {
+        +string AccountId
+        +decimal Credit
+        +string Currency
+        +decimal Debit
+        +string? Description
+        +LedgerDimensionSetDto? Dimensions
+        +Guid LineId
+    }
+    class Meridian_Contracts_AssetOperations_PostedJournalImpactValidator["PostedJournalImpactValidator"] {
+    }
+    class Meridian_Contracts_AssetOperations_ProjectAssetAccountingEventRequestDto["ProjectAssetAccountingEventRequestDto"] {
+        +string Actor
+        +AssetAccountingCorrectionReferenceDto? Correction
+        +string Currency
+        +EconomicEventReferenceDto EconomicEvent
+        +decimal EventAmount
+        +AssetAccountingEventKindDto EventKind
+        +long ExpectedPeriodVersion
+        +string? Notes
+        +DateTimeOffset ProjectedAtUtc
+        +ProjectedAccountingEffectDto ProjectedEffect
+        +ProjectionLineageDto ProjectionLineage
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
+    }
+    class Meridian_Contracts_AssetOperations_ProjectedAccountingEffectDto["ProjectedAccountingEffectDto"] {
+        +string Currency
+        +IReadOnlyList~ProjectedAccountingEffectLineDto~ Lines
+        +string ModelKey
+        +string ModelVersion
+        +DateOnly ProjectionAsOfDate
+        +Guid ProjectionRunId
+        +decimal TotalCredits
+        +decimal TotalDebits
+    }
+    class Meridian_Contracts_AssetOperations_ProjectedAccountingEffectLineDto["ProjectedAccountingEffectLineDto"] {
+        +string AccountId
+        +decimal Credit
+        +string Currency
+        +decimal Debit
+        +string? Description
+        +LedgerDimensionSetDto? Dimensions
+    }
     class Meridian_Contracts_AssetOperations_ProjectionLineageDto["ProjectionLineageDto"] {
         +Guid? BookPositionId
         +string EngineVersion
@@ -371,10 +557,55 @@ classDiagram
         +DateOnly ProjectionAsOfDate
         +Guid? ProjectionEventId
         +Guid ProjectionRunId
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
         +string Scenario
         +string SourceDomain
-        +string? SourceEntityId
     }
+    class Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto["RetainedEvidenceIdentityDto"] {
+        +string ContentHashSha256
+        +DateOnly EffectiveDate
+        +string EvidenceId
+        +string EvidenceUri
+        +long EvidenceVersion
+        +DateTimeOffset RetainedAtUtc
+        +string RetainedBy
+        +DateTimeOffset ReviewedAtUtc
+        +string ReviewedBy
+        +string ReviewStatus
+        +string SourceReference
+        +string SourceSystem
+    }
+    class Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityValidator["RetainedEvidenceIdentityValidator"] {
+    }
+    Meridian_Contracts_AssetOperations_AppendAssetAccountingLifecycleStageRequestDto --> Meridian_Contracts_AssetOperations_AssetAccountingLifecycleStageDto
+    Meridian_Contracts_AssetOperations_AppendAssetAccountingLifecycleStageRequestDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetAccountingEventSpineAppendResultDto --> Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto
+    Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto --> Meridian_Contracts_AssetOperations_AssetAccountingCorrectionReferenceDto
+    Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto --> Meridian_Contracts_AssetOperations_AssetAccountingEventKindDto
+    Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto --> Meridian_Contracts_AssetOperations_AssetAccountingEventScopeDto
+    Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto --> Meridian_Contracts_AssetOperations_AssetAccountingStageEvidenceDto
+    Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto --> Meridian_Contracts_AssetOperations_AssetLotMutationInstructionDto
+    Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto --> Meridian_Contracts_AssetOperations_EconomicEventReferenceDto
+    Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto --> Meridian_Contracts_AssetOperations_PostedJournalImpactDto
+    Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto --> Meridian_Contracts_AssetOperations_ProjectedAccountingEffectDto
+    Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto --> Meridian_Contracts_AssetOperations_ProjectionLineageDto
+    Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetAccountingPostingCandidateDto --> Meridian_Contracts_AssetOperations_AssetAccountingEventSpineDto
+    Meridian_Contracts_AssetOperations_AssetAccountingPostingCandidateRequestDto --> Meridian_Contracts_AssetOperations_AssetAccountingEventKindDto
+    Meridian_Contracts_AssetOperations_AssetAccountingPostingCandidateRequestDto --> Meridian_Contracts_AssetOperations_AssetAccountingEventScopeDto
+    Meridian_Contracts_AssetOperations_AssetAccountingPostingCandidateRequestDto --> Meridian_Contracts_AssetOperations_AssetLotMutationInstructionDto
+    Meridian_Contracts_AssetOperations_AssetAccountingPostingCandidateRequestDto --> Meridian_Contracts_AssetOperations_EconomicEventReferenceDto
+    Meridian_Contracts_AssetOperations_AssetAccountingPostingCandidateRequestDto --> Meridian_Contracts_AssetOperations_ProjectionLineageDto
+    Meridian_Contracts_AssetOperations_AssetAccountingPostingCandidateRequestDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetAccountingStageEvidenceDto --> Meridian_Contracts_AssetOperations_AssetAccountingLifecycleStageDto
+    Meridian_Contracts_AssetOperations_AssetAccountingStageEvidenceDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetActualActivityDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetCashFlowProjectionRunDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetLedgerProjectionDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetLifecycleEventDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetLotMutationInstructionDto --> Meridian_Contracts_AssetOperations_AssetAcquisitionLotDto
+    Meridian_Contracts_AssetOperations_AssetLotMutationInstructionDto --> Meridian_Contracts_AssetOperations_AssetDisposalLotSelectionDto
+    Meridian_Contracts_AssetOperations_AssetLotMutationInstructionDto --> Meridian_Contracts_AssetOperations_AssetLotMutationIntentDto
     Meridian_Contracts_AssetOperations_AssetOperationsDetailDto --> Meridian_Contracts_AssetOperations_AssetActualActivityDto
     Meridian_Contracts_AssetOperations_AssetOperationsDetailDto --> Meridian_Contracts_AssetOperations_AssetCashFlowProjectionRunDto
     Meridian_Contracts_AssetOperations_AssetOperationsDetailDto --> Meridian_Contracts_AssetOperations_AssetLedgerProjectionDto
@@ -390,6 +621,7 @@ classDiagram
     Meridian_Contracts_AssetOperations_AssetOperationsDetailDto --> Meridian_Contracts_AssetOperations_InstrumentRoleDto
     Meridian_Contracts_AssetOperations_AssetOperationsDetailDto --> Meridian_Contracts_AssetOperations_PositionEconomicStateDto
     Meridian_Contracts_AssetOperations_AssetOperationsDetailDto --> Meridian_Contracts_AssetOperations_ProjectionLineageDto
+    Meridian_Contracts_AssetOperations_AssetOperationsDetailDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
     Meridian_Contracts_AssetOperations_AssetOperationsProjectionDto --> Meridian_Contracts_AssetOperations_AssetActualActivityDto
     Meridian_Contracts_AssetOperations_AssetOperationsProjectionDto --> Meridian_Contracts_AssetOperations_AssetCashFlowProjectionRunDto
     Meridian_Contracts_AssetOperations_AssetOperationsProjectionDto --> Meridian_Contracts_AssetOperations_AssetLedgerProjectionDto
@@ -405,12 +637,24 @@ classDiagram
     Meridian_Contracts_AssetOperations_AssetOperationsProjectionDto --> Meridian_Contracts_AssetOperations_InstrumentRoleDto
     Meridian_Contracts_AssetOperations_AssetOperationsProjectionDto --> Meridian_Contracts_AssetOperations_PositionEconomicStateDto
     Meridian_Contracts_AssetOperations_AssetOperationsProjectionDto --> Meridian_Contracts_AssetOperations_ProjectionLineageDto
+    Meridian_Contracts_AssetOperations_AssetOperationsProjectionDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetOperationsReadinessDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetProjectedCashFlowDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetReconciliationResultDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetReconciliationRunDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetTermsObligationTimelineEventDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
     Meridian_Contracts_AssetOperations_AssetTermsObligationsTimelineDto --> Meridian_Contracts_AssetOperations_AssetTermsObligationTimelineEventDto
     Meridian_Contracts_AssetOperations_AssetTermsObligationsTimelineDto --> Meridian_Contracts_AssetOperations_AssetTimelineVarianceDto
+    Meridian_Contracts_AssetOperations_AssetTermsObligationsTimelineDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetTermsVersionDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_AssetTimelineVarianceDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
     Meridian_Contracts_AssetOperations_BookPositionDto --> Meridian_Contracts_AssetOperations_EconomicEventReferenceDto
     Meridian_Contracts_AssetOperations_BookPositionDto --> Meridian_Contracts_AssetOperations_PositionEconomicStateDto
     Meridian_Contracts_AssetOperations_BookPositionDto --> Meridian_Contracts_AssetOperations_ProjectionLineageDto
+    Meridian_Contracts_AssetOperations_BookPositionDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_EconomicEventReferenceDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
     Meridian_Contracts_AssetOperations_InstrumentRoleDto --> Meridian_Contracts_AssetOperations_EconomicEventReferenceDto
+    Meridian_Contracts_AssetOperations_InstrumentRoleDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
     Meridian_Contracts_AssetOperations_PortfolioCashLadderBucketDto --> Meridian_Contracts_AssetOperations_PortfolioCashLadderSourceSliceDto
     Meridian_Contracts_AssetOperations_PortfolioCashLadderDto --> Meridian_Contracts_AssetOperations_PortfolioCashLadderBucketDto
     Meridian_Contracts_AssetOperations_PortfolioCashLadderDto --> Meridian_Contracts_AssetOperations_PortfolioCashLadderContributionDto
@@ -418,4 +662,16 @@ classDiagram
     Meridian_Contracts_AssetOperations_PortfolioCashLadderPositionDto --> Meridian_Contracts_AssetOperations_AssetOperationsDetailDto
     Meridian_Contracts_AssetOperations_PositionEconomicStateDto --> Meridian_Contracts_AssetOperations_EconomicEventReferenceDto
     Meridian_Contracts_AssetOperations_PositionEconomicStateDto --> Meridian_Contracts_AssetOperations_ProjectionLineageDto
+    Meridian_Contracts_AssetOperations_PositionEconomicStateDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_PostedJournalImpactDto --> Meridian_Contracts_AssetOperations_JournalPostingStatusDto
+    Meridian_Contracts_AssetOperations_PostedJournalImpactDto --> Meridian_Contracts_AssetOperations_PostedJournalImpactLineDto
+    Meridian_Contracts_AssetOperations_ProjectAssetAccountingEventRequestDto --> Meridian_Contracts_AssetOperations_AssetAccountingCorrectionReferenceDto
+    Meridian_Contracts_AssetOperations_ProjectAssetAccountingEventRequestDto --> Meridian_Contracts_AssetOperations_AssetAccountingEventKindDto
+    Meridian_Contracts_AssetOperations_ProjectAssetAccountingEventRequestDto --> Meridian_Contracts_AssetOperations_AssetAccountingEventScopeDto
+    Meridian_Contracts_AssetOperations_ProjectAssetAccountingEventRequestDto --> Meridian_Contracts_AssetOperations_EconomicEventReferenceDto
+    Meridian_Contracts_AssetOperations_ProjectAssetAccountingEventRequestDto --> Meridian_Contracts_AssetOperations_ProjectedAccountingEffectDto
+    Meridian_Contracts_AssetOperations_ProjectAssetAccountingEventRequestDto --> Meridian_Contracts_AssetOperations_ProjectionLineageDto
+    Meridian_Contracts_AssetOperations_ProjectAssetAccountingEventRequestDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto
+    Meridian_Contracts_AssetOperations_ProjectedAccountingEffectDto --> Meridian_Contracts_AssetOperations_ProjectedAccountingEffectLineDto
     Meridian_Contracts_AssetOperations_ProjectionLineageDto --> Meridian_Contracts_AssetOperations_EconomicEventReferenceDto
+    Meridian_Contracts_AssetOperations_ProjectionLineageDto --> Meridian_Contracts_AssetOperations_RetainedEvidenceIdentityDto

--- a/docs/generated/database/diagrams/contracts-ledger-contracts-page-01.mmd
+++ b/docs/generated/database/diagrams/contracts-ledger-contracts-page-01.mmd
@@ -51,27 +51,32 @@ classDiagram
     class Meridian_Contracts_AccountingSystem_AccountingDimensionalCertificationLaneKindDto["AccountingDimensionalCertificationLaneKindDto"] {
     }
     class Meridian_Contracts_AccountingSystem_AccountingDimensionalReportingReadinessDto["AccountingDimensionalReportingReadinessDto"] {
+        +IReadOnlyList~AccountingDimensionalCertificationArtifactDto~ CertificationArtifacts
+        +string? CompanyId
         +bool CrossPeriodReportDimensionQueriesCertified
         +IReadOnlyList~string~ EvidenceReferences
         +bool ExternalExportDimensionMappingCertified
+        +string? FundProfileId
         +bool JournalQueryDimensionFiltersCertified
         +Guid? LedgerBookId
         +bool LedgerLineDimensionsPersistedCertified
         +bool PeriodReportDimensionQueriesCertified
         +bool ReportPackageDimensionProvenanceCertified
-        +bool TrialBalanceDimensionFiltersCertified
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
     }
     class Meridian_Contracts_AccountingSystem_AccountingLedgerBookWorkflowReadinessDto["AccountingLedgerBookWorkflowReadinessDto"] {
+        +IReadOnlyList~AccountingWorkflowCertificationArtifactDto~ CertificationArtifacts
         +bool ClosePlanConfigurationLedgerBookNativeCertified
         +bool CloseReportingLedgerBookNativeCertified
+        +string? CompanyId
         +bool DirectLendingLedgerBookNativeCertified
         +IReadOnlyList~string~ EvidenceReferences
         +bool ExternalGlLedgerBookNativeCertified
+        +string? FundProfileId
         +bool JournalLifecycleLedgerBookNativeCertified
         +Guid? LedgerBookId
         +bool PostingRulesLedgerBookNativeCertified
         +bool ReconciliationLedgerBookNativeCertified
-        +bool StrategyLedgerReadLedgerBookNativeCertified
     }
     class Meridian_Contracts_AccountingSystem_AccountingMigrationRolloutPlanItemDto["AccountingMigrationRolloutPlanItemDto"] {
         +string? ActionRoute
@@ -172,6 +177,10 @@ classDiagram
         +string Actor
         +AccountingMigrationRunWorkerPlanDto Plan
     }
+    class Meridian_Contracts_AccountingSystem_AccountingProductionCertificationEvidenceSubjectTypes["AccountingProductionCertificationEvidenceSubjectTypes"] {
+    }
+    class Meridian_Contracts_AccountingSystem_AccountingProductionCertificationEvidenceValidator["AccountingProductionCertificationEvidenceValidator"] {
+    }
     class Meridian_Contracts_AccountingSystem_AccountingProductionCertificationProfileDto["AccountingProductionCertificationProfileDto"] {
         +bool ClosePlanConfigurationLedgerBookNativeCertified
         +bool CloseReportingLedgerBookNativeCertified
@@ -192,6 +201,7 @@ classDiagram
         +string? CorrelationId
         +IReadOnlyList~string~ EvidenceLinks
         +AccountingProductionCertificationProfileDto Profile
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ RetainedEvidence
     }
     class Meridian_Contracts_AccountingSystem_AccountingProductionGapDto["AccountingProductionGapDto"] {
         +IReadOnlyList~AccountingProductionReadinessAreaDto~ Areas
@@ -506,12 +516,12 @@ classDiagram
         +bool AuditReviewToolingConfigured
         +bool BrowserAccountingAdminSurfaceConfigured
         +bool BulkImportExportSafeguardsConfigured
+        +IReadOnlyList~AccountingTenantAdminCertificationArtifactDto~ CertificationArtifacts
         +bool ChartAdministrationStudioConfigured
         +bool CloseSetupStudioConfigured
         +string? CompanyId
         +bool DimensionMappingStudioConfigured
         +bool DisasterRecoveryRunbookConfigured
-        +IReadOnlyList~string~ EvidenceReferences
     }
     class Meridian_Contracts_AccountingSystem_AccountingWorkflowCertificationArtifactDto["AccountingWorkflowCertificationArtifactDto"] {
         +string CertificationId
@@ -671,29 +681,6 @@ classDiagram
         +decimal TotalDebits
         +IReadOnlyList~AccountingConfigurationValidationIssueDto~ ValidationIssues
     }
-    class Meridian_Contracts_Ledger_AccountingPolicyDto["AccountingPolicyDto"] {
-        +AccountingBasisKindDto AccountingBasis
-        +DateTimeOffset CreatedAt
-        +string DisplayName
-        +DateOnly EffectiveFrom
-        +DateOnly? EffectiveTo
-        +string? FundProfileId
-        +Guid? FundStructureNodeId
-        +string? InstrumentId
-        +bool IsDefault
-        +string PolicyId
-        +AccountingPolicyRulePackDto? RulePack
-        +string RulesJson
-    }
-    class Meridian_Contracts_Ledger_AccountingPolicyQuery["AccountingPolicyQuery"] {
-        +AccountingBasisKindDto AccountingBasis
-        +DateOnly? EffectiveDate
-        +string? FundProfileId
-        +Guid? FundStructureNodeId
-        +string? InstrumentId
-        +string? PolicyId
-        +Guid? SourceEventId
-    }
     Meridian_Contracts_AccountingSystem_AccountingCertificationArtifactIssueDto --> Meridian_Contracts_Ledger_AccountingConfigurationValidationSeverityDto
     Meridian_Contracts_AccountingSystem_AccountingDimensionalCertificationArtifactDto --> Meridian_Contracts_AccountingSystem_AccountingCertificationArtifactIssueDto
     Meridian_Contracts_AccountingSystem_AccountingDimensionalCertificationArtifactDto --> Meridian_Contracts_AccountingSystem_AccountingCertificationArtifactStatusDto
@@ -701,6 +688,8 @@ classDiagram
     Meridian_Contracts_AccountingSystem_AccountingDimensionalCertificationLaneDto --> Meridian_Contracts_AccountingSystem_AccountingCertificationArtifactIssueDto
     Meridian_Contracts_AccountingSystem_AccountingDimensionalCertificationLaneDto --> Meridian_Contracts_AccountingSystem_AccountingCertificationArtifactLaneStatusDto
     Meridian_Contracts_AccountingSystem_AccountingDimensionalCertificationLaneDto --> Meridian_Contracts_AccountingSystem_AccountingDimensionalCertificationLaneKindDto
+    Meridian_Contracts_AccountingSystem_AccountingDimensionalReportingReadinessDto --> Meridian_Contracts_AccountingSystem_AccountingDimensionalCertificationArtifactDto
+    Meridian_Contracts_AccountingSystem_AccountingLedgerBookWorkflowReadinessDto --> Meridian_Contracts_AccountingSystem_AccountingWorkflowCertificationArtifactDto
     Meridian_Contracts_AccountingSystem_AccountingMigrationRolloutPlanItemDto --> Meridian_Contracts_AccountingSystem_AccountingMigrationRunKindDto
     Meridian_Contracts_AccountingSystem_AccountingMigrationRolloutPlanItemDto --> Meridian_Contracts_AccountingSystem_AccountingMigrationRunStatusDto
     Meridian_Contracts_AccountingSystem_AccountingMigrationRolloutPlanItemDto --> Meridian_Contracts_AccountingSystem_AccountingProductionReadinessStatusDto
@@ -769,6 +758,7 @@ classDiagram
     Meridian_Contracts_AccountingSystem_AccountingTenantAdministrationProfileDto --> Meridian_Contracts_AccountingSystem_AccountingApprovalQueueConfigurationDto
     Meridian_Contracts_AccountingSystem_AccountingTenantAdministrationProfileDto --> Meridian_Contracts_AccountingSystem_AccountingDimensionMappingConfigurationDto
     Meridian_Contracts_AccountingSystem_AccountingTenantAdministrationProfileUpsertRequestDto --> Meridian_Contracts_AccountingSystem_AccountingTenantAdministrationProfileDto
+    Meridian_Contracts_AccountingSystem_AccountingTenantAdministrationReadinessDto --> Meridian_Contracts_AccountingSystem_AccountingTenantAdminCertificationArtifactDto
     Meridian_Contracts_AccountingSystem_AccountingWorkflowCertificationArtifactDto --> Meridian_Contracts_AccountingSystem_AccountingCertificationArtifactIssueDto
     Meridian_Contracts_AccountingSystem_AccountingWorkflowCertificationArtifactDto --> Meridian_Contracts_AccountingSystem_AccountingCertificationArtifactStatusDto
     Meridian_Contracts_AccountingSystem_AccountingWorkflowCertificationArtifactDto --> Meridian_Contracts_AccountingSystem_AccountingWorkflowCertificationLaneDto
@@ -788,5 +778,3 @@ classDiagram
     Meridian_Contracts_Ledger_AccountingConfigurationWorkspaceDto --> Meridian_Contracts_Ledger_AccountingConfigurationValidationIssueDto
     Meridian_Contracts_Ledger_AccountingJournalTemplatePreviewDto --> Meridian_Contracts_Ledger_AccountingConfigurationValidationIssueDto
     Meridian_Contracts_Ledger_AccountingJournalTemplatePreviewDto --> Meridian_Contracts_Ledger_AccountingJournalPreviewLineDto
-    Meridian_Contracts_Ledger_AccountingPolicyDto --> Meridian_Contracts_Ledger_AccountingBasisKindDto
-    Meridian_Contracts_Ledger_AccountingPolicyQuery --> Meridian_Contracts_Ledger_AccountingBasisKindDto

--- a/docs/generated/database/diagrams/contracts-ledger-contracts-page-02.mmd
+++ b/docs/generated/database/diagrams/contracts-ledger-contracts-page-02.mmd
@@ -1,5 +1,28 @@
 classDiagram
     %% ledger-contracts: module mapping, not DTO/table equivalence
+    class Meridian_Contracts_Ledger_AccountingPolicyDto["AccountingPolicyDto"] {
+        +AccountingBasisKindDto AccountingBasis
+        +DateTimeOffset CreatedAt
+        +string DisplayName
+        +DateOnly EffectiveFrom
+        +DateOnly? EffectiveTo
+        +string? FundProfileId
+        +Guid? FundStructureNodeId
+        +string? InstrumentId
+        +bool IsDefault
+        +string PolicyId
+        +AccountingPolicyRulePackDto? RulePack
+        +string RulesJson
+    }
+    class Meridian_Contracts_Ledger_AccountingPolicyQuery["AccountingPolicyQuery"] {
+        +AccountingBasisKindDto AccountingBasis
+        +DateOnly? EffectiveDate
+        +string? FundProfileId
+        +Guid? FundStructureNodeId
+        +string? InstrumentId
+        +string? PolicyId
+        +Guid? SourceEventId
+    }
     class Meridian_Contracts_Ledger_AccountingPolicyRuleDto["AccountingPolicyRuleDto"] {
         +bool AllowsAutoPosting
         +string? Description
@@ -39,13 +62,16 @@ classDiagram
     class Meridian_Contracts_Ledger_AccountingPostingEvidenceReferenceDto["AccountingPostingEvidenceReferenceDto"] {
         +string? ContentHash
         +string? Description
+        +DateOnly? EffectiveDate
         +string EvidenceId
+        +long? EvidenceVersion
         +AccountingPostingEvidenceKindDto Kind
         +DateTimeOffset RetainedAtUtc
         +string RetainedBy
-        +string SourceSystem
-        +string? SubjectId
-        +string Uri
+        +DateTimeOffset? ReviewedAtUtc
+        +string? Reviewer
+        +string? ReviewStatus
+        +string? SourceReference
     }
     class Meridian_Contracts_Ledger_AccountingPostingIntentDto["AccountingPostingIntentDto"] {
     }
@@ -691,10 +717,7 @@ classDiagram
         +string LineId
         +AccountingTemplateLineSideDto Side
     }
-    class Meridian_Contracts_Ledger_IAccountingActionAuditStore["IAccountingActionAuditStore"] {
-    }
-    class Meridian_Contracts_Ledger_IAccountingConfigurationService["IAccountingConfigurationService"] {
-    }
+    Meridian_Contracts_Ledger_AccountingPolicyDto --> Meridian_Contracts_Ledger_AccountingPolicyRulePackDto
     Meridian_Contracts_Ledger_AccountingPolicyRuleDto --> Meridian_Contracts_Ledger_AccountingTreatmentKindDto
     Meridian_Contracts_Ledger_AccountingPolicyRulePackDto --> Meridian_Contracts_Ledger_AccountingPolicyRuleDto
     Meridian_Contracts_Ledger_AccountingPostingCommandDto --> Meridian_Contracts_Ledger_AccountingPostingApprovalStateDto

--- a/docs/generated/database/diagrams/contracts-ledger-contracts-page-03.mmd
+++ b/docs/generated/database/diagrams/contracts-ledger-contracts-page-03.mmd
@@ -1,5 +1,9 @@
 classDiagram
     %% ledger-contracts: module mapping, not DTO/table equivalence
+    class Meridian_Contracts_Ledger_IAccountingActionAuditStore["IAccountingActionAuditStore"] {
+    }
+    class Meridian_Contracts_Ledger_IAccountingConfigurationService["IAccountingConfigurationService"] {
+    }
     class Meridian_Contracts_Ledger_IAccountingConfigurationStore["IAccountingConfigurationStore"] {
     }
     class Meridian_Contracts_Ledger_ICapitalAccountWorkbenchService["ICapitalAccountWorkbenchService"] {
@@ -596,6 +600,7 @@ classDiagram
     class Meridian_Contracts_Ledger_PostPostingRuleJournalCandidateRequestDto["PostPostingRuleJournalCandidateRequestDto"] {
         +OperationsActionOriginDto ActionOrigin
         +string Actor
+        +IReadOnlyList~RetainedEvidenceIdentityDto~ ApprovalEvidence
         +string ApprovalId
         +string? ApprovalNotes
         +PostingRuleJournalCandidateRequestDto Candidate
@@ -619,7 +624,10 @@ classDiagram
     }
     class Meridian_Contracts_Ledger_PostedPostingRuleJournalCandidateResultDto["PostedPostingRuleJournalCandidateResultDto"] {
         +PostingRuleJournalCandidateResultDto Candidate
+        +PostedJournalImpactDto? JournalImpact
+        +IReadOnlyList~AssetAccountingStageEvidenceDto~ LifecycleStages
         +PostedLedgerJournalEntryResultDto PostedJournal
+        +Guid? TaxLotMutationBatchId
         +bool WasReplay
     }
     class Meridian_Contracts_Ledger_PostingRuleDto["PostingRuleDto"] {
@@ -650,36 +658,13 @@ classDiagram
         +string Actor
         +LedgerAdjustmentApprovalMetadataDto? AdjustmentApproval
         +Guid AggregateId
+        +AssetLotMutationInstructionDto? AssetLotMutation
         +AccountingBookContextDto? BookContext
         +Guid? BookPositionId
         +string? CompanyId
         +Guid? CorrelationId
         +string? CounterpartyId
         +string Currency
-        +string Description
-    }
-    class Meridian_Contracts_Ledger_PostingRuleJournalCandidateResultDto["PostingRuleJournalCandidateResultDto"] {
-        +AccountingBookContextDto? BookContext
-        +Guid? BookPositionId
-        +bool CanPostWithoutAdditionalApproval
-        +bool CanSubmitForApproval
-        +RuleDryRunResultDto DryRunResult
-        +EconomicEventReferenceDto? EconomicEvent
-        +IReadOnlyList~string~ EvidenceLinks
-        +IReadOnlyList~GeneratedPostingLineDto~ GeneratedPostingLines
-        +bool HasBlockingIssues
-        +decimal Imbalance
-        +bool IsBalanced
-        +IReadOnlyList~PostingRuleJournalCandidateIssueDto~ Issues
-    }
-    class Meridian_Contracts_Ledger_PreviewJournalTemplateRequest["PreviewJournalTemplateRequest"] {
-        +string Actor
-        +string? CompanyId
-        +string? CorrelationId
-        +string FundProfileId
-        +Guid? LedgerBookId
-        +string TemplateId
-        +string? TenantId
     }
     Meridian_Contracts_Ledger_InvestorCapitalStatementDto --> Meridian_Contracts_Ledger_LedgerDimensionSetDto
     Meridian_Contracts_Ledger_JournalEntryLifecycleActionRequestDto --> Meridian_Contracts_Ledger_JournalEntryLifecycleActionDto
@@ -747,9 +732,7 @@ classDiagram
     Meridian_Contracts_Ledger_PaymentIntentWorkflowDto --> Meridian_Contracts_Ledger_PaymentIntentWorkflowStatusDto
     Meridian_Contracts_Ledger_PostPostingRuleJournalCandidateRequestDto --> Meridian_Contracts_Ledger_PostingRuleJournalCandidateRequestDto
     Meridian_Contracts_Ledger_PostedPostingRuleJournalCandidateResultDto --> Meridian_Contracts_Ledger_PostedLedgerJournalEntryResultDto
-    Meridian_Contracts_Ledger_PostedPostingRuleJournalCandidateResultDto --> Meridian_Contracts_Ledger_PostingRuleJournalCandidateResultDto
     Meridian_Contracts_Ledger_PostingRuleDto --> Meridian_Contracts_Ledger_LedgerDimensionSetDto
     Meridian_Contracts_Ledger_PostingRuleJournalCandidateRequestDto --> Meridian_Contracts_Ledger_LedgerAdjustmentApprovalMetadataDto
     Meridian_Contracts_Ledger_PostingRuleJournalCandidateRequestDto --> Meridian_Contracts_Ledger_LedgerDimensionSetDto
     Meridian_Contracts_Ledger_PostingRuleJournalCandidateRequestDto --> Meridian_Contracts_Ledger_LedgerPostingKindDto
-    Meridian_Contracts_Ledger_PostingRuleJournalCandidateResultDto --> Meridian_Contracts_Ledger_PostingRuleJournalCandidateIssueDto

--- a/docs/generated/database/diagrams/contracts-ledger-contracts-page-04.mmd
+++ b/docs/generated/database/diagrams/contracts-ledger-contracts-page-04.mmd
@@ -1,5 +1,28 @@
 classDiagram
     %% ledger-contracts: module mapping, not DTO/table equivalence
+    class Meridian_Contracts_Ledger_PostingRuleJournalCandidateResultDto["PostingRuleJournalCandidateResultDto"] {
+        +AccountingBookContextDto? BookContext
+        +Guid? BookPositionId
+        +bool CanPostWithoutAdditionalApproval
+        +bool CanSubmitForApproval
+        +RuleDryRunResultDto DryRunResult
+        +EconomicEventReferenceDto? EconomicEvent
+        +IReadOnlyList~string~ EvidenceLinks
+        +IReadOnlyList~GeneratedPostingLineDto~ GeneratedPostingLines
+        +bool HasBlockingIssues
+        +decimal Imbalance
+        +bool IsBalanced
+        +IReadOnlyList~PostingRuleJournalCandidateIssueDto~ Issues
+    }
+    class Meridian_Contracts_Ledger_PreviewJournalTemplateRequest["PreviewJournalTemplateRequest"] {
+        +string Actor
+        +string? CompanyId
+        +string? CorrelationId
+        +string FundProfileId
+        +Guid? LedgerBookId
+        +string TemplateId
+        +string? TenantId
+    }
     class Meridian_Contracts_Ledger_PrivateCapitalActivityProjectionDto["PrivateCapitalActivityProjectionDto"] {
         +int ApprovalQueueCount
         +int CapitalAccountCount
@@ -450,6 +473,7 @@ classDiagram
         +bool PeriodIsLocked
         +string? TenantId
     }
+    Meridian_Contracts_Ledger_PostingRuleJournalCandidateResultDto --> Meridian_Contracts_Ledger_RuleDryRunResultDto
     Meridian_Contracts_Ledger_PrivateCapitalActivityProjectionDto --> Meridian_Contracts_Ledger_PrivateCapitalCapitalAccountActivityDto
     Meridian_Contracts_Ledger_PrivateCapitalActivityProjectionDto --> Meridian_Contracts_Ledger_PrivateCapitalCapitalAccountSubledgerDto
     Meridian_Contracts_Ledger_PrivateCapitalActivityProjectionDto --> Meridian_Contracts_Ledger_PrivateCapitalCapitalAccountSubledgerEntryDto

--- a/docs/generated/database/diagrams/contracts-security-master-contracts-page-02.mmd
+++ b/docs/generated/database/diagrams/contracts-security-master-contracts-page-02.mmd
@@ -187,8 +187,22 @@ classDiagram
     }
     class Meridian_Contracts_SecurityMaster_SecurityAssetSpecificTermsUpcasterChain["SecurityAssetSpecificTermsUpcasterChain"] {
     }
+    class Meridian_Contracts_SecurityMaster_SecurityAssetSpecificTermsUpcasterPipeline["SecurityAssetSpecificTermsUpcasterPipeline"] {
+        +SecurityAssetSpecificTermsUpcasterPipeline Instance
+    }
     class Meridian_Contracts_SecurityMaster_SecurityAssetSpecificTermsV0ToCurrentUpcaster["SecurityAssetSpecificTermsV0ToCurrentUpcaster"] {
         +SecurityAssetSpecificTermsV0ToCurrentUpcaster Instance
+    }
+    class Meridian_Contracts_SecurityMaster_SecurityAssetTermField["SecurityAssetTermField"] {
+        +IReadOnlyList~string~ Aliases
+        +string Key
+        +bool Required
+        +SecurityAssetTermFieldType Type
+    }
+    class Meridian_Contracts_SecurityMaster_SecurityAssetTermFieldType["SecurityAssetTermFieldType"] {
+    }
+    class Meridian_Contracts_SecurityMaster_SecurityAssetTermsSchema["SecurityAssetTermsSchema"] {
+        +IReadOnlyCollection~string~ AssetClasses
     }
     class Meridian_Contracts_SecurityMaster_SecurityCashFlowSourceDto["SecurityCashFlowSourceDto"] {
         +DateTimeOffset? ClientConfirmedAt
@@ -514,39 +528,6 @@ classDiagram
         +IReadOnlyList~StructuredCashFlowLedgerPosting~ Postings
         +Guid SecurityId
     }
-    class Meridian_Contracts_SecurityMaster_StructuredCashFlowLeg["StructuredCashFlowLeg"] {
-        +decimal? CurrentIndexRate
-        +string? DayCountConvention
-        +CashFlowLegDirection? Direction
-        +bool ExchangesPrincipal
-        +decimal? FixedRate
-        +string? IndexName
-        +string LegId
-        +decimal? Notional
-        +string? PaymentFrequency
-        +CashFlowLegRateKind RateKind
-        +decimal? SpreadBps
-    }
-    class Meridian_Contracts_SecurityMaster_StructuredCashFlowLegSchedule["StructuredCashFlowLegSchedule"] {
-        +CashFlowLegDirection? Direction
-        +string LegId
-        +CashFlowLegRateKind RateKind
-        +IReadOnlyList~StructuredCashFlowScheduleEntry~ Schedule
-    }
-    class Meridian_Contracts_SecurityMaster_StructuredCashFlowProjectionDto["StructuredCashFlowProjectionDto"] {
-        +DateTimeOffset AsOf
-        +IReadOnlyList~StructuredFactorScheduleEntry~? FactorSchedule
-        +IReadOnlyList~StructuredCashFlowLegSchedule~? LegSchedules
-        +StructuredCashFlowScenario Scenario
-        +IReadOnlyList~StructuredCashFlowScheduleEntry~ Schedule
-        +Guid SecurityId
-        +StructuredCashFlowSourceKind SourceKind
-        +DateTimeOffset? SourceLastUpdatedUtc
-        +StructuredCashFlowStaleness Staleness
-        +StructuredCashFlowTerms? TermsUsed
-    }
-    class Meridian_Contracts_SecurityMaster_StructuredCashFlowScenario["StructuredCashFlowScenario"] {
-    }
     Meridian_Contracts_SecurityMaster_SecurityAliasDto --> Meridian_Contracts_SecurityMaster_SecurityAliasScope
     Meridian_Contracts_SecurityMaster_SecurityAssetClassDescriptor --> Meridian_Contracts_SecurityMaster_SecurityIdentifierKind
     Meridian_Contracts_SecurityMaster_SecurityAssetProfileDefinitionDto --> Meridian_Contracts_SecurityMaster_SecurityAssetProfileAccountingImpactHintDto
@@ -571,7 +552,9 @@ classDiagram
     Meridian_Contracts_SecurityMaster_SecurityAssetProfilePromotionSignalDto --> Meridian_Contracts_SecurityMaster_SecurityAssetProfilePromotionSignalSeverityDto
     Meridian_Contracts_SecurityMaster_SecurityAssetProfileTermsDto --> Meridian_Contracts_SecurityMaster_SecurityAssetProfileApprovalMetadataDto
     Meridian_Contracts_SecurityMaster_SecurityAssetProfileTermsDto --> Meridian_Contracts_SecurityMaster_SecurityEvidenceLinkDto
+    Meridian_Contracts_SecurityMaster_SecurityAssetSpecificTermsUpcasterPipeline --> Meridian_Contracts_SecurityMaster_SecurityAssetSpecificTerms
     Meridian_Contracts_SecurityMaster_SecurityAssetSpecificTermsV0ToCurrentUpcaster --> Meridian_Contracts_SecurityMaster_SecurityAssetSpecificTerms
+    Meridian_Contracts_SecurityMaster_SecurityAssetTermField --> Meridian_Contracts_SecurityMaster_SecurityAssetTermFieldType
     Meridian_Contracts_SecurityMaster_SecurityDetailDto --> Meridian_Contracts_SecurityMaster_SecurityAliasDto
     Meridian_Contracts_SecurityMaster_SecurityDetailDto --> Meridian_Contracts_SecurityMaster_SecurityIdentifierDto
     Meridian_Contracts_SecurityMaster_SecurityDetailDto --> Meridian_Contracts_SecurityMaster_SecurityStatusDto
@@ -604,5 +587,3 @@ classDiagram
     Meridian_Contracts_SecurityMaster_SecurityValidationSnapshotRequestDto --> Meridian_Contracts_SecurityMaster_SecurityValidationWorkflowDto
     Meridian_Contracts_SecurityMaster_StructuredCashFlowLedgerPosting --> Meridian_Contracts_SecurityMaster_StructuredCashFlowLedgerLine
     Meridian_Contracts_SecurityMaster_StructuredCashFlowLedgerPostingResult --> Meridian_Contracts_SecurityMaster_StructuredCashFlowLedgerPosting
-    Meridian_Contracts_SecurityMaster_StructuredCashFlowProjectionDto --> Meridian_Contracts_SecurityMaster_StructuredCashFlowLegSchedule
-    Meridian_Contracts_SecurityMaster_StructuredCashFlowProjectionDto --> Meridian_Contracts_SecurityMaster_StructuredCashFlowScenario

--- a/docs/generated/database/diagrams/contracts-security-master-contracts-page-03.mmd
+++ b/docs/generated/database/diagrams/contracts-security-master-contracts-page-03.mmd
@@ -1,5 +1,38 @@
 classDiagram
     %% security-master-contracts: module mapping, not DTO/table equivalence
+    class Meridian_Contracts_SecurityMaster_StructuredCashFlowLeg["StructuredCashFlowLeg"] {
+        +decimal? CurrentIndexRate
+        +string? DayCountConvention
+        +CashFlowLegDirection? Direction
+        +bool ExchangesPrincipal
+        +decimal? FixedRate
+        +string? IndexName
+        +string LegId
+        +decimal? Notional
+        +string? PaymentFrequency
+        +CashFlowLegRateKind RateKind
+        +decimal? SpreadBps
+    }
+    class Meridian_Contracts_SecurityMaster_StructuredCashFlowLegSchedule["StructuredCashFlowLegSchedule"] {
+        +CashFlowLegDirection? Direction
+        +string LegId
+        +CashFlowLegRateKind RateKind
+        +IReadOnlyList~StructuredCashFlowScheduleEntry~ Schedule
+    }
+    class Meridian_Contracts_SecurityMaster_StructuredCashFlowProjectionDto["StructuredCashFlowProjectionDto"] {
+        +DateTimeOffset AsOf
+        +IReadOnlyList~StructuredFactorScheduleEntry~? FactorSchedule
+        +IReadOnlyList~StructuredCashFlowLegSchedule~? LegSchedules
+        +StructuredCashFlowScenario Scenario
+        +IReadOnlyList~StructuredCashFlowScheduleEntry~ Schedule
+        +Guid SecurityId
+        +StructuredCashFlowSourceKind SourceKind
+        +DateTimeOffset? SourceLastUpdatedUtc
+        +StructuredCashFlowStaleness Staleness
+        +StructuredCashFlowTerms? TermsUsed
+    }
+    class Meridian_Contracts_SecurityMaster_StructuredCashFlowScenario["StructuredCashFlowScenario"] {
+    }
     class Meridian_Contracts_SecurityMaster_StructuredCashFlowScheduleEntry["StructuredCashFlowScheduleEntry"] {
         +decimal Factor
         +decimal InterestAmount
@@ -72,5 +105,14 @@ classDiagram
         +DateTimeOffset ValidFrom
         +DateTimeOffset? ValidTo
     }
+    Meridian_Contracts_SecurityMaster_StructuredCashFlowLegSchedule --> Meridian_Contracts_SecurityMaster_StructuredCashFlowScheduleEntry
+    Meridian_Contracts_SecurityMaster_StructuredCashFlowProjectionDto --> Meridian_Contracts_SecurityMaster_StructuredCashFlowLegSchedule
+    Meridian_Contracts_SecurityMaster_StructuredCashFlowProjectionDto --> Meridian_Contracts_SecurityMaster_StructuredCashFlowScenario
+    Meridian_Contracts_SecurityMaster_StructuredCashFlowProjectionDto --> Meridian_Contracts_SecurityMaster_StructuredCashFlowScheduleEntry
+    Meridian_Contracts_SecurityMaster_StructuredCashFlowProjectionDto --> Meridian_Contracts_SecurityMaster_StructuredCashFlowSourceKind
+    Meridian_Contracts_SecurityMaster_StructuredCashFlowProjectionDto --> Meridian_Contracts_SecurityMaster_StructuredCashFlowStaleness
+    Meridian_Contracts_SecurityMaster_StructuredCashFlowProjectionDto --> Meridian_Contracts_SecurityMaster_StructuredCashFlowTerms
+    Meridian_Contracts_SecurityMaster_StructuredCashFlowProjectionDto --> Meridian_Contracts_SecurityMaster_StructuredFactorScheduleEntry
+    Meridian_Contracts_SecurityMaster_StructuredCashFlowTerms --> Meridian_Contracts_SecurityMaster_StructuredCashFlowLeg
     Meridian_Contracts_SecurityMaster_StructuredCashFlowTerms --> Meridian_Contracts_SecurityMaster_StructuredFactorScheduleEntry
     Meridian_Contracts_SecurityMaster_UpsertCashFlowSourceRequest --> Meridian_Contracts_SecurityMaster_StructuredCashFlowSourceKind

--- a/src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs
+++ b/src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs
@@ -312,11 +312,15 @@ internal sealed class StorageFeatureRegistration : IServiceFeatureRegistration
             services.AddSingleton<ISecurityMasterImportService, SecurityMasterImportService>();
             services.AddSingleton<ISecurityMasterIngestStatusService>(sp => (ISecurityMasterIngestStatusService)sp.GetRequiredService<ISecurityMasterImportService>());
 
-            // Migrate-on-read upcaster for asset-specific-terms payloads, shared by the projection
-            // store (queryable schema_version column + read normalization).
+            // Migrate-on-read upcaster pipeline for asset-specific-terms payloads, shared by the
+            // projection store (queryable schema_version column + read normalization). Registering the
+            // composed pipeline (v0 stamping + cross-family economic-terms v2 -> v1 flattening) rather
+            // than the bare v0->current upcaster keeps the store's schema_version promotion consistent
+            // with the mapping guard: a v2 economic-terms document is flattened to the accepted legacy
+            // version instead of being promoted as an unsupported version the guard would reject.
             services.AddSingleton<
                 Meridian.Contracts.Schema.ISchemaUpcaster<Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTerms>,
-                Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsV0ToCurrentUpcaster>();
+                Meridian.Contracts.SecurityMaster.SecurityAssetSpecificTermsUpcasterPipeline>();
 
             // Durable audit/versioning spine: the golden-record conflict store and the governed
             // revision-lifecycle store are Postgres-backed so resolutions and approval state survive

--- a/src/Meridian.Contracts/SecurityMaster/SecurityAssetSpecificTermsUpcasterChain.cs
+++ b/src/Meridian.Contracts/SecurityMaster/SecurityAssetSpecificTermsUpcasterChain.cs
@@ -154,3 +154,28 @@ public static class SecurityAssetSpecificTermsUpcasterChain
         }
     }
 }
+
+/// <summary>
+/// The registered <see cref="ISchemaUpcaster{T}"/> form of <see cref="SecurityAssetSpecificTermsUpcasterChain"/>:
+/// a single injectable choke point that composes the full asset-specific-terms migrate-on-read chain
+/// (v0 stamping plus cross-family economic-terms v2 → v1 flattening). Registering this instead of the
+/// bare <see cref="SecurityAssetSpecificTermsV0ToCurrentUpcaster"/> makes the projection store's
+/// <c>schema_version</c> promotion flatten a v2 economic-terms document to the accepted legacy version
+/// before persisting, so the store no longer promotes a version the mapping guard would reject. Unknown
+/// future versions still pass through with their version preserved, keeping acceptance the guard's decision.
+/// </summary>
+public sealed class SecurityAssetSpecificTermsUpcasterPipeline : ISchemaUpcaster<SecurityAssetSpecificTerms>
+{
+    /// <summary>Shared stateless instance for callers that resolve the pipeline outside DI.</summary>
+    public static SecurityAssetSpecificTermsUpcasterPipeline Instance { get; } = new();
+
+    /// <summary>The oldest (unstamped legacy) payload family this pipeline reads from.</summary>
+    public int FromSchemaVersion => 0;
+
+    /// <summary>The normalized asset-specific-terms version the pipeline resolves accepted payloads to.</summary>
+    public int ToSchemaVersion => AssetSpecificTermsSchema.Legacy;
+
+    /// <summary>Normalizes a stored asset-specific-terms payload through the full chain.</summary>
+    public SecurityAssetSpecificTerms? Upcast(string json)
+        => SecurityAssetSpecificTermsUpcasterChain.Normalize(json);
+}

--- a/src/Meridian.Contracts/SecurityMaster/SecurityAssetTermsSchema.cs
+++ b/src/Meridian.Contracts/SecurityMaster/SecurityAssetTermsSchema.cs
@@ -1,0 +1,355 @@
+namespace Meridian.Contracts.SecurityMaster;
+
+/// <summary>
+/// The JSON value shape a Security Master asset-specific-term field takes in the flat
+/// (<see cref="AssetSpecificTermsSchema.Legacy"/>) payload. This is the codec-level type, distinct
+/// from the operator-facing <see cref="SecurityAssetProfileFieldTypeDto"/> used by custom profiles.
+/// </summary>
+public enum SecurityAssetTermFieldType
+{
+    /// <summary>A JSON string.</summary>
+    String,
+
+    /// <summary>A JSON number read as <see cref="decimal"/>.</summary>
+    Decimal,
+
+    /// <summary>A JSON number read as <see cref="int"/>.</summary>
+    Integer,
+
+    /// <summary>A JSON boolean.</summary>
+    Boolean,
+
+    /// <summary>A JSON string parsed as a <see cref="System.DateOnly"/> (or an ISO timestamp).</summary>
+    Date,
+
+    /// <summary>A JSON string parsed as a <see cref="System.Guid"/>.</summary>
+    Guid,
+
+    /// <summary>A JSON array.</summary>
+    Array,
+
+    /// <summary>A nested JSON object.</summary>
+    Object
+}
+
+/// <summary>
+/// One declarative field in the per-asset-class asset-specific-terms contract: the canonical JSON
+/// key, its value type, whether the serialize side always emits it, and any legacy flat key aliases
+/// a tolerant reader should also accept.
+/// </summary>
+public sealed record SecurityAssetTermField(
+    string Key,
+    SecurityAssetTermFieldType Type,
+    bool Required,
+    IReadOnlyList<string> Aliases)
+{
+    /// <summary>A field the serialize side always emits (a non-optional domain field).</summary>
+    public static SecurityAssetTermField Req(string key, SecurityAssetTermFieldType type, params string[] aliases)
+        => new(key, type, Required: true, aliases);
+
+    /// <summary>A field emitted only when its optional domain value is present.</summary>
+    public static SecurityAssetTermField Opt(string key, SecurityAssetTermFieldType type, params string[] aliases)
+        => new(key, type, Required: false, aliases);
+}
+
+/// <summary>
+/// The single declarative source of truth for the flat, per-asset-class asset-specific-terms field
+/// contract. Historically the same field/type table was hand-maintained three times — the F# serialize
+/// side (<c>Interop.SecurityMaster.assetSpecificTermsJson</c>), the C# deserialize side
+/// (<c>SecurityMasterMapping.ToSecurityKind</c>), and the relational projection decoders in the Postgres
+/// store — which let them silently drift (e.g. the projection store reading a nested <c>coupon</c> object
+/// the serializer never wrote, so bond coupon columns landed null). This table names each class's fields
+/// once so those codec surfaces can be validated against a single contract instead of against each other.
+/// It mirrors the data-driven pattern already proven by <c>AssetClassValidatorRegistry</c>.
+/// </summary>
+/// <remarks>
+/// Keys and types are taken from the authoritative serialize contract (the F# <c>SecurityKind</c>
+/// term records). Fields carrying nested/collection shapes are typed <see cref="SecurityAssetTermFieldType.Array"/>
+/// or <see cref="SecurityAssetTermFieldType.Object"/>; their inner shapes are not enumerated here.
+/// </remarks>
+public static class SecurityAssetTermsSchema
+{
+    private static SecurityAssetTermField Req(string key, SecurityAssetTermFieldType type, params string[] aliases)
+        => SecurityAssetTermField.Req(key, type, aliases);
+
+    private static SecurityAssetTermField Opt(string key, SecurityAssetTermFieldType type, params string[] aliases)
+        => SecurityAssetTermField.Opt(key, type, aliases);
+
+    private static readonly IReadOnlyDictionary<string, IReadOnlyList<SecurityAssetTermField>> FieldsByAssetClass =
+        new Dictionary<string, IReadOnlyList<SecurityAssetTermField>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Equity"] =
+            [
+                Opt("shareClass", SecurityAssetTermFieldType.String),
+                Opt("votingRightsCat", SecurityAssetTermFieldType.String),
+                Opt("classification", SecurityAssetTermFieldType.String),
+                Opt("preferredTerms", SecurityAssetTermFieldType.Object),
+                Opt("convertibleTerms", SecurityAssetTermFieldType.Object)
+            ],
+            ["Option"] =
+            [
+                Req("underlyingId", SecurityAssetTermFieldType.Guid),
+                Req("putCall", SecurityAssetTermFieldType.String),
+                Req("strike", SecurityAssetTermFieldType.Decimal),
+                Req("expiry", SecurityAssetTermFieldType.Date),
+                Req("multiplier", SecurityAssetTermFieldType.Decimal),
+                Opt("optChainId", SecurityAssetTermFieldType.String),
+                Opt("exerciseStyle", SecurityAssetTermFieldType.String),
+                Opt("settlementType", SecurityAssetTermFieldType.String),
+                Req("isAdjusted", SecurityAssetTermFieldType.Boolean),
+                Opt("lastTradingDt", SecurityAssetTermFieldType.Date)
+            ],
+            ["Future"] =
+            [
+                Req("rootSymbol", SecurityAssetTermFieldType.String),
+                Req("contractMonth", SecurityAssetTermFieldType.String),
+                Req("expiry", SecurityAssetTermFieldType.Date),
+                Req("multiplier", SecurityAssetTermFieldType.Decimal),
+                Opt("lastTradingDt", SecurityAssetTermFieldType.Date),
+                Opt("firstNoticeDt", SecurityAssetTermFieldType.Date),
+                Opt("deliveryMonthDt", SecurityAssetTermFieldType.Date),
+                Opt("settlementType", SecurityAssetTermFieldType.String),
+                Opt("deliveryLocationCode", SecurityAssetTermFieldType.String),
+                Req("isRollTarget", SecurityAssetTermFieldType.Boolean),
+                Opt("rollWindowDays", SecurityAssetTermFieldType.Integer)
+            ],
+            ["Bond"] =
+            [
+                Req("maturity", SecurityAssetTermFieldType.Date),
+                Opt("issueDate", SecurityAssetTermFieldType.Date),
+                // couponType/couponRate/floatingIndex/spreadBps/dayCount are emitted flat by the
+                // serializer; the legacy nested "coupon" object shape is read as a fallback.
+                Opt("couponType", SecurityAssetTermFieldType.String),
+                Opt("couponRate", SecurityAssetTermFieldType.Decimal),
+                Opt("floatingIndex", SecurityAssetTermFieldType.String),
+                Opt("spreadBps", SecurityAssetTermFieldType.Decimal),
+                Opt("capRate", SecurityAssetTermFieldType.Decimal),
+                Opt("floorRate", SecurityAssetTermFieldType.Decimal),
+                Opt("dayCount", SecurityAssetTermFieldType.String, "dayCountConvention"),
+                Req("isCallable", SecurityAssetTermFieldType.Boolean),
+                Opt("callDate", SecurityAssetTermFieldType.Date),
+                Opt("issuerName", SecurityAssetTermFieldType.String),
+                Opt("seniority", SecurityAssetTermFieldType.String),
+                Req("subclass", SecurityAssetTermFieldType.String),
+                Opt("par", SecurityAssetTermFieldType.Decimal),
+                Opt("paymentFrequency", SecurityAssetTermFieldType.String),
+                Opt("legalFinalMaturity", SecurityAssetTermFieldType.Date),
+                Opt("preRefundDate", SecurityAssetTermFieldType.Date),
+                Opt("mandatoryPutDate", SecurityAssetTermFieldType.Date)
+            ],
+            ["FxSpot"] =
+            [
+                Req("baseCurrency", SecurityAssetTermFieldType.String),
+                Req("quoteCurrency", SecurityAssetTermFieldType.String)
+            ],
+            ["Deposit"] =
+            [
+                Req("depositType", SecurityAssetTermFieldType.String),
+                Req("institutionName", SecurityAssetTermFieldType.String),
+                Opt("maturity", SecurityAssetTermFieldType.Date),
+                Opt("interestRate", SecurityAssetTermFieldType.Decimal),
+                Opt("dayCount", SecurityAssetTermFieldType.String),
+                Req("isCallable", SecurityAssetTermFieldType.Boolean)
+            ],
+            ["MoneyMarketFund"] =
+            [
+                Opt("fundFamily", SecurityAssetTermFieldType.String),
+                Req("sweepEligible", SecurityAssetTermFieldType.Boolean),
+                Opt("weightedAverageMaturityDays", SecurityAssetTermFieldType.Integer),
+                Req("liquidityFeeEligible", SecurityAssetTermFieldType.Boolean)
+            ],
+            ["CertificateOfDeposit"] =
+            [
+                Req("issuerName", SecurityAssetTermFieldType.String),
+                Req("maturity", SecurityAssetTermFieldType.Date),
+                Opt("couponRate", SecurityAssetTermFieldType.Decimal),
+                Opt("callableDate", SecurityAssetTermFieldType.Date),
+                Opt("dayCount", SecurityAssetTermFieldType.String)
+            ],
+            ["CommercialPaper"] =
+            [
+                Req("issuerName", SecurityAssetTermFieldType.String),
+                Req("maturity", SecurityAssetTermFieldType.Date),
+                Opt("discountRate", SecurityAssetTermFieldType.Decimal),
+                Opt("dayCount", SecurityAssetTermFieldType.String),
+                Req("isAssetBacked", SecurityAssetTermFieldType.Boolean)
+            ],
+            ["TreasuryBill"] =
+            [
+                Req("maturity", SecurityAssetTermFieldType.Date),
+                Opt("auctionDate", SecurityAssetTermFieldType.Date),
+                Opt("cusip", SecurityAssetTermFieldType.String),
+                Opt("discountRate", SecurityAssetTermFieldType.Decimal)
+            ],
+            ["Repo"] =
+            [
+                Req("counterparty", SecurityAssetTermFieldType.String),
+                Req("startDate", SecurityAssetTermFieldType.Date),
+                Req("endDate", SecurityAssetTermFieldType.Date),
+                Opt("repoRate", SecurityAssetTermFieldType.Decimal),
+                Opt("collateralType", SecurityAssetTermFieldType.String),
+                Opt("haircut", SecurityAssetTermFieldType.Decimal)
+            ],
+            ["CashSweep"] =
+            [
+                Req("programName", SecurityAssetTermFieldType.String),
+                Req("sweepVehicleType", SecurityAssetTermFieldType.String),
+                Opt("sweepFrequency", SecurityAssetTermFieldType.String),
+                Opt("targetAccountType", SecurityAssetTermFieldType.String),
+                Opt("yieldRate", SecurityAssetTermFieldType.Decimal)
+            ],
+            ["OtherSecurity"] =
+            [
+                Req("category", SecurityAssetTermFieldType.String),
+                Opt("subType", SecurityAssetTermFieldType.String),
+                Opt("maturity", SecurityAssetTermFieldType.Date),
+                Opt("issuerName", SecurityAssetTermFieldType.String),
+                Opt("settlementType", SecurityAssetTermFieldType.String)
+            ],
+            ["CustomAsset"] =
+            [
+                // Profile-backed custom assets carry the profile envelope; the class-specific fields
+                // are dynamic and live under profileFields, governed by the approved profile version.
+                Req("customProfileId", SecurityAssetTermFieldType.String),
+                Req("profileVersion", SecurityAssetTermFieldType.Integer),
+                Req("profileFields", SecurityAssetTermFieldType.Object),
+                Opt("profileApproval", SecurityAssetTermFieldType.Object)
+            ],
+            ["Swap"] =
+            [
+                Req("effectiveDate", SecurityAssetTermFieldType.Date),
+                Req("maturityDate", SecurityAssetTermFieldType.Date),
+                Req("legs", SecurityAssetTermFieldType.Array)
+            ],
+            ["DirectLoan"] =
+            [
+                Req("borrower", SecurityAssetTermFieldType.String),
+                Opt("maturity", SecurityAssetTermFieldType.Date),
+                Opt("referenceIndex", SecurityAssetTermFieldType.String),
+                Opt("spreadBps", SecurityAssetTermFieldType.Decimal),
+                Opt("currentCouponRate", SecurityAssetTermFieldType.Decimal),
+                Opt("resetFrequency", SecurityAssetTermFieldType.String),
+                Opt("pricingSource", SecurityAssetTermFieldType.String),
+                Req("covenants", SecurityAssetTermFieldType.Array),
+                Req("principalSchedule", SecurityAssetTermFieldType.Array)
+            ],
+            ["StructuredCredit"] =
+            [
+                Req("tranche", SecurityAssetTermFieldType.String),
+                Opt("poolId", SecurityAssetTermFieldType.String),
+                Req("collateralType", SecurityAssetTermFieldType.String),
+                Req("originalFace", SecurityAssetTermFieldType.Decimal),
+                Opt("currentFactor", SecurityAssetTermFieldType.Decimal),
+                Req("couponOrIndex", SecurityAssetTermFieldType.String),
+                Opt("factorSchedule", SecurityAssetTermFieldType.String)
+            ],
+            ["PrivateFundInterest"] =
+            [
+                Req("gpSponsor", SecurityAssetTermFieldType.String),
+                Req("strategy", SecurityAssetTermFieldType.String),
+                Req("vintage", SecurityAssetTermFieldType.Integer),
+                Req("commitment", SecurityAssetTermFieldType.Decimal),
+                Opt("fundedAmount", SecurityAssetTermFieldType.Decimal),
+                Opt("unfundedAmount", SecurityAssetTermFieldType.Decimal),
+                Req("navDate", SecurityAssetTermFieldType.Date),
+                Opt("lockup", SecurityAssetTermFieldType.String)
+            ],
+            ["PrivateCompanyEquity"] =
+            [
+                Req("issuer", SecurityAssetTermFieldType.String),
+                Req("shareClass", SecurityAssetTermFieldType.String),
+                Req("round", SecurityAssetTermFieldType.String),
+                Opt("ownershipPercent", SecurityAssetTermFieldType.Decimal),
+                Req("costBasis", SecurityAssetTermFieldType.Decimal),
+                Opt("latestValuation", SecurityAssetTermFieldType.Decimal),
+                Opt("transferRestrictions", SecurityAssetTermFieldType.String)
+            ],
+            ["RealEstateHolding"] =
+            [
+                Req("propertyType", SecurityAssetTermFieldType.String),
+                Req("addressOrMarket", SecurityAssetTermFieldType.String),
+                Req("ownershipPercent", SecurityAssetTermFieldType.Decimal),
+                Req("appraisalValue", SecurityAssetTermFieldType.Decimal),
+                Req("valuationDate", SecurityAssetTermFieldType.Date),
+                Opt("debtStack", SecurityAssetTermFieldType.String),
+                Opt("sponsor", SecurityAssetTermFieldType.String)
+            ],
+            ["CommitmentGuarantee"] =
+            [
+                Req("counterparty", SecurityAssetTermFieldType.String),
+                Opt("beneficiary", SecurityAssetTermFieldType.String),
+                Req("committedAmount", SecurityAssetTermFieldType.Decimal),
+                Opt("unfundedAmount", SecurityAssetTermFieldType.Decimal),
+                Req("effectiveDate", SecurityAssetTermFieldType.Date),
+                Opt("expiryDate", SecurityAssetTermFieldType.Date),
+                Opt("feeRate", SecurityAssetTermFieldType.Decimal),
+                Opt("collateral", SecurityAssetTermFieldType.String),
+                Req("covenants", SecurityAssetTermFieldType.Array)
+            ],
+            ["Commodity"] =
+            [
+                Req("commodityType", SecurityAssetTermFieldType.String),
+                Opt("denomination", SecurityAssetTermFieldType.String),
+                Opt("contractSize", SecurityAssetTermFieldType.Decimal)
+            ],
+            ["CryptoCurrency"] =
+            [
+                Req("baseCurrency", SecurityAssetTermFieldType.String),
+                Req("quoteCurrency", SecurityAssetTermFieldType.String),
+                Opt("network", SecurityAssetTermFieldType.String)
+            ],
+            ["Cfd"] =
+            [
+                Req("underlyingAssetClass", SecurityAssetTermFieldType.String),
+                Opt("underlyingDescription", SecurityAssetTermFieldType.String),
+                Opt("leverage", SecurityAssetTermFieldType.Decimal)
+            ],
+            ["Warrant"] =
+            [
+                Req("underlyingId", SecurityAssetTermFieldType.Guid),
+                Req("warrantType", SecurityAssetTermFieldType.String),
+                Opt("strike", SecurityAssetTermFieldType.Decimal),
+                Opt("expiry", SecurityAssetTermFieldType.Date),
+                Opt("multiplier", SecurityAssetTermFieldType.Decimal)
+            ],
+            ["InvestmentFund"] =
+            [
+                Opt("fundType", SecurityAssetTermFieldType.String),
+                Opt("fundFamily", SecurityAssetTermFieldType.String),
+                Opt("navCurrency", SecurityAssetTermFieldType.String),
+                Opt("distributionPolicy", SecurityAssetTermFieldType.String),
+                Opt("isStableNav", SecurityAssetTermFieldType.Boolean),
+                Opt("pricingSource", SecurityAssetTermFieldType.String)
+            ]
+        };
+
+    /// <summary>The asset classes with a declared terms schema.</summary>
+    public static IReadOnlyCollection<string> AssetClasses { get; } = FieldsByAssetClass.Keys.ToArray();
+
+    /// <summary>The declared fields for <paramref name="assetClass"/>, or an empty list when none is declared.</summary>
+    public static IReadOnlyList<SecurityAssetTermField> Fields(string assetClass)
+        => FieldsByAssetClass.TryGetValue(assetClass, out var fields) ? fields : [];
+
+    /// <summary>Tries to resolve the declared fields for <paramref name="assetClass"/>.</summary>
+    public static bool TryGetFields(string assetClass, out IReadOnlyList<SecurityAssetTermField> fields)
+        => FieldsByAssetClass.TryGetValue(assetClass, out fields!);
+
+    /// <summary>The declared field for <paramref name="key"/> in <paramref name="assetClass"/>, or <see langword="null"/>.</summary>
+    public static SecurityAssetTermField? Field(string assetClass, string key)
+    {
+        if (!FieldsByAssetClass.TryGetValue(assetClass, out var fields))
+        {
+            return null;
+        }
+
+        foreach (var field in fields)
+        {
+            if (string.Equals(field.Key, key, StringComparison.OrdinalIgnoreCase))
+            {
+                return field;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Meridian.Storage/SecurityMaster/PostgresSecurityMasterStore.cs
+++ b/src/Meridian.Storage/SecurityMaster/PostgresSecurityMasterStore.cs
@@ -27,6 +27,38 @@ public sealed class PostgresSecurityMasterStore : ISecurityMasterStore
     private const string MoneyMarketFundProjectionTable = "money_market_fund_projection";
     private const string CertificateOfDepositProjectionTable = "certificate_of_deposit_projection";
 
+    /// <summary>
+    /// A registered per-asset-class relational projection writer: the asset class it owns and the
+    /// upsert-or-delete operation the store fans out to for every persisted record.
+    /// </summary>
+    private sealed record AssetProjectionWriter(
+        string AssetClass,
+        Func<PostgresSecurityMasterStore, NpgsqlConnection, NpgsqlTransaction, SecurityProjectionRecord, CancellationToken, Task> WriteAsync);
+
+    /// <summary>
+    /// The ordered registry of per-asset-class projection writers. Replaces the previous hard-coded
+    /// fan-out block so adding a projected asset class is a single additive registration here, and the
+    /// projected set is enumerable for the catalog-vs-projection coverage guard.
+    /// </summary>
+    private static readonly IReadOnlyList<AssetProjectionWriter> ProjectionWriters =
+    [
+        new("Bond", static (store, c, t, r, ct) => store.UpsertBondProjectionTablesAsync(c, t, r, ct)),
+        new("Option", static (store, c, t, r, ct) => store.UpsertOptionProjectionTablesAsync(c, t, r, ct)),
+        new("Equity", static (store, c, t, r, ct) => store.UpsertEquityProjectionAsync(c, t, r, ct)),
+        new("Future", static (store, c, t, r, ct) => store.UpsertFutureProjectionAsync(c, t, r, ct)),
+        new("FxSpot", static (store, c, t, r, ct) => store.UpsertFxSpotProjectionAsync(c, t, r, ct)),
+        new("Swap", static (store, c, t, r, ct) => store.UpsertSwapProjectionAsync(c, t, r, ct)),
+        new("Commodity", static (store, c, t, r, ct) => store.UpsertCommodityProjectionAsync(c, t, r, ct)),
+        new("CryptoCurrency", static (store, c, t, r, ct) => store.UpsertCryptoProjectionAsync(c, t, r, ct)),
+        new("Deposit", static (store, c, t, r, ct) => store.UpsertDepositProjectionAsync(c, t, r, ct)),
+        new("MoneyMarketFund", static (store, c, t, r, ct) => store.UpsertMoneyMarketFundProjectionAsync(c, t, r, ct)),
+        new("CertificateOfDeposit", static (store, c, t, r, ct) => store.UpsertCertificateOfDepositProjectionAsync(c, t, r, ct)),
+    ];
+
+    /// <summary>The asset classes that have a dedicated relational projection, in fan-out order.</summary>
+    internal static IReadOnlyList<string> ProjectedAssetClasses { get; } =
+        ProjectionWriters.Select(static writer => writer.AssetClass).ToArray();
+
     private readonly SecurityMasterOptions _options;
     private readonly ISchemaUpcaster<SecurityAssetSpecificTerms> _assetSpecificTermsUpcaster;
 
@@ -36,7 +68,7 @@ public sealed class PostgresSecurityMasterStore : ISecurityMasterStore
     {
         _options = options;
         _assetSpecificTermsUpcaster = assetSpecificTermsUpcaster
-            ?? SecurityAssetSpecificTermsV0ToCurrentUpcaster.Instance;
+            ?? SecurityAssetSpecificTermsUpcasterPipeline.Instance;
     }
 
     public async Task UpsertProjectionAsync(SecurityProjectionRecord record, CancellationToken ct = default)
@@ -346,17 +378,15 @@ public sealed class PostgresSecurityMasterStore : ISecurityMasterStore
 
         await ReplaceIdentifiersAsync(connection, transaction, record.SecurityId, record.Identifiers, ct).ConfigureAwait(false);
         await ReplaceAliasesAsync(connection, transaction, record.SecurityId, record.Aliases, ct).ConfigureAwait(false);
-        await UpsertBondProjectionTablesAsync(connection, transaction, record, ct).ConfigureAwait(false);
-        await UpsertOptionProjectionTablesAsync(connection, transaction, record, ct).ConfigureAwait(false);
-        await UpsertEquityProjectionAsync(connection, transaction, record, ct).ConfigureAwait(false);
-        await UpsertFutureProjectionAsync(connection, transaction, record, ct).ConfigureAwait(false);
-        await UpsertFxSpotProjectionAsync(connection, transaction, record, ct).ConfigureAwait(false);
-        await UpsertSwapProjectionAsync(connection, transaction, record, ct).ConfigureAwait(false);
-        await UpsertCommodityProjectionAsync(connection, transaction, record, ct).ConfigureAwait(false);
-        await UpsertCryptoProjectionAsync(connection, transaction, record, ct).ConfigureAwait(false);
-        await UpsertDepositProjectionAsync(connection, transaction, record, ct).ConfigureAwait(false);
-        await UpsertMoneyMarketFundProjectionAsync(connection, transaction, record, ct).ConfigureAwait(false);
-        await UpsertCertificateOfDepositProjectionAsync(connection, transaction, record, ct).ConfigureAwait(false);
+
+        // Fan out to every registered per-asset-class projection writer. Each writer upserts its own
+        // projection when the record matches its asset class and deletes any stale row otherwise, so
+        // every writer runs for every record (class changes clean up the previous projection). Adding a
+        // projected asset class is a single additive registration in ProjectionWriters plus its writer.
+        foreach (var writer in ProjectionWriters)
+        {
+            await writer.WriteAsync(this, connection, transaction, record, ct).ConfigureAwait(false);
+        }
     }
 
     private async Task UpsertBondProjectionTablesAsync(
@@ -944,7 +974,7 @@ public sealed class PostgresSecurityMasterStore : ISecurityMasterStore
         command.Parameters.AddWithValue("version", projection.Version);
     }
 
-    private static bool TryBuildBondProjection(SecurityProjectionRecord record, out BondProjectionWriteModel projection)
+    internal static bool TryBuildBondProjection(SecurityProjectionRecord record, out BondProjectionWriteModel projection)
     {
         if (!TryGetOptionalDateOnly(record.AssetSpecificTerms, "maturity", out var maturityDate) || maturityDate is null)
         {
@@ -956,12 +986,23 @@ public sealed class PostgresSecurityMasterStore : ISecurityMasterStore
         var issueDate = GetOptionalDateOnly(record.AssetSpecificTerms, "issueDate");
         var callDate = GetOptionalDateOnly(record.AssetSpecificTerms, "callDate");
         var isCallable = GetOptionalBool(record.AssetSpecificTerms, "isCallable") ?? false;
+
+        // The serializer (Interop.SecurityMaster.assetSpecificTermsJson) writes the coupon flat, per the
+        // Bond entry in SecurityAssetTermsSchema: couponType/couponRate/floatingIndex/spreadBps/dayCount.
+        // Reading a nested "coupon" object here previously left every coupon column null for canonically
+        // serialized bonds (silent data loss); read the flat shape first and fall back to the legacy
+        // nested object only for externally-authored payloads that still use it.
         var coupon = GetOptionalObject(record.AssetSpecificTerms, "coupon");
-        var couponKind = coupon.HasValue ? GetOptionalString(coupon.Value, "kind") : null;
-        var fixedCouponRate = coupon.HasValue ? GetOptionalDecimal(coupon.Value, "rate") : null;
-        var floatingRateIndex = coupon.HasValue ? GetOptionalString(coupon.Value, "index") : null;
-        var floatingSpreadBps = coupon.HasValue ? GetOptionalDecimal(coupon.Value, "spreadBps") : null;
-        var dayCountConvention = coupon.HasValue ? GetOptionalString(coupon.Value, "dayCountConvention") : null;
+        var couponKind = GetOptionalString(record.AssetSpecificTerms, "couponType")
+            ?? (coupon.HasValue ? GetOptionalString(coupon.Value, "kind") : null);
+        var fixedCouponRate = GetOptionalDecimal(record.AssetSpecificTerms, "couponRate")
+            ?? (coupon.HasValue ? GetOptionalDecimal(coupon.Value, "rate") : null);
+        var floatingRateIndex = GetOptionalString(record.AssetSpecificTerms, "floatingIndex")
+            ?? (coupon.HasValue ? GetOptionalString(coupon.Value, "index") : null);
+        var floatingSpreadBps = GetOptionalDecimal(record.AssetSpecificTerms, "spreadBps")
+            ?? (coupon.HasValue ? GetOptionalDecimal(coupon.Value, "spreadBps") : null);
+        var dayCountConvention = GetOptionalString(record.AssetSpecificTerms, "dayCount")
+            ?? (coupon.HasValue ? GetOptionalString(coupon.Value, "dayCountConvention") : null);
 
         var lifecycleStat =
             record.EffectiveTo.HasValue ? "Retired" :
@@ -1403,12 +1444,8 @@ public sealed class PostgresSecurityMasterStore : ISecurityMasterStore
         SecurityProjectionRecord record,
         CancellationToken ct)
     {
-        var effectiveDate = GetOptionalDateOnly(record.AssetSpecificTerms, "effectiveDate");
-        var maturityDate = GetOptionalDateOnly(record.AssetSpecificTerms, "maturityDate");
-
         if (!string.Equals(record.AssetClass, "Swap", StringComparison.OrdinalIgnoreCase) ||
-            effectiveDate is null ||
-            maturityDate is null)
+            !TryBuildSwapProjection(record, out var projection))
         {
             await using var del = connection.CreateCommand();
             del.Transaction = transaction;
@@ -1417,8 +1454,6 @@ public sealed class PostgresSecurityMasterStore : ISecurityMasterStore
             await del.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
             return;
         }
-
-        var swapType = GetOptionalString(record.AssetSpecificTerms, "swapType");
 
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
@@ -1442,16 +1477,114 @@ public sealed class PostgresSecurityMasterStore : ISecurityMasterStore
                 primary_identifier_value = excluded.primary_identifier_value,
                 version = excluded.version;
             """;
-        command.Parameters.AddWithValue("security_id", record.SecurityId);
-        command.Parameters.AddWithValue("display_name", record.DisplayName);
-        command.Parameters.AddWithValue("currency", record.Currency);
-        command.Parameters.AddWithValue("swap_type", (object?)swapType ?? DBNull.Value);
-        command.Parameters.AddWithValue("effective_date", effectiveDate.Value.ToDateTime(TimeOnly.MinValue));
-        command.Parameters.AddWithValue("maturity_date", maturityDate.Value.ToDateTime(TimeOnly.MinValue));
-        command.Parameters.AddWithValue("lifecycle_stat", "Active");
-        command.Parameters.AddWithValue("primary_identifier_value", record.PrimaryIdentifierValue);
-        command.Parameters.AddWithValue("version", record.Version);
+        command.Parameters.AddWithValue("security_id", projection.SecurityId);
+        command.Parameters.AddWithValue("display_name", projection.DisplayName);
+        command.Parameters.AddWithValue("currency", projection.Currency);
+        command.Parameters.AddWithValue("swap_type", (object?)projection.SwapType ?? DBNull.Value);
+        command.Parameters.AddWithValue("effective_date", projection.EffectiveDate.ToDateTime(TimeOnly.MinValue));
+        command.Parameters.AddWithValue("maturity_date", projection.MaturityDate.ToDateTime(TimeOnly.MinValue));
+        command.Parameters.AddWithValue("lifecycle_stat", projection.LifecycleStat);
+        command.Parameters.AddWithValue("primary_identifier_value", projection.PrimaryIdentifierValue);
+        command.Parameters.AddWithValue("version", projection.Version);
         await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    internal static bool TryBuildSwapProjection(SecurityProjectionRecord record, out SwapProjectionWriteModel projection)
+    {
+        var effectiveDate = GetOptionalDateOnly(record.AssetSpecificTerms, "effectiveDate");
+        var maturityDate = GetOptionalDateOnly(record.AssetSpecificTerms, "maturityDate");
+        if (effectiveDate is null || maturityDate is null)
+        {
+            projection = default!;
+            return false;
+        }
+
+        projection = new SwapProjectionWriteModel(
+            record.SecurityId,
+            record.DisplayName,
+            record.Currency,
+            DeriveSwapType(record.AssetSpecificTerms),
+            effectiveDate.Value,
+            maturityDate.Value,
+            "Active",
+            record.PrimaryIdentifierValue,
+            record.Version);
+        return true;
+    }
+
+    /// <summary>
+    /// Resolves the queryable <c>swap_type</c> from the swap terms. The serializer emits swap economics
+    /// as <c>legs</c> (per the Swap entry in <see cref="SecurityAssetTermsSchema"/>) and never a
+    /// <c>swapType</c> field, so reading only <c>swapType</c> left the column null for every canonically
+    /// serialized swap; derive it from the leg types instead, honouring an explicit <c>swapType</c> when a
+    /// non-canonical payload supplies one.
+    /// </summary>
+    internal static string? DeriveSwapType(JsonElement assetSpecificTerms)
+    {
+        var explicitType = GetOptionalString(assetSpecificTerms, "swapType");
+        if (!string.IsNullOrWhiteSpace(explicitType))
+        {
+            return explicitType;
+        }
+
+        if (!assetSpecificTerms.TryGetProperty("legs", out var legs) || legs.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        var legTypes = new List<string>();
+        var hasFixed = false;
+        var hasFloating = false;
+        foreach (var leg in legs.EnumerateArray())
+        {
+            var legType = GetOptionalString(leg, "legType");
+            if (string.IsNullOrWhiteSpace(legType))
+            {
+                continue;
+            }
+
+            legType = legType.Trim();
+            var alreadySeen = false;
+            foreach (var seen in legTypes)
+            {
+                if (string.Equals(seen, legType, StringComparison.OrdinalIgnoreCase))
+                {
+                    alreadySeen = true;
+                    break;
+                }
+            }
+
+            if (!alreadySeen)
+            {
+                legTypes.Add(legType);
+            }
+
+            if (string.Equals(legType, "Fixed", StringComparison.OrdinalIgnoreCase))
+            {
+                hasFixed = true;
+            }
+            else if (string.Equals(legType, "Floating", StringComparison.OrdinalIgnoreCase))
+            {
+                hasFloating = true;
+            }
+        }
+
+        if (legTypes.Count == 0)
+        {
+            return null;
+        }
+
+        if (hasFixed && hasFloating)
+        {
+            return "FixedFloat";
+        }
+
+        if (hasFloating && !hasFixed && legTypes.Count == 1)
+        {
+            return "BasisFloat";
+        }
+
+        return string.Join("/", legTypes);
     }
 
     private async Task UpsertCommodityProjectionAsync(
@@ -1795,7 +1928,7 @@ public sealed class PostgresSecurityMasterStore : ISecurityMasterStore
         return false;
     }
 
-    private sealed record BondProjectionWriteModel(
+    internal sealed record BondProjectionWriteModel(
         Guid SecurityId,
         string? IssuerName,
         string? Seniority,
@@ -1834,5 +1967,16 @@ public sealed class PostgresSecurityMasterStore : ISecurityMasterStore
         DateOnly? LastTradingDate,
         string LifecycleStat,
         DateTimeOffset ListedAt,
+        long Version);
+
+    internal sealed record SwapProjectionWriteModel(
+        Guid SecurityId,
+        string DisplayName,
+        string Currency,
+        string? SwapType,
+        DateOnly EffectiveDate,
+        DateOnly MaturityDate,
+        string LifecycleStat,
+        string PrimaryIdentifierValue,
         long Version);
 }

--- a/tests/Meridian.Tests/SecurityMaster/SecurityAssetSpecificTermsUpcasterPipelineTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/SecurityAssetSpecificTermsUpcasterPipelineTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using FluentAssertions;
 using Meridian.Contracts.SecurityMaster;
 using Xunit;
@@ -18,7 +19,9 @@ public sealed class SecurityAssetSpecificTermsUpcasterPipelineTests
     [Fact]
     public void Upcast_UnstampedLegacyPayload_ResolvesToLegacyVersion()
     {
-        var result = _pipeline.Upcast("""{"shareClass":"Common"}""");
+        var json = JsonSerializer.Serialize(new { shareClass = "Common" });
+
+        var result = _pipeline.Upcast(json);
 
         result.Should().NotBeNull();
         result!.SchemaVersion.Should().Be(AssetSpecificTermsSchema.Legacy);
@@ -29,10 +32,14 @@ public sealed class SecurityAssetSpecificTermsUpcasterPipelineTests
     {
         // A cross-family v2 economic-terms document reaching the asset-specific-terms slot: the pipeline
         // flattens it to the accepted legacy shape so the promoted version matches what the guard accepts.
-        var result = _pipeline.Upcast(
-            $$"""
-            {"schemaVersion":{{EconomicTermsSchema.Current}},"maturity":{"maturityDate":"2030-06-30"},"coupon":{"couponType":"Fixed","couponRate":5.25}}
-            """);
+        var json = JsonSerializer.Serialize(new
+        {
+            schemaVersion = EconomicTermsSchema.Current,
+            maturity = new { maturityDate = "2030-06-30" },
+            coupon = new { couponType = "Fixed", couponRate = 5.25m }
+        });
+
+        var result = _pipeline.Upcast(json);
 
         result.Should().NotBeNull();
         result!.SchemaVersion.Should().Be(AssetSpecificTermsSchema.Legacy);
@@ -43,10 +50,14 @@ public sealed class SecurityAssetSpecificTermsUpcasterPipelineTests
     [Fact]
     public void Upcast_CustomAssetProfilePayload_PreservesItsVersion()
     {
-        var result = _pipeline.Upcast(
-            $$"""
-            {"schemaVersion":{{AssetSpecificTermsSchema.CustomAssetProfile}},"customProfileId":"co-invest-spv","profileVersion":1}
-            """);
+        var json = JsonSerializer.Serialize(new
+        {
+            schemaVersion = AssetSpecificTermsSchema.CustomAssetProfile,
+            customProfileId = "co-invest-spv",
+            profileVersion = 1
+        });
+
+        var result = _pipeline.Upcast(json);
 
         result.Should().NotBeNull();
         result!.SchemaVersion.Should().Be(AssetSpecificTermsSchema.CustomAssetProfile);

--- a/tests/Meridian.Tests/SecurityMaster/SecurityAssetSpecificTermsUpcasterPipelineTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/SecurityAssetSpecificTermsUpcasterPipelineTests.cs
@@ -1,0 +1,67 @@
+using FluentAssertions;
+using Meridian.Contracts.SecurityMaster;
+using Xunit;
+
+namespace Meridian.Tests.SecurityMaster;
+
+/// <summary>
+/// The registered <see cref="SecurityAssetSpecificTermsUpcasterPipeline"/> is the single choke point the
+/// projection store promotes <c>schema_version</c> through. It must compose the full migrate-on-read chain
+/// (v0 stamping plus cross-family economic-terms v2 -> v1 flattening) so the store never promotes a version
+/// the mapping guard would reject, while preserving unknown future versions.
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class SecurityAssetSpecificTermsUpcasterPipelineTests
+{
+    private readonly SecurityAssetSpecificTermsUpcasterPipeline _pipeline = new();
+
+    [Fact]
+    public void Upcast_UnstampedLegacyPayload_ResolvesToLegacyVersion()
+    {
+        var result = _pipeline.Upcast("""{"shareClass":"Common"}""");
+
+        result.Should().NotBeNull();
+        result!.SchemaVersion.Should().Be(AssetSpecificTermsSchema.Legacy);
+    }
+
+    [Fact]
+    public void Upcast_EconomicTermsV2Document_FlattensToAcceptedLegacyVersion()
+    {
+        // A cross-family v2 economic-terms document reaching the asset-specific-terms slot: the pipeline
+        // flattens it to the accepted legacy shape so the promoted version matches what the guard accepts.
+        var result = _pipeline.Upcast(
+            $$"""
+            {"schemaVersion":{{EconomicTermsSchema.Current}},"maturity":{"maturityDate":"2030-06-30"},"coupon":{"couponType":"Fixed","couponRate":5.25}}
+            """);
+
+        result.Should().NotBeNull();
+        result!.SchemaVersion.Should().Be(AssetSpecificTermsSchema.Legacy);
+        result.Payload.TryGetProperty("maturityDate", out _).Should().BeTrue("the v2 maturity block is flattened");
+        result.Payload.TryGetProperty("couponType", out _).Should().BeTrue("the v2 coupon block is flattened");
+    }
+
+    [Fact]
+    public void Upcast_CustomAssetProfilePayload_PreservesItsVersion()
+    {
+        var result = _pipeline.Upcast(
+            $$"""
+            {"schemaVersion":{{AssetSpecificTermsSchema.CustomAssetProfile}},"customProfileId":"co-invest-spv","profileVersion":1}
+            """);
+
+        result.Should().NotBeNull();
+        result!.SchemaVersion.Should().Be(AssetSpecificTermsSchema.CustomAssetProfile);
+    }
+
+    [Fact]
+    public void Upcast_InvalidJson_ReturnsNull()
+    {
+        _pipeline.Upcast("not json").Should().BeNull();
+    }
+
+    [Fact]
+    public void SchemaBounds_MatchTheComposedChain()
+    {
+        _pipeline.FromSchemaVersion.Should().Be(0);
+        _pipeline.ToSchemaVersion.Should().Be(AssetSpecificTermsSchema.Legacy);
+    }
+}

--- a/tests/Meridian.Tests/SecurityMaster/SecurityAssetTermsSchemaTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/SecurityAssetTermsSchemaTests.cs
@@ -1,0 +1,120 @@
+using FluentAssertions;
+using Meridian.Contracts.SecurityMaster;
+using Meridian.Storage.SecurityMaster;
+using Xunit;
+
+namespace Meridian.Tests.SecurityMaster;
+
+/// <summary>
+/// Guards the single declarative asset-specific-terms field/type table (<see cref="SecurityAssetTermsSchema"/>)
+/// against drift: it must stay in lock-step with the authoritative asset-class catalog, declare each
+/// class's fields without duplication, and remain the shared reference the projection and validation
+/// codecs are measured against. Also binds the store's projection coverage to the catalog so the
+/// catalog-vs-projection gap stays explicit and enforced rather than accidental.
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class SecurityAssetTermsSchemaTests
+{
+    // The asset classes the platform deliberately does not give a dedicated relational projection.
+    // Adding a catalog class without a projection forces this list to be updated in review, so the
+    // 26-vs-11 catalog-vs-projection gap is a conscious decision instead of silent drift.
+    private static readonly string[] IntentionallyUnprojectedAssetClasses =
+    [
+        "CommercialPaper",
+        "TreasuryBill",
+        "Repo",
+        "CashSweep",
+        "OtherSecurity",
+        "CustomAsset",
+        "DirectLoan",
+        "StructuredCredit",
+        "PrivateFundInterest",
+        "PrivateCompanyEquity",
+        "RealEstateHolding",
+        "CommitmentGuarantee",
+        "Cfd",
+        "Warrant",
+        "InvestmentFund"
+    ];
+
+    [Fact]
+    public void Schema_DeclaresEveryCatalogAssetClass()
+    {
+        SecurityAssetTermsSchema.AssetClasses
+            .Should().BeEquivalentTo(
+                SecurityAssetClassCatalog.AssetClasses,
+                "the terms schema is the single source of truth for every catalog asset class");
+    }
+
+    [Fact]
+    public void Schema_HasNoDuplicateFieldKeysWithinAnyAssetClass()
+    {
+        foreach (var assetClass in SecurityAssetTermsSchema.AssetClasses)
+        {
+            var fields = SecurityAssetTermsSchema.Fields(assetClass);
+            var distinctKeys = fields
+                .Select(static field => field.Key)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Count();
+
+            distinctKeys.Should().Be(fields.Count, $"'{assetClass}' must not repeat a field key");
+        }
+    }
+
+    [Fact]
+    public void Schema_EveryFieldHasKeyAndNonNullAliases()
+    {
+        foreach (var assetClass in SecurityAssetTermsSchema.AssetClasses)
+        {
+            foreach (var field in SecurityAssetTermsSchema.Fields(assetClass))
+            {
+                field.Key.Should().NotBeNullOrWhiteSpace();
+                field.Aliases.Should().NotBeNull();
+            }
+        }
+    }
+
+    [Fact]
+    public void Schema_ExposesTheFlatCouponContractTheProjectionReads()
+    {
+        // Regression anchor for the bond silent-data-loss fix: the coupon is a flat contract, not a
+        // nested "coupon" object. If these move, the projection decoder and serializer must move with them.
+        SecurityAssetTermsSchema.Field("Bond", "couponType").Should().NotBeNull();
+        SecurityAssetTermsSchema.Field("Bond", "couponRate")!.Type.Should().Be(SecurityAssetTermFieldType.Decimal);
+        SecurityAssetTermsSchema.Field("Bond", "dayCount").Should().NotBeNull();
+        SecurityAssetTermsSchema.Field("Bond", "coupon").Should().BeNull("the coupon is serialized flat, not nested");
+    }
+
+    [Fact]
+    public void Schema_SwapExposesLegsNotSwapType()
+    {
+        SecurityAssetTermsSchema.Field("Swap", "legs")!.Type.Should().Be(SecurityAssetTermFieldType.Array);
+        SecurityAssetTermsSchema.Field("Swap", "swapType").Should().BeNull("swap economics are carried as legs");
+    }
+
+    [Fact]
+    public void ProjectionCoverage_IsASubsetOfTheCatalogWithASchemaEntry()
+    {
+        foreach (var assetClass in PostgresSecurityMasterStore.ProjectedAssetClasses)
+        {
+            SecurityAssetClassCatalog.AssetClasses.Should().Contain(assetClass,
+                $"projected class '{assetClass}' must be a real catalog asset class");
+            SecurityAssetTermsSchema.TryGetFields(assetClass, out _).Should().BeTrue(
+                $"projected class '{assetClass}' must have a declared terms schema");
+        }
+    }
+
+    [Fact]
+    public void ProjectionCoverage_PartitionsTheCatalogIntoProjectedAndDeclaredGaps()
+    {
+        var projected = PostgresSecurityMasterStore.ProjectedAssetClasses;
+
+        projected.Should().NotIntersectWith(IntentionallyUnprojectedAssetClasses,
+            "a class is either projected or a declared gap, never both");
+
+        projected
+            .Concat(IntentionallyUnprojectedAssetClasses)
+            .Should().BeEquivalentTo(SecurityAssetClassCatalog.AssetClasses,
+                "every catalog class must be either projected or an explicitly declared projection gap");
+    }
+}

--- a/tests/Meridian.Tests/SecurityMaster/SecurityMasterProjectionCodecTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/SecurityMasterProjectionCodecTests.cs
@@ -1,0 +1,162 @@
+using System.Text.Json;
+using FluentAssertions;
+using Meridian.Contracts.SecurityMaster;
+using Meridian.Storage.SecurityMaster;
+using Xunit;
+
+namespace Meridian.Tests.SecurityMaster;
+
+/// <summary>
+/// Regression guards for the relational projection decoders in <see cref="PostgresSecurityMasterStore"/>.
+/// These previously read field shapes the serializer never wrote — a nested <c>coupon</c> object for bonds
+/// and a <c>swapType</c> field for swaps — so canonically serialized records silently projected null
+/// coupon columns and a null swap type. The decoders now read the flat contract declared in
+/// <see cref="SecurityAssetTermsSchema"/>; these tests assert the columns are populated end-to-end from a
+/// canonical payload without a live database.
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class SecurityMasterProjectionCodecTests
+{
+    [Fact]
+    public void Bond_FlatFixedCoupon_PopulatesCouponColumns()
+    {
+        // The canonical serializer emits the coupon flat (couponType/couponRate/dayCount), never nested.
+        var record = Record("Bond", new
+        {
+            schemaVersion = 1,
+            maturity = "2030-01-01",
+            couponType = "Fixed",
+            couponRate = 5.0m,
+            dayCount = "30/360",
+            isCallable = false,
+            subclass = "Corporate",
+            issuerName = "ACME"
+        });
+
+        PostgresSecurityMasterStore.TryBuildBondProjection(record, out var projection).Should().BeTrue();
+
+        projection.CouponKind.Should().Be("Fixed");
+        projection.FixedCouponRate.Should().Be(5.0m);
+        projection.DayCountConvention.Should().Be("30/360");
+        projection.MaturityDate.Should().Be(new DateOnly(2030, 1, 1));
+    }
+
+    [Fact]
+    public void Bond_FlatFloatingCoupon_PopulatesFloatingColumns()
+    {
+        var record = Record("Bond", new
+        {
+            schemaVersion = 1,
+            maturity = "2032-06-30",
+            couponType = "Floating",
+            floatingIndex = "SOFR",
+            spreadBps = 125m,
+            dayCount = "ACT/360",
+            isCallable = false,
+            subclass = "FloatingRate"
+        });
+
+        PostgresSecurityMasterStore.TryBuildBondProjection(record, out var projection).Should().BeTrue();
+
+        projection.CouponKind.Should().Be("Floating");
+        projection.FloatingRateIndex.Should().Be("SOFR");
+        projection.FloatingSpreadBps.Should().Be(125m);
+        projection.DayCountConvention.Should().Be("ACT/360");
+    }
+
+    [Fact]
+    public void Bond_LegacyNestedCoupon_StillPopulatesCouponColumns()
+    {
+        // Backward compatibility: externally-authored payloads that still use the nested "coupon"
+        // object are read via the fallback path.
+        var record = Record("Bond", new
+        {
+            schemaVersion = 1,
+            maturity = "2030-01-01",
+            coupon = new { kind = "Fixed", rate = 4.5m, dayCountConvention = "30/360" },
+            isCallable = false,
+            subclass = "Corporate"
+        });
+
+        PostgresSecurityMasterStore.TryBuildBondProjection(record, out var projection).Should().BeTrue();
+
+        projection.CouponKind.Should().Be("Fixed");
+        projection.FixedCouponRate.Should().Be(4.5m);
+        projection.DayCountConvention.Should().Be("30/360");
+    }
+
+    [Fact]
+    public void Swap_FixedAndFloatingLegs_DerivesFixedFloatSwapType()
+    {
+        var record = Record("Swap", new
+        {
+            schemaVersion = 1,
+            effectiveDate = "2024-01-01",
+            maturityDate = "2029-01-01",
+            legs = new object[]
+            {
+                new { legType = "Fixed", currency = "USD", fixedRate = 3.5m },
+                new { legType = "Floating", currency = "USD", index = "SOFR" }
+            }
+        });
+
+        PostgresSecurityMasterStore.TryBuildSwapProjection(record, out var projection).Should().BeTrue();
+
+        projection.SwapType.Should().Be("FixedFloat");
+        projection.EffectiveDate.Should().Be(new DateOnly(2024, 1, 1));
+        projection.MaturityDate.Should().Be(new DateOnly(2029, 1, 1));
+    }
+
+    [Fact]
+    public void Swap_TwoFloatingLegs_DerivesBasisFloatSwapType()
+    {
+        var terms = JsonSerializer.SerializeToElement(new
+        {
+            legs = new object[]
+            {
+                new { legType = "Floating", currency = "USD", index = "SOFR" },
+                new { legType = "Floating", currency = "USD", index = "FEDFUNDS" }
+            }
+        });
+
+        PostgresSecurityMasterStore.DeriveSwapType(terms).Should().Be("BasisFloat");
+    }
+
+    [Fact]
+    public void Swap_ExplicitSwapType_IsHonouredOverLegDerivation()
+    {
+        var terms = JsonSerializer.SerializeToElement(new
+        {
+            swapType = "OIS",
+            legs = new object[] { new { legType = "Fixed", currency = "USD" } }
+        });
+
+        PostgresSecurityMasterStore.DeriveSwapType(terms).Should().Be("OIS");
+    }
+
+    [Fact]
+    public void Swap_NoLegsAndNoSwapType_YieldsNull()
+    {
+        var terms = JsonSerializer.SerializeToElement(new { });
+
+        PostgresSecurityMasterStore.DeriveSwapType(terms).Should().BeNull();
+    }
+
+    private static SecurityProjectionRecord Record(string assetClass, object assetSpecificTerms)
+        => new(
+            SecurityId: Guid.NewGuid(),
+            AssetClass: assetClass,
+            Status: SecurityStatusDto.Active,
+            DisplayName: "Test Security",
+            Currency: "USD",
+            PrimaryIdentifierKind: "Ticker",
+            PrimaryIdentifierValue: "TEST",
+            CommonTerms: JsonSerializer.SerializeToElement(new { }),
+            AssetSpecificTerms: JsonSerializer.SerializeToElement(assetSpecificTerms),
+            Provenance: JsonSerializer.SerializeToElement(new { }),
+            Version: 1,
+            EffectiveFrom: DateTimeOffset.UtcNow.AddDays(-1),
+            EffectiveTo: null,
+            Identifiers: Array.Empty<SecurityIdentifierDto>(),
+            Aliases: Array.Empty<SecurityAliasDto>());
+}


### PR DESCRIPTION
## Summary

Introduces a single declarative per-asset-class field/type table for Security Master asset-specific terms and routes the drifting codec surfaces through it, replacing three hand-maintained per-class matches that had silently fallen out of sync.

- **New `SecurityAssetTermsSchema`** (`Meridian.Contracts`) — the single source of truth for the flat asset-specific-terms contract across all 26 asset classes, mirroring the data-driven pattern already proven by `AssetClassValidatorRegistry`. Keys/types are taken from the authoritative F# serialize contract (`SecurityKind` term records).
- **Bond projection decoder fix (silent data loss):** the store read a nested `coupon` object the serializer never writes (the serializer emits `couponType`/`couponRate`/`floatingIndex`/`spreadBps`/`dayCount` flat), so `bond_projection` coupon columns landed `null` for every canonically serialized bond. It now reads the flat contract, with a fallback to the legacy nested shape for externally-authored payloads.
- **Swap projection decoder fix (silent data loss):** the store read a phantom `swapType` field and ignored `legs`, leaving `swap_type` `null`. It now derives `swap_type` from the actual leg types (`FixedFloat`/`BasisFloat`/…), honouring an explicit `swapType` when a non-canonical payload supplies one.
- **`IAssetProjectionWriter` registry:** the hard-coded 11-call projection fan-out in the 1,839-line store is replaced by an ordered writer registry, making "add a projected class" an additive registration. The projected set is exposed so a coverage guard binds it to `SecurityAssetClassCatalog` (26 classes, 11 projected, 15 explicitly-declared gaps) instead of letting the two drift.
- **Schema-version single choke point:** the composed asset-specific-terms upcaster chain is now registered as the single `ISchemaUpcaster<SecurityAssetSpecificTerms>` the store promotes `schema_version` through, so a cross-family v2 economic-terms document flattens to the accepted legacy version instead of being promoted as a version the mapping guard would reject. The stored blob is unchanged; only the queryable version column is reconciled.

Scope is the codec/projection/schema trio named by the branch. The governance-unification and provenance/typed-form lanes from the broader epic are intentionally **not** included here — each is a larger, higher-risk change (governance would invert a documented invariant; provenance needs new DTO/DB/UI surfaces) and belongs in its own PR.

## Reason

The per-class asset-terms codec is the subsystem path with a real outage/silent-data-loss history: three independent hand-written per-class field lists (F# serialize, C# deserialize, and the relational projection decoders) had no shared contract binding them, so the projection decoders drifted to shapes the serializer never emits — producing null coupon columns for bonds and null swap types — and the store promoted a `schema_version` the mapping guard rejects. A single declarative table plus coverage/decode guards removes the drift and prevents its recurrence.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully — not runnable in this dev environment (no local .NET SDK); relying on GitHub Actions `quality-gate` for build/test.
- [x] Relevant unit tests were added or updated — schema↔catalog lock-step and projection-coverage partition; bond/swap decode-completeness regression guards (flat + legacy-nested coupon, leg-derived swap types); upcaster pipeline flatten/preserve behavior.
- [ ] Relevant integration tests were added or updated — the existing Postgres round-trip suite covers the write path and is unaffected; the new decode guards are DB-free.
- [ ] GitHub Actions `quality-gate` passed — pending on this PR.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdQMPdyzc72dfa7nMdzrWH

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdQMPdyzc72dfa7nMdzrWH)_