### PR TITLE
Require full transaction detail match before treating ExternalTransactionId as Exact

### DIFF
--- a/src/Meridian.FinancialOperations/Reconciliation/StatementMatchingEngine.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementMatchingEngine.cs
@@ -174,7 +174,10 @@ public sealed class StatementMatchingEngine
             request.InternalLedgerTransactions,
             matchedStatements,
             matchedInternal,
-            (statement, internalTransaction) => HasSameExternalTransactionId(statement, internalTransaction),
+            (statement, internalTransaction) => HasSameExternalTransactionId(statement, internalTransaction)
+                && SameTransactionIdentity(statement, internalTransaction)
+                && statement.Quantity == internalTransaction.Quantity
+                && statement.NetAmount == internalTransaction.NetAmount,
             (statement, internalTransaction) => CreateTransactionResult(
                 statement,
                 internalTransaction,
@@ -183,7 +186,7 @@ public sealed class StatementMatchingEngine
                 [TransactionExternalIdRuleId],
                 TransactionVariance(statement, internalTransaction),
                 TransactionTolerance(tolerance),
-                "Exact transaction match on external transaction ID."),
+                "Exact transaction match on external transaction ID and transaction details."),
             results);
 
         MatchStage(

--- a/tests/Meridian.Tests/Application/Reconciliation/StatementMatchingEngineTests.cs
+++ b/tests/Meridian.Tests/Application/Reconciliation/StatementMatchingEngineTests.cs
@@ -71,6 +71,31 @@ public sealed class StatementMatchingEngineTests
     }
 
     [Fact]
+    public void Run_WhenExternalTransactionIdMatchesButTransactionDetailsDiffer_EmitsUnmatchedBreaks()
+    {
+        var engine = new StatementMatchingEngine();
+        var request = new StatementMatchingRequest(
+            [],
+            [],
+            [new NormalizedStatementTransaction("stmt-tx-1", "EXT-123", "EVIL-ACCT", "TSLA", null, new DateOnly(2026, 5, 29), new DateOnly(2026, 5, 30), "SELL", 999m, 999m, "broker:tx:1")],
+            [],
+            [],
+            [new InternalLedgerTransaction("int-tx-1", "EXT-123", "A1", "MSFT", null, new DateOnly(2026, 5, 27), new DateOnly(2026, 5, 28), "BUY", 5m, -100m, "internal:tx:1")],
+            Tolerances());
+
+        var result = engine.Run(request);
+
+        result.Results.Should().HaveCount(2);
+        result.Results.Should().OnlyContain(match => match.MatchTier == StatementMatchTier.Unmatched);
+        result.Results.Should().Contain(match => match.BrokerEvidenceReference == "broker:tx:1"
+            && match.InternalEvidenceReference == null
+            && match.RuleIds.Contains("statement-transaction-break-v1"));
+        result.Results.Should().Contain(match => match.BrokerEvidenceReference == null
+            && match.InternalEvidenceReference == "internal:tx:1"
+            && match.RuleIds.Contains("statement-transaction-break-v1"));
+    }
+
+    [Fact]
     public void Run_WhenOnlyLooseCandidatesExist_EmitsCandidateBeforeBreaks()
     {
         var engine = new StatementMatchingEngine();


### PR DESCRIPTION
### Motivation
- Prevent statement rows from suppressing reconciliation breaks by reusing an `ExternalTransactionId` while changing account, instrument, dates, type, quantity, or amount. 
- Harden the live statement-run matcher so an `ExternalTransactionId` alone cannot create a false `Exact` match and hide material ledger-vs-custodian discrepancies.

### Description
- Change transaction exact-match predicate in `StatementMatchingEngine` so `HasSameExternalTransactionId` must also satisfy `SameTransactionIdentity` and exact `Quantity` and `NetAmount` equality before emitting an `Exact` match. 
- Update the `Exact` explanation text to reflect that transaction details are required as well as the external id. 
- Add a regression test `Run_WhenExternalTransactionIdMatchesButTransactionDetailsDiffer_EmitsUnmatchedBreaks` in `tests/Meridian.Tests/Application/Reconciliation/StatementMatchingEngineTests.cs` that proves a reused external id with materially different transaction details produces unmatched broker- and internal-side breaks. 

### Testing
- Ran `git diff --check` which passed locally. 
- Attempted to run the focused tests with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~StatementMatchingEngineTests"`, but the local environment is missing the .NET SDK so the test run was blocked (`dotnet: command not found`). 
- Ran `python3 build/python/cli/buildctl.py validation-status --summary` which reported no active locks or build processes, and `bash scripts/ci.sh` was attempted but blocked at the .NET SDK verification step for the same reason; authoritative CI runs on GitHub Actions remain required to validate the change end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60518919d883209ca650896e84d036)