### PR TITLE
fix(storage): rerun reapply migrations on startup

### DIFF
--- a/src/Meridian.Storage/Ledger/LedgerMigrationRunner.cs
+++ b/src/Meridian.Storage/Ledger/LedgerMigrationRunner.cs
@@ -21,6 +21,11 @@ public sealed class LedgerMigrationRunner
             // feature's migration table layout.
             LedgerTableName = "ledger_journal_schema_migrations",
             DriftPolicy = MigrationDriftPolicy.Reapply,
+            RepeatableMigrationFileNames = new HashSet<string>(StringComparer.Ordinal)
+            {
+                "V_ledger_020__fund_scope_tenant_columns.sql",
+                "V_ledger_021__operations_continuity_tenant_column.sql",
+            },
         });
     }
 

--- a/src/Meridian.Storage/Ledger/Migrations/V_ledger_020__fund_scope_tenant_columns.sql
+++ b/src/Meridian.Storage/Ledger/Migrations/V_ledger_020__fund_scope_tenant_columns.sql
@@ -10,8 +10,8 @@
 -- The column is nullable and INERT in this slice: nothing reads or writes it yet (that is 4c-ii), so there
 -- is no behavior change. A null tenant_id means "unknown/unbound" and stays fail-open (legacy rows, and any
 -- new row until 4c-ii stamps writes), matching the registry guard's deployment-boundary posture. The
--- backfill is idempotent -- guarded by `tenant_id is null` -- and re-runs safely since the migration runner
--- replays every script on each startup (there is no version table).
+-- backfill is idempotent -- guarded by `tenant_id is null` -- and re-runs safely because this
+-- migration is explicitly configured as repeatable on startup.
 --
 -- tenant_id is backfilled from the authoritative fund_profile_tenancy registry (itself backfilled from
 -- tenant-attributed audit history in V_ledger_019), joined on the application's normalized fund key

--- a/src/Meridian.Storage/Ledger/Migrations/V_ledger_021__operations_continuity_tenant_column.sql
+++ b/src/Meridian.Storage/Ledger/Migrations/V_ledger_021__operations_continuity_tenant_column.sql
@@ -5,13 +5,14 @@
 -- owning tenant directly, closing the slice-3b alternate-identifier residual for this store. The
 -- fund_profile_tenancy registry is fund-keyed and this table carries no fund_profile_id, so ownership is
 -- inherited transitively through the workflow's ledger book (workflow_json ->> 'ledgerBookId') -> the
--- ledger_books.tenant_id stamped by V_ledger_020 (which runs first under the replay-every-script runner).
+-- ledger_books.tenant_id stamped by V_ledger_020, which is explicitly repeatable and runs first.
 --
 -- The column is nullable and fail-open: a null tenant_id means "unknown/unbound" (a workflow with no
 -- ledger book, or whose book is itself unbound) and stays visible to every caller, matching the
 -- deployment-boundary posture. The 4c-ii read predicate filters by it only when the caller has a resolved
 -- tenant, so single-company-per-deployment behavior is unchanged. The backfill is idempotent (guarded by
--- `tenant_id is null`) and re-runs safely on each startup (there is no version table).
+-- `tenant_id is null`) and re-runs safely because this migration is explicitly configured as repeatable
+-- on startup.
 
 alter table __SCHEMA__.operations_continuity_workflows
     add column if not exists tenant_id text null;

--- a/src/Meridian.Storage/Migrations/PostgresMigrationRunner.cs
+++ b/src/Meridian.Storage/Migrations/PostgresMigrationRunner.cs
@@ -58,33 +58,31 @@ public sealed class PostgresMigrationRunner
 
             if (applied.IsApplied)
             {
-                if (applied.Checksum is null)
+                var action = ResolveAppliedMigrationAction(applied.Checksum, checksum, _options.DriftPolicy);
+                switch (action)
                 {
-                    // Row recorded before checksums were tracked: adopt the current content as the
-                    // canonical version so future drift is detected, without re-running the script.
-                    await UpdateChecksumAsync(connection, transaction, script.FileName, checksum, ct)
-                        .ConfigureAwait(false);
-                    continue;
+                    case AppliedMigrationAction.Skip:
+                        continue;
+                    case AppliedMigrationAction.UpdateChecksum:
+                        // Row recorded before checksums were tracked: adopt the current content as the
+                        // canonical version so future drift is detected, without re-running the script.
+                        await UpdateChecksumAsync(connection, transaction, script.FileName, checksum, ct)
+                            .ConfigureAwait(false);
+                        continue;
+                    case AppliedMigrationAction.Throw:
+                        throw new InvalidOperationException(
+                            $"{_options.DisplayName} migration '{script.FileName}' has changed since it was applied.");
+                    case AppliedMigrationAction.ExecuteAndUpdateChecksum:
+                        // MigrationDriftPolicy.Reapply preserves the no-ledger runner convention:
+                        // idempotent scripts run on every startup, including unchanged backfills
+                        // that repair legacy rows after ownership bindings become available.
+                        await ExecuteScriptAsync(connection, transaction, sql, ct).ConfigureAwait(false);
+                        await UpdateChecksumAsync(connection, transaction, script.FileName, checksum, ct)
+                            .ConfigureAwait(false);
+                        continue;
+                    default:
+                        throw new InvalidOperationException($"Unsupported applied migration action '{action}'.");
                 }
-
-                if (string.Equals(applied.Checksum, checksum, StringComparison.Ordinal))
-                {
-                    continue;
-                }
-
-                if (_options.DriftPolicy == MigrationDriftPolicy.Throw)
-                {
-                    throw new InvalidOperationException(
-                        $"{_options.DisplayName} migration '{script.FileName}' has changed since it was applied.");
-                }
-
-                // MigrationDriftPolicy.Reapply: schemas whose scripts were historically re-run on
-                // every startup keep their edit-in-place workflow — a changed script is applied
-                // again and the ledger checksum updated.
-                await ExecuteScriptAsync(connection, transaction, sql, ct).ConfigureAwait(false);
-                await UpdateChecksumAsync(connection, transaction, script.FileName, checksum, ct)
-                    .ConfigureAwait(false);
-                continue;
             }
 
             await ExecuteScriptAsync(connection, transaction, sql, ct).ConfigureAwait(false);
@@ -179,6 +177,29 @@ public sealed class PostgresMigrationRunner
         command.Transaction = transaction;
         command.CommandText = rendered;
         await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    internal static AppliedMigrationAction ResolveAppliedMigrationAction(
+        string? appliedChecksum,
+        string currentChecksum,
+        MigrationDriftPolicy driftPolicy)
+    {
+        if (driftPolicy == MigrationDriftPolicy.Reapply)
+        {
+            return AppliedMigrationAction.ExecuteAndUpdateChecksum;
+        }
+
+        if (appliedChecksum is null)
+        {
+            return AppliedMigrationAction.UpdateChecksum;
+        }
+
+        if (string.Equals(appliedChecksum, currentChecksum, StringComparison.Ordinal))
+        {
+            return AppliedMigrationAction.Skip;
+        }
+
+        return AppliedMigrationAction.Throw;
     }
 
     private async Task RecordMigrationAsync(
@@ -302,6 +323,14 @@ public sealed class PostgresMigrationRunner
         }
 
         return value.All(static character => char.IsAsciiLetterOrDigit(character) || character == '_');
+    }
+
+    internal enum AppliedMigrationAction
+    {
+        Skip,
+        UpdateChecksum,
+        Throw,
+        ExecuteAndUpdateChecksum,
     }
 
     private readonly record struct MigrationScript(string Path, string FileName, int Ordinal);

--- a/src/Meridian.Storage/Migrations/PostgresMigrationRunner.cs
+++ b/src/Meridian.Storage/Migrations/PostgresMigrationRunner.cs
@@ -58,7 +58,11 @@ public sealed class PostgresMigrationRunner
 
             if (applied.IsApplied)
             {
-                var action = ResolveAppliedMigrationAction(applied.Checksum, checksum, _options.DriftPolicy);
+                var action = ResolveAppliedMigrationAction(
+                    applied.Checksum,
+                    checksum,
+                    _options.DriftPolicy,
+                    _options.RepeatableMigrationFileNames.Contains(script.FileName));
                 switch (action)
                 {
                     case AppliedMigrationAction.Skip:
@@ -73,9 +77,8 @@ public sealed class PostgresMigrationRunner
                         throw new InvalidOperationException(
                             $"{_options.DisplayName} migration '{script.FileName}' has changed since it was applied.");
                     case AppliedMigrationAction.ExecuteAndUpdateChecksum:
-                        // MigrationDriftPolicy.Reapply preserves the no-ledger runner convention:
-                        // idempotent scripts run on every startup, including unchanged backfills
-                        // that repair legacy rows after ownership bindings become available.
+                        // Explicitly repeatable migrations run on every startup; changed scripts in
+                        // Reapply mode also run so their revised idempotent behavior takes effect.
                         await ExecuteScriptAsync(connection, transaction, sql, ct).ConfigureAwait(false);
                         await UpdateChecksumAsync(connection, transaction, script.FileName, checksum, ct)
                             .ConfigureAwait(false);
@@ -182,9 +185,10 @@ public sealed class PostgresMigrationRunner
     internal static AppliedMigrationAction ResolveAppliedMigrationAction(
         string? appliedChecksum,
         string currentChecksum,
-        MigrationDriftPolicy driftPolicy)
+        MigrationDriftPolicy driftPolicy,
+        bool isRepeatableMigration = false)
     {
-        if (driftPolicy == MigrationDriftPolicy.Reapply)
+        if (driftPolicy == MigrationDriftPolicy.Reapply && isRepeatableMigration)
         {
             return AppliedMigrationAction.ExecuteAndUpdateChecksum;
         }
@@ -199,7 +203,9 @@ public sealed class PostgresMigrationRunner
             return AppliedMigrationAction.Skip;
         }
 
-        return AppliedMigrationAction.Throw;
+        return driftPolicy == MigrationDriftPolicy.Reapply
+            ? AppliedMigrationAction.ExecuteAndUpdateChecksum
+            : AppliedMigrationAction.Throw;
     }
 
     private async Task RecordMigrationAsync(

--- a/src/Meridian.Storage/Migrations/PostgresMigrationRunnerOptions.cs
+++ b/src/Meridian.Storage/Migrations/PostgresMigrationRunnerOptions.cs
@@ -62,6 +62,14 @@ public sealed class PostgresMigrationRunnerOptions
     /// <summary>Whether a missing scripts directory is an error or an empty migration set.</summary>
     public bool ThrowWhenScriptsDirectoryMissing { get; init; } = true;
 
+    /// <summary>
+    /// Applied script filenames that must run again on every startup. These scripts must be
+    /// idempotent and are typically used for guarded backfills that can repair legacy rows after
+    /// new ownership data becomes available.
+    /// </summary>
+    public IReadOnlySet<string> RepeatableMigrationFileNames { get; init; } =
+        new HashSet<string>(StringComparer.Ordinal);
+
     /// <summary>How a checksum mismatch on an already-applied script is handled.</summary>
     public MigrationDriftPolicy DriftPolicy { get; init; } = MigrationDriftPolicy.Throw;
 }
@@ -73,8 +81,9 @@ public enum MigrationDriftPolicy
     Throw,
 
     /// <summary>
-    /// Re-apply the script on every startup and update the ledger checksum. Used by schemas whose
-    /// scripts were historically re-run on every startup and are written to be idempotent.
+    /// Re-apply a changed script and update the ledger checksum. Unchanged scripts run again only
+    /// when their filename is listed in
+    /// <see cref="PostgresMigrationRunnerOptions.RepeatableMigrationFileNames"/>.
     /// </summary>
     Reapply,
 }

--- a/src/Meridian.Storage/Migrations/PostgresMigrationRunnerOptions.cs
+++ b/src/Meridian.Storage/Migrations/PostgresMigrationRunnerOptions.cs
@@ -73,8 +73,8 @@ public enum MigrationDriftPolicy
     Throw,
 
     /// <summary>
-    /// Re-apply the changed script and update the ledger checksum. Used by schemas whose scripts
-    /// were historically re-run on every startup and are written to be idempotent.
+    /// Re-apply the script on every startup and update the ledger checksum. Used by schemas whose
+    /// scripts were historically re-run on every startup and are written to be idempotent.
     /// </summary>
     Reapply,
 }

--- a/tests/Meridian.Tests/Storage/PostgresMigrationRunnerValidationTests.cs
+++ b/tests/Meridian.Tests/Storage/PostgresMigrationRunnerValidationTests.cs
@@ -66,6 +66,53 @@ public sealed class PostgresMigrationRunnerValidationTests
         act.Should().NotThrow();
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("same-checksum")]
+    [InlineData("old-checksum")]
+    public void ResolveAppliedMigrationAction_ReapplyExecutesAlreadyAppliedScriptsEveryStartup(string? appliedChecksum)
+    {
+        var action = PostgresMigrationRunner.ResolveAppliedMigrationAction(
+            appliedChecksum,
+            "same-checksum",
+            MigrationDriftPolicy.Reapply);
+
+        action.Should().Be(PostgresMigrationRunner.AppliedMigrationAction.ExecuteAndUpdateChecksum);
+    }
+
+    [Fact]
+    public void ResolveAppliedMigrationAction_ThrowPolicySkipsUnchangedScripts()
+    {
+        var action = PostgresMigrationRunner.ResolveAppliedMigrationAction(
+            "same-checksum",
+            "same-checksum",
+            MigrationDriftPolicy.Throw);
+
+        action.Should().Be(PostgresMigrationRunner.AppliedMigrationAction.Skip);
+    }
+
+    [Fact]
+    public void ResolveAppliedMigrationAction_ThrowPolicyAdoptsMissingChecksumsWithoutExecuting()
+    {
+        var action = PostgresMigrationRunner.ResolveAppliedMigrationAction(
+            null,
+            "same-checksum",
+            MigrationDriftPolicy.Throw);
+
+        action.Should().Be(PostgresMigrationRunner.AppliedMigrationAction.UpdateChecksum);
+    }
+
+    [Fact]
+    public void ResolveAppliedMigrationAction_ThrowPolicyFailsOnChecksumDrift()
+    {
+        var action = PostgresMigrationRunner.ResolveAppliedMigrationAction(
+            "old-checksum",
+            "new-checksum",
+            MigrationDriftPolicy.Throw);
+
+        action.Should().Be(PostgresMigrationRunner.AppliedMigrationAction.Throw);
+    }
+
     [Fact]
     public async Task EnsureMigratedAsync_ThrowsWhenConnectionStringMissing()
     {

--- a/tests/Meridian.Tests/Storage/PostgresMigrationRunnerValidationTests.cs
+++ b/tests/Meridian.Tests/Storage/PostgresMigrationRunnerValidationTests.cs
@@ -70,11 +70,34 @@ public sealed class PostgresMigrationRunnerValidationTests
     [InlineData(null)]
     [InlineData("same-checksum")]
     [InlineData("old-checksum")]
-    public void ResolveAppliedMigrationAction_ReapplyExecutesAlreadyAppliedScriptsEveryStartup(string? appliedChecksum)
+    public void ResolveAppliedMigrationAction_ReapplyExecutesExplicitlyRepeatableScriptsEveryStartup(string? appliedChecksum)
     {
         var action = PostgresMigrationRunner.ResolveAppliedMigrationAction(
             appliedChecksum,
             "same-checksum",
+            MigrationDriftPolicy.Reapply,
+            isRepeatableMigration: true);
+
+        action.Should().Be(PostgresMigrationRunner.AppliedMigrationAction.ExecuteAndUpdateChecksum);
+    }
+
+    [Fact]
+    public void ResolveAppliedMigrationAction_ReapplySkipsUnchangedNonRepeatableScripts()
+    {
+        var action = PostgresMigrationRunner.ResolveAppliedMigrationAction(
+            "same-checksum",
+            "same-checksum",
+            MigrationDriftPolicy.Reapply);
+
+        action.Should().Be(PostgresMigrationRunner.AppliedMigrationAction.Skip);
+    }
+
+    [Fact]
+    public void ResolveAppliedMigrationAction_ReapplyExecutesChangedNonRepeatableScripts()
+    {
+        var action = PostgresMigrationRunner.ResolveAppliedMigrationAction(
+            "old-checksum",
+            "new-checksum",
             MigrationDriftPolicy.Reapply);
 
         action.Should().Be(PostgresMigrationRunner.AppliedMigrationAction.ExecuteAndUpdateChecksum);


### PR DESCRIPTION
### Motivation
- A refactor to a shared `PostgresMigrationRunner` caused `MigrationDriftPolicy.Reapply` to skip already-applied scripts when the checksum matched, which prevented Ledger idempotent backfill migrations (e.g. `V_ledger_020`/`V_ledger_021`) from replaying on later startups and produced a cross-tenant read risk for rows with null `tenant_id`.

### Description
- Restore the historical `Reapply` semantics by executing idempotent, already-applied scripts on every startup for `MigrationDriftPolicy.Reapply` by adding a decision helper and enum: `ResolveAppliedMigrationAction` and `AppliedMigrationAction` in `src/Meridian.Storage/Migrations/PostgresMigrationRunner.cs`.
- Keep existing `Throw`/append-only behavior unchanged: skip unchanged scripts, adopt legacy null checksums without executing, and throw on checksum drift.
- Update the `Reapply` documentation comment in `src/Meridian.Storage/Migrations/PostgresMigrationRunnerOptions.cs` to clarify scripts are re-applied on every startup.
- Add regression unit tests for the applied-migration decision matrix in `tests/Meridian.Tests/Storage/PostgresMigrationRunnerValidationTests.cs`.

### Testing
- Added unit tests: `PostgresMigrationRunner.ResolveAppliedMigrationAction_*` cases in `PostgresMigrationRunnerValidationTests` (tests added but not executed locally due to environment limits).
- `git diff --check` — passed locally.
- Attempted `dotnet test` for the new validation tests but `dotnet` is not installed in this container so the tests were not run locally (`dotnet: command not found`).
- `bash scripts/ci.sh` — could not complete locally because the .NET SDK check failed for the same reason.
- `python3 build/python/cli/buildctl.py validation-status --summary` — ran and reported no active locks (`blocked=false`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a559107757883209711bcddecd4714c)