### PR TITLE
Require ledger certification for daily mark-to-market batch lifecycle

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/LedgerEndpoints.JournalAutomation.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/LedgerEndpoints.JournalAutomation.cs
@@ -374,7 +374,7 @@ public static partial class LedgerEndpoints
             DailyValuationBatchLifecycleRequestDto request,
             HttpContext context) =>
         {
-            if (!HasLedgerMutationPermission(context))
+            if (!HasLedgerCertificationPermission(context))
             {
                 return EndpointHelpers.Forbidden();
             }

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.JournalAutomation.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.JournalAutomation.cs
@@ -102,6 +102,26 @@ public sealed partial class WorkstationEndpointsTests
         result!.Runs.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task DailyMarkToMarketBatchLifecycle_RequiresLedgerCertificationPermission()
+    {
+        await using var app = await CreateAppAsync(
+            mapLedgerApi: true,
+            currentUserPermissions: Meridian.Identity.Auth.UserPermission.ManageDirectLending);
+
+        using var response = await app.GetTestClient().PostAsJsonAsync(
+            UiApiRoutes.LedgerJournalAutomationDailyMarkToMarketBatchLifecycle,
+            new DailyValuationBatchLifecycleRequestDto(
+                "daily-mtm-alpha",
+                "fund-alpha",
+                "browser-user",
+                "Attempt to release retained valuation batch.",
+                ["evidence://daily-mtm/batch/daily-mtm-alpha"]),
+            ServerJsonOptions);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
     private static AutomatedJournalScheduleWorkItem MonthlySchedule(string scheduleId)
         => new(
             ScheduleId: scheduleId,


### PR DESCRIPTION
### Motivation
- The daily mark-to-market batch lifecycle endpoint performed approval/post actions but was guarded by `HasLedgerMutationPermission`, which also allows `ManageDirectLending` and thereby permitted a lower-privilege user to finalize posted journals.

### Description
- Replace the endpoint guard in `src/Meridian.Ui.Shared/Endpoints/LedgerEndpoints.JournalAutomation.cs` to use `HasLedgerCertificationPermission` instead of `HasLedgerMutationPermission` for the `/api/ledger/journal-automation/daily-mark-to-market-batch-lifecycle` route.
- Add a regression test `DailyMarkToMarketBatchLifecycle_RequiresLedgerCertificationPermission` in `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.JournalAutomation.cs` that asserts a caller with only `UserPermission.ManageDirectLending` receives `403 Forbidden`.

### Testing
- A Python check confirmed the endpoint now uses `HasLedgerCertificationPermission` and the new test is present and asserts `ManageDirectLending`-only callers are forbidden.
- `git diff --check` passed with no whitespace or index errors.
- Running `dotnet test` and `bash scripts/ci.sh` was blocked in this environment because `dotnet` is not installed, so full automated test execution must be validated in CI (GitHub Actions) or a developer machine with the .NET SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57a9e7f2f88320ae464fe97a00d8b0)