### PR TITLE
test(reporting): lock entity scope control identity

### DIFF
--- a/src/Meridian.Ui/dashboard/src/screens/report-run-parameters-screen.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/report-run-parameters-screen.test.tsx
@@ -341,7 +341,9 @@ describe("ReportRunParametersScreen", () => {
 
     expect(screen.getByRole("heading", { name: "Report Parameters" })).toBeInTheDocument();
     expect(screen.getByLabelText("Fund profile")).toHaveValue("fund-alpha");
-    expect(screen.getByLabelText("Entity / fund / portfolio")).toHaveValue("AllEntities");
+    const entityScopeSelect = screen.getByLabelText("Entity / fund / portfolio");
+    expect(entityScopeSelect).toHaveAttribute("id", "report-entity-scope");
+    expect(entityScopeSelect).toHaveValue("AllEntities");
     expect(screen.getByLabelText("Ledger book code")).toHaveValue("Primary GL");
     expect(screen.getByLabelText("Accounting basis")).toHaveValue("Gaap");
     expect(screen.getByLabelText("Output format")).toHaveValue("Pdf");


### PR DESCRIPTION
### Motivation
- Prevent a brittle browser regression by ensuring the reporting run-parameters UI test asserts the Entity / fund / portfolio select retains its stable DOM identity (`report-entity-scope`) and default value so the downstream `verify-browser` snapshot/interaction failure is guarded against silent label/control rewiring.

### Description
- Add an assertion to `src/Meridian.Ui/dashboard/src/screens/report-run-parameters-screen.test.tsx` that the Entity scope select has `id="report-entity-scope"` and the expected default value (`AllEntities`) to strengthen the reporting component regression coverage.

### Testing
- Ran the focused dashboard unit test: `npm --prefix src/Meridian.Ui/dashboard run test:vitest -- src/screens/report-run-parameters-screen.test.tsx` and the targeted Vitest run passed (`12` tests passed).
- Ran the file-size ratchet check: `python3 build/scripts/ci/check-file-size.py` and it passed (no new/grown god files).
- Attempted the full local gate `bash scripts/ci.sh` but the environment lacks a `dotnet` SDK so the script exited early at the .NET SDK verification step (CI remains blocked locally; GitHub Actions is the authoritative integration run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60caeab64c8320be281c4a0f0c8917)