### PR TITLE
test(reporting): remove stale partial stream fixture

### DIFF
--- a/tests/Meridian.Tests/Ui/ReportingRunStreamEndpointTests.cs
+++ b/tests/Meridian.Tests/Ui/ReportingRunStreamEndpointTests.cs
@@ -329,35 +329,11 @@ public sealed class ReportingRunStreamEndpointTests
         string requestCompanyId = SeededCompanyId,
         bool grantAdminOverride = false)
     {
-        // Certified orchestration rejects partially-bound contracts (ValidateCertifiedContract),
-        // so seed the tenant-scoped run through the store fallback instead of ExecuteAsync: these
-        // tests exercise streaming and access enforcement, not certification.
-        var seededManifest = new ReportingOutputManifest(
-            SeededRunId,
-            "investor-monthly-statement",
-            new DateOnly(2026, 5, 1),
-            ReportingRunStatus.Draft,
-            ImmutableArray<ReportingSectionManifest>.Empty,
-            ImmutableArray<string>.Empty,
-            1,
-            ReportingRunTrigger.AdHoc,
-            OperationalScope: new ReportingOperationalScope(
-                SeededTenantId,
-                "organization-a",
-                SeededCompanyId,
-                FundId: null,
-                BookId: "book-a",
-                PeriodId: "2026-05"),
-            ImmutableAccessScope: new ReportingAccessScope(
-                "policy-a",
-                "1",
-                ReportingGovernanceAccessMode.CompanyWide,
-                OwnerPrincipalId: null,
-                AllowOwnerAccess: false,
-                Principals: ImmutableArray<ReportingAccessPrincipalScope>.Empty,
-                PolicyHash: "policy-hash-a"));
         var orchestration = new ReportingOrchestrationService(
             new DefaultReportingTemplateCatalog(), new DeterministicReportingSectionRenderer(), () => FixedNow);
+        // Exercise the same complete certified-contract path used in production before testing
+        // stream authorization and subscription behavior. A partial fixture would be rejected by
+        // ValidateCertifiedContract before the endpoint can expose the seeded run.
         await orchestration.ExecuteAsync(BuildCertifiedStreamContract(), CancellationToken.None);
 
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions


### PR DESCRIPTION
### Motivation
- Remove a stale, partially-bound `ReportingOutputManifest` fixture from the reporting stream test host because governed reporting now requires fully certified contracts (`ValidateCertifiedContract`) and the partial fixture caused mismatch with the hardened validation path.

### Description
- Delete the unused local `seededManifest` in `tests/Meridian.Tests/Ui/ReportingRunStreamEndpointTests.cs` and ensure the test host seeds the run via the full certified path by calling `await orchestration.ExecuteAsync(BuildCertifiedStreamContract(), ...)`.

### Testing
- Ran `git diff --check` which produced no issues (passed).
- Attempted repository CI via `bash scripts/ci.sh` and targeted `dotnet test`, but both were blocked because the environment lacks the `.NET` SDK (`dotnet: command not found`).
- Committed the change as `test(reporting): remove stale partial stream fixture` and verified the test file diff (`tests/Meridian.Tests/Ui/ReportingRunStreamEndpointTests.cs`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60cf131c3c8320aa80c567bde506f4)