### PR TITLE
Require authorization for strategy lifecycle controls

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/StrategyLifecycleEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/StrategyLifecycleEndpoints.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Meridian.Contracts.Operations;
+using Meridian.Identity.Auth;
 using Meridian.Strategies.Models;
 using Meridian.Strategies.Services;
 using Microsoft.AspNetCore.Builder;
@@ -132,6 +133,7 @@ public static class StrategyLifecycleEndpoints
         .Produces<VerifiedOperationOutcome>(503)
         .Produces(404)
         .Produces(503)
+        .RequirePermission(UserPermission.ManageStrategies)
         .RequireRateLimiting(UiEndpoints.MutationRateLimitPolicy);
 
         group.MapPost("/{strategyId}/stop", async (string strategyId, HttpContext context) =>
@@ -210,6 +212,7 @@ public static class StrategyLifecycleEndpoints
         .Produces<VerifiedOperationOutcome>(503)
         .Produces(404)
         .Produces(503)
+        .RequirePermission(UserPermission.ManageStrategies)
         .RequireRateLimiting(UiEndpoints.MutationRateLimitPolicy);
 
         group.MapPost("/{strategyId}/reconcile", async (string strategyId, HttpContext context) =>
@@ -290,6 +293,7 @@ public static class StrategyLifecycleEndpoints
         .Produces<VerifiedOperationOutcome>(503)
         .Produces(404)
         .Produces(503)
+        .RequirePermission(UserPermission.ManageStrategies)
         .RequireRateLimiting(UiEndpoints.MutationRateLimitPolicy);
     }
 

--- a/tests/Meridian.Tests/Ui/StrategyLifecycleEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/StrategyLifecycleEndpointsTests.cs
@@ -1,12 +1,31 @@
+using System.Net;
+using System.Text.Json;
 using FluentAssertions;
 using Meridian.Contracts.Operations;
+using Meridian.Identity.Auth;
 using Meridian.Ui.Shared.Endpoints;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
 using Xunit;
 
 namespace Meridian.Tests.Ui;
 
 public sealed class StrategyLifecycleEndpointsTests
 {
+    [Theory]
+    [InlineData("/api/strategies/strategy-1/pause")]
+    [InlineData("/api/strategies/strategy-1/stop")]
+    [InlineData("/api/strategies/strategy-1/reconcile")]
+    public async Task LifecycleMutation_WhenUserLacksManageStrategiesPermission_ReturnsForbidden(string route)
+    {
+        await using var app = await CreateAppAsync(UserPermission.ViewStrategies);
+
+        var response = await app.GetTestClient().PostAsync(route, content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
     [Fact]
     public void CreateEndpointFailureOutcome_ForBlockedPrerequisite_ReturnsValidReceipt()
     {
@@ -42,5 +61,24 @@ public sealed class StrategyLifecycleEndpointsTests
             action.Guidance.Contains("Do not repeat", StringComparison.Ordinal) &&
             action.Route == "/api/strategies/strategy-1/reconcile");
         VerifiedOperationOutcomeValidator.Validate(outcome).Should().BeEmpty();
+    }
+
+    private static async Task<WebApplication> CreateAppAsync(UserPermission permissions)
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = "Development"
+        });
+        builder.WebHost.UseTestServer();
+
+        var app = builder.Build();
+        app.Use(async (context, next) =>
+        {
+            context.Items[LoginSessionMiddleware.CurrentUserPermissionsKey] = permissions;
+            await next();
+        });
+        app.MapStrategyLifecycleEndpoints(new JsonSerializerOptions());
+        await app.StartAsync();
+        return app;
     }
 }


### PR DESCRIPTION
### Motivation
- Promoted live strategies are now registered with the shared `StrategyLifecycleManager`, making them reachable by the lifecycle HTTP endpoints; those endpoints previously allowed authenticated low-privilege users to pause, stop, or reconcile active runs because they lacked permission checks.

### Description
- Add `RequirePermission(UserPermission.ManageStrategies)` to the `/api/strategies/{strategyId}/pause`, `/stop`, and `/reconcile` endpoint mappings in `src/Meridian.Ui.Shared/Endpoints/StrategyLifecycleEndpoints.cs` to enforce RBAC on lifecycle mutations.
- Add `using Meridian.Identity.Auth;` where needed to reference `UserPermission` helpers.
- Add endpoint coverage in `tests/Meridian.Tests/Ui/StrategyLifecycleEndpointsTests.cs` that asserts a user with only `ViewStrategies` receives `403 Forbidden` for pause, stop, and reconcile mutations.

### Testing
- `python build/python/cli/buildctl.py validation-status --summary` was run and reported no active locks (passed). 
- `git diff --check` was run locally and reported no whitespace/patch issues (passed). 
- Attempted to run the targeted unit tests with `dotnet test --filter FullyQualifiedName~StrategyLifecycleEndpointsTests`, but the environment lacks the .NET SDK so the command could not be executed (`dotnet: command not found`).
- Running `bash scripts/ci.sh` is blocked in this environment for the same reason (CI .NET SDK verification step failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5eb4da1e348320a667b8ebee90738a)