### PR TITLE
Partners' capital allocation breakout + capital-call plan → governed drafts

### DIFF
--- a/src/Meridian.Ledger/CapitalCallScheduleDraftBuilder.cs
+++ b/src/Meridian.Ledger/CapitalCallScheduleDraftBuilder.cs
@@ -1,0 +1,76 @@
+using Meridian.Contracts.Ledger;
+
+namespace Meridian.Ledger;
+
+/// <summary>
+/// Composes a planned fund-level capital call into the set of governed capital-call issuance drafts:
+/// one balanced <see cref="AutomatedJournalDraft"/> per investor plan line, built through
+/// <see cref="CapitalCallDraftFactory"/> so every draft carries a deterministic idempotency key and
+/// flows through the standard <see cref="AutomatedJournalApproval"/> submit → approve → post
+/// lifecycle. This closes the wiring gap between <see cref="CapitalCallPlanBuilder"/> — which
+/// apportions a fund-level call across the commitment register — and the governed journal, which
+/// previously had no caller turning the plan into postings.
+/// </summary>
+public static class CapitalCallScheduleDraftBuilder
+{
+    /// <summary>
+    /// Builds and returns the governed issuance drafts for a fund-level call, planning it over the
+    /// supplied commitment roll-forwards first. Fails closed when the plan is not executable.
+    /// </summary>
+    public static IReadOnlyList<AutomatedJournalDraft> BuildIssuanceDrafts(
+        CapitalCallPlanRequest request,
+        DateTimeOffset occurredAtUtc,
+        IReadOnlyDictionary<string, IReadOnlyList<JournalEvidenceReference>>? evidenceByCommitmentId = null)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return BuildIssuanceDrafts(CapitalCallPlanBuilder.Build(request), occurredAtUtc, evidenceByCommitmentId);
+    }
+
+    /// <summary>
+    /// Builds the governed issuance drafts for an already-planned capital call. Each executable plan
+    /// line becomes one balanced <c>Dr capital-call receivable / Cr investor capital</c> draft, in a
+    /// deterministic per-investor order. Throws when the plan is not executable (allocated amount does
+    /// not tie to the requested amount, no lines survive, or a critical validation issue is present)
+    /// so a broken commitment state can never silently issue notices or postings.
+    /// </summary>
+    /// <param name="plan">The apportioned capital-call plan produced by <see cref="CapitalCallPlanBuilder"/>.</param>
+    /// <param name="occurredAtUtc">Wall-clock time the drafts are produced (audit/occurrence stamp).</param>
+    /// <param name="evidenceByCommitmentId">
+    /// Optional retained evidence references keyed by commitment id, attached to the matching draft.
+    /// </param>
+    public static IReadOnlyList<AutomatedJournalDraft> BuildIssuanceDrafts(
+        CapitalCallPlan plan,
+        DateTimeOffset occurredAtUtc,
+        IReadOnlyDictionary<string, IReadOnlyList<JournalEvidenceReference>>? evidenceByCommitmentId = null)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        if (!plan.IsExecutable)
+        {
+            var criticalCount = plan.ValidationIssues.Count(static issue =>
+                issue.Severity == AccountingConfigurationValidationSeverityDto.Critical);
+            throw new InvalidOperationException(FormattableString.Invariant(
+                $"Capital call '{plan.Request.CallId}' is not executable: allocated {plan.AllocatedAmount} of requested {plan.Request.AmountToCall} across {plan.Lines.Count} line(s) with {criticalCount} critical validation issue(s)."));
+        }
+
+        var drafts = new List<AutomatedJournalDraft>(plan.Lines.Count);
+        foreach (var line in plan.Lines
+            .OrderBy(static line => line.Commitment.InvestorId, StringComparer.Ordinal)
+            .ThenBy(static line => line.InstallmentId, StringComparer.Ordinal))
+        {
+            var evidence = evidenceByCommitmentId is not null
+                && evidenceByCommitmentId.TryGetValue(line.Commitment.CommitmentId, out var references)
+                    ? references
+                    : null;
+
+            drafts.Add(CapitalCallDraftFactory.BuildCapitalCallDraft(
+                line.Commitment,
+                line.InstallmentId,
+                line.CallAmount,
+                effectiveDate: plan.Request.NoticeDate,
+                occurredAtUtc: occurredAtUtc,
+                evidenceReferences: evidence));
+        }
+
+        return drafts;
+    }
+}

--- a/src/Meridian.Ledger/LedgerAccounts.cs
+++ b/src/Meridian.Ledger/LedgerAccounts.cs
@@ -380,6 +380,31 @@ public static class LedgerAccounts
     internal static bool UsesInstrumentSymbol(LedgerAccount account)
         => account.Symbol is not null && InstrumentSymbolAccountNames.Contains(account.Name);
 
+    /// <summary>
+    /// Fund-level fee expense account names posted by the automated fee-accrual path
+    /// (<c>ManagementFeeExpenseFor</c>, <c>PerformanceFeeExpenseFor</c>). These are the fees a
+    /// partners' capital statement reports separately from other operating expenses; keep in sync
+    /// with the fee accrual producers. Trading costs such as commissions and borrow fees are
+    /// deliberately excluded — they are operating expenses, not fund management/incentive fees.
+    /// </summary>
+    private static readonly HashSet<string> FundFeeExpenseAccountNames = new(StringComparer.Ordinal)
+    {
+        "Management Fee Expense",
+        "Performance Fee Expense",
+    };
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="account"/> is a fund-level management or
+    /// performance/incentive fee expense account, so a partners' capital statement can present fee
+    /// allocations separately from other operating-expense allocations.
+    /// </summary>
+    public static bool IsFundFeeExpenseAccount(LedgerAccount account)
+    {
+        ArgumentNullException.ThrowIfNull(account);
+        return account.AccountType == LedgerAccountType.Expense
+            && FundFeeExpenseAccountNames.Contains(account.Name);
+    }
+
     private static LedgerAccount CreateScoped(string name, LedgerAccountType accountType, string financialAccountId)
         => new(name, accountType, FinancialAccountId: NormalizeAccountId(financialAccountId));
 

--- a/src/Meridian.Ledger/LedgerFinancialStatementBuilder.cs
+++ b/src/Meridian.Ledger/LedgerFinancialStatementBuilder.cs
@@ -167,7 +167,7 @@ public static class LedgerFinancialStatementBuilder
 
         var movements = equityAccounts.ToDictionary(
             static account => account,
-            static _ => (Contributions: 0m, Distributions: 0m, Allocated: 0m, Other: 0m));
+            static _ => (Contributions: 0m, Distributions: 0m, Allocated: 0m, Income: 0m, Expense: 0m, Fee: 0m, Other: 0m));
 
         foreach (var entry in PeriodEntries(ledger, periodStart, asOf))
         {
@@ -194,17 +194,63 @@ public static class LedgerFinancialStatementBuilder
                 MatchesScope(line, financialAccountId, lineDimensions)
                 && line.Account.AccountType is LedgerAccountType.Asset or LedgerAccountType.Liability);
 
+            // When an entry closes P&L directly into named capital accounts, split the allocated
+            // movement into the fee and (non-fee) expense amounts moved out of P&L — measured with
+            // the closing sign, where a credited expense leg reduces capital — so the income/gain
+            // component falls out as the balancing figure. This keeps each line's decomposition tied
+            // to its allocated result exactly (income − expense − fee == allocated) while attributing
+            // the fee and expense drivers a fund accountant reports separately.
+            var allocatedLines = equityLines
+                .Where(line => hasIncomeCounterpart
+                    && !line.Account.Name.Equals("Retained Earnings", StringComparison.Ordinal))
+                .ToArray();
+            var (closedExpense, closedFee) = ClassifyClosedExpenseAndFee(entry, financialAccountId, lineDimensions);
+            var allocatedTotal = allocatedLines.Sum(static line => line.Credit - line.Debit);
+            var attributedExpense = 0m;
+            var attributedFee = 0m;
+
+            for (var index = 0; index < allocatedLines.Length; index++)
+            {
+                var line = allocatedLines[index];
+                var signed = line.Credit - line.Debit;
+                decimal expense;
+                decimal fee;
+                if (index == allocatedLines.Length - 1)
+                {
+                    expense = closedExpense - attributedExpense;
+                    fee = closedFee - attributedFee;
+                }
+                else if (allocatedTotal != 0m)
+                {
+                    expense = LedgerCurrencyRounding.RoundCurrency(closedExpense * signed / allocatedTotal);
+                    fee = LedgerCurrencyRounding.RoundCurrency(closedFee * signed / allocatedTotal);
+                    attributedExpense += expense;
+                    attributedFee += fee;
+                }
+                else
+                {
+                    expense = 0m;
+                    fee = 0m;
+                }
+
+                var current = movements[line.Account];
+                current.Allocated += signed;
+                current.Expense += expense;
+                current.Fee += fee;
+                // Income/gain is the residual so income − expense − fee == the allocated movement exactly.
+                current.Income += signed + expense + fee;
+                movements[line.Account] = current;
+            }
+
             foreach (var line in equityLines)
             {
+                var isRetainedEarnings = line.Account.Name.Equals("Retained Earnings", StringComparison.Ordinal);
+                if (hasIncomeCounterpart && !isRetainedEarnings)
+                    continue; // already handled as an allocation above.
+
                 var signed = line.Credit - line.Debit;
                 var current = movements[line.Account];
-                var isRetainedEarnings = line.Account.Name.Equals("Retained Earnings", StringComparison.Ordinal);
-
-                if (hasIncomeCounterpart && !isRetainedEarnings)
-                {
-                    current.Allocated += signed;
-                }
-                else if (hasSettlementCounterpart)
+                if (hasSettlementCounterpart)
                 {
                     if (signed >= 0m)
                         current.Contributions += signed;
@@ -234,6 +280,9 @@ public static class LedgerFinancialStatementBuilder
                     movement.Contributions,
                     movement.Distributions,
                     movement.Allocated,
+                    movement.Income,
+                    movement.Expense,
+                    movement.Fee,
                     movement.Other,
                     ending);
             })
@@ -262,6 +311,11 @@ public static class LedgerFinancialStatementBuilder
         var netIncomeAtStart = NetIncomeOf(beginningBalances);
         var periodNetIncome = PeriodNetIncomeFromActivity(
             ledger, periodStart, asOf, financialAccountId, lineDimensions);
+        // Decompose the same period P&L activity into the income/gain, (non-fee) expense, and fee
+        // drivers, so income − expense − fee == periodNetIncome (the undistributed line's allocated
+        // result) exactly, using the identical closing-entry exclusion.
+        var (undistributedIncome, undistributedExpense, undistributedFee) = PeriodPnlComponentsFromActivity(
+            ledger, periodStart, asOf, financialAccountId, lineDimensions);
         var closedToEquity = (netIncome - netIncomeAtStart) - periodNetIncome;
         if (netIncome != 0m || netIncomeAtStart != 0m || periodNetIncome != 0m || closedToEquity != 0m)
         {
@@ -273,6 +327,9 @@ public static class LedgerFinancialStatementBuilder
                 Contributions: 0m,
                 Distributions: 0m,
                 AllocatedResult: periodNetIncome,
+                IncomeGainAllocations: undistributedIncome,
+                ExpenseAllocations: undistributedExpense,
+                FeeAllocations: undistributedFee,
                 OtherMovements: closedToEquity,
                 EndingCapital: netIncome));
         }
@@ -289,6 +346,9 @@ public static class LedgerFinancialStatementBuilder
             orderedRollForwards.Sum(static rollForward => rollForward.Contributions),
             orderedRollForwards.Sum(static rollForward => rollForward.Distributions),
             orderedRollForwards.Sum(static rollForward => rollForward.AllocatedResult),
+            orderedRollForwards.Sum(static rollForward => rollForward.IncomeGainAllocations),
+            orderedRollForwards.Sum(static rollForward => rollForward.ExpenseAllocations),
+            orderedRollForwards.Sum(static rollForward => rollForward.FeeAllocations),
             orderedRollForwards.Sum(static rollForward => rollForward.OtherMovements),
             orderedRollForwards.Sum(static rollForward => rollForward.EndingCapital),
             orderedRollForwards);
@@ -344,6 +404,86 @@ public static class LedgerFinancialStatementBuilder
         }
 
         return total;
+    }
+
+    /// <summary>
+    /// Decomposes current-period net income (excluding Retained-Earnings closing transfers, matching
+    /// <see cref="PeriodNetIncomeFromActivity"/>) into its income/gain, (non-fee) expense, and fund-fee
+    /// drivers. Revenue legs contribute (credit − debit) to income; expense legs contribute
+    /// (debit − credit) to either the fee or the expense bucket. By construction
+    /// <c>income − expense − fee</c> equals <see cref="PeriodNetIncomeFromActivity"/> for the same scope.
+    /// </summary>
+    private static (decimal Income, decimal Expense, decimal Fee) PeriodPnlComponentsFromActivity(
+        IReadOnlyLedger ledger,
+        DateTimeOffset periodStart,
+        DateTimeOffset asOf,
+        string? financialAccountId,
+        LedgerLineDimensionSet? lineDimensions)
+    {
+        var income = 0m;
+        var expense = 0m;
+        var fee = 0m;
+        foreach (var entry in PeriodEntries(ledger, periodStart, asOf))
+        {
+            var closesToRetainedEarnings = entry.Lines.Any(line =>
+                MatchesScope(line, financialAccountId, lineDimensions)
+                && line.Account.AccountType == LedgerAccountType.Equity
+                && line.Account.Name.Equals("Retained Earnings", StringComparison.Ordinal));
+            if (closesToRetainedEarnings)
+                continue;
+
+            foreach (var line in entry.Lines)
+            {
+                if (!MatchesScope(line, financialAccountId, lineDimensions))
+                    continue;
+
+                switch (line.Account.AccountType)
+                {
+                    case LedgerAccountType.Revenue:
+                        income += line.Credit - line.Debit;
+                        break;
+                    case LedgerAccountType.Expense when LedgerAccounts.IsFundFeeExpenseAccount(line.Account):
+                        fee += line.Debit - line.Credit;
+                        break;
+                    case LedgerAccountType.Expense:
+                        expense += line.Debit - line.Credit;
+                        break;
+                }
+            }
+        }
+
+        return (income, expense, fee);
+    }
+
+    /// <summary>
+    /// Sums the fund-fee and (non-fee) operating-expense amounts closed OUT of P&amp;L into named
+    /// capital accounts within one journal entry, measured with the closing sign where a credited
+    /// expense leg reduces capital. Used to attribute the fee and expense drivers of a direct
+    /// per-partner allocation; the income/gain component is then the balancing figure so a line's
+    /// decomposition ties exactly to its allocated movement.
+    /// </summary>
+    private static (decimal Expense, decimal Fee) ClassifyClosedExpenseAndFee(
+        JournalEntry entry,
+        string? financialAccountId,
+        LedgerLineDimensionSet? lineDimensions)
+    {
+        var expense = 0m;
+        var fee = 0m;
+        foreach (var line in entry.Lines)
+        {
+            if (!MatchesScope(line, financialAccountId, lineDimensions)
+                || line.Account.AccountType != LedgerAccountType.Expense)
+            {
+                continue;
+            }
+
+            if (LedgerAccounts.IsFundFeeExpenseAccount(line.Account))
+                fee += line.Credit - line.Debit;
+            else
+                expense += line.Credit - line.Debit;
+        }
+
+        return (expense, fee);
     }
 
     private static bool IsCashAccount(LedgerAccount account)

--- a/src/Meridian.Ledger/LedgerPartnersCapitalStatement.cs
+++ b/src/Meridian.Ledger/LedgerPartnersCapitalStatement.cs
@@ -3,6 +3,15 @@ using Meridian.Contracts.Ledger;
 namespace Meridian.Ledger;
 
 /// <summary>Period roll-forward of one partner/equity capital account.</summary>
+/// <remarks>
+/// <see cref="AllocatedResult"/> is the net income/expense allocated to this capital account for the
+/// period. It is decomposed additively into <see cref="IncomeGainAllocations"/> (revenue and gains,
+/// which increase capital), <see cref="ExpenseAllocations"/> (operating expenses other than fund
+/// fees, which reduce capital), and <see cref="FeeAllocations"/> (management, performance, and
+/// incentive fees, which reduce capital), so a partners' capital statement can present the drivers
+/// a fund accountant reports rather than a single lumped figure. The decomposition holds
+/// <c>AllocatedResult == IncomeGainAllocations - ExpenseAllocations - FeeAllocations</c>.
+/// </remarks>
 public sealed record LedgerPartnersCapitalRollForward(
     LedgerAccount CapitalAccount,
     string AccountName,
@@ -11,6 +20,9 @@ public sealed record LedgerPartnersCapitalRollForward(
     decimal Contributions,
     decimal Distributions,
     decimal AllocatedResult,
+    decimal IncomeGainAllocations,
+    decimal ExpenseAllocations,
+    decimal FeeAllocations,
     decimal OtherMovements,
     decimal EndingCapital)
 {
@@ -20,6 +32,13 @@ public sealed record LedgerPartnersCapitalRollForward(
 
     /// <summary>Difference between the rolled-forward and observed ending capital. Zero when reconciled.</summary>
     public decimal ReconciliationVariance => ComputedEndingCapital - EndingCapital;
+
+    /// <summary>
+    /// Difference between <see cref="AllocatedResult"/> and its income/expense/fee decomposition.
+    /// Zero when the breakout ties to the net allocated result.
+    /// </summary>
+    public decimal AllocationComponentsVariance =>
+        AllocatedResult - (IncomeGainAllocations - ExpenseAllocations - FeeAllocations);
 }
 
 /// <summary>
@@ -34,6 +53,9 @@ public sealed record LedgerPartnersCapitalStatement(
     decimal Contributions,
     decimal Distributions,
     decimal AllocatedResult,
+    decimal IncomeGainAllocations,
+    decimal ExpenseAllocations,
+    decimal FeeAllocations,
     decimal OtherMovements,
     decimal EndingCapital,
     IReadOnlyList<LedgerPartnersCapitalRollForward> Accounts)
@@ -44,6 +66,13 @@ public sealed record LedgerPartnersCapitalStatement(
 
     /// <summary>Difference between the rolled-forward and observed ending capital. Zero when reconciled.</summary>
     public decimal ReconciliationVariance => ComputedEndingCapital - EndingCapital;
+
+    /// <summary>
+    /// Difference between the aggregate <see cref="AllocatedResult"/> and its income/expense/fee
+    /// decomposition. Zero when the breakout ties to the net allocated result.
+    /// </summary>
+    public decimal AllocationComponentsVariance =>
+        AllocatedResult - (IncomeGainAllocations - ExpenseAllocations - FeeAllocations);
 
     /// <summary>True when the aggregate roll-forward ties to ending capital.</summary>
     public bool IsReconciled => Math.Abs(ReconciliationVariance) <= LedgerToleranceConstants.Balance;

--- a/src/Meridian.Ledger/LedgerReportPackBuilder.cs
+++ b/src/Meridian.Ledger/LedgerReportPackBuilder.cs
@@ -202,7 +202,7 @@ public static class LedgerReportPackBuilder
     private static LedgerReportPackArtifact CreatePartnersCapitalArtifact(string name, LedgerPartnersCapitalStatement? partnersCapital)
     {
         var builder = new StringBuilder();
-        builder.AppendLine("AccountName,InvestorId,BeginningCapital,Contributions,Distributions,AllocatedResult,OtherMovements,EndingCapital");
+        builder.AppendLine("AccountName,InvestorId,BeginningCapital,Contributions,Distributions,IncomeGainAllocations,ExpenseAllocations,FeeAllocations,AllocatedResult,OtherMovements,EndingCapital");
         if (partnersCapital is not null)
         {
             foreach (var account in partnersCapital.Accounts
@@ -219,6 +219,12 @@ public static class LedgerReportPackBuilder
                 builder.Append(',');
                 builder.Append(FormatDecimal(account.Distributions));
                 builder.Append(',');
+                builder.Append(FormatDecimal(account.IncomeGainAllocations));
+                builder.Append(',');
+                builder.Append(FormatDecimal(account.ExpenseAllocations));
+                builder.Append(',');
+                builder.Append(FormatDecimal(account.FeeAllocations));
+                builder.Append(',');
                 builder.Append(FormatDecimal(account.AllocatedResult));
                 builder.Append(',');
                 builder.Append(FormatDecimal(account.OtherMovements));
@@ -232,6 +238,12 @@ public static class LedgerReportPackBuilder
             builder.Append(FormatDecimal(partnersCapital.Contributions));
             builder.Append(',');
             builder.Append(FormatDecimal(partnersCapital.Distributions));
+            builder.Append(',');
+            builder.Append(FormatDecimal(partnersCapital.IncomeGainAllocations));
+            builder.Append(',');
+            builder.Append(FormatDecimal(partnersCapital.ExpenseAllocations));
+            builder.Append(',');
+            builder.Append(FormatDecimal(partnersCapital.FeeAllocations));
             builder.Append(',');
             builder.Append(FormatDecimal(partnersCapital.AllocatedResult));
             builder.Append(',');

--- a/src/Meridian.Ledger/LedgerReportPresentation.cs
+++ b/src/Meridian.Ledger/LedgerReportPresentation.cs
@@ -116,7 +116,9 @@ public static class LedgerReportPresentation
                 Money(account.BeginningCapital),
                 Money(account.Contributions),
                 Money(account.Distributions),
-                Money(account.AllocatedResult),
+                Money(account.IncomeGainAllocations),
+                Money(account.ExpenseAllocations),
+                Money(account.FeeAllocations),
                 Money(account.EndingCapital),
             ])
             .ToList();
@@ -126,13 +128,15 @@ public static class LedgerReportPresentation
             Money(partnersCapital.BeginningCapital),
             Money(partnersCapital.Contributions),
             Money(partnersCapital.Distributions),
-            Money(partnersCapital.AllocatedResult),
+            Money(partnersCapital.IncomeGainAllocations),
+            Money(partnersCapital.ExpenseAllocations),
+            Money(partnersCapital.FeeAllocations),
             Money(partnersCapital.EndingCapital),
         ]);
 
         return new LedgerReportTable(
             "Statement of Changes in Partners' Capital",
-            ["Partner", "Beginning", "Contributions", "Distributions", "Allocated", "Ending"],
+            ["Partner", "Beginning", "Contributions", "Distributions", "Income & Gains", "Expenses", "Fees", "Ending"],
             rows);
     }
 

--- a/src/Meridian.Ledger/README.md
+++ b/src/Meridian.Ledger/README.md
@@ -35,7 +35,15 @@ income-statement and balance-sheet rows with net-income and accounting-equation 
 `BuildForPeriod` additionally derives a direct-method `LedgerCashFlowStatement` (operating /
 investing / financing, reconciled to beginning and ending cash) and a
 `LedgerPartnersCapitalStatement` roll-forward (beginning capital, contributions, distributions,
-allocated result, ending capital per equity account) from the period's journal activity.
+allocated result, ending capital per equity account) from the period's journal activity. The
+allocated result is additionally decomposed into `IncomeGainAllocations`, `ExpenseAllocations`, and
+`FeeAllocations` (management and performance fees, identified by
+`LedgerAccounts.IsFundFeeExpenseAccount`) so a client-grade partners' capital statement reports the
+income/expense/fee drivers a fund accountant delivers rather than one lumped figure; the split holds
+`AllocatedResult == IncomeGainAllocations - ExpenseAllocations - FeeAllocations` on every line, so it
+never disturbs the existing ending-capital reconciliation, and it flows through both the
+partners-capital CSV artifact and the shared `LedgerReportPresentation` table that drives the Xlsx/Pdf
+renderers.
 `LedgerReportPackBuilder` emits those statements as CSV/JSON pack artifacts, and
 `LedgerScheduledReportExportPackageBuilder` now honors every declared `LedgerReportExportFormat`:
 Csv, Json, RegulatoryXml natively plus real binary Xlsx/Pdf through the
@@ -54,8 +62,13 @@ capital → preferred return → automatic GP catch-up → carried-interest spli
 (`ShareClass`, `ShareClassUnitRegisterProjector`, `NavPerUnitCalculator`, `EqualizationCalculator`)
 for unitized NAV-per-unit with single-NAV equalisation. `PrivateCapitalCommitments` plus
 `CapitalCallDraftFactory` and `CapitalCallPlanBuilder` add the LP commitment register,
-uncalled-commitment roll-forward invariant, and governed capital-call drafting; the
-`CommitmentRollForwardCalculator` and `DefaultInterestCalculator` live in
+uncalled-commitment roll-forward invariant, and governed capital-call drafting;
+`CapitalCallScheduleDraftBuilder` closes the wiring gap between the two — it apportions a fund-level
+call over the commitment roll-forwards (`CapitalCallPlanBuilder`) and turns each executable plan line
+into a balanced governed issuance draft (`CapitalCallDraftFactory`) in a deterministic per-investor
+order, failing closed when the plan does not tie to the requested amount, so callers post capital
+calls through the standard `AutomatedJournalApproval` lifecycle instead of leaving the kernels
+uncalled. The `CommitmentRollForwardCalculator` and `DefaultInterestCalculator` live in
 `Meridian.FinancialOperations/PrivateCapital`.
 `Ledger.CalculateNetBalance` exposes the ledger-owned normal-balance calculation over the shared
 F# posting kernel so storage and reporting projections do not duplicate account-type math.

--- a/tests/Meridian.Tests/Ledger/CapitalCallScheduleDraftBuilderTests.cs
+++ b/tests/Meridian.Tests/Ledger/CapitalCallScheduleDraftBuilderTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using FluentAssertions;
+
+using Meridian.Ledger;
+
+using Xunit;
+
+namespace Meridian.Tests.Ledger;
+
+/// <summary>
+/// Coverage for composing a fund-level capital-call plan into the set of governed issuance drafts
+/// (W9-NAV-006): the previously-uncalled <see cref="CapitalCallPlanBuilder"/> and
+/// <see cref="CapitalCallDraftFactory"/> kernels are wired into balanced governed drafts ready for
+/// the automated-journal approval lifecycle.
+/// </summary>
+public sealed class CapitalCallScheduleDraftBuilderTests
+{
+    private static readonly DateTimeOffset OccurredAt = new(2026, 3, 15, 12, 0, 0, TimeSpan.Zero);
+    private static readonly DateOnly NoticeDate = new(2026, 3, 15);
+    private static readonly DateOnly DueDate = new(2026, 3, 29);
+
+    private static InvestorCommitment Commitment(string commitmentId, string investorId, decimal total)
+        => new(
+            commitmentId,
+            fundProfileId: "fund-a",
+            ledgerBookId: null,
+            capitalAccountId: $"ca-{investorId}",
+            investorId: investorId,
+            currency: "USD",
+            totalCommitment: total,
+            commitmentDate: new DateOnly(2025, 1, 1),
+            investmentPeriodEndDate: null,
+            status: CommitmentStatus.Active);
+
+    private static CommitmentRollForward FreshRollForward(InvestorCommitment commitment)
+        => new(commitment, CumulativeCalled: 0m, CumulativeRecallableRestored: 0m, CumulativeExpired: 0m, Steps: [], ValidationIssues: []);
+
+    private static CapitalCallPlanRequest CallRequest(decimal amountToCall, params CommitmentRollForward[] rollForwards)
+        => new("call-1", "fund-a", amountToCall, NoticeDate, DueDate, rollForwards);
+
+    [Fact]
+    public void BuildsOneBalancedGovernedDraftPerInvestor_ProRataOverUncalled()
+    {
+        var lp1 = FreshRollForward(Commitment("cmt-1", "lp-1", 6_000_000m));
+        var lp2 = FreshRollForward(Commitment("cmt-2", "lp-2", 4_000_000m));
+
+        var drafts = CapitalCallScheduleDraftBuilder.BuildIssuanceDrafts(
+            CallRequest(1_000_000m, lp1, lp2), OccurredAt);
+
+        drafts.Should().HaveCount(2);
+        drafts.Should().OnlyContain(draft => draft.IsBalanced);
+        drafts.Should().OnlyContain(draft => draft.Event.Kind == AutomatedJournalEventKind.CapitalCallIssued);
+
+        // Deterministic per-investor order and pro-rata-by-uncalled split (60% / 40%).
+        var first = drafts[0];
+        var second = drafts[1];
+        first.Metadata.InvestorId.Should().Be("lp-1");
+        first.Event.Amount.Should().Be(600_000m);
+        second.Metadata.InvestorId.Should().Be("lp-2");
+        second.Event.Amount.Should().Be(400_000m);
+
+        // Each draft debits the LP's capital-call receivable and credits its investor capital.
+        first.Lines.Should().SatisfyRespectively(
+            line => { line.account.Name.Should().Be("Capital Call Receivable"); line.debit.Should().Be(600_000m); },
+            line => { line.account.Name.Should().Be("Investor Capital"); line.credit.Should().Be(600_000m); });
+
+        // The call sum ties exactly to the requested amount.
+        drafts.Sum(draft => draft.TotalDebits).Should().Be(1_000_000m);
+    }
+
+    [Fact]
+    public void DraftsCarryDeterministicIdempotencyKeysAndCapitalAccountIdentity()
+    {
+        var lp1 = FreshRollForward(Commitment("cmt-1", "lp-1", 6_000_000m));
+        var lp2 = FreshRollForward(Commitment("cmt-2", "lp-2", 4_000_000m));
+        var request = CallRequest(1_000_000m, lp1, lp2);
+
+        var first = CapitalCallScheduleDraftBuilder.BuildIssuanceDrafts(request, OccurredAt);
+        var second = CapitalCallScheduleDraftBuilder.BuildIssuanceDrafts(request, OccurredAt);
+
+        var firstKeys = first.Select(d => d.Metadata.IdempotencyKey).ToArray();
+        var secondKeys = second.Select(d => d.Metadata.IdempotencyKey).ToArray();
+
+        firstKeys.Should().Equal("capital-call:cmt-1:call-1:cmt-1", "capital-call:cmt-2:call-1:cmt-2");
+        secondKeys.Should().Equal(firstKeys); // stable across runs -> idempotent re-issue
+
+        first[0].Metadata.CapitalAccountId.Should().Be("ca-lp-1");
+        first[0].Metadata.FundEventId.Should().Be("fund-event:fund-a:capital-call:call-1:cmt-1");
+    }
+
+    [Fact]
+    public void AttachesRetainedEvidenceToTheMatchingCommitmentDraft()
+    {
+        var lp1 = FreshRollForward(Commitment("cmt-1", "lp-1", 6_000_000m));
+        var evidence = new JournalEvidenceReference(
+            EvidenceId: "call-notice:cmt-1",
+            Uri: "/api/private-capital/fund-a/calls/call-1/notice.pdf",
+            Kind: "capital-call-notice",
+            SourceSystem: "private-capital",
+            RetainedAtUtc: OccurredAt,
+            RetainedBy: "tester",
+            SubjectId: "cmt-1");
+        var evidenceByCommitment = new Dictionary<string, IReadOnlyList<JournalEvidenceReference>>
+        {
+            ["cmt-1"] = [evidence],
+        };
+
+        var drafts = CapitalCallScheduleDraftBuilder.BuildIssuanceDrafts(
+            CallRequest(500_000m, lp1), OccurredAt, evidenceByCommitment);
+
+        drafts.Should().ContainSingle();
+        drafts[0].Metadata.EvidenceReferences.Should().ContainSingle(reference => reference.EvidenceId == "call-notice:cmt-1");
+    }
+
+    [Fact]
+    public void ThrowsWhenPlanIsNotExecutable_CallExceedsUncalledCapacity()
+    {
+        var lp1 = FreshRollForward(Commitment("cmt-1", "lp-1", 1_000_000m));
+
+        var act = () => CapitalCallScheduleDraftBuilder.BuildIssuanceDrafts(
+            CallRequest(5_000_000m, lp1), OccurredAt);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*not executable*");
+    }
+}

--- a/tests/Meridian.Tests/Ledger/PartnersCapitalAllocationBreakoutTests.cs
+++ b/tests/Meridian.Tests/Ledger/PartnersCapitalAllocationBreakoutTests.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Linq;
+
+using FluentAssertions;
+
+using Meridian.Ledger;
+
+using Xunit;
+
+namespace Meridian.Tests.Ledger;
+
+/// <summary>
+/// Golden coverage for the partners' capital statement allocation breakout: the single lumped
+/// allocated result is decomposed into income/gain, (non-fee) expense, and fund-fee drivers so a
+/// client-grade statement can report the components a fund accountant delivers (W9-REPORT-005),
+/// without disturbing the existing reconciliation invariants.
+/// </summary>
+public sealed class PartnersCapitalAllocationBreakoutTests
+{
+    private static readonly DateTimeOffset PeriodStart = new(2025, 12, 31, 0, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset AsOf = new(2026, 12, 31, 0, 0, 0, TimeSpan.Zero);
+
+    private static LedgerFinancialStatements BuildForPeriod(Meridian.Ledger.Ledger ledger)
+        => LedgerFinancialStatementBuilder.BuildForPeriod(ledger, PeriodStart, AsOf);
+
+    [Fact]
+    public void Undistributed_AllocatedResult_SplitsIntoIncomeExpenseAndFee()
+    {
+        var ledger = new Meridian.Ledger.Ledger();
+        var capital = LedgerAccounts.InvestorCapitalFor("lp-1");
+
+        // Opening capital before the period.
+        ledger.PostLines(new DateTimeOffset(2025, 6, 15, 0, 0, 0, TimeSpan.Zero), "opening contribution",
+            [(LedgerAccounts.Cash, 5_000_000m, 0m), (capital, 0m, 5_000_000m)]);
+
+        // In-period P&L flowing through revenue/expense and cash (no direct capital allocation), so it
+        // rides the aggregate Undistributed Net Income line.
+        ledger.PostLines(new DateTimeOffset(2026, 3, 31, 0, 0, 0, TimeSpan.Zero), "interest income",
+            [(LedgerAccounts.Cash, 200_000m, 0m), (LedgerAccounts.CashInterestIncome, 0m, 200_000m)]);
+        ledger.PostLines(new DateTimeOffset(2026, 6, 30, 0, 0, 0, TimeSpan.Zero), "management fee",
+            [(LedgerAccounts.ManagementFeeExpenseFor("fund-a"), 100_000m, 0m), (LedgerAccounts.Cash, 0m, 100_000m)]);
+        ledger.PostLines(new DateTimeOffset(2026, 9, 30, 0, 0, 0, TimeSpan.Zero), "brokerage commission",
+            [(LedgerAccounts.CommissionExpense, 20_000m, 0m), (LedgerAccounts.Cash, 0m, 20_000m)]);
+
+        var partnersCapital = BuildForPeriod(ledger).PartnersCapital!;
+        var undistributed = partnersCapital.Accounts.Single(a => a.AccountName == "Undistributed Net Income");
+
+        undistributed.IncomeGainAllocations.Should().Be(200_000m);
+        undistributed.FeeAllocations.Should().Be(100_000m);           // management fee is a fund fee
+        undistributed.ExpenseAllocations.Should().Be(20_000m);        // commission is an operating expense, not a fee
+        undistributed.AllocatedResult.Should().Be(80_000m);           // 200k income - 100k fee - 20k expense
+        undistributed.AllocationComponentsVariance.Should().Be(0m);
+
+        partnersCapital.IncomeGainAllocations.Should().Be(200_000m);
+        partnersCapital.ExpenseAllocations.Should().Be(20_000m);
+        partnersCapital.FeeAllocations.Should().Be(100_000m);
+        partnersCapital.AllocatedResult.Should().Be(80_000m);
+        partnersCapital.AllocationComponentsVariance.Should().Be(0m);
+        partnersCapital.IsReconciled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void PerformanceFee_LandsInFeeBucketAlongsideManagementFee()
+    {
+        var ledger = new Meridian.Ledger.Ledger();
+        var capital = LedgerAccounts.InvestorCapitalFor("lp-1");
+
+        ledger.PostLines(new DateTimeOffset(2025, 6, 15, 0, 0, 0, TimeSpan.Zero), "opening contribution",
+            [(LedgerAccounts.Cash, 5_000_000m, 0m), (capital, 0m, 5_000_000m)]);
+        ledger.PostLines(new DateTimeOffset(2026, 3, 31, 0, 0, 0, TimeSpan.Zero), "realized gain",
+            [(LedgerAccounts.Cash, 500_000m, 0m), (LedgerAccounts.RealizedGainFor("fund-a"), 0m, 500_000m)]);
+        ledger.PostLines(new DateTimeOffset(2026, 6, 30, 0, 0, 0, TimeSpan.Zero), "management fee",
+            [(LedgerAccounts.ManagementFeeExpenseFor("fund-a"), 100_000m, 0m), (LedgerAccounts.Cash, 0m, 100_000m)]);
+        ledger.PostLines(new DateTimeOffset(2026, 9, 30, 0, 0, 0, TimeSpan.Zero), "performance fee",
+            [(LedgerAccounts.PerformanceFeeExpenseFor("fund-a"), 60_000m, 0m), (LedgerAccounts.Cash, 0m, 60_000m)]);
+
+        var partnersCapital = BuildForPeriod(ledger).PartnersCapital!;
+
+        partnersCapital.IncomeGainAllocations.Should().Be(500_000m);
+        partnersCapital.FeeAllocations.Should().Be(160_000m);   // 100k management + 60k performance
+        partnersCapital.ExpenseAllocations.Should().Be(0m);
+        partnersCapital.AllocatedResult.Should().Be(340_000m);  // 500k - 160k
+        partnersCapital.AllocationComponentsVariance.Should().Be(0m);
+        partnersCapital.IsReconciled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void DirectAllocationToInvestorCapital_DecomposesWithClosingSign()
+    {
+        var ledger = new Meridian.Ledger.Ledger();
+        var capital = LedgerAccounts.InvestorCapitalFor("lp-1");
+        var managementFee = LedgerAccounts.ManagementFeeExpenseFor("fund-a");
+
+        // Opening capital before the period.
+        ledger.PostLines(new DateTimeOffset(2025, 6, 15, 0, 0, 0, TimeSpan.Zero), "opening contribution",
+            [(LedgerAccounts.Cash, 1_000_000m, 0m), (capital, 0m, 1_000_000m)]);
+
+        // In-period income earned and a fee accrued through P&L...
+        ledger.PostLines(new DateTimeOffset(2026, 3, 31, 0, 0, 0, TimeSpan.Zero), "interest income",
+            [(LedgerAccounts.Cash, 300_000m, 0m), (LedgerAccounts.CashInterestIncome, 0m, 300_000m)]);
+        ledger.PostLines(new DateTimeOffset(2026, 6, 30, 0, 0, 0, TimeSpan.Zero), "management fee",
+            [(managementFee, 100_000m, 0m), (LedgerAccounts.Cash, 0m, 100_000m)]);
+
+        // ...then closed directly into the LP's capital account: gross income in, fee out.
+        ledger.PostLines(new DateTimeOffset(2026, 12, 30, 0, 0, 0, TimeSpan.Zero), "allocate net to capital",
+            [(LedgerAccounts.CashInterestIncome, 300_000m, 0m), (managementFee, 0m, 100_000m), (capital, 0m, 200_000m)]);
+
+        var partnersCapital = BuildForPeriod(ledger).PartnersCapital!;
+        var lp = partnersCapital.Accounts.Single(a => a.InvestorId == "lp-1");
+
+        lp.AllocatedResult.Should().Be(200_000m);           // net moved into capital
+        lp.IncomeGainAllocations.Should().Be(300_000m);     // gross income allocated
+        lp.FeeAllocations.Should().Be(100_000m);            // fee charged against the allocation
+        lp.ExpenseAllocations.Should().Be(0m);
+        lp.AllocationComponentsVariance.Should().Be(0m);    // 300k - 0 - 100k == 200k
+        lp.EndingCapital.Should().Be(1_200_000m);
+
+        // The P&L accounts are zeroed by the close, so no undistributed line survives and the
+        // aggregate breakout equals the single LP line.
+        partnersCapital.Accounts.Should().NotContain(a => a.AccountName == "Undistributed Net Income");
+        partnersCapital.IncomeGainAllocations.Should().Be(300_000m);
+        partnersCapital.FeeAllocations.Should().Be(100_000m);
+        partnersCapital.AllocatedResult.Should().Be(200_000m);
+        partnersCapital.AllocationComponentsVariance.Should().Be(0m);
+        partnersCapital.IsReconciled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReportPack_PartnersCapitalCsvAndTable_ExposeTheBreakoutColumns()
+    {
+        var ledger = new Meridian.Ledger.Ledger();
+        var capital = LedgerAccounts.InvestorCapitalFor("lp-1");
+        ledger.PostLines(new DateTimeOffset(2025, 6, 15, 0, 0, 0, TimeSpan.Zero), "opening contribution",
+            [(LedgerAccounts.Cash, 5_000_000m, 0m), (capital, 0m, 5_000_000m)]);
+        ledger.PostLines(new DateTimeOffset(2026, 3, 31, 0, 0, 0, TimeSpan.Zero), "interest income",
+            [(LedgerAccounts.Cash, 200_000m, 0m), (LedgerAccounts.CashInterestIncome, 0m, 200_000m)]);
+        ledger.PostLines(new DateTimeOffset(2026, 6, 30, 0, 0, 0, TimeSpan.Zero), "management fee",
+            [(LedgerAccounts.ManagementFeeExpenseFor("fund-a"), 100_000m, 0m), (LedgerAccounts.Cash, 0m, 100_000m)]);
+
+        var request = new LedgerReportPackRequest(
+            reportId: "rp-1",
+            fundId: "fund-a",
+            periodId: "2026",
+            periodStart: PeriodStart,
+            periodEnd: AsOf,
+            asOf: AsOf,
+            baseCurrency: "USD",
+            generatedBy: "tester",
+            generatedAtUtc: AsOf);
+
+        var pack = LedgerReportPackBuilder.Build(ledger, request);
+
+        var csv = pack.Artifacts.Single(a => a.Name == "partners-capital-statement.csv").Content;
+        csv.Should().Contain("IncomeGainAllocations,ExpenseAllocations,FeeAllocations,AllocatedResult");
+
+        // The shared presentation table drives both the built-in and the client-grade PDF/XLSX
+        // renderers, so the fee/income/expense columns reach the Excel deliverable.
+        var table = LedgerReportPresentation.BuildTables(pack)
+            .Single(t => t.Title == "Statement of Changes in Partners' Capital");
+        table.Headers.Should().ContainInOrder("Income & Gains", "Expenses", "Fees");
+
+        // The XLSX bytes render deterministically from that table.
+        var workbook = BuiltInLedgerReportBinaryRenderer.Instance.RenderWorkbook(pack);
+        workbook.Should().NotBeEmpty();
+    }
+}


### PR DESCRIPTION
<!-- phase:PR7 -->

## Summary

Two ledger-backed fund-accounting completions in `Meridian.Ledger` that wire existing, tested kernels into the last mile instead of leaving them uncalled.

**W9-REPORT-005 — partners' capital statement now reports its drivers.** The statement of changes in partners' capital previously collapsed every allocation into a single `AllocatedResult` column. It now decomposes that into `IncomeGainAllocations`, `ExpenseAllocations`, and `FeeAllocations` on every roll-forward line and on the aggregate:

- Fund fees (management, performance) are identified centrally via a new `LedgerAccounts.IsFundFeeExpenseAccount`, so trading costs (commissions, borrow fees) are classified as operating expenses, not fund fees.
- The undistributed-net-income line splits its period P&L exactly; direct per-partner allocations use the closing sign with income/gain as the balancing figure, so `AllocatedResult == IncomeGainAllocations − ExpenseAllocations − FeeAllocations` holds on every line and the existing ending-capital reconciliation math is byte-for-byte unchanged.
- The breakout flows through the partners-capital CSV pack artifact **and** the shared `LedgerReportPresentation` table that drives both the built-in and client-grade QuestPDF/ClosedXML Xlsx/Pdf renderers, so the fee/income/expense columns reach the Excel/PDF deliverable.

**W9-NAV-006 — capital-call schedules now produce governed postings.** Added `CapitalCallScheduleDraftBuilder`, which apportions a fund-level call over the commitment roll-forwards (`CapitalCallPlanBuilder`) and turns each executable plan line into a balanced governed issuance draft (`CapitalCallDraftFactory`) in a deterministic per-investor order, failing closed when the plan does not tie to the requested amount. This closes the wiring gap between the plan builder and the governed journal, which previously had no caller — the drafts are ready for the standard `AutomatedJournalApproval` submit → approve → post lifecycle.

## Reason

The named primary customers (fund admins/CFOs) need the numbers and the deliverable at the last mile. The hard math already existed and was tested but uncalled: the partners' capital statement lumped income/expense/fees into one figure (missing the `W9-REPORT-005` exit criterion "income/expense/gain allocations, fees … per partner and per period"), and the tested capital-call plan/draft kernels had no caller composing a plan into governed postings (`W9-NAV-006`). Both changes are additive completions that reuse the existing kernels.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Notes on validation:
- `Meridian.Ledger` builds clean (`0 Error(s)`), and all new + existing partners-capital/period-statement tests pass (**16 passed**, including the 8 pre-existing `LedgerPeriodStatementsTests` regressions). New tests: `PartnersCapitalAllocationBreakoutTests` (breakout, invariant, reconciliation, CSV/table/Xlsx render) and `CapitalCallScheduleDraftBuilderTests` (balanced per-investor drafts, pro-rata split, deterministic idempotency keys, evidence attachment, fail-closed).
- The **full solution does not build on this branch today** because of a pre-existing, unrelated breakage in `Meridian.FinancialOperations/Reconciliation` (duplicate `StatementRunMatchResult` across `StatementRunMatcher.cs`/`StatementRunMatchingService.cs` and a duplicate `ResolveToleranceProfileAsync` in `StatementRunWorkflowService.cs`). These files are unrelated to this change and predate it, so `scripts/ci.sh`/`quality-gate` cannot pass until they are reconciled. My Ledger changes were therefore validated with an isolated test project referencing only `Meridian.Ledger`.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)