### PR TITLE
Fix demo workstation remote binding

### DIFF
--- a/src/Meridian/DemoWorkspaceCli.cs
+++ b/src/Meridian/DemoWorkspaceCli.cs
@@ -35,11 +35,13 @@ internal static class DemoWorkspaceCli
         CancellationToken ct = default)
     {
         string baseDataRoot;
+        int demoPort;
         try
         {
             var parsed = CliArguments.Parse(args);
             var configStore = new ConfigStore(parsed.ConfigPath);
             baseDataRoot = configStore.GetDataRoot(configStore.Load());
+            demoPort = parsed.HttpPort ?? 8080;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -67,7 +69,7 @@ internal static class DemoWorkspaceCli
                 return 0;
             }
 
-            var demoConfig = WriteDemoConfig(seeder.DemoRoot);
+            var demoConfig = WriteDemoConfig(seeder.DemoRoot, demoPort);
             PrepareDemoRuntimeEnvironment();
             Console.WriteLine("Starting the browser workstation on the seeded demo workspace...");
             return await SharedStartupBootstrapper.RunAsync(
@@ -77,14 +79,16 @@ internal static class DemoWorkspaceCli
         }
 
         // Bare --demo / MERIDIAN_DEMO: serve an already-seeded workspace.
-        var existingConfig = ResolveDemoConfigPath(seeder.DemoRoot);
-        if (!File.Exists(existingConfig))
+        if (!File.Exists(ResolveDemoConfigPath(seeder.DemoRoot)))
         {
             Console.Error.WriteLine(
                 $"No seeded demo workspace found at {seeder.DemoRoot}. Run 'dotnet run --project src/Meridian -- --seed-demo' first.");
             return 3;
         }
 
+        // Rewrite existing generated configs so workspaces seeded before loopback enforcement also
+        // cannot inherit a remote host binding from their environment.
+        var existingConfig = WriteDemoConfig(seeder.DemoRoot, demoPort);
         PrepareDemoRuntimeEnvironment();
         return await SharedStartupBootstrapper.RunAsync(
             BuildServeArgs(args, existingConfig),
@@ -176,12 +180,19 @@ internal static class DemoWorkspaceCli
     /// Writes a minimal demo config whose absolute <c>dataRoot</c> is the isolated demo root, so a
     /// workstation host started with <c>--config &lt;this&gt;</c> reads exactly the seeded stores.
     /// </summary>
-    private static string WriteDemoConfig(string demoRoot)
+    internal static string WriteDemoConfig(string demoRoot, int port = 8080)
     {
         var configPath = ResolveDemoConfigPath(demoRoot);
         var config = new JsonObject
         {
             ["dataRoot"] = demoRoot,
+            // Demo mode deliberately binds only to loopback. This prevents inherited host URL
+            // environment variables from exposing the optional-auth demo workstation remotely.
+            ["ApiHost"] = new JsonObject
+            {
+                ["DeploymentMode"] = "LocalWorkstation",
+                ["Urls"] = new JsonArray($"http://localhost:{port}"),
+            },
         };
 
         File.WriteAllText(configPath, config.ToJsonString());

--- a/tests/Meridian.Tests/Demo/DemoWorkspaceSeederTests.cs
+++ b/tests/Meridian.Tests/Demo/DemoWorkspaceSeederTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Meridian;
 using Meridian.Contracts.Configuration;
 using Meridian.Contracts.Workstation;
 using Meridian.Storage.Operations;
@@ -8,6 +9,7 @@ using Meridian.Strategies.Services;
 using Meridian.Strategies.Storage;
 using Meridian.Testing;
 using Meridian.Ui.Shared.Services;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -19,6 +21,28 @@ namespace Meridian.Tests.Demo;
 /// </summary>
 public sealed class DemoWorkspaceSeederTests
 {
+    [Fact]
+    public void WriteDemoConfig_WhenRemoteUrlEnvironmentVariableIsSet_UsesLoopbackBinding()
+    {
+        using var artifacts = TestArtifactDirectory.Create(nameof(WriteDemoConfig_WhenRemoteUrlEnvironmentVariableIsSet_UsesLoopbackBinding));
+        var demoRoot = Path.Combine(artifacts.RootPath, "demo-workspace");
+        Directory.CreateDirectory(demoRoot);
+
+        var configPath = DemoWorkspaceCli.WriteDemoConfig(demoRoot);
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ASPNETCORE_URLS"] = "http://0.0.0.0:8080",
+            })
+            .AddJsonFile(configPath)
+            .Build();
+
+        var options = ApiHostOptions.FromConfiguration(configuration, port: 8080);
+
+        options.DeploymentMode.Should().Be(MeridianApiDeploymentMode.LocalWorkstation);
+        options.Urls.Should().Equal("http://localhost:8080");
+    }
+
     [Fact]
     public async Task SeedAsync_ProducesSeededProvenanceThatSurvivesRestart()
     {
@@ -72,4 +96,5 @@ public sealed class DemoWorkspaceSeederTests
             NullLogger<FileReconciliationBreakQueueRepository>.Instance);
         (await breaks.GetAllAsync()).Should().HaveCount(DemoTenantBlueprint.BreakDefinitions.Count);
     }
+
 }


### PR DESCRIPTION
### Motivation
- The demo startup path could inherit remote `ASPNETCORE_URLS`/`MERIDIAN_API_URLS` bindings and, combined with the demo forcing `MDC_AUTH_MODE=optional`, expose an unauthenticated demo UI to remote attackers.
- The intent is to keep the one-command seeded demo convenient for fresh checkouts while preventing accidental remote exposure of the optional-auth demo server.

### Description
- Pin the generated demo `appsettings.demo.json` to a `LocalWorkstation` posture and a loopback-only URL by adding an `ApiHost` object with `DeploymentMode = "LocalWorkstation"` and `Urls = ["http://localhost:<port>"]` to the generated demo config via `WriteDemoConfig`.
- Preserve custom port selection by reading `--http-port` (via `CliArguments`) and emitting the chosen loopback port into the generated config, and rewrite any existing generated demo config before serving so pre-seeded workspaces are protected too.
- Change `WriteDemoConfig` to accept a `port` parameter and make it `internal` so tests can call it, and update `RunAsync` to compute and pass the demo port when generating or rewriting the demo config.
- Add a regression test `WriteDemoConfig_WhenRemoteUrlEnvironmentVariableIsSet_UsesLoopbackBinding` to `tests/Meridian.Tests/Demo/DemoWorkspaceSeederTests.cs` that asserts an inherited remote `ASPNETCORE_URLS` value does not override the generated loopback binding.

### Testing
- Ran `git diff --check`, which produced no style/patch errors.
- Installed .NET 10 locally and invoked a targeted test run: `PATH=/tmp/dotnet:$PATH DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter 'FullyQualifiedName~DemoWorkspaceSeederTests'`, which performed restore/build and started the filtered test run (execution began but the test runner attachment was later detached during handoff, so the run is not fully recorded here).
- Launched the repository validation script `PATH=/tmp/dotnet:$PATH DOTNET_CLI_TELEMETRY_OPTOUT=1 bash scripts/ci.sh`, which progressed through restore and the web-workstation build (existing repository warnings only) but was still running at handoff time; no CI failures were observed during the portions that completed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60cbae33488320aba249206665a0f6)