### PR TITLE
Validate statement account identity before reconciliation

### DIFF
--- a/src/Meridian.FinancialOperations/Reconciliation/StatementRunMatcher.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementRunMatcher.cs
@@ -38,6 +38,8 @@ internal static class StatementRunMatcher
         var statementTransactions = new List<NormalizedStatementTransaction>();
         var rowByEvidence = new Dictionary<string, CanonicalStatementRow>(StringComparer.OrdinalIgnoreCase);
 
+        ValidateRowAccounts(rows, import.ExternalAccountId);
+
         // A statement run reconciles a single custodian account, so the account dimension is a
         // run-level constant. Normalize the statement side to the run's external (custodian) account
         // key — the same key the internal populations use — so institutional statements whose per-row
@@ -120,6 +122,21 @@ internal static class StatementRunMatcher
         }
 
         return new StatementRunMatchResult(breaks, matchCount);
+    }
+
+    // Imported rows are retained evidence. Do not erase their recorded account identity by mapping
+    // them to a caller-supplied run account unless the two agree; otherwise a statement for a
+    // different account could be reconciled against this run's internal population.
+    private static void ValidateRowAccounts(
+        IReadOnlyList<CanonicalStatementRow> rows,
+        string externalAccountId)
+    {
+        var expectedAccount = externalAccountId.Trim();
+        if (rows.Any(row => !string.Equals(row.Account.Trim(), expectedAccount, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new InvalidDataException(
+                "Statement rows must all identify the statement run's external account.");
+        }
     }
 
     private static NormalizedStatementPosition MapPosition(

--- a/src/Meridian.Infrastructure/Reconciliation/BrokerStatementInfrastructure.cs
+++ b/src/Meridian.Infrastructure/Reconciliation/BrokerStatementInfrastructure.cs
@@ -147,6 +147,7 @@ public sealed class CsvBrokerStatementService(ICanonicalStatementStore store) : 
         try
         {
             var rows = await ParseFileAsync(request.SourcePath, request, importId: "validation", ct).ConfigureAwait(false);
+            ValidateRowAccounts(rows, request.ExternalAccountId);
             return new BrokerStatementValidationResult(true, errors, rows.Count);
         }
         catch (InvalidDataException ex)
@@ -174,6 +175,7 @@ public sealed class CsvBrokerStatementService(ICanonicalStatementStore store) : 
         var importId = duplicateKey;
         var normalizedRequest = request.WithSourceFileHash(sourceFileHash);
         var rows = await ParseFileAsync(request.SourcePath, normalizedRequest, importId, ct).ConfigureAwait(false);
+        ValidateRowAccounts(rows, normalizedRequest.ExternalAccountId);
         var import = new CanonicalStatementImport(
             importId,
             normalizedRequest.Broker,
@@ -323,6 +325,18 @@ public sealed class CsvBrokerStatementService(ICanonicalStatementStore store) : 
         }
 
         return rows;
+    }
+
+    private static void ValidateRowAccounts(
+        IReadOnlyList<CanonicalStatementRow> rows,
+        string externalAccountId)
+    {
+        var expectedAccount = externalAccountId.Trim();
+        if (rows.Any(row => !string.Equals(row.Account.Trim(), expectedAccount, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new InvalidDataException(
+                "Statement rows must all identify the statement run's external account.");
+        }
     }
 
     private static IReadOnlyList<string> ParseCsvLine(string line, int rowNumber)

--- a/src/Meridian.Infrastructure/Reconciliation/IbFlexStatementService.cs
+++ b/src/Meridian.Infrastructure/Reconciliation/IbFlexStatementService.cs
@@ -94,6 +94,11 @@ public sealed class IbFlexBrokerStatementService(ICanonicalStatementStore store)
                 $"Flex report contains rows for {distinctAccounts.Length} different accounts; a statement run reconciles a single account. "
                 + "Split the report into one document per account before importing.");
         }
+        else if (distinctAccounts.Length == 1
+            && !string.Equals(distinctAccounts[0], request.ExternalAccountId?.Trim(), StringComparison.OrdinalIgnoreCase))
+        {
+            errors.Add("Flex report account does not match the statement run external account.");
+        }
 
         return new BrokerStatementValidationResult(errors.Count == 0, errors, rowCount);
     }
@@ -151,6 +156,11 @@ public sealed class IbFlexBrokerStatementService(ICanonicalStatementStore store)
         {
             throw new InvalidDataException(
                 $"Flex report contains rows for {distinctAccounts.Length} different accounts, but a statement run reconciles a single account. Split the report into one document per account before importing.");
+        }
+        if (distinctAccounts.Length == 1
+            && !string.Equals(distinctAccounts[0], normalizedRequest.ExternalAccountId, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidDataException("Flex report account does not match the statement run external account.");
         }
 
         var import = new CanonicalStatementImport(

--- a/tests/Meridian.Tests/Reconciliation/IbFlexStatementServiceTests.cs
+++ b/tests/Meridian.Tests/Reconciliation/IbFlexStatementServiceTests.cs
@@ -81,6 +81,17 @@ public sealed class IbFlexStatementServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task Validate_FlexReportForAnotherAccount_Fails()
+    {
+        var path = WriteFlexFile(SampleFlexXml);
+
+        var result = await _service.ValidateAsync(MakeRequest(path) with { ExternalAccountId = "U7654321" });
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(error => error.Contains("external account", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public async Task Validate_MissingFile_Fails()
     {
         var result = await _service.ValidateAsync(MakeRequest(Path.Combine(_tempDir, "missing.xml")));

--- a/tests/Meridian.Tests/Reconciliation/StatementRunWorkflowServiceTests.cs
+++ b/tests/Meridian.Tests/Reconciliation/StatementRunWorkflowServiceTests.cs
@@ -37,9 +37,9 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
     {
         var path = await WriteStatementAsync(
             "empty-book.csv",
-            "FUND-1,SPY,10,500,5000,position,2026-05-28,,USD,,",
-            "FUND-1,,0,0,2500.25,cash,2026-05-28,,USD,,",
-            "FUND-1,MSFT,5,20,100,trade,2026-05-28,,USD,,EXT-9");
+            "EXT-1,SPY,10,500,5000,position,2026-05-28,,USD,,",
+            "EXT-1,,0,0,2500.25,cash,2026-05-28,,USD,,",
+            "EXT-1,MSFT,5,20,100,trade,2026-05-28,,USD,,EXT-9");
         var workflow = CreateWorkflow();
 
         var result = await workflow.CreateAsync(Request(path), CancellationToken.None);
@@ -57,9 +57,9 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
     {
         var path = await WriteStatementAsync(
             "matched.csv",
-            "FUND-1,SPY,10,500,5000,position,2026-05-28,,USD,,",
-            "FUND-1,,0,0,2500.25,cash,2026-05-28,,USD,,",
-            "FUND-1,MSFT,5,20,-100,trade,2026-05-28,2026-05-30,USD,,EXT-9");
+            "EXT-1,SPY,10,500,5000,position,2026-05-28,,USD,,",
+            "EXT-1,,0,0,2500.25,cash,2026-05-28,,USD,,",
+            "EXT-1,MSFT,5,20,-100,trade,2026-05-28,2026-05-30,USD,,EXT-9");
         var workflow = CreateWorkflow(Populations(new InternalReconciliationPopulations(
             [new InternalPortfolioPosition("i-spy", "EXT-1", "SPY", new DateOnly(2026, 5, 28), 10m, 5000m, "internal:pos:spy")],
             [new InternalCashBalance("i-cash", "EXT-1", "USD", 2500.25m, "internal:cash", new DateOnly(2026, 5, 28))],
@@ -72,6 +72,25 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task CreateAsync_WhenStatementRowAccountDiffersFromRunAccount_FailsBeforePersistingOrMatching()
+    {
+        var path = await WriteStatementAsync(
+            "wrong-account.csv",
+            "OTHER-ACCOUNT,SPY,10,500,5000,position,2026-05-28,,USD,,");
+        var workflow = CreateWorkflow(Populations(new InternalReconciliationPopulations(
+            [new InternalPortfolioPosition("i-spy", "EXT-1", "SPY", new DateOnly(2026, 5, 28), 10m, 5000m, "internal:pos:spy")],
+            [],
+            [])));
+
+        var act = async () => await workflow.CreateAsync(Request(path), CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidDataException>()
+            .WithMessage("*external account*");
+        var imports = await new JsonCanonicalStatementStore(_root).ListImportsAsync();
+        imports.Should().BeEmpty("an account-mismatched statement must not be retained as a reconcilable run");
+    }
+
+    [Fact]
     public async Task CreateAsync_WhenCashBalanceDateDiffersFromInternal_DoesNotMatchOnAmountAlone()
     {
         // The statement closing balance carries the same amount as the internal book but a different date
@@ -79,7 +98,7 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
         // period-appropriate internal balance on account, currency, and amount alone; it surfaces as a break.
         var path = await WriteStatementAsync(
             "wrong-period-cash.csv",
-            "FUND-1,,0,0,2500.25,cash,2026-04-30,,USD,,");
+            "EXT-1,,0,0,2500.25,cash,2026-04-30,,USD,,");
         var workflow = CreateWorkflow(Populations(new InternalReconciliationPopulations(
             [],
             [new InternalCashBalance("i-cash", "EXT-1", "USD", 2500.25m, "internal:cash", new DateOnly(2026, 5, 31))],
@@ -100,7 +119,7 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
         // 1,000 EUR converts to 1,085 USD at 1.085; the internal book holds 1,085 USD for the account.
         var path = await WriteStatementAsync(
             "fx.csv",
-            "FUND-1,,0,0,1000,cash,2026-05-28,,EUR,,");
+            "EXT-1,,0,0,1000,cash,2026-05-28,,EUR,,");
         var workflow = CreateWorkflow(
             Populations(new InternalReconciliationPopulations(
                 [],
@@ -118,7 +137,7 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
     {
         var path = await WriteStatementAsync(
             "fx-missing.csv",
-            "FUND-1,,0,0,1000,cash,2026-05-28,,EUR,,");
+            "EXT-1,,0,0,1000,cash,2026-05-28,,EUR,,");
         var workflow = CreateWorkflow(Populations(new InternalReconciliationPopulations(
             [],
             [new InternalCashBalance("i-cash", "FUND-1", "USD", 1085m, "internal:cash", new DateOnly(2026, 5, 28))],
@@ -136,7 +155,7 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
     {
         var path = await WriteStatementAsync(
             "internal-only.csv",
-            "FUND-1,SPY,10,500,5000,position,2026-05-28,,USD,,");
+            "EXT-1,SPY,10,500,5000,position,2026-05-28,,USD,,");
         var workflow = CreateWorkflow(Populations(new InternalReconciliationPopulations(
             [
                 new InternalPortfolioPosition("i-spy", "EXT-1", "SPY", new DateOnly(2026, 5, 28), 10m, 5000m, "internal:pos:spy"),
@@ -171,7 +190,7 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
         // profile, not a hard-coded default, drives the thresholds.
         var path = await WriteStatementAsync(
             "tolerance-default.csv",
-            "FUND-1,,0,0,1000.50,cash,2026-05-28,,USD,,");
+            "EXT-1,,0,0,1000.50,cash,2026-05-28,,USD,,");
         var workflow = CreateWorkflow(Populations(new InternalReconciliationPopulations(
             [],
             [new InternalCashBalance("i-cash", "EXT-1", "USD", 1000m, "internal:cash", new DateOnly(2026, 5, 28))],
@@ -190,7 +209,7 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
         // ToleranceProfileId threads into the matcher instead of always using the default thresholds.
         var path = await WriteStatementAsync(
             "tolerance-loose.csv",
-            "FUND-1,,0,0,1000.50,cash,2026-05-28,,USD,,");
+            "EXT-1,,0,0,1000.50,cash,2026-05-28,,USD,,");
         var looseProfile = new StatementToleranceProfile(
             "statement-loose",
             1,
@@ -220,7 +239,7 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
         // id, so the persisted profile is always the profile actually applied.
         var path = await WriteStatementAsync(
             "unknown-tolerance.csv",
-            "FUND-1,,0,0,1000,cash,2026-05-28,,USD,,");
+            "EXT-1,,0,0,1000,cash,2026-05-28,,USD,,");
         var workflow = CreateWorkflow();
 
         var act = async () => await workflow.CreateAsync(
@@ -243,7 +262,7 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
         // could exact-match a same-day ledger transaction instead of blocking the import.
         var path = await WriteStatementAsync(
             "bad-settlement.csv",
-            "FUND-1,MSFT,5,20,-100,trade,2026-05-28,not-a-date,USD,,EXT-9");
+            "EXT-1,MSFT,5,20,-100,trade,2026-05-28,not-a-date,USD,,EXT-9");
         var workflow = CreateWorkflow();
 
         var act = async () => await workflow.CreateAsync(Request(path), CancellationToken.None);


### PR DESCRIPTION
### Motivation
- Prevent a reconciliation integrity bug where the run-level `ExternalAccountId` could overwrite per-row account identities and allow rows from another account to be reconciled against the run's internal book.
- Ensure imported canonical evidence preserves its recorded account identity and that imports are rejected when rows do not belong to the declared run account.

### Description
- Add per-row account validation in the CSV import path by introducing `ValidateRowAccounts` and invoking it in `CsvBrokerStatementService.ValidateAsync` and `CsvBrokerStatementService.ImportAsync` (`src/Meridian.Infrastructure/Reconciliation/BrokerStatementInfrastructure.cs`).
- Add a matcher-level fail-closed guard in `StatementRunMatcher` that validates persisted/imported `CanonicalStatementRow.Account` values match the run `ExternalAccountId` before mapping and matching (`src/Meridian.FinancialOperations/Reconciliation/StatementRunMatcher.cs`).
- Enforce the same account check for IB Flex parsing/validation and import paths so a single-account Flex report that does not match the run account is rejected (`src/Meridian.Infrastructure/Reconciliation/IbFlexStatementService.cs`).
- Update tests to use `ExternalAccountId`-aligned rows and add regression tests that verify CSV and Flex imports fail when the statement row account differs from the run account (`tests/Meridian.Tests/Reconciliation/StatementRunWorkflowServiceTests.cs`, `tests/Meridian.Tests/Reconciliation/IbFlexStatementServiceTests.cs`).
- Commit recorded on branch `codex/statement-account-validation` (commit `ecea0585`) and a PR metadata record was prepared.

### Testing
- Ran `git diff --check` and local repository checks; no style/diff issues were reported. (success)
- Attempted the canonical validation command `bash scripts/ci.sh`, but the environment lacks the .NET SDK and `dotnet` invocation failed with `dotnet: command not found`, so the full test suite could not be executed here (blocked).
- New unit tests were added to cover the account-mismatch paths, but running the xUnit suite requires `dotnet` in CI; please run `bash scripts/ci.sh` or the repository's GitHub Actions `Meridian CI / quality-gate` to execute them (expected to pass after CI runs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60516f15e083209fb597306af1d674)