### PR TITLE
IBKR: expose runtime mode, provide account/portfolio/activity sync, and block live routing on simulated runtimes

### DIFF
--- a/docs/operators/provider-onboarding-interactive-brokers.md
+++ b/docs/operators/provider-onboarding-interactive-brokers.md
@@ -56,6 +56,8 @@ In TWS/Gateway:
 - confirm build mode exposed by status endpoint matches intended mode,
 - confirm socket readiness and Client Portal readiness when enabled,
 - verify market data, historical bars, and paper-order roundtrip,
+- verify that the runtime surface reports `Paper` for paper TWS/Gateway and `Live` only for a vendor-enabled live connection; a guidance or smoke build must never be promoted as live,
+- import an account-scoped IB Flex report and reconcile its trades, cash transactions, fees, interest, FX conversions, and corporate actions against the API/TWS snapshot; investigate every variance before live promotion,
 - ensure live routing remains disabled until paper validation is complete.
 
 ## Evidence requirements

--- a/docs/source/generated/source-hash-manifest.json
+++ b/docs/source/generated/source-hash-manifest.json
@@ -191,8 +191,8 @@
       "id": "SRC-INFRASTRUCTURE",
       "path": "src/Meridian.Infrastructure",
       "readme": "src/Meridian.Infrastructure/README.md",
-      "readme_hash": "4180aa83aa7f1121bf52bf9ee41a009e42f1bd7dc3aa3ce37a4c1fc29f6ea7f9",
-      "source_hash": "7fac6574f8e46da01a537e0887e23ec5bbbe0fbee66ea90d747d3440713a193d"
+      "readme_hash": "c6015eceed0be87a25be91e2d10f7010cb07faa75579bd8aaefeafc612563418",
+      "source_hash": "6251b39285d598cb1e4037406c36a52fc48fd42536d9563ebc7cdca36343766e"
     },
     {
       "id": "SRC-LAUNCHER",

--- a/src/Meridian.Execution.Sdk/BrokerageOrderPlacementGate.cs
+++ b/src/Meridian.Execution.Sdk/BrokerageOrderPlacementGate.cs
@@ -38,6 +38,15 @@ public static class BrokerageOrderPlacementGate
             flow = new BrokerFlowFlags();
         }
 
+        // A broker selected for production routing must be backed by a real runtime.  In
+        // particular, an IBAPI guidance/simulation build must never become a live route merely
+        // because the surrounding configuration has completed its other promotion gates.
+        if (configuration.LiveExecutionEnabled && IsSimulatedMode(executionMode))
+        {
+            return BrokerageOrderPlacementGateDecision.Rejected(
+                $"Live execution cannot route through broker '{gatewayId}' because its runtime mode is {executionMode}.");
+        }
+
         if (IsSimulatedMode(executionMode))
         {
             return flow.PaperOrderFlowEnabled

--- a/src/Meridian.Infrastructure/Adapters/Core/ProviderCapabilityDescriptorCatalog.cs
+++ b/src/Meridian.Infrastructure/Adapters/Core/ProviderCapabilityDescriptorCatalog.cs
@@ -29,7 +29,7 @@ public static class ProviderCapabilityDescriptorCatalog
             InstrumentTypes: [InstrumentType.Equity, InstrumentType.EquityOption, InstrumentType.Crypto]),
         new("synthetic", Historical: typeof(SyntheticHistoricalDataProvider),
             InstrumentTypes: [InstrumentType.Equity]),
-        new("ib", Historical: typeof(IBHistoricalDataProvider),
+        new("ib", typeof(IBMarketDataClient), typeof(IBHistoricalDataProvider), Brokerage: typeof(IBBrokerageGateway),
             InstrumentTypes:
             [
                 InstrumentType.Equity, InstrumentType.EquityOption, InstrumentType.IndexOption,

--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBBrokerageGateway.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBBrokerageGateway.cs
@@ -25,7 +25,12 @@ namespace Meridian.Infrastructure.Adapters.InteractiveBrokers;
 [ImplementsAdr("ADR-001", "IB brokerage provider implementation")]
 [ImplementsAdr("ADR-004", "All async methods support CancellationToken")]
 [ImplementsAdr("ADR-005", "Attribute-based provider discovery")]
-public sealed class IBBrokerageGateway : IBrokerageGateway
+public sealed class IBBrokerageGateway :
+    IBrokerageGateway,
+    IExecutionGatewayModeProvider,
+    IBrokerageAccountCatalog,
+    IBrokeragePortfolioSync,
+    IBrokerageActivitySync
 {
     private static readonly TimeSpan CallbackTimeout = TimeSpan.FromSeconds(10);
 
@@ -36,6 +41,7 @@ public sealed class IBBrokerageGateway : IBrokerageGateway
     private readonly ConcurrentDictionary<int, SubmittedOrderContext> _submittedOrders = new();
     private readonly ConcurrentDictionary<string, int> _gatewayOrderIdsByExternalId = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<int, BrokerOrder> _openOrders = new();
+    private readonly ConcurrentDictionary<string, IBExecutionUpdate> _executions = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<int, PendingOrderOperation> _pendingOrderOperations = new();
     private readonly ConcurrentDictionary<int, AccountSummaryCollector> _accountSummaryRequests = new();
     private readonly SemaphoreSlim _openOrdersGate = new(1, 1);
@@ -80,6 +86,30 @@ public sealed class IBBrokerageGateway : IBrokerageGateway
 
     /// <inheritdoc />
     public string BrokerDisplayName => "Interactive Brokers";
+
+    /// <summary>
+    /// Exposes the actual runtime posture to the OMS. A guidance build is explicitly simulation,
+    /// which prevents a configuration-only promotion from treating it as a live broker.
+    /// </summary>
+    public Meridian.Execution.Sdk.ExecutionMode ExecutionMode
+    {
+        get
+        {
+#if IBAPI_VENDOR
+            return _options.UsePaperTrading
+                ? Meridian.Execution.Sdk.ExecutionMode.Paper
+                : Meridian.Execution.Sdk.ExecutionMode.Live;
+#else
+            return Meridian.Execution.Sdk.ExecutionMode.Simulation;
+#endif
+        }
+    }
+
+    /// <inheritdoc />
+    public string ProviderId => "ibkr";
+
+    /// <inheritdoc />
+    public string ProviderDisplayName => BrokerDisplayName;
 
     /// <inheritdoc />
     public BrokerageCapabilities BrokerageCapabilities { get; } = new()
@@ -302,6 +332,110 @@ public sealed class IBBrokerageGateway : IBrokerageGateway
             _openOrdersSnapshotBuffer = null;
             _openOrdersGate.Release();
         }
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<BrokerageExternalAccountDto>> GetAccountsAsync(CancellationToken ct = default)
+    {
+        var account = await GetAccountInfoAsync(ct).ConfigureAwait(false);
+        return
+        [
+            new BrokerageExternalAccountDto(
+                ProviderId,
+                account.AccountId,
+                string.IsNullOrWhiteSpace(account.AccountId) ? BrokerDisplayName : $"{BrokerDisplayName} {account.AccountId}",
+                account.Status,
+                account.Currency,
+                account.RetrievedAt,
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["gatewayId"] = GatewayId,
+                    ["executionMode"] = ExecutionMode.ToString()
+                })
+        ];
+    }
+
+    /// <inheritdoc />
+    public async Task<BrokeragePortfolioSnapshotDto> GetPortfolioSnapshotAsync(
+        string externalAccountId,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(externalAccountId);
+
+        var accountTask = GetAccountInfoAsync(ct);
+        var positionsTask = GetPositionsAsync(ct);
+        await Task.WhenAll(accountTask, positionsTask).ConfigureAwait(false);
+
+        var account = await accountTask.ConfigureAwait(false);
+        var positions = await positionsTask.ConfigureAwait(false);
+        var accountId = string.IsNullOrWhiteSpace(externalAccountId) ? account.AccountId : externalAccountId;
+        return new BrokeragePortfolioSnapshotDto(
+            new BrokerageExternalAccountDto(
+                ProviderId,
+                accountId,
+                string.IsNullOrWhiteSpace(account.AccountId) ? BrokerDisplayName : $"{BrokerDisplayName} {account.AccountId}",
+                account.Status,
+                account.Currency,
+                account.RetrievedAt,
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["gatewayId"] = GatewayId,
+                    ["executionMode"] = ExecutionMode.ToString()
+                }),
+            new BrokerageBalanceSnapshotDto(account.Cash, account.Equity, account.BuyingPower, account.Currency),
+            positions.Select(position => new BrokeragePositionSnapshotDto(
+                position.Symbol,
+                position.Quantity,
+                position.AverageEntryPrice,
+                position.MarketPrice,
+                position.MarketValue,
+                position.UnrealizedPnl,
+                position.AssetClass,
+                position.Description,
+                position.PositionId,
+                account.Currency,
+                position.Metadata)).ToArray(),
+            DateTimeOffset.UtcNow);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// TWS publishes executions during the connected session. This intentionally returns only
+    /// those source-identified callbacks; Flex imports remain the controlled backstop for cash,
+    /// dividends, interest, fees, FX conversions, and prior-session activity.
+    /// </remarks>
+    public async Task<BrokerageActivitySnapshotDto> GetActivitySnapshotAsync(
+        string externalAccountId,
+        DateTimeOffset? since = null,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(externalAccountId);
+
+        var orders = await GetOpenOrdersAsync(ct).ConfigureAwait(false);
+        var fills = _executions.Values
+            .Where(execution => string.Equals(execution.Account, externalAccountId, StringComparison.OrdinalIgnoreCase))
+            .Where(execution => !since.HasValue || execution.ExecutedAt >= since.Value)
+            .OrderBy(execution => execution.ExecutedAt)
+            .Select(execution => new BrokerageFillSnapshotDto(
+                execution.ExecutionId,
+                execution.OrderId.ToString(),
+                execution.Symbol,
+                IBCanonicalPayloadMapper.ParseSide(execution.Side, execution.Metadata),
+                execution.Shares,
+                (decimal)execution.Price,
+                execution.ExecutedAt,
+                execution.Exchange))
+            .ToArray();
+
+        return new BrokerageActivitySnapshotDto(
+            ProviderId,
+            externalAccountId,
+            DateTimeOffset.UtcNow,
+            orders.Select(order => new BrokerageOrderSnapshotDto(
+                order.OrderId, order.ClientOrderId, order.Symbol, order.Side, order.Type, order.Status,
+                order.Quantity, order.FilledQuantity, order.LimitPrice, order.StopPrice, order.CreatedAt)).ToArray(),
+            fills,
+            Array.Empty<BrokerageCashTransactionDto>());
     }
 
     /// <inheritdoc />
@@ -658,6 +792,9 @@ public sealed class IBBrokerageGateway : IBrokerageGateway
 
     private void OnExecutionDetailsReceived(object? sender, IBExecutionUpdate update)
     {
+        if (!string.IsNullOrWhiteSpace(update.ExecutionId))
+            _executions[update.ExecutionId] = update;
+
         var gatewayOrderId = update.OrderId;
         var context = _submittedOrders.TryGetValue(gatewayOrderId, out var tracked) ? tracked : null;
         var orderQuantity = context?.Quantity ?? update.CumulativeQuantity;

--- a/src/Meridian.Infrastructure/Meridian.Infrastructure.csproj
+++ b/src/Meridian.Infrastructure/Meridian.Infrastructure.csproj
@@ -91,7 +91,7 @@
     <Error Condition="'$(EnableIbApiSmoke)' == 'true' and '$(EnableIbApiRuntime)' == 'true'" Text="EnableIbApiSmoke=true cannot be combined with EnableIbApiVendor=true or legacy DefineConstants=IBAPI. Use one Interactive Brokers build mode at a time." />
     <Error Condition="'$(EnableIbApiRuntime)' == 'true' and '$(EnableIbApiSmoke)' != 'true' and '$(IBApiProjectPath)' != '' and !Exists('$(IBApiProjectPath)')" Text="IBApiProjectPath '$(IBApiProjectPath)' was provided but does not exist." />
     <Error Condition="'$(EnableIbApiRuntime)' == 'true' and '$(EnableIbApiSmoke)' != 'true' and '$(IBApiDllPath)' != '' and !Exists('$(IBApiDllPath)')" Text="IBApiDllPath '$(IBApiDllPath)' was provided but does not exist." />
-    <Error Condition="'$(EnableIbApiRuntime)' == 'true' and '$(EnableIbApiSmoke)' != 'true' and '$(ResolvedIbApiProjectPath)' == '' and '$(ResolvedIbApiDllPath)' == ''" Text="Interactive Brokers vendor mode was requested but no official IBApi project or DLL was resolved. Place the vendor SDK under external\IBApi, or set IBApiProjectPath/IBApiDllPath. See docs/providers/interactive-brokers-setup.md." />
+    <Error Condition="'$(EnableIbApiRuntime)' == 'true' and '$(EnableIbApiSmoke)' != 'true' and '$(ResolvedIbApiProjectPath)' == '' and '$(ResolvedIbApiDllPath)' == ''" Text="Interactive Brokers vendor mode was requested but no official IBApi project or DLL was resolved. Place the vendor SDK under external\IBApi, or set IBApiProjectPath/IBApiDllPath. See docs/operators/provider-onboarding-interactive-brokers.md." />
   </Target>
 
   <!-- Provider implementation templates live under docs/examples/provider-template/ and are no longer part of this project. -->

--- a/src/Meridian.Infrastructure/README.md
+++ b/src/Meridian.Infrastructure/README.md
@@ -104,7 +104,12 @@ corporate-action, and factor evidence without placing orders. Adapter readiness 
 any write-capable live execution path back to the shared execution governance gates.
 Interactive Brokers contract construction resolves default SecType values from the Contracts-owned
 `InstrumentTypeDescriptorCatalog`, while still honoring explicit provider SecType overrides such
-as `GOVT` for government bonds.
+as `GOVT` for government bonds. The IBKR gateway exposes its actual execution mode to the shared
+OMS, so guidance or smoke builds are simulation-only and cannot be promoted into live routing by
+configuration. It also owns account catalog, portfolio snapshot, and connected-session execution
+sync: source-identified TWS execution callbacks provide fills and open-order evidence, while
+account-scoped Flex imports remain the controlled reconciliation backstop for fees, cash,
+dividends, interest, FX conversions, corporate actions, and prior-session activity.
 The brokerage gateway template remains an obsolete copy-target, but its scaffold behavior is
 deterministic: provider-discovery metadata, option-backed identity/capabilities, configurable
 connection readiness, option-backed account/position reads, and in-memory open-order tracking let

--- a/src/Meridian/HostedBrokerageGatewayServiceCollectionExtensions.cs
+++ b/src/Meridian/HostedBrokerageGatewayServiceCollectionExtensions.cs
@@ -38,8 +38,9 @@ internal static class HostedBrokerageGatewayServiceCollectionExtensions
         });
         services.AddBrokerageGateway("ib", sp => sp.GetRequiredService<IBBrokerageGateway>());
         services.AddBrokerageGateway("ibkr", sp => sp.GetRequiredService<IBBrokerageGateway>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IBrokerageAccountCatalog, IbBrokerageSyncAdapter>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IBrokeragePortfolioSync, IbBrokerageSyncAdapter>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IBrokerageAccountCatalog>(sp => sp.GetRequiredService<IBBrokerageGateway>()));
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IBrokeragePortfolioSync>(sp => sp.GetRequiredService<IBBrokerageGateway>()));
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IBrokerageActivitySync>(sp => sp.GetRequiredService<IBBrokerageGateway>()));
 
         RegisterOptionalStockSharpGateway(services);
 
@@ -109,62 +110,6 @@ internal static class HostedBrokerageGatewayServiceCollectionExtensions
             DateTimeOffset? since,
             CancellationToken ct)
             => _activitySync.GetActivitySnapshotAsync(externalAccountId, since, ct);
-    }
-
-    private sealed class IbBrokerageSyncAdapter(IBBrokerageGateway gateway) :
-        IBrokerageAccountCatalog,
-        IBrokeragePortfolioSync
-    {
-        public string ProviderId => "ibkr";
-
-        public string ProviderDisplayName => "Interactive Brokers";
-
-        public async Task<IReadOnlyList<BrokerageExternalAccountDto>> GetAccountsAsync(CancellationToken ct)
-        {
-            var account = await gateway.GetAccountInfoAsync(ct).ConfigureAwait(false);
-            return [new BrokerageExternalAccountDto(
-                ProviderId: ProviderId,
-                AccountId: account.AccountId,
-                DisplayName: string.IsNullOrWhiteSpace(account.AccountId) ? ProviderDisplayName : $"{ProviderDisplayName} {account.AccountId}",
-                Status: account.Status,
-                Currency: account.Currency,
-                RetrievedAt: account.RetrievedAt)];
-        }
-
-        public async Task<BrokeragePortfolioSnapshotDto> GetPortfolioSnapshotAsync(string externalAccountId, CancellationToken ct)
-        {
-            var account = await gateway.GetAccountInfoAsync(ct).ConfigureAwait(false);
-            var positions = await gateway.GetPositionsAsync(ct).ConfigureAwait(false);
-            var now = DateTimeOffset.UtcNow;
-            var accountDto = new BrokerageExternalAccountDto(
-                ProviderId: ProviderId,
-                AccountId: string.IsNullOrWhiteSpace(externalAccountId) ? account.AccountId : externalAccountId,
-                DisplayName: string.IsNullOrWhiteSpace(account.AccountId) ? ProviderDisplayName : $"{ProviderDisplayName} {account.AccountId}",
-                Status: account.Status,
-                Currency: account.Currency,
-                RetrievedAt: account.RetrievedAt);
-
-            return new BrokeragePortfolioSnapshotDto(
-                Account: accountDto,
-                Balance: new BrokerageBalanceSnapshotDto(
-                    Cash: account.Cash,
-                    Equity: account.Equity,
-                    BuyingPower: account.BuyingPower,
-                    Currency: account.Currency),
-                Positions: positions.Select(position => new BrokeragePositionSnapshotDto(
-                    Symbol: position.Symbol,
-                    Quantity: position.Quantity,
-                    AverageEntryPrice: position.AverageEntryPrice,
-                    MarketPrice: position.MarketPrice,
-                    MarketValue: position.MarketValue,
-                    UnrealizedPnl: position.UnrealizedPnl,
-                    AssetClass: position.AssetClass,
-                    Description: position.Description,
-                    PositionId: position.PositionId,
-                    Currency: account.Currency,
-                    Metadata: position.Metadata)).ToArray(),
-                RetrievedAt: now);
-        }
     }
 
     private sealed class StockSharpBrokerageGatewayAccessor(IServiceProvider services, Type gatewayType)

--- a/tests/Meridian.Tests/Execution/BrokerageOrderPlacementGateTests.cs
+++ b/tests/Meridian.Tests/Execution/BrokerageOrderPlacementGateTests.cs
@@ -131,6 +131,20 @@ public sealed class BrokerageOrderPlacementGateTests : IDisposable
         decision.RejectReason.Should().Contain("Live execution must be explicitly enabled");
     }
 
+    [Fact]
+    public void Evaluate_LiveConfiguredWithSimulationRuntime_Rejects()
+    {
+        var configuration = CreateLiveReadyConfiguration(gateway: "ib");
+
+        var decision = BrokerageOrderPlacementGate.Evaluate(
+            configuration,
+            selectedGatewayId: "ib",
+            selectedExecutionMode: ExecutionMode.Simulation);
+
+        decision.IsAllowed.Should().BeFalse();
+        decision.RejectReason.Should().Contain("cannot route").And.Contain("Simulation");
+    }
+
     [Theory]
     [InlineData(nameof(BrokerageConfiguration.ReadOnlyPhaseEnabled), "read-only phase is disabled")]
     [InlineData(nameof(BrokerageConfiguration.PaperTradingPhaseEnabled), "paper-trading phase is disabled")]

--- a/tests/Meridian.Tests/Execution/HostedBrokerageGatewayRegistrationTests.cs
+++ b/tests/Meridian.Tests/Execution/HostedBrokerageGatewayRegistrationTests.cs
@@ -43,7 +43,7 @@ public sealed class HostedBrokerageGatewayRegistrationTests
         provider.GetServices<IBrokerageActivitySync>()
             .Select(sync => sync.ProviderId)
             .Should()
-            .Contain(["alpaca", "robinhood"]);
+            .Contain(["alpaca", "ibkr", "robinhood"]);
 
         var surfaces = HostedBrokerageGatewayRuntimeSurfaceCatalog.Build(provider);
         surfaces.Should().Contain(surface =>
@@ -65,7 +65,7 @@ public sealed class HostedBrokerageGatewayRegistrationTests
             surface.GatewayIdMatchesRuntimeKey &&
             surface.SupportsAccountCatalog &&
             surface.SupportsPortfolioSync &&
-            !surface.SupportsActivitySync &&
+            surface.SupportsActivitySync &&
             surface.ValidationIssues.Count == 0);
         surfaces.Should().Contain(surface =>
             surface.GatewayId == "ibkr" &&

--- a/tests/Meridian.Tests/Infrastructure/Providers/IBBrokerageGatewayTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/IBBrokerageGatewayTests.cs
@@ -394,6 +394,45 @@ public sealed class IBBrokerageGatewayTests
         account.Status.Should().Be("paper");
     }
 
+    [Fact]
+    public async Task ReadSideSync_MapsAccountPortfolioAndSessionExecutionEvidence()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var client = new FakeIbBrokerageClient
+        {
+            OnRequestNextValidId = c => c.RaiseNextValidId(9001),
+            OnRequestAccountSummary = (c, requestId) =>
+            {
+                c.RaiseAccountSummary(new IBAccountSummaryUpdate(requestId, "DU123456", "NetLiquidation", "125000", "USD", now));
+                c.RaiseAccountSummary(new IBAccountSummaryUpdate(requestId, "DU123456", "TotalCashValue", "25000", "USD", now));
+                c.RaiseAccountSummary(new IBAccountSummaryUpdate(requestId, "DU123456", "BuyingPower", "50000", "USD", now));
+                c.RaiseAccountSummaryCompleted(requestId);
+            },
+            OnRequestPositions = c =>
+            {
+                c.RaisePosition(new IBPositionUpdate("DU123456", "IEF", "BOND", 5m, 99.5d, "USD", "SMART", null, now));
+                c.RaisePositionsCompleted();
+            },
+            OnRequestOpenOrders = c => c.RaiseOpenOrdersCompleted()
+        };
+
+        await using var sut = CreateSut(client);
+        await sut.ConnectAsync();
+        client.RaiseExecution(new IBExecutionUpdate(
+            9001, "IEF", "BOT", 5m, 99.5d, 5m, 99.5d, "exec-9001", "DU123456", "SMART", 17L,
+            new Dictionary<string, string> { ["conId"] = "1234" }, now));
+
+        var accounts = await ((IBrokerageAccountCatalog)sut).GetAccountsAsync();
+        var portfolio = await ((IBrokeragePortfolioSync)sut).GetPortfolioSnapshotAsync("DU123456");
+        var activity = await ((IBrokerageActivitySync)sut).GetActivitySnapshotAsync("DU123456", now.AddMinutes(-1));
+
+        accounts.Should().ContainSingle(account => account.ProviderId == "ibkr" && account.AccountId == "DU123456");
+        portfolio.Positions.Should().ContainSingle(position => position.Symbol == "IEF" && position.AssetClass == "bond");
+        activity.Fills.Should().ContainSingle(fill =>
+            fill.FillId == "exec-9001" && fill.OrderId == "9001" && fill.Venue == "SMART");
+        activity.CashTransactions.Should().BeEmpty("cash, fee, dividend, and FX evidence is supplied by the controlled Flex backstop");
+    }
+
     private static async Task<ExecutionReport> ReadUntilAsync(
         IAsyncEnumerable<ExecutionReport> stream,
         Func<ExecutionReport, bool> predicate,

--- a/tests/Meridian.Tests/Providers/ProviderCapabilityDescriptorCatalogTests.cs
+++ b/tests/Meridian.Tests/Providers/ProviderCapabilityDescriptorCatalogTests.cs
@@ -9,6 +9,7 @@ using Meridian.Infrastructure.Adapters.Core;
 using Meridian.Infrastructure.Adapters.Edgar;
 using Meridian.Infrastructure.Adapters.Finnhub;
 using Meridian.Infrastructure.Adapters.Fred;
+using Meridian.Infrastructure.Adapters.InteractiveBrokers;
 using Meridian.Infrastructure.Adapters.NasdaqDataLink;
 using Meridian.Infrastructure.Adapters.Robinhood;
 using Meridian.Infrastructure.Adapters.Tiingo;
@@ -73,9 +74,11 @@ public sealed class ProviderCapabilityDescriptorCatalogTests
         services.AddSingleton(new AlpacaOptions(
             KeyId: "AKTESTDESCRIPTOR0001",
             SecretKey: "descriptor-secret-for-di-tests"));
+        services.AddSingleton(new IBOptions());
         services.AddSingleton<IMarketEventPublisher, TestMarketEventPublisher>();
         services.AddSingleton<QuoteCollector>();
         services.AddSingleton<TradeDataCollector>();
+        services.AddSingleton<MarketDepthCollector>();
 
         foreach (var descriptor in ProviderCapabilityDescriptorCatalog.Descriptors)
         {
@@ -114,6 +117,11 @@ public sealed class ProviderCapabilityDescriptorCatalogTests
         robinhood.Brokerage.Should().Be(typeof(RobinhoodBrokerageGateway));
         robinhood.CorporateActions.Should().BeNull(
             "Robinhood has no dedicated ICorporateActionProvider implementation in the runtime catalog");
+
+        var ibkr = descriptorsById["ib"];
+        ibkr.Streaming.Should().Be(typeof(IBMarketDataClient));
+        ibkr.Historical.Should().Be(typeof(IBHistoricalDataProvider));
+        ibkr.Brokerage.Should().Be(typeof(IBBrokerageGateway));
 
         descriptorsById.Keys.Should().Contain("edgar");
         var edgar = descriptorsById["edgar"];


### PR DESCRIPTION
### Motivation

- Ensure guidance/smoke IB API builds remain simulation-only so configuration promotion cannot accidentally enable live routing. 
- Surface IB runtime posture and connected-session execution evidence to the OMS and support account/portfolio/activity sync from the connected gateway. 
- Keep provider capability metadata and DI registration aligned with the implemented IB gateway interfaces.

### Description

- Add an `ExecutionMode` property to `IBBrokerageGateway` and make it implement `IBrokerageAccountCatalog`, `IBrokeragePortfolioSync`, and `IBrokerageActivitySync` so the gateway can expose accounts, portfolio snapshots, and connected-session fills. 
- Persist TWS execution callbacks, map them into fills, and add `GetAccountsAsync`, `GetPortfolioSnapshotAsync`, and `GetActivitySnapshotAsync` implementations that return source-identified session evidence while leaving Flex imports as the reconciliation backstop. 
- Prevent live routing through a broker when the runtime is simulation/guidance by rejecting in `BrokerageOrderPlacementGate` if `LiveExecutionEnabled` is requested while the selected runtime is simulation. 
- Update DI registration in `HostedBrokerageGatewayServiceCollectionExtensions` to register `IBBrokerageGateway` as implementations of the account/portfolio/activity interfaces and adjust the runtime surface/catalog descriptor list to include IB implementations. 
- Update operator docs and README to document the enforcement of runtime posture and adjust an MSBuild error message path and the generated `source-hash-manifest.json` to reflect these changes.

### Testing

- Ran the unit test suite for the infrastructure and execution layers via `dotnet test tests/Meridian.Tests`, including `BrokerageOrderPlacementGateTests`, `HostedBrokerageGatewayRegistrationTests`, `IBBrokerageGatewayTests`, and `ProviderCapabilityDescriptorCatalogTests`. 
- The added tests verifying that a simulated IB runtime cannot be used for live routing and that account/portfolio/execution evidence is mapped from connected-session callbacks were executed. 
- All automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60ca78b70483209a14fac693adf5a8)