### PR TITLE
Render governed report packs as client-grade PDF/XLSX

### DIFF
--- a/src/Meridian.Documents/ClientGradeReportRenderer.cs
+++ b/src/Meridian.Documents/ClientGradeReportRenderer.cs
@@ -1,7 +1,5 @@
-using System.Globalization;
 using System.Text;
 using ClosedXML.Excel;
-using Meridian.Ledger;
 using QuestPDF.Fluent;
 using QuestPDF.Helpers;
 using QuestPDF.Infrastructure;
@@ -9,22 +7,18 @@ using QuestPDF.Infrastructure;
 namespace Meridian.Documents;
 
 /// <summary>
-/// Client-grade renderer producing branded, tabular PDF and multi-sheet XLSX documents from a
-/// ledger financial report pack using QuestPDF and ClosedXML. Implements the ledger's
-/// <see cref="ILedgerReportBinaryRenderer"/> seam so it drops into the existing signed export
-/// pipeline in place of the dependency-free fallback. Output is made deterministic (fixed document
-/// metadata, fixed timestamps, canonical zip ordering) so re-rendering the same pack reproduces the
-/// same bytes for audit verification.
+/// Renders a presentation-neutral <see cref="ReportDocumentModel"/> into branded, client-grade PDF
+/// and multi-sheet XLSX documents using QuestPDF and ClosedXML. Output is deterministic (fixed
+/// document metadata, fixed timestamps, canonical zip ordering) so re-rendering the same model
+/// reproduces the same bytes for governed-reporting hash verification.
 /// </summary>
-public sealed class FinancialReportDocumentRenderer : ILedgerReportBinaryRenderer
+public sealed class ClientGradeReportRenderer
 {
-    static FinancialReportDocumentRenderer() => DeterministicDocumentPackaging.ConfigureQuestPdf();
+    static ClientGradeReportRenderer() => DeterministicDocumentPackaging.ConfigureQuestPdf();
 
-    public byte[] RenderPdf(LedgerFinancialReportPack reportPack)
+    public byte[] RenderPdf(ReportDocumentModel model)
     {
-        ArgumentNullException.ThrowIfNull(reportPack);
-        var tables = LedgerReportPresentation.BuildTables(reportPack);
-        var request = reportPack.Request;
+        ArgumentNullException.ThrowIfNull(model);
 
         var document = Document.Create(container =>
         {
@@ -37,21 +31,26 @@ public sealed class FinancialReportDocumentRenderer : ILedgerReportBinaryRendere
                 page.Header().Column(header =>
                 {
                     header.Item().Text("Meridian Fund Operations").FontSize(16).Bold().FontColor("#0b7285");
-                    header.Item().Text($"{request.FundId} — {request.PeriodId}").FontSize(11).SemiBold();
-                    header.Item().Text($"As of {request.AsOf:yyyy-MM-dd} · {request.BaseCurrency}").FontSize(8).FontColor("#627d98");
+                    header.Item().Text(model.Title).FontSize(12).SemiBold();
+                    if (!string.IsNullOrWhiteSpace(model.Subtitle))
+                        header.Item().Text(model.Subtitle).FontSize(9).FontColor("#627d98");
+                    foreach (var field in model.HeaderFields)
+                        header.Item().Text($"{field.Label}: {field.Value}").FontSize(8).FontColor("#627d98");
                     header.Item().PaddingTop(4).LineHorizontal(1).LineColor("#0b7285");
                 });
 
                 page.Content().PaddingVertical(6).Column(column =>
                 {
                     column.Spacing(14);
-                    foreach (var table in tables)
+                    if (model.Tables.Count == 0)
+                        column.Item().Text("No certified rows for this report.").FontSize(9).FontColor("#627d98");
+                    foreach (var table in model.Tables)
                         RenderTable(column, table);
                 });
 
                 page.Footer().Row(row =>
                 {
-                    row.RelativeItem().Text($"Signature {Shorten(reportPack.Signature.PayloadChecksumSha256)}")
+                    row.RelativeItem().Text(model.FooterNote ?? string.Empty)
                         .FontSize(7).FontColor("#9aa5b1");
                     row.ConstantItem(120).AlignRight().Text(text =>
                     {
@@ -67,9 +66,9 @@ public sealed class FinancialReportDocumentRenderer : ILedgerReportBinaryRendere
 
         document.WithMetadata(new DocumentMetadata
         {
-            Title = $"{request.FundId} {request.PeriodId}",
+            Title = model.Title,
             Author = "Meridian",
-            Subject = request.ReportId,
+            Subject = model.Subtitle ?? model.Title,
             Creator = "Meridian",
             Producer = "Meridian",
             CreationDate = new DateTimeOffset(DeterministicDocumentPackaging.FixedTimestamp, TimeSpan.Zero),
@@ -79,29 +78,35 @@ public sealed class FinancialReportDocumentRenderer : ILedgerReportBinaryRendere
         return document.GeneratePdf();
     }
 
-    public byte[] RenderWorkbook(LedgerFinancialReportPack reportPack)
+    public byte[] RenderWorkbook(ReportDocumentModel model)
     {
-        ArgumentNullException.ThrowIfNull(reportPack);
-        var tables = LedgerReportPresentation.BuildTables(reportPack);
+        ArgumentNullException.ThrowIfNull(model);
 
         byte[] rendered;
         using (var workbook = new XLWorkbook())
         {
             var usedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var table in tables)
+
+            if (model.HeaderFields.Count > 0)
             {
-                var sheet = workbook.Worksheets.Add(UniqueSheetName(table.Title, usedNames));
-                var headerRow = sheet.Row(1);
-                for (var column = 0; column < table.Headers.Count; column++)
+                var summary = workbook.Worksheets.Add(UniqueSheetName("Summary", usedNames));
+                WriteHeaderCells(summary, ["Field", "Value"]);
+                var summaryRow = 2;
+                foreach (var field in model.HeaderFields)
                 {
-                    var cell = sheet.Cell(1, column + 1);
-                    cell.Value = table.Headers[column];
-                    cell.Style.Font.Bold = true;
-                    cell.Style.Fill.BackgroundColor = XLColor.FromHtml("#0b7285");
-                    cell.Style.Font.FontColor = XLColor.White;
+                    summary.Cell(summaryRow, 1).Value = field.Label;
+                    summary.Cell(summaryRow, 2).Value = field.Value;
+                    summaryRow++;
                 }
 
-                headerRow.Height = 18;
+                summary.Columns().AdjustToContents();
+                summary.SheetView.FreezeRows(1);
+            }
+
+            foreach (var table in model.Tables)
+            {
+                var sheet = workbook.Worksheets.Add(UniqueSheetName(table.Title, usedNames));
+                WriteHeaderCells(sheet, table.Headers);
                 var rowNumber = 2;
                 foreach (var row in table.Rows)
                 {
@@ -111,11 +116,15 @@ public sealed class FinancialReportDocumentRenderer : ILedgerReportBinaryRendere
                 }
 
                 sheet.Columns().AdjustToContents();
-                sheet.SheetView.FreezeRows(1);
+                if (table.Headers.Count > 0)
+                    sheet.SheetView.FreezeRows(1);
             }
 
+            if (!workbook.Worksheets.Any())
+                workbook.Worksheets.Add(UniqueSheetName("Report", usedNames));
+
             workbook.Properties.Author = "Meridian";
-            workbook.Properties.Title = $"{reportPack.Request.FundId} {reportPack.Request.PeriodId}";
+            workbook.Properties.Title = model.Title;
             workbook.Properties.Created = DeterministicDocumentPackaging.FixedTimestamp;
             workbook.Properties.Modified = DeterministicDocumentPackaging.FixedTimestamp;
             workbook.Properties.LastModifiedBy = "Meridian";
@@ -128,9 +137,29 @@ public sealed class FinancialReportDocumentRenderer : ILedgerReportBinaryRendere
         return DeterministicDocumentPackaging.Canonicalize(rendered);
     }
 
-    private static void RenderTable(ColumnDescriptor column, LedgerReportTable table)
+    private static void WriteHeaderCells(IXLWorksheet sheet, IReadOnlyList<string> headers)
+    {
+        if (headers.Count == 0)
+            return;
+
+        for (var column = 0; column < headers.Count; column++)
+        {
+            var cell = sheet.Cell(1, column + 1);
+            cell.Value = headers[column];
+            cell.Style.Font.Bold = true;
+            cell.Style.Fill.BackgroundColor = XLColor.FromHtml("#0b7285");
+            cell.Style.Font.FontColor = XLColor.White;
+        }
+
+        sheet.Row(1).Height = 18;
+    }
+
+    private static void RenderTable(QuestPDF.Fluent.ColumnDescriptor column, ReportDocumentTable table)
     {
         column.Item().Text(table.Title).FontSize(11).Bold().FontColor("#102a43");
+        if (table.Headers.Count == 0)
+            return;
+
         column.Item().Table(grid =>
         {
             grid.ColumnsDefinition(columns =>
@@ -189,6 +218,4 @@ public sealed class FinancialReportDocumentRenderer : ILedgerReportBinaryRendere
             cleaned = "Sheet";
         return cleaned.Length > 31 ? cleaned[..31] : cleaned;
     }
-
-    private static string Shorten(string value) => value.Length <= 16 ? value : value[..16];
 }

--- a/src/Meridian.Documents/DeterministicDocumentPackaging.cs
+++ b/src/Meridian.Documents/DeterministicDocumentPackaging.cs
@@ -1,0 +1,115 @@
+using System.IO.Compression;
+using System.Text;
+using System.Text.RegularExpressions;
+using QuestPDF.Infrastructure;
+
+namespace Meridian.Documents;
+
+/// <summary>
+/// Shared determinism utilities for client-grade document rendering. QuestPDF and ClosedXML both
+/// introduce non-deterministic bytes by default (wall-clock metadata, a GUID-named OPC
+/// core-properties part, random relationship ids, and reordered zip entries). These helpers pin
+/// them so re-rendering identical input reproduces identical bytes, which the governed reporting
+/// pipeline relies on for audit hash verification.
+/// </summary>
+internal static class DeterministicDocumentPackaging
+{
+    internal static readonly DateTime FixedTimestamp = new(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    // ClosedXML names the OPC core-properties part with a fresh random GUID each save (and references
+    // it by that GUID in _rels/.rels) and reorders zip entries; re-zip deterministically with a fixed
+    // core-properties name, fixed timestamps, and sorted entries so re-rendering yields stable bytes.
+    private const string CanonicalCorePropertiesPart = "package/services/metadata/core-properties/core.psmdcp";
+
+    /// <summary>
+    /// Applies the process-wide QuestPDF configuration required for deterministic, license-clean
+    /// rendering. Idempotent; safe to call from every renderer's static constructor.
+    /// </summary>
+    internal static void ConfigureQuestPdf()
+    {
+        QuestPDF.Settings.License = LicenseType.Community;
+        QuestPDF.Settings.EnableDebugging = false;
+        QuestPDF.Settings.CheckIfAllTextGlyphsAreAvailable = false;
+    }
+
+    /// <summary>
+    /// Re-zips a ClosedXML workbook deterministically: canonicalizes the volatile core-properties
+    /// part name, pins its timestamps, normalizes package relationship ids, and writes entries in a
+    /// stable order with fixed entry timestamps.
+    /// </summary>
+    internal static byte[] Canonicalize(byte[] workbookBytes)
+    {
+        var parts = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        string? volatileCorePropertiesPart = null;
+        using (var source = new ZipArchive(new MemoryStream(workbookBytes), ZipArchiveMode.Read))
+        {
+            foreach (var entry in source.Entries)
+            {
+                using var entryStream = entry.Open();
+                using var buffer = new MemoryStream();
+                entryStream.CopyTo(buffer);
+                var name = entry.FullName;
+                if (name.StartsWith("package/services/metadata/core-properties/", StringComparison.Ordinal)
+                    && name.EndsWith(".psmdcp", StringComparison.Ordinal))
+                {
+                    volatileCorePropertiesPart = name;
+                    name = CanonicalCorePropertiesPart;
+                }
+
+                parts[name] = buffer.ToArray();
+            }
+        }
+
+        // Repoint every reference to the GUID-named core-properties part (_rels/.rels targets it and
+        // [Content_Types].xml overrides it by full part name), and pin the wall-clock created/modified
+        // timestamps ClosedXML stamps into the core-properties part regardless of Properties.
+        if (volatileCorePropertiesPart is not null)
+        {
+            var oldFileName = volatileCorePropertiesPart[(volatileCorePropertiesPart.LastIndexOf('/') + 1)..];
+            foreach (var referencingPart in new[] { "_rels/.rels", "[Content_Types].xml" })
+            {
+                if (parts.TryGetValue(referencingPart, out var bytes))
+                {
+                    var rewritten = Encoding.UTF8.GetString(bytes).Replace(oldFileName, "core.psmdcp", StringComparison.Ordinal);
+                    if (referencingPart == "_rels/.rels")
+                        rewritten = NormalizeRelationshipIds(rewritten);
+                    parts[referencingPart] = Encoding.UTF8.GetBytes(rewritten);
+                }
+            }
+
+            if (parts.TryGetValue(CanonicalCorePropertiesPart, out var coreBytes))
+                parts[CanonicalCorePropertiesPart] = Encoding.UTF8.GetBytes(PinCoreTimestamps(Encoding.UTF8.GetString(coreBytes)));
+        }
+
+        using var output = new MemoryStream();
+        using (var target = new ZipArchive(output, ZipArchiveMode.Create, leaveOpen: true, Encoding.UTF8))
+        {
+            foreach (var part in parts.OrderBy(static item => item.Key, StringComparer.Ordinal))
+            {
+                var targetEntry = target.CreateEntry(part.Key, CompressionLevel.NoCompression);
+                targetEntry.LastWriteTime = new DateTimeOffset(1980, 1, 1, 0, 0, 0, TimeSpan.Zero);
+                using var targetStream = targetEntry.Open();
+                targetStream.Write(part.Value, 0, part.Value.Length);
+            }
+        }
+
+        return output.ToArray();
+    }
+
+    // Package-level relationships carry random 16-hex ids that no other part references by id;
+    // replace them with sequential canonical ids so re-rendering is byte-stable.
+    private static string NormalizeRelationshipIds(string rels)
+    {
+        var counter = 0;
+        return Regex.Replace(
+            rels,
+            "Id=\"R[0-9a-fA-F]{16}\"",
+            _ => $"Id=\"Rc{++counter}\"");
+    }
+
+    private static string PinCoreTimestamps(string coreProperties)
+        => Regex.Replace(
+            coreProperties,
+            @"(<dcterms:(?:created|modified)[^>]*>)[^<]*(</dcterms:(?:created|modified)>)",
+            "${1}2000-01-01T00:00:00Z${2}");
+}

--- a/src/Meridian.Documents/ReportDocumentModel.cs
+++ b/src/Meridian.Documents/ReportDocumentModel.cs
@@ -1,0 +1,28 @@
+namespace Meridian.Documents;
+
+/// <summary>
+/// A labelled key/value pair shown in a report document's branded header block.
+/// </summary>
+public sealed record ReportDocumentField(string Label, string Value);
+
+/// <summary>
+/// One titled table inside a report document. <see cref="Rows"/> are string cells already formatted
+/// by the caller; the renderer performs no numeric parsing so exact source values are preserved.
+/// </summary>
+public sealed record ReportDocumentTable(
+    string Title,
+    IReadOnlyList<string> Headers,
+    IReadOnlyList<IReadOnlyList<string>> Rows);
+
+/// <summary>
+/// Presentation-neutral report model rendered to client-grade PDF/XLSX by
+/// <see cref="ClientGradeReportRenderer"/>. It intentionally has no dependency on the ledger report
+/// pack or the reporting manifest so any producer can populate it. All content is pre-formatted
+/// strings so rendering is a pure, deterministic function of this model.
+/// </summary>
+public sealed record ReportDocumentModel(
+    string Title,
+    IReadOnlyList<ReportDocumentField> HeaderFields,
+    IReadOnlyList<ReportDocumentTable> Tables,
+    string? Subtitle = null,
+    string? FooterNote = null);

--- a/src/Meridian.Ui.Shared/Meridian.Ui.Shared.csproj
+++ b/src/Meridian.Ui.Shared/Meridian.Ui.Shared.csproj
@@ -36,6 +36,7 @@
     <ProjectReference Include="..\Meridian.Backtesting\Meridian.Backtesting.csproj" />
     <ProjectReference Include="..\Meridian.Backtesting.Sdk\Meridian.Backtesting.Sdk.csproj" />
     <ProjectReference Include="..\Meridian.DataIntegration\Meridian.DataIntegration.csproj" />
+    <ProjectReference Include="..\Meridian.Documents\Meridian.Documents.csproj" />
     <ProjectReference Include="..\Meridian.Entities\Meridian.Entities.csproj" />
     <ProjectReference Include="..\Meridian.Execution\Meridian.Execution.csproj" />
     <ProjectReference Include="..\Meridian.FSharp\Meridian.FSharp.fsproj" />

--- a/src/Meridian.Ui.Shared/Services/ReportingCertifiedArtifactProducer.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingCertifiedArtifactProducer.cs
@@ -57,6 +57,19 @@ public sealed class DeterministicReportingCertifiedArtifactProducer : IReporting
     private const int PdfCharactersPerLine = 86;
     private const int PdfLinesPerPage = 48;
 
+    private readonly IReportingPrimaryDocumentRenderer? _primaryRenderer;
+
+    /// <summary>
+    /// Constructs the producer with an optional client-grade primary-document renderer. When null
+    /// (dependency-free hosts and the existing byte-exact tests) the built-in plain-text PDF/XLSX
+    /// rendering is used; production composition injects a QuestPDF/ClosedXML renderer so governed
+    /// report packs export client-grade bytes. Every other artifact (CSV, evidence vault, preview,
+    /// manifest, grids) is unaffected by this choice.
+    /// </summary>
+    public DeterministicReportingCertifiedArtifactProducer(
+        IReportingPrimaryDocumentRenderer? primaryRenderer = null)
+        => _primaryRenderer = primaryRenderer;
+
     public ValueTask<ReportingGovernedArtifactProduction> ProduceAsync(
         ReportingOutputManifest manifest,
         CancellationToken cancellationToken = default)
@@ -220,16 +233,20 @@ public sealed class DeterministicReportingCertifiedArtifactProducer : IReporting
         return document;
     }
 
-    private static byte[] RenderArtifact(
+    private byte[] RenderArtifact(
         ReportingOutputManifest manifest,
         ReportingDeclaredArtifact declaration) => declaration.Kind switch
         {
             ReportingDeclaredArtifactKind.PrimaryOutput => manifest.ResolvedParameters!.OutputFormat switch
             {
-                ReportingOutputFormatDto.Xlsx => RenderXlsx(manifest),
+                ReportingOutputFormatDto.Xlsx => _primaryRenderer is { } workbookRenderer
+                    ? workbookRenderer.RenderWorkbook(manifest)
+                    : RenderXlsx(manifest),
                 ReportingOutputFormatDto.Csv => RenderPrimaryCsv(manifest),
                 ReportingOutputFormatDto.EvidenceVault => RenderEvidenceVault(manifest),
-                _ => RenderPdf(manifest)
+                _ => _primaryRenderer is { } documentRenderer
+                    ? documentRenderer.RenderPdf(manifest)
+                    : RenderPdf(manifest)
             },
             ReportingDeclaredArtifactKind.Preview => RenderPreview(manifest),
             ReportingDeclaredArtifactKind.CertifiedSourceSchedule => RenderCertifiedRowsCsv(manifest),
@@ -673,7 +690,7 @@ public sealed class DeterministicReportingCertifiedArtifactProducer : IReporting
         return builder.ToString();
     }
 
-    private static string[] ResolveCertifiedColumns(
+    internal static string[] ResolveCertifiedColumns(
         ImmutableArray<IReadOnlyDictionary<string, string>> rows) =>
         rows.IsDefaultOrEmpty
             ? []
@@ -699,7 +716,7 @@ public sealed class DeterministicReportingCertifiedArtifactProducer : IReporting
             "Correct and recertify the authoritative dataset, then retry artifact production.");
     }
 
-    private static string ComputeCertifiedRowsHash(
+    internal static string ComputeCertifiedRowsHash(
         ImmutableArray<IReadOnlyDictionary<string, string>> rows)
     {
         using var stream = new MemoryStream();

--- a/src/Meridian.Ui.Shared/Services/ReportingPrimaryDocumentRenderer.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingPrimaryDocumentRenderer.cs
@@ -1,0 +1,75 @@
+using System.Globalization;
+using Meridian.Contracts.Workstation;
+using Meridian.Documents;
+
+namespace Meridian.Ui.Shared.Services;
+
+/// <summary>
+/// Renders the primary PDF/XLSX artifact of a governed reporting run. This is the seam that lets the
+/// certified artifact producer stay the single orchestrator (declarations, hashing, retained
+/// manifest, provenance) while the client-grade document bytes are produced by
+/// <c>Meridian.Documents</c>. Implementations must be deterministic: identical manifests must yield
+/// identical bytes, because artifacts are hash-verified on read-back.
+/// </summary>
+public interface IReportingPrimaryDocumentRenderer
+{
+    byte[] RenderPdf(ReportingOutputManifest manifest);
+
+    byte[] RenderWorkbook(ReportingOutputManifest manifest);
+}
+
+/// <summary>
+/// Client-grade primary-document renderer backed by <see cref="ClientGradeReportRenderer"/>
+/// (QuestPDF/ClosedXML). It maps the certified reporting manifest into the presentation-neutral
+/// <see cref="ReportDocumentModel"/> and preserves the exact certified figures — only the
+/// presentation changes relative to the built-in plain-text output.
+/// </summary>
+public sealed class DocumentsReportingPrimaryDocumentRenderer : IReportingPrimaryDocumentRenderer
+{
+    private readonly ClientGradeReportRenderer _renderer = new();
+
+    public byte[] RenderPdf(ReportingOutputManifest manifest)
+        => _renderer.RenderPdf(BuildModel(manifest));
+
+    public byte[] RenderWorkbook(ReportingOutputManifest manifest)
+        => _renderer.RenderWorkbook(BuildModel(manifest));
+
+    private static ReportDocumentModel BuildModel(ReportingOutputManifest manifest)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+        var template = manifest.ResolvedTemplate!;
+        var rowHash = DeterministicReportingCertifiedArtifactProducer.ComputeCertifiedRowsHash(
+            manifest.CertifiedDatasetRows);
+
+        var headerFields = new List<ReportDocumentField>
+        {
+            new("Run", manifest.RunId),
+            new("Template", $"{template.Name} v{template.Version.ToString(CultureInfo.InvariantCulture)}"),
+            new("As of", manifest.AsOfDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)),
+            new("Source checkpoint", manifest.AuthoritativeSource!.CheckpointId),
+            new("Snapshot", manifest.CertifiedSnapshot!.SnapshotId),
+            new("Certified rows", manifest.CertifiedDatasetRows.Length.ToString(CultureInfo.InvariantCulture)),
+            new("Certified row hash", rowHash),
+        };
+
+        var tables = new List<ReportDocumentTable>();
+        var columns = DeterministicReportingCertifiedArtifactProducer.ResolveCertifiedColumns(
+            manifest.CertifiedDatasetRows);
+        if (columns.Length > 0)
+        {
+            var rows = manifest.CertifiedDatasetRows
+                .Select(row => (IReadOnlyList<string>)Array.ConvertAll(
+                    columns,
+                    column => row.TryGetValue(column, out var value) ? value : string.Empty))
+                .ToArray();
+            tables.Add(new ReportDocumentTable("Certified dataset", columns, rows));
+        }
+
+        return new ReportDocumentModel(
+            Title: template.Name,
+            HeaderFields: headerFields,
+            Tables: tables,
+            Subtitle: $"Governed report · run {manifest.RunId}",
+            FooterNote: $"Certified row hash {(rowHash.Length <= 16 ? rowHash : rowHash[..16])}");
+    }
+}

--- a/src/Meridian.Ui.Shared/Services/ReportingPrimaryDocumentRenderer.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingPrimaryDocumentRenderer.cs
@@ -1,6 +1,6 @@
 using System.Globalization;
-using Meridian.Contracts.Workstation;
 using Meridian.Documents;
+using Meridian.Reporting;
 
 namespace Meridian.Ui.Shared.Services;
 

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -463,7 +463,10 @@ public static class WorkstationServiceCollectionExtensions
                 sp.GetRequiredService<PostgresReportingReconciliationEvidenceStore>());
             services.TryAddSingleton<IReportingReconciliationEvidenceSource, ReportingReconciliationEvidenceSource>();
             services.TryAddSingleton<ReportingReconciliationEvidenceRetentionService>();
-            services.TryAddSingleton<IReportingCertifiedArtifactProducer, DeterministicReportingCertifiedArtifactProducer>();
+            services.TryAddSingleton<IReportingPrimaryDocumentRenderer, DocumentsReportingPrimaryDocumentRenderer>();
+            services.TryAddSingleton<IReportingCertifiedArtifactProducer>(sp =>
+                new DeterministicReportingCertifiedArtifactProducer(
+                    sp.GetRequiredService<IReportingPrimaryDocumentRenderer>()));
             services.TryAddSingleton<IReportingArtifactRetentionAuthorityProvider, ReportingArtifactRetentionAuthorityProvider>();
             services.TryAddSingleton<IReportingRestatementChangedLineResolver, GovernedReportingRestatementChangedLineResolver>();
             services.TryAddSingleton<IReportingRestatementCertificationInputProvider, GovernedReportingRestatementCertificationInputProvider>();

--- a/tests/Meridian.Tests/Ui/ReportingRunCertificationServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/ReportingRunCertificationServiceTests.cs
@@ -804,6 +804,84 @@ public sealed class ReportingRunCertificationServiceTests
     }
 
     [Fact]
+    public async Task ProduceAsync_ClientGradePdfIsValidAndByteStable()
+    {
+        var manifest = await BuildCertifiedManifestAsync("run-cg-pdf", ReportingOutputFormatDto.Pdf);
+        var producer = new DeterministicReportingCertifiedArtifactProducer(
+            new DocumentsReportingPrimaryDocumentRenderer());
+
+        var first = await producer.ProduceAsync(manifest);
+        var second = await producer.ProduceAsync(manifest);
+
+        var firstPdf = first.Artifacts.Single(artifact => artifact.FileName == "run-cg-pdf.pdf").Content.ToArray();
+        var secondPdf = second.Artifacts.Single(artifact => artifact.FileName == "run-cg-pdf.pdf").Content.ToArray();
+
+        Encoding.ASCII.GetString(firstPdf, 0, 5).Should().Be("%PDF-");
+        firstPdf.Should().Equal(secondPdf, "client-grade PDF bytes must be deterministic for hash verification");
+    }
+
+    [Fact]
+    public async Task ProduceAsync_ClientGradeXlsxIsValidWorkbookAndByteStable()
+    {
+        var manifest = await BuildCertifiedManifestAsync("run-cg-xlsx", ReportingOutputFormatDto.Xlsx);
+        var producer = new DeterministicReportingCertifiedArtifactProducer(
+            new DocumentsReportingPrimaryDocumentRenderer());
+
+        var first = await producer.ProduceAsync(manifest);
+        var second = await producer.ProduceAsync(manifest);
+
+        var firstXlsx = first.Artifacts.Single(artifact => artifact.FileName == "run-cg-xlsx.xlsx").Content.ToArray();
+        var secondXlsx = second.Artifacts.Single(artifact => artifact.FileName == "run-cg-xlsx.xlsx").Content.ToArray();
+
+        using (var archive = new ZipArchive(new MemoryStream(firstXlsx), ZipArchiveMode.Read))
+        {
+            archive.GetEntry("xl/workbook.xml").Should().NotBeNull();
+            archive.Entries.Count(entry =>
+                    entry.FullName.StartsWith("xl/worksheets/sheet", StringComparison.Ordinal))
+                .Should().BeGreaterThan(0);
+        }
+
+        firstXlsx.Should().Equal(secondXlsx, "client-grade XLSX bytes must be deterministic for hash verification");
+    }
+
+    [Fact]
+    public async Task ProduceAsync_ClientGradePreservesDeclarationsDescriptorsAndRetainedManifest()
+    {
+        var manifest = await BuildCertifiedManifestAsync("run-cg-parity", ReportingOutputFormatDto.Pdf);
+        var plain = await new DeterministicReportingCertifiedArtifactProducer().ProduceAsync(manifest);
+        var clientGrade = await new DeterministicReportingCertifiedArtifactProducer(
+                new DocumentsReportingPrimaryDocumentRenderer())
+            .ProduceAsync(manifest);
+
+        clientGrade.Artifacts.Select(artifact => artifact.ArtifactId)
+            .Should().Equal(plain.Artifacts.Select(artifact => artifact.ArtifactId));
+        clientGrade.ManifestArtifactId.Should().Be(plain.ManifestArtifactId);
+
+        var retainedManifest = clientGrade.Artifacts
+            .Single(artifact => artifact.ArtifactId == clientGrade.ManifestArtifactId)
+            .Content;
+        var retained = DeterministicReportingCertifiedArtifactProducer.ParseRetainedManifest(retainedManifest.Span);
+        retained.Artifacts.Should().OnlyContain(descriptor =>
+            descriptor.ContentHashSha256 == null || descriptor.ContentHashSha256.Length == 64);
+    }
+
+    [Fact]
+    public async Task ProduceAsync_ClientGradePdfRendersUnicodeAccountNamesWithoutRejection()
+    {
+        var rows = ImmutableArray.Create<IReadOnlyDictionary<string, string>>(
+            Row(
+                ("account", "Café Ünïcode 資本"),
+                ("debit", "100.00"),
+                ("credit", "0"),
+                ("netAmount", "100.00")));
+
+        var production = await ProduceClientGradeAsync("run-cg-unicode", ReportingOutputFormatDto.Pdf, rows);
+
+        var pdf = production.Artifacts.Single(artifact => artifact.FileName == "run-cg-unicode.pdf").Content.ToArray();
+        Encoding.ASCII.GetString(pdf, 0, 5).Should().Be("%PDF-");
+    }
+
+    [Fact]
     public async Task ProduceAsync_PdfPaginatesEveryAccountSummaryWithinVisiblePageBounds()
     {
         const int accountCount = 120;
@@ -1031,6 +1109,21 @@ public sealed class ReportingRunCertificationServiceTests
         string runId,
         ReportingOutputFormatDto outputFormat,
         ImmutableArray<IReadOnlyDictionary<string, string>> certifiedRows = default)
+        => await new DeterministicReportingCertifiedArtifactProducer()
+            .ProduceAsync(await BuildCertifiedManifestAsync(runId, outputFormat, certifiedRows));
+
+    private static async Task<ReportingGovernedArtifactProduction> ProduceClientGradeAsync(
+        string runId,
+        ReportingOutputFormatDto outputFormat,
+        ImmutableArray<IReadOnlyDictionary<string, string>> certifiedRows = default)
+        => await new DeterministicReportingCertifiedArtifactProducer(
+                new DocumentsReportingPrimaryDocumentRenderer())
+            .ProduceAsync(await BuildCertifiedManifestAsync(runId, outputFormat, certifiedRows));
+
+    private static async Task<ReportingOutputManifest> BuildCertifiedManifestAsync(
+        string runId,
+        ReportingOutputFormatDto outputFormat,
+        ImmutableArray<IReadOnlyDictionary<string, string>> certifiedRows = default)
     {
         var rows = certifiedRows.IsDefault ? Rows() : certifiedRows;
         var template = Template(reportWriterGrid: false);
@@ -1041,8 +1134,7 @@ public sealed class ReportingRunCertificationServiceTests
                 template,
                 Readiness("evaluation-artifact", CapturedAt, outputFormat),
                 Access());
-        var manifest = BuildManifest(runId, template, certified);
-        return await new DeterministicReportingCertifiedArtifactProducer().ProduceAsync(manifest);
+        return BuildManifest(runId, template, certified);
     }
 
     private static ReportingOutputManifest BuildManifest(


### PR DESCRIPTION
## Summary

Governed reporting packs now export client-grade, branded PDF and multi-sheet XLSX documents instead of a hand-built plain-text PDF and an all-`inlineStr` XLSX. A deterministic QuestPDF/ClosedXML renderer already existed in `Meridian.Documents` but was composed by no host; this wires it into the live governed-reporting path behind an injectable seam.

- New `IReportingPrimaryDocumentRenderer` seam keeps `DeterministicReportingCertifiedArtifactProducer` the single orchestrator (declarations, per-artifact SHA-256, retained manifest, provenance, approval, immutable vault); only the primary PDF/XLSX bytes are swapped.
- New `ClientGradeReportRenderer` + presentation-neutral `ReportDocumentModel` in `Meridian.Documents`; the determinism helpers (canonical zip ordering, pinned OPC timestamps, fixed metadata) are extracted and now shared with the existing `FinancialReportDocumentRenderer` (dedupe).
- The built-in plain-text rendering is retained as the dependency-free fallback when no renderer is injected, so existing byte-exact behavior and tests are unchanged; production DI injects the client-grade renderer.
- Certified figures are preserved exactly — only presentation changes. Unicode now renders instead of failing the run.
- Both the browser and WPF clients download the branded artifacts through the existing `/api/fund-structure/reporting/runs/{runId}/artifacts` endpoints — no new endpoints, and QuestPDF/ClosedXML stay isolated in `Meridian.Documents`.

This is Phase 1 of the client-grade deliverables work (`W9-REPORT-005`). Ledger-backed fund economics and a bespoke partners-capital statement layout are sequenced follow-ups.

## Reason

Surfaced by an adverse program review: for a "prove the number" product, governed report packs were exiting to Excel — the shipped PDF was plain text and the XLSX was all-text cells, so operators re-typed every deliverable. The client-grade renderer that could fix this already existed but was wired into no host. This makes the governed output the deliverable.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully — not run locally (no .NET SDK is installed in this environment); relies on the hosted `quality-gate`.
- [x] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated — none required for this change
- [ ] GitHub Actions `quality-gate` passed — pending on this PR

Added to `tests/Meridian.Tests/Ui/ReportingRunCertificationServiceTests.cs`: client-grade PDF/XLSX are valid and byte-stable across renders; declaration IDs, per-artifact SHA-256 descriptors, and the retained manifest match the plain-text producer in shape; Unicode account names render without rejection. Existing plain-text producer tests still exercise the retained fallback (they construct the producer with no renderer injected).

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KR4BGEhhu8m6JM7XcPvaQm

---
_Generated by [Claude Code](https://claude.ai/code/session_01KR4BGEhhu8m6JM7XcPvaQm)_