### PR TITLE
Add storage topology Mermaid diagram and register it in docs index

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -50,6 +50,7 @@ This directory contains documentation about the system's design, architectural d
 | [MVVM Guidelines](mvvm-guidelines.md) | Browser workstation and WPF desktop view-model boundaries |
 | [Layer Boundaries](layer-boundaries.md) | Project dependency rules and enforcement |
 | [Storage Design](storage-design.md) | Tiered storage pipeline and WAL design |
+| [Storage Topology Diagram](diagrams/meridian-storage-topology.mmd) | File-backed and PostgreSQL durable stores, control services, and their consumers |
 | [Deterministic Canonicalization](deterministic-canonicalization.md) | Data normalization and deduplication |
 | [Desktop Layers](desktop-layers.md) | WPF desktop application architecture |
 | [Why This Architecture](why-this-architecture.md) | Design rationale and tradeoffs |

--- a/docs/architecture/diagrams/meridian-storage-topology.mmd
+++ b/docs/architecture/diagrams/meridian-storage-topology.mmd
@@ -1,0 +1,95 @@
+flowchart TB
+  classDef input fill:#eef2ff,stroke:#4338ca,color:#1e1b4b
+  classDef durable fill:#ecfdf5,stroke:#047857,color:#064e3b
+  classDef control fill:#fffbeb,stroke:#b45309,color:#78350f
+  classDef relational fill:#eff6ff,stroke:#1d4ed8,color:#1e3a8a
+  classDef consumer fill:#fdf2f8,stroke:#be185d,color:#831843
+  classDef boundary fill:#f8fafc,stroke:#475569,color:#0f172a
+
+  subgraph Inputs["Durable-input sources"]
+    direction LR
+    Market["Market and historical data"]:::input
+    Provider["Provider integration payloads<br/>and quarantine evidence"]:::input
+    Operations["Operational workflow,<br/>reconciliation, and audit events"]:::input
+    Accounting["Accounting, fund, banking,<br/>and lending commands"]:::input
+  end
+
+  subgraph FileStore["File-backed durable storage (DataRoot)"]
+    direction TB
+    Wal["Write-ahead log<br/>crash recovery and replay"]:::durable
+    Atomic["Atomic-file writer<br/>complete replacement before swap"]:::durable
+    Jsonl["JSONL market-data and<br/>operational evidence"]:::durable
+    Parquet["Parquet analytical/archive data"]:::durable
+    Sidecars["Backfill checkpoints, quality outcomes,<br/>runtime receipts, configuration, and sidecars"]:::durable
+    CaseHistory["Operational case history<br/>hash-chained JSONL"]:::durable
+    IntegrationEvidence["Provider manifests, raw payloads,<br/>staging, quarantine, and handoff evidence"]:::durable
+  end
+
+  subgraph Control["Storage control, lineage, and lifecycle"]
+    direction LR
+    Catalog["Catalog, search, and lineage"]:::control
+    Quality["Quality trends and<br/>confidence evidence"]:::control
+    Coordination["Shared-storage leases"]:::control
+    Tiering["Retention, tier migration,<br/>packaging, and export"]:::control
+  end
+
+  subgraph Postgres["PostgreSQL governed-record stores"]
+    direction LR
+    Security["Security Master and<br/>Direct Lending"]:::relational
+    Fund["Fund Structure, Fund Accounts,<br/>Banking, and Money Market"]:::relational
+    Ledger["Ledger journals, periods,<br/>tax lots, and continuity"]:::relational
+    Reporting["Immutable report artifacts,<br/>governance, delivery, and audit"]:::relational
+    AssetOps["Asset Operations<br/>projections and evidence"]:::relational
+  end
+
+  subgraph Consumers["Consumers and derived outputs"]
+    direction LR
+    Runtime["Meridian host and<br/>application services"]:::consumer
+    Workstations["Browser and WPF<br/>workstations"]:::consumer
+    Replay["Replay, backtesting,<br/>reconciliation, and reporting"]:::consumer
+    Exports["Portable packages and<br/>governed exports"]:::consumer
+  end
+
+  Market --> Wal
+  Provider --> Wal
+  Operations --> CaseHistory
+  Operations --> IntegrationEvidence
+  Accounting --> Ledger
+  Accounting --> Fund
+  Accounting --> AssetOps
+
+  Wal --> Jsonl
+  Wal --> Parquet
+  Atomic --> Sidecars
+  Atomic --> CaseHistory
+  Atomic --> IntegrationEvidence
+  Jsonl --> Catalog
+  Parquet --> Catalog
+  Sidecars --> Catalog
+  CaseHistory --> Catalog
+  IntegrationEvidence --> Catalog
+  Catalog --> Quality
+  Catalog --> Tiering
+  Coordination -. "lease state" .-> Atomic
+  Tiering -. "promote / retain" .-> Jsonl
+  Tiering -. "archive" .-> Parquet
+
+  Security --> Ledger
+  Fund --> Ledger
+  AssetOps --> Ledger
+  Ledger --> Reporting
+  CaseHistory -. "workflow evidence" .-> Ledger
+  CaseHistory -. "workflow evidence" .-> Reporting
+
+  Jsonl --> Replay
+  Parquet --> Replay
+  Catalog --> Replay
+  Security --> Runtime
+  Fund --> Runtime
+  Ledger --> Workstations
+  Reporting --> Workstations
+  Quality --> Workstations
+  Tiering --> Exports
+  Reporting --> Exports
+
+  class Inputs,FileStore,Control,Postgres,Consumers boundary

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -39,6 +39,7 @@ The index below keeps basename references for readability; use the folders above
 | **Data Flow** | End-to-end data flow from sources to export | `data-flow.dot` |
 | **Provider Architecture** | Data provider abstraction, manifest-driven setup, sync-run evidence, staging, and reconciliation handoff | `provider-architecture.dot` |
 | **Storage Architecture** | Storage pipeline with WAL, compression, tiering | `storage-architecture.dot` |
+| **Storage Topology** | Maintained Mermaid view of file-backed stores, PostgreSQL governed records, lifecycle controls, and consumers | `../architecture/diagrams/meridian-storage-topology.mmd` |
 | **Event Pipeline Sequence** | Detailed event processing sequence | `event-pipeline-sequence.dot` |
 | **Resilience Patterns** | Circuit breakers, retry, failover patterns | `resilience-patterns.dot` |
 | **Deployment Options** | Standalone and Docker deployment paths | `deployment-options.dot` |

--- a/docs/source/data/diagram-index.yml
+++ b/docs/source/data/diagram-index.yml
@@ -4,6 +4,26 @@ schema:
   minimum_renderer_version: "1.0.0"
 
 diagrams:
+  - id: DIA-STORAGE-TOPOLOGY
+    title: Storage topology
+    source: docs/architecture/diagrams/meridian-storage-topology.mmd
+    output: docs/architecture/assets/meridian-storage-topology.svg
+    type: mermaid
+    modules:
+      - SRC-STORAGE
+      - SRC-APP
+      - SRC-CONTRACTS
+      - SRC-LEDGER
+      - SRC-UI-SHARED
+    roadmap_items:
+      - W1-DATA-001
+      - W3-CONT-001
+      - W4-RECON-001
+      - W4-RPT-001
+      - W5-ACCT-001
+    update_when:
+      - File-backed or PostgreSQL persistence ownership changes.
+      - Storage control, lifecycle, or governed-publication paths change.
   - id: DIA-ASSURANCE-LOOP
     title: Meridian assurance loop
     source: docs/architecture/diagrams/meridian-assurance-loop.mmd

--- a/docs/source/data/source-modules.yml
+++ b/docs/source/data/source-modules.yml
@@ -255,6 +255,7 @@ modules:
       - dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~EtlJobDefinitionStoreTests|FullyQualifiedName~EtlJobOrchestratorTests" --logger "console;verbosity=normal" /m:1 /nr:false /p:EnableWindowsTargeting=true /p:UseSharedCompilation=false --no-restore
     diagrams:
       - DIA-ASSURANCE-LOOP
+      - DIA-STORAGE-TOPOLOGY
     todos: []
     last_reviewed: 2026-07-15
 

--- a/docs/source/generated/MANIFEST.json
+++ b/docs/source/generated/MANIFEST.json
@@ -6,11 +6,11 @@
   "inputs": [
     {
       "path": "docs/source/data/diagram-index.yml",
-      "sha256": "aa8a2d0ad0b2eaf9406508d1146f41681aaac51715b3c71d574b44d0f77a6292"
+      "sha256": "94ce292eaabc99717939e36546e339644b461c3227ac9124b905b7c9168c1855"
     },
     {
       "path": "docs/source/data/source-modules.yml",
-      "sha256": "d909812d25312bb03fe34feb6a6ce8edd0cd214c2cd4e116d5d1e8e2e6ee10db"
+      "sha256": "fcfba099aeab3620bcf2f42517d4ad5b8cff82e31332adeb55bef924b3e54ec3"
     },
     {
       "path": "docs/source/data/source-readme-coverage.yml",


### PR DESCRIPTION
### Motivation
- Provide a maintained visual of the storage topology describing file-backed durable stores, PostgreSQL governed-record stores, lifecycle controls, and consumers. 
- Surface the topology in the documentation index and module metadata so it is discoverable and included in automated doc generation. 

### Description
- Add a new Mermaid diagram file at `docs/architecture/diagrams/meridian-storage-topology.mmd` that documents WAL, file-backed stores, control services, Postgres stores, and consumers. 
- Register the diagram in the architecture README by adding a `Storage Topology Diagram` link in `docs/architecture/README.md`. 
- Add an index entry for `DIA-STORAGE-TOPOLOGY` in `docs/source/data/diagram-index.yml` and reference the diagram from `docs/diagrams/README.md`. 
- Include `DIA-STORAGE-TOPOLOGY` in the `SRC-STORAGE` module's `diagrams` list in `docs/source/data/source-modules.yml` and update `docs/source/generated/MANIFEST.json` checksums produced by the docs generator. 

### Testing
- Ran the docs generator `build/scripts/docs/render-source-docs.py` to regenerate the manifest and validate the new diagram entry, and the run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60ca4bcaa88320a6ea3e3ab5b70663)