### PR TITLE
Prevent tenantless operations workflows from unresolved ledger book IDs

### DIFF
--- a/src/Meridian.FinancialOperations/OperationsContinuity/OperationsContinuityWorkflowService.cs
+++ b/src/Meridian.FinancialOperations/OperationsContinuity/OperationsContinuityWorkflowService.cs
@@ -3033,6 +3033,16 @@ public sealed class OperationsContinuityWorkflowService : IOperationsContinuityW
                 []));
         }
 
+        if (request.LedgerBookId == Guid.Empty)
+        {
+            blockers.Add(new OperationsWorkflowBlockerDto(
+                "LEDGER_BOOK_REQUIRED",
+                "Ledger book id must be omitted for fund-level workflows or set to a valid ledger book id.",
+                null,
+                "Error",
+                []));
+        }
+
         return blockers;
     }
 

--- a/src/Meridian.FinancialOperations/OperationsContinuity/PostgresOperationsContinuityStore.cs
+++ b/src/Meridian.FinancialOperations/OperationsContinuity/PostgresOperationsContinuityStore.cs
@@ -49,7 +49,6 @@ public sealed class PostgresOperationsContinuityStore :
         await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
         await using var transaction = await connection.BeginTransactionAsync(IsolationLevel.Serializable, ct).ConfigureAwait(false);
 
-        await EnsureLedgerBookTenantResolvableAsync(connection, transaction, workflow, ct).ConfigureAwait(false);
         await UpsertWorkflowAsync(connection, transaction, workflow, ct).ConfigureAwait(false);
 
         await transaction.CommitAsync(ct).ConfigureAwait(false);
@@ -218,6 +217,8 @@ public sealed class PostgresOperationsContinuityStore :
         await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
         await using var transaction = await connection.BeginTransactionAsync(IsolationLevel.Serializable, ct).ConfigureAwait(false);
 
+        // Reject an unresolved book before a transactional ledger append can create any related writes.
+        await EnsureLedgerBookTenantResolvableAsync(connection, transaction, workflow, ct).ConfigureAwait(false);
         await _ledgerJournalStore.AppendAsync(connection, transaction, journalEntry, ct).ConfigureAwait(false);
         var audit = await AppendAuditAsync(connection, transaction, auditDraft, ct).ConfigureAwait(false);
         workflow.Touch(audit.OccurredAtUtc);
@@ -349,6 +350,10 @@ public sealed class PostgresOperationsContinuityStore :
         OperationsContinuityWorkflow workflow,
         CancellationToken ct)
     {
+        // Keep the tenant-resolution precondition at the write seam so all workflow upserts, including
+        // transactional workflow starts, reject book-scoped workflows that cannot be tenant-stamped.
+        await EnsureLedgerBookTenantResolvableAsync(connection, transaction, workflow, ct).ConfigureAwait(false);
+
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
         command.CommandText =

--- a/src/Meridian.FinancialOperations/OperationsContinuity/PostgresOperationsContinuityStore.cs
+++ b/src/Meridian.FinancialOperations/OperationsContinuity/PostgresOperationsContinuityStore.cs
@@ -49,6 +49,7 @@ public sealed class PostgresOperationsContinuityStore :
         await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
         await using var transaction = await connection.BeginTransactionAsync(IsolationLevel.Serializable, ct).ConfigureAwait(false);
 
+        await EnsureLedgerBookTenantResolvableAsync(connection, transaction, workflow, ct).ConfigureAwait(false);
         await UpsertWorkflowAsync(connection, transaction, workflow, ct).ConfigureAwait(false);
 
         await transaction.CommitAsync(ct).ConfigureAwait(false);
@@ -424,8 +425,10 @@ public sealed class PostgresOperationsContinuityStore :
         // Trust-on-first-use fallback tenant for a genuinely BOOK-LESS workflow only: the resolved tenant of
         // the operator performing the write. Bound to null whenever a ledger book is present, so a
         // book-scoped workflow always derives its tenant from the authoritative fund registry (see the stamp
-        // SQL) and can never be mis-stamped with a caller tenant that differs from the fund's owner. Null for
-        // a background/non-request writer, which stays fail-open. Trimmed to match the write-side stamp.
+        // SQL) and can never be mis-stamped with a caller tenant that differs from the fund's owner. The
+        // pre-insert ledger-book tenant guard rejects unresolved book scopes before they can persist a
+        // tenantless fail-open workflow. Null for a background/non-request writer, which stays fail-open
+        // only for genuinely book-less workflows. Trimmed to match the write-side stamp.
         var callerTenantStamp = ResolveCallerTenant();
         var bookLessCallerTenant = workflow.LedgerBookId is null && !string.IsNullOrWhiteSpace(callerTenantStamp)
             ? (object)callerTenantStamp.Trim()
@@ -437,6 +440,37 @@ public sealed class PostgresOperationsContinuityStore :
         {
             throw new InvalidOperationException(
                 $"Operations continuity workflow '{workflow.WorkflowId}' was not saved because the stored version is newer or equal.");
+        }
+    }
+
+    private async Task EnsureLedgerBookTenantResolvableAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        OperationsContinuityWorkflow workflow,
+        CancellationToken ct)
+    {
+        if (workflow.LedgerBookId is null)
+        {
+            return;
+        }
+
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText =
+            $"""
+            select t.tenant_id
+            from {Qualified("ledger_books")} b
+            join {Qualified("fund_profile_tenancy")} t
+              on t.fund_profile_id = lower(trim(b.fund_profile_id))
+            where b.ledger_book_id = @tenant_ledger_book_id
+            """;
+        command.Parameters.AddWithValue("tenant_ledger_book_id", workflow.LedgerBookId.Value);
+
+        var tenantId = await command.ExecuteScalarAsync(ct).ConfigureAwait(false) as string;
+        if (string.IsNullOrWhiteSpace(tenantId))
+        {
+            throw new InvalidOperationException(
+                $"Operations continuity workflow '{workflow.WorkflowId}' cannot be saved because ledger book '{workflow.LedgerBookId.Value}' does not resolve to a claimed fund tenant.");
         }
     }
 

--- a/tests/Meridian.Tests/Application/OperationsContinuityPostgresRoundTripTests.cs
+++ b/tests/Meridian.Tests/Application/OperationsContinuityPostgresRoundTripTests.cs
@@ -31,6 +31,42 @@ public sealed class OperationsContinuityPostgresRoundTripTests
     }
 
     [LedgerDatabaseFact]
+    public async Task PostgresOperationsContinuityStore_ShouldRejectUnresolvedBookWhenStartingWorkflowTransactionally()
+    {
+        await using var database = await LedgerPostgresTestDatabase.CreateAsync();
+        var workflow = OperationsContinuityWorkflow.Start(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "2026-05-invalid-book-transactional-start",
+            securityMasterSnapshotId: Guid.NewGuid(),
+            brokerSource: "postgres-fixture",
+            now: DateTimeOffset.UtcNow,
+            ledgerBookId: Guid.NewGuid());
+        var auditDraft = new OperationsWorkflowAuditDraft(
+            workflow.WorkflowId,
+            workflow.FundAccountId,
+            workflow.PeriodId,
+            "workflow-started",
+            OperationsWorkflowStatusDto.NotStarted,
+            OperationsWorkflowStatusDto.NotStarted,
+            OperationsGateKeyDto.BrokerIngest,
+            OperationsGateStatusDto.NotStarted,
+            OperationsGateStatusDto.InProgress,
+            "ops-user",
+            "Reject an unresolved book before committing the workflow start.",
+            "postgres-unresolved-book-transactional-start",
+            EvidenceLinks());
+
+        var act = () => database.OperationsStore.CommitWorkflowStartAsync(workflow, auditDraft);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*does not resolve to a claimed fund tenant*");
+
+        (await database.OperationsStore.GetAsync(workflow.WorkflowId)).Should().BeNull();
+        (await database.OperationsStore.GetTimelineAsync(workflow.WorkflowId)).Should().BeEmpty();
+    }
+
+    [LedgerDatabaseFact]
     public async Task PostgresOperationsContinuityStore_ShouldRoundTripTransactionalLedgerPosting()
     {
         await using var database = await LedgerPostgresTestDatabase.CreateAsync();

--- a/tests/Meridian.Tests/Application/OperationsContinuityPostgresRoundTripTests.cs
+++ b/tests/Meridian.Tests/Application/OperationsContinuityPostgresRoundTripTests.cs
@@ -12,6 +12,25 @@ namespace Meridian.Tests.Application;
 public sealed class OperationsContinuityPostgresRoundTripTests
 {
     [LedgerDatabaseFact]
+    public async Task PostgresOperationsContinuityStore_ShouldRejectBookScopedWorkflowWhenTenantCannotBeResolved()
+    {
+        await using var database = await LedgerPostgresTestDatabase.CreateAsync();
+        var workflow = OperationsContinuityWorkflow.Start(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "2026-05-invalid-book",
+            securityMasterSnapshotId: Guid.NewGuid(),
+            brokerSource: "postgres-fixture",
+            now: DateTimeOffset.UtcNow,
+            ledgerBookId: Guid.NewGuid());
+
+        var act = () => database.OperationsStore.SaveAsync(workflow);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*does not resolve to a claimed fund tenant*");
+    }
+
+    [LedgerDatabaseFact]
     public async Task PostgresOperationsContinuityStore_ShouldRoundTripTransactionalLedgerPosting()
     {
         await using var database = await LedgerPostgresTestDatabase.CreateAsync();

--- a/tests/Meridian.Tests/Application/OperationsContinuityWorkflowServiceTests.cs
+++ b/tests/Meridian.Tests/Application/OperationsContinuityWorkflowServiceTests.cs
@@ -126,6 +126,25 @@ public sealed class OperationsContinuityWorkflowServiceTests
     }
 
     [Fact]
+    public async Task StartWorkflowAsync_ShouldRejectEmptyLedgerBookScope()
+    {
+        var service = CreateService(out _, out _);
+
+        var result = await service.StartWorkflowAsync(new OperationsStartWorkflowRequestDto(
+            Guid.NewGuid(),
+            "2026-05",
+            SecurityMasterSnapshotId: Guid.NewGuid(),
+            BrokerSource: "ibkr",
+            Actor: "ops-user",
+            Rationale: "Attempt to open an invalid book-scoped workflow.",
+            LedgerBookId: Guid.Empty));
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be("VALIDATION_FAILED");
+        result.Blockers.Should().Contain(blocker => blocker.Code == "LEDGER_BOOK_REQUIRED");
+    }
+
+    [Fact]
     public async Task StartWorkflowAsync_ShouldRejectDuplicateOpenWorkflowForSameFundAndPeriod()
     {
         var service = CreateService(out _, out _);


### PR DESCRIPTION
### Motivation
- Fix a cross-tenant isolation vulnerability where a bogus non-null `LedgerBookId` could cause `tenant_id` to be persisted as `NULL`, making workflows visible and mutable across tenants.
- Preserve the intended behavior that book-scoped workflows are stamped from the authoritative fund tenancy while keeping caller-tenant fallback limited to genuinely book-less workflows.

### Description
- Add a pre-insert guard `EnsureLedgerBookTenantResolvableAsync` in `PostgresOperationsContinuityStore.SaveAsync` that queries `ledger_books` -> `fund_profile_tenancy` and throws when a supplied `LedgerBookId` does not resolve to a claimed fund tenant, preventing insert/update of tenantless records.
- Keep the storage-side stamping SQL but enforce resolution before the upsert so unresolved book IDs cannot produce `tenant_id = NULL` even when the caller fallback is bound to `NULL` for book-scoped flows (comment clarified in `PostgresOperationsContinuityStore.cs`).
- Reject `Guid.Empty` ledger book scopes early by adding a validation blocker in `ValidateStartRequest` in `OperationsContinuityWorkflowService` to prevent client-supplied empty GUIDs from reaching storage.
- Add automated coverage: `StartWorkflowAsync_ShouldRejectEmptyLedgerBookScope` (unit) and `PostgresOperationsContinuityStore_ShouldRejectBookScopedWorkflowWhenTenantCannotBeResolved` (Postgres integration) under `tests/Meridian.Tests/Application/`.

### Testing
- Added unit and integration tests: `StartWorkflowAsync_ShouldRejectEmptyLedgerBookScope` and `PostgresOperationsContinuityStore_ShouldRejectBookScopedWorkflowWhenTenantCannotBeResolved` which exercise the new validation and storage guard.
- Local repository checks `git diff --check` passed and `python build/python/cli/buildctl.py validation-status --summary` returned normal validation-state results in this environment.
- Running the targeted `dotnet test` and full `bash scripts/ci.sh` was blocked in this container because `dotnet` is not installed, so the new tests could not be executed here (CI/GitHub Actions should run the tests as part of the PR validation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4481e6836883208729a48787ac3a20)