### PR TITLE
Require scoped account authorization for statement-run creation

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.Reconciliation.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.Reconciliation.cs
@@ -1,7 +1,9 @@
 using System.Text.Json;
 using Meridian.FinancialOperations.OperationsContinuity;
 using Meridian.Contracts.Api;
+using Meridian.Contracts.FundStructure;
 using Meridian.Identity.Auth;
+using Meridian.PortfolioRecords.Accounts;
 using Meridian.Contracts.Workstation;
 using Meridian.Strategies.Interfaces;
 using Meridian.Strategies.Services;
@@ -131,7 +133,8 @@ public static partial class WorkstationEndpoints
         group.MapPost(WorkstationSubroute(UiApiRoutes.ReconciliationStatementRuns), async (
             StatementRunCreateDto request,
             HttpContext context,
-            [FromServices] IReconciliationApiService? service) =>
+            [FromServices] IReconciliationApiService? service,
+            [FromServices] IAccountQueryService? accounts) =>
         {
             if (!HasReconciliationMutationPermission(context))
             {
@@ -146,6 +149,12 @@ public static partial class WorkstationEndpoints
             if (!TryResolveCurrentUser(context, out var currentUser))
             {
                 return Results.Unauthorized();
+            }
+
+            var accountGuard = await RequireStatementRunAccountAccessAsync(request, accounts, context).ConfigureAwait(false);
+            if (accountGuard is not null)
+            {
+                return accountGuard;
             }
 
             var trustedRequest = request with { ImportedBy = currentUser };
@@ -531,5 +540,71 @@ public static partial class WorkstationEndpoints
         .Produces(403)
         .Produces(501);
 
+    }
+
+    private static async Task<IResult?> RequireStatementRunAccountAccessAsync(
+        StatementRunCreateDto request,
+        IAccountQueryService? accounts,
+        HttpContext context)
+    {
+        // The retained-book provider treats FundAccountId as an authority to load internal positions
+        // and cash. Resolve it server-side before importing so a reconciliation mutator cannot select
+        // another account and receive its unmatched internal records as breaks.
+        if (accounts is null || !Guid.TryParse(request.FundAccountId, out var accountId))
+        {
+            return EndpointHelpers.Forbidden();
+        }
+
+        var account = await accounts.GetAccountAsync(accountId, context.RequestAborted).ConfigureAwait(false);
+        if (account is null || !account.IsActive || !IsStatementSourceBoundToAccount(request, account))
+        {
+            return EndpointHelpers.Forbidden();
+        }
+
+        if (EndpointAuthorization.HasPermission(context, UserPermission.AdminMaintenance))
+        {
+            return null;
+        }
+
+        // Do not fall back to a broad role permission when scoped authorization is unavailable.
+        // This route returns account-level reconciliation evidence, so the absence of the scoped
+        // authorizer must fail closed rather than silently grant every reconciliation mutator access.
+        if (context.RequestServices.GetService<IScopedAuthorizationService>() is null)
+        {
+            return EndpointHelpers.Forbidden();
+        }
+
+        var allowed = await EndpointAuthorization.HasScopedPermissionAsync(
+            context,
+            UserPermission.ManageDirectLending,
+            AccessScopeKindDto.Account,
+            accountId,
+            context.RequestAborted).ConfigureAwait(false);
+        return allowed ? null : EndpointHelpers.Forbidden();
+    }
+
+    private static bool IsStatementSourceBoundToAccount(StatementRunCreateDto request, AccountSummaryDto account)
+    {
+        var externalAccountId = request.ExternalAccountId?.Trim();
+        var sourceInstitution = request.SourceInstitution?.Trim();
+        if (string.IsNullOrWhiteSpace(externalAccountId) || string.IsNullOrWhiteSpace(sourceInstitution))
+        {
+            return false;
+        }
+
+        var externalAccountMatches = new[]
+        {
+            account.AccountCode,
+            account.CustodianDetails?.SubAccountNumber,
+            account.BankDetails?.AccountNumber,
+            account.BankDetails?.Iban
+        }.Any(candidate => string.Equals(candidate?.Trim(), externalAccountId, StringComparison.OrdinalIgnoreCase));
+        var institutionMatches = new[]
+        {
+            account.Institution,
+            account.BankDetails?.BankName
+        }.Any(candidate => string.Equals(candidate?.Trim(), sourceInstitution, StringComparison.OrdinalIgnoreCase));
+
+        return externalAccountMatches && institutionMatches;
     }
 }

--- a/tests/Meridian.Tests/Ui/WorkstationStatementReconciliationEndpointTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationStatementReconciliationEndpointTests.cs
@@ -7,6 +7,8 @@ using Meridian.Contracts.Workstation;
 using Meridian.Domain.Reconciliation;
 using Meridian.FinancialOperations.Reconciliation;
 using Meridian.FinancialOperations.Reconciliation.Connectors;
+using Meridian.PortfolioRecords.Accounts;
+using Meridian.PortfolioRecords.FundAccounts;
 using Meridian.Ui.Shared.Contracts.Reconciliation;
 using Meridian.Ui.Shared.Evidence;
 using Microsoft.AspNetCore.TestHost;
@@ -100,10 +102,13 @@ public sealed partial class WorkstationEndpointsTests
     public async Task MapWorkstationEndpoints_StatementRunMutationRoutes_ShouldTrustAuthenticatedActor()
     {
         var service = new StubReconciliationApiService();
+        var accountId = Guid.NewGuid();
+        var accounts = CreateStatementAccount(accountId);
         await using var app = await CreateAppAsync(services =>
         {
             services.AddSingleton<IReconciliationApiService>(service);
-        });
+            services.AddSingleton<IAccountQueryService>(accounts);
+        }, currentUserPermissions: Meridian.Identity.Auth.UserPermission.AdminMaintenance);
         var client = app.GetTestClient();
 
         var create = await client.PostAsJsonAsync(
@@ -111,8 +116,8 @@ public sealed partial class WorkstationEndpointsTests
             new StatementRunCreateDto(
                 Broker: "custodian",
                 SourceInstitution: "Sample Custodian",
-                FundAccountId: "fund-1",
-                ExternalAccountId: "external-1",
+                FundAccountId: accountId.ToString("D"),
+                ExternalAccountId: "external-allowed",
                 StatementPeriodStart: new DateOnly(2026, 5, 1),
                 StatementPeriodEnd: new DateOnly(2026, 5, 31),
                 SourcePath: @"C:\imports\statement.csv",
@@ -133,6 +138,87 @@ public sealed partial class WorkstationEndpointsTests
         service.ReconciledRequests.Should().ContainSingle();
         service.ReconciledRequests[0].RunId.Should().Be("statement-run-1");
         service.ReconciledRequests[0].Request.Actor.Should().Be("ops-user");
+    }
+
+    [Fact]
+    public async Task MapWorkstationEndpoints_StatementRunCreate_ShouldRejectUnboundExternalAccount()
+    {
+        var service = new StubReconciliationApiService();
+        var accounts = CreateStatementAccount(Guid.NewGuid());
+        var account = (await accounts.ListAccountsAsync(null, null, null)).Single();
+        await using var app = await CreateAppAsync(services =>
+        {
+            services.AddSingleton<IReconciliationApiService>(service);
+            services.AddSingleton<IAccountQueryService>(accounts);
+        }, currentUserPermissions: Meridian.Identity.Auth.UserPermission.AdminMaintenance);
+
+        var response = await app.GetTestClient().PostAsJsonAsync(
+            UiApiRoutes.ReconciliationStatementRuns,
+            new StatementRunCreateDto(
+                Broker: "custodian",
+                SourceInstitution: "Sample Custodian",
+                FundAccountId: account.AccountId.ToString("D"),
+                ExternalAccountId: "external-other",
+                StatementPeriodStart: new DateOnly(2026, 5, 1),
+                StatementPeriodEnd: new DateOnly(2026, 5, 31),
+                SourcePath: @"C:\imports\statement.csv",
+                OriginalFileName: "statement.csv",
+                MappingProfileId: "mapping-v1",
+                ToleranceProfileId: "tolerance-v1",
+                ImportedBy: "browser-spoof"),
+            ServerJsonOptions);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        service.CreatedRequests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task MapWorkstationEndpoints_StatementRunCreate_ShouldRejectUnscopedAccount()
+    {
+        var service = new StubReconciliationApiService();
+        var accounts = CreateStatementAccount(Guid.NewGuid());
+        var account = (await accounts.ListAccountsAsync(null, null, null)).Single();
+        await using var app = await CreateAppAsync(services =>
+        {
+            services.AddSingleton<IReconciliationApiService>(service);
+            services.AddSingleton<IAccountQueryService>(accounts);
+        }, currentUserPermissions: Meridian.Identity.Auth.UserPermission.ManageDirectLending);
+
+        var response = await app.GetTestClient().PostAsJsonAsync(
+            UiApiRoutes.ReconciliationStatementRuns,
+            new StatementRunCreateDto(
+                Broker: "custodian",
+                SourceInstitution: "Sample Custodian",
+                FundAccountId: account.AccountId.ToString("D"),
+                ExternalAccountId: "external-allowed",
+                StatementPeriodStart: new DateOnly(2026, 5, 1),
+                StatementPeriodEnd: new DateOnly(2026, 5, 31),
+                SourcePath: @"C:\imports\statement.csv",
+                OriginalFileName: "statement.csv",
+                MappingProfileId: "mapping-v1",
+                ToleranceProfileId: "tolerance-v1",
+                ImportedBy: "browser-spoof"),
+            ServerJsonOptions);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        service.CreatedRequests.Should().BeEmpty();
+    }
+
+    private static InMemoryFundAccountService CreateStatementAccount(Guid accountId)
+    {
+        var accounts = new InMemoryFundAccountService();
+        accounts.CreateAccountAsync(new Meridian.Contracts.FundStructure.CreateAccountRequest(
+            accountId,
+            Meridian.Contracts.FundStructure.AccountTypeDto.Custody,
+            "ACCOUNT-ALLOWED",
+            "Allowed statement account",
+            "USD",
+            DateTimeOffset.UtcNow,
+            "test-operator",
+            Institution: "Sample Custodian",
+            CustodianDetails: new Meridian.Contracts.FundStructure.CustodianAccountDetailsDto(
+                "external-allowed", null, null, null, null, null, null, null))).GetAwaiter().GetResult();
+        return accounts;
     }
 
     private static MultipartFormDataContent BuildStatementToReportContent()


### PR DESCRIPTION
### Motivation

- Prevent disclosure of internal account positions/cash via statement imports by ensuring the server resolves and authorizes the requested fund account before the internal-book provider is invoked.

### Description

- Added a server-side guard in the statement-run creation endpoint to resolve `FundAccountId` and require an active account before proceeding, in `WorkstationEndpoints.Reconciliation.cs` via `RequireStatementRunAccountAccessAsync`.
- Require that the statement `ExternalAccountId` and `SourceInstitution` match the retained account bindings using `IsStatementSourceBoundToAccount`, so only a bound external account can trigger population of the internal book.
- Enforce scoped authorization for non-admin callers: non-admins must have `ManageDirectLending` on the target account via the scoped authorizer, and the absence of a scoped authorizer fails closed.
- Added endpoint-level tests in `tests/Meridian.Tests/Ui/WorkstationStatementReconciliationEndpointTests.cs` that cover an accepted bound request and rejected cases for an unbound external account and for unscoped account access.

### Testing

- Ran `git diff --check` and it passed.
- Ran repository validation `python build/python/cli/buildctl.py validation-status --summary` and it reported `blocked=false` (no active build blockers).
- Attempted `dotnet test` and `bash scripts/ci.sh` but they could not be executed in the environment because the .NET SDK is not installed (`dotnet: command not found`), so the new xUnit tests were added but not executed locally.
- New tests were added to the test project to exercise the positive and negative authorization paths and should be executed by CI (`bash scripts/ci.sh` / GitHub Actions) in an environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60522dc43483209ff9fc7e194e56ad)