### PR TITLE
Add per-asset Alpaca streams, provider stream diagnostics, and trading eligibility; extend trading parameters DTO

### DIFF
--- a/src/Meridian.Application/SecurityMaster/SecurityMasterQueryService.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityMasterQueryService.cs
@@ -172,13 +172,22 @@ public sealed class SecurityMasterQueryService :
 
         return new TradingParametersDto(
             SecurityId: securityId,
-            LotSize: ReadDecimal(common, "lotSize"),
-            TickSize: ReadDecimal(common, "tickSize"),
+            LotSize: ReadDecimal(common, "lotSize") ?? ReadDecimal(common, "minimumTradeIncrement"),
+            TickSize: ReadDecimal(common, "tickSize") ?? ReadDecimal(common, "priceIncrement"),
             ContractMultiplier: ReadDecimal(common, "contractMultiplier"),
             MarginRequirementPct: ReadDecimal(common, "marginRequirementPct"),
             TradingHoursUtc: ReadString(common, "tradingHoursUtc"),
             CircuitBreakerThresholdPct: ReadDecimal(common, "circuitBreakerThresholdPct"),
-            AsOf: asOf);
+            AsOf: asOf)
+        {
+            IsMarginable = ReadBool(common, "isMarginable"),
+            IsShortable = ReadBool(common, "isShortable"),
+            IsEasyToBorrow = ReadBool(common, "isEasyToBorrow"),
+            IsFractionable = ReadBool(common, "isFractionable"),
+            MinimumOrderSize = ReadDecimal(common, "minimumOrderSize"),
+            MinimumTradeIncrement = ReadDecimal(common, "minimumTradeIncrement"),
+            PriceIncrement = ReadDecimal(common, "priceIncrement")
+        };
     }
 
     private static decimal? ReadDecimal(System.Text.Json.JsonElement element, string propertyName)

--- a/src/Meridian.Contracts/Api/UiDashboardModels.cs
+++ b/src/Meridian.Contracts/Api/UiDashboardModels.cs
@@ -93,6 +93,16 @@ public record ProviderComparisonResponse(
     int HealthyProviders);
 
 /// <summary>Response containing provider connection status.</summary>
+public record ProviderStreamStatusResponse(
+    string AssetClass,
+    string Feed,
+    string Entitlement,
+    string LifecycleState,
+    bool IsConnected,
+    bool IsDegraded,
+    string? DegradationReason);
+
+/// <summary>Response containing provider connection status.</summary>
 public record ProviderStatusResponse(
     string ProviderId,
     string Name,
@@ -114,7 +124,8 @@ public record ProviderStatusResponse(
     int? RecoveringSubscriptions = null,
     DateTimeOffset? LastSubscriptionMessageAt = null,
     string? ConnectionState = null,
-    bool DiagnosticsAvailable = false);
+    bool DiagnosticsAvailable = false,
+    IReadOnlyList<ProviderStreamStatusResponse>? Streams = null);
 
 /// <summary>Response containing detailed provider metrics.</summary>
 public record ProviderMetricsResponse(

--- a/src/Meridian.Contracts/SecurityMaster/SecurityDtos.cs
+++ b/src/Meridian.Contracts/SecurityMaster/SecurityDtos.cs
@@ -135,7 +135,16 @@ public sealed record TradingParametersDto(
     decimal? MarginRequirementPct,
     string? TradingHoursUtc,
     decimal? CircuitBreakerThresholdPct,
-    DateTimeOffset AsOf);
+    DateTimeOffset AsOf)
+{
+    public bool? IsMarginable { get; init; }
+    public bool? IsShortable { get; init; }
+    public bool? IsEasyToBorrow { get; init; }
+    public bool? IsFractionable { get; init; }
+    public decimal? MinimumOrderSize { get; init; }
+    public decimal? MinimumTradeIncrement { get; init; }
+    public decimal? PriceIncrement { get; init; }
+}
 
 /// <summary>
 /// A single corporate action event envelope returned by the corporate actions query.

--- a/src/Meridian.Core/Config/AlpacaOptions.cs
+++ b/src/Meridian.Core/Config/AlpacaOptions.cs
@@ -19,5 +19,12 @@ public sealed record AlpacaOptions(
     string SecretKey = "",
     string Feed = "iex",            // stocks: iex, sip, delayed_sip, boats, overnight, otc; streams also support test
     bool UseSandbox = false,        // stream.data.sandbox.alpaca.markets / paper-api.alpaca.markets
-    bool SubscribeQuotes = false    // if true, subscribes to quotes too (currently not wired to L2 collector)
-);
+    bool SubscribeQuotes = false,   // if true, subscribes to quotes too (currently not wired to L2 collector)
+    string? OptionsFeed = null,     // indicative (default) or opra; OPRA requires the corresponding entitlement
+    string CryptoFeed = "us",
+    string NewsFeed = "basic"
+)
+{
+    /// <summary>Equity feed retained under its original configuration name for compatibility.</summary>
+    public string EquitiesFeed => Feed;
+}

--- a/src/Meridian.Core/Subscriptions/Models/SymbolSearchResult.cs
+++ b/src/Meridian.Core/Subscriptions/Models/SymbolSearchResult.cs
@@ -110,7 +110,23 @@ public sealed record SymbolDetails(
 
     // <summary>When the details were last updated.</summary>
     DateTimeOffset? LastUpdated = null
-);
+)
+{
+    public SymbolTradingEligibility? TradingEligibility { get; init; }
+}
+
+/// <summary>Provider-supplied borrow and order-increment evidence for a symbol.</summary>
+public sealed record SymbolTradingEligibility(
+    bool? IsTradable,
+    bool? IsMarginable,
+    bool? IsShortable,
+    bool? IsEasyToBorrow,
+    bool? IsFractionable,
+    decimal? MaintenanceMarginRequirement,
+    decimal? MinimumOrderSize,
+    decimal? MinimumTradeIncrement,
+    decimal? PriceIncrement,
+    string? Source);
 
 /// <summary>
 /// Request for symbol search/autocomplete.

--- a/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaAssetStreamAdapters.cs
+++ b/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaAssetStreamAdapters.cs
@@ -1,0 +1,63 @@
+using Meridian.Core.Config;
+using Meridian.Domain.Collectors;
+using Meridian.Infrastructure.Resilience;
+
+namespace Meridian.Infrastructure.Adapters.Alpaca;
+
+/// <summary>Marker for independently connectable Alpaca asset-class stream adapters.</summary>
+public interface IAlpacaAssetStream
+{
+    MarketDataAssetClass AssetClass { get; }
+}
+
+/// <summary>Dedicated Alpaca US options WebSocket adapter.</summary>
+public sealed class AlpacaOptionsMarketDataClient : AlpacaMarketDataClient
+{
+    public AlpacaOptionsMarketDataClient(TradeDataCollector trades, QuoteCollector quotes, AlpacaOptions options)
+        : base(trades, quotes, options) { }
+
+    public override MarketDataAssetClass AssetClass => MarketDataAssetClass.Options;
+    public override string ProviderId => "alpaca-options-stream";
+    public override string ProviderDisplayName => "Alpaca Options Streaming";
+
+    protected override Uri BuildWebSocketUri() => AlpacaEndpoints.OptionsWssUri(Host);
+
+    private string Host => Options.UseSandbox ? AlpacaEndpoints.SandboxHost : AlpacaEndpoints.LiveHost;
+}
+
+/// <summary>Dedicated Alpaca US crypto WebSocket adapter.</summary>
+public sealed class AlpacaCryptoMarketDataClient : AlpacaMarketDataClient
+{
+    public AlpacaCryptoMarketDataClient(TradeDataCollector trades, QuoteCollector quotes, AlpacaOptions options)
+        : base(trades, quotes, options) { }
+
+    public override MarketDataAssetClass AssetClass => MarketDataAssetClass.Crypto;
+    public override string ProviderId => "alpaca-crypto-stream";
+    public override string ProviderDisplayName => "Alpaca Crypto Streaming";
+
+    protected override Uri BuildWebSocketUri() => AlpacaEndpoints.CryptoWssUri(Host);
+
+    private string Host => Options.UseSandbox ? AlpacaEndpoints.SandboxHost : AlpacaEndpoints.LiveHost;
+}
+
+/// <summary>
+/// Dedicated Alpaca news WebSocket adapter. News does not implement trade or quote subscriptions;
+/// callers can still connect and surface its entitlement independently from price streams.
+/// </summary>
+public sealed class AlpacaNewsMarketDataClient : AlpacaMarketDataClient
+{
+    public AlpacaNewsMarketDataClient(TradeDataCollector trades, QuoteCollector quotes, AlpacaOptions options)
+        : base(trades, quotes, options) { }
+
+    public override MarketDataAssetClass AssetClass => MarketDataAssetClass.News;
+    public override string ProviderId => "alpaca-news-stream";
+    public override string ProviderDisplayName => "Alpaca News Streaming";
+
+    protected override Uri BuildWebSocketUri() => AlpacaEndpoints.NewsWssUri(Host);
+
+    public override int SubscribeTrades(Meridian.Contracts.Configuration.SymbolConfig cfg) => -1;
+
+    public override int SubscribeMarketDepth(Meridian.Contracts.Configuration.SymbolConfig cfg) => -1;
+
+    private string Host => Options.UseSandbox ? AlpacaEndpoints.SandboxHost : AlpacaEndpoints.LiveHost;
+}

--- a/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaConstants.cs
+++ b/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaConstants.cs
@@ -16,6 +16,15 @@ internal static class AlpacaEndpoints
     /// </summary>
     public static Uri WssUri(string host, string feed) =>
         new($"wss://{host}/v2/{feed}");
+
+    /// <summary>Dedicated endpoint for the US crypto stream.</summary>
+    public static Uri CryptoWssUri(string host) => new($"wss://{host}/v1beta3/crypto/us");
+
+    /// <summary>Dedicated endpoint for the options stream.</summary>
+    public static Uri OptionsWssUri(string host) => new($"wss://{host}/v1beta1/options");
+
+    /// <summary>Dedicated endpoint for the news stream.</summary>
+    public static Uri NewsWssUri(string host) => new($"wss://{host}/v1beta1/news");
 }
 
 /// <summary>

--- a/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaMarketDataClient.cs
+++ b/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaMarketDataClient.cs
@@ -15,7 +15,7 @@ using AlpacaOptions = Meridian.Core.Config.AlpacaOptions;
 namespace Meridian.Infrastructure.Adapters.Alpaca;
 
 /// <summary>
-/// Alpaca Market Data client (WebSocket) that implements the IMarketDataClient abstraction.
+/// Alpaca equities market-data stream adapter (WebSocket) that implements the IMarketDataClient abstraction.
 /// Extends <see cref="WebSocketProviderBase"/>, which centralises connection lifecycle,
 /// resilience (retry + circuit breaker), heartbeat monitoring, and automatic reconnection.
 /// ~80 LOC of WebSocket boilerplate removed compared to the previous direct implementation.
@@ -42,11 +42,11 @@ namespace Meridian.Infrastructure.Adapters.Alpaca;
     EnvironmentVariables = new[] { "ALPACA_SECRET_KEY", "ALPACA__SECRETKEY" },
     DisplayName = "API Secret Key",
     Description = "Alpaca API secret key from https://app.alpaca.markets/brokerage/papers")]
-public sealed class AlpacaMarketDataClient : WebSocketProviderBase
+public class AlpacaMarketDataClient : WebSocketProviderBase, IAlpacaAssetStream
 {
     private readonly TradeDataCollector _tradeCollector;
     private readonly QuoteCollector _quoteCollector;
-    private readonly AlpacaOptions _opt;
+    protected readonly AlpacaOptions Options;
 
     // Content-based trade deduplication: sliding window keyed on (symbol, price, size, timestamp).
     // Alpaca's WebSocket is known to re-deliver identical trade messages during reconnections and
@@ -65,14 +65,17 @@ public sealed class AlpacaMarketDataClient : WebSocketProviderBase
     {
         _tradeCollector = tradeCollector ?? throw new ArgumentNullException(nameof(tradeCollector));
         _quoteCollector = quoteCollector ?? throw new ArgumentNullException(nameof(quoteCollector));
-        _opt = opt ?? throw new ArgumentNullException(nameof(opt));
-        if (string.IsNullOrWhiteSpace(_opt.KeyId) || string.IsNullOrWhiteSpace(_opt.SecretKey))
+        Options = opt ?? throw new ArgumentNullException(nameof(opt));
+        if (string.IsNullOrWhiteSpace(Options.KeyId) || string.IsNullOrWhiteSpace(Options.SecretKey))
             throw new ArgumentException("Alpaca KeyId/SecretKey required.");
     }
 
 
     /// <inheritdoc/>
     public override bool IsEnabled => true;
+
+    /// <summary>The asset class served by this independent WebSocket adapter.</summary>
+    public virtual MarketDataAssetClass AssetClass => MarketDataAssetClass.Equities;
 
     /// <inheritdoc/>
     public override string ProviderId => "alpaca";
@@ -98,6 +101,17 @@ public sealed class AlpacaMarketDataClient : WebSocketProviderBase
         MinRequestDelay = TimeSpan.FromMilliseconds(300)
     };
 
+    /// <summary>
+    /// Returns diagnostics for every distinct Alpaca asset-class stream. Equities is backed by
+    /// this live adapter; options, crypto, and news remain separately visible rather than being
+    /// incorrectly reported as covered by the equities socket.
+    /// </summary>
+    public override WebSocketConnectionDiagnostics GetConnectionDiagnosticsSnapshot()
+    {
+        var snapshot = base.GetConnectionDiagnosticsSnapshot();
+        return snapshot with { Streams = AlpacaStreamProfiles.Create(Options, snapshot, AssetClass) };
+    }
+
     /// <inheritdoc/>
     public ProviderCredentialField[] ProviderCredentialFields => new[]
     {
@@ -118,9 +132,9 @@ public sealed class AlpacaMarketDataClient : WebSocketProviderBase
     /// <inheritdoc/>
     protected override Uri BuildWebSocketUri()
     {
-        var host = _opt.UseSandbox ? "stream.data.sandbox.alpaca.markets" : "stream.data.alpaca.markets";
-        var uri = new Uri($"wss://{host}/v2/{_opt.Feed}");
-        Log.Information("Connecting to Alpaca WebSocket at {Uri} (Sandbox: {UseSandbox})", uri, _opt.UseSandbox);
+        var host = Options.UseSandbox ? "stream.data.sandbox.alpaca.markets" : "stream.data.alpaca.markets";
+        var uri = new Uri($"wss://{host}/v2/{Options.Feed}");
+        Log.Information("Connecting to Alpaca {AssetClass} WebSocket at {Uri} (Sandbox: {UseSandbox})", AssetClass, uri, Options.UseSandbox);
         return uri;
     }
 
@@ -132,7 +146,7 @@ public sealed class AlpacaMarketDataClient : WebSocketProviderBase
     /// </remarks>
     protected override Task AuthenticateAsync(CancellationToken ct)
     {
-        var authMsg = BuildAuthenticationMessage(_opt);
+        var authMsg = BuildAuthenticationMessage(Options);
         Log.Debug("Sending authentication message to Alpaca");
         return SendAsync(authMsg, ct);
     }
@@ -183,7 +197,7 @@ public sealed class AlpacaMarketDataClient : WebSocketProviderBase
 
             var trades = Subscriptions.GetSymbolsByKind("trades");
             var quotes = Subscriptions.GetSymbolsByKind("quotes");
-            var json = BuildSubscriptionMessage(_opt.SubscribeQuotes, trades, quotes);
+            var json = BuildSubscriptionMessage(Options.SubscribeQuotes, trades, quotes);
             await SendAsync(json, ct).ConfigureAwait(false);
         }
         catch (Exception ex)
@@ -225,7 +239,7 @@ public sealed class AlpacaMarketDataClient : WebSocketProviderBase
     {
         // Not supported for stocks: Alpaca provides quotes, not full L2 depth updates.
         // If you later add QuoteCollector -> L2Snapshot mapping, wire it here.
-        if (!_opt.SubscribeQuotes)
+        if (!Options.SubscribeQuotes)
             return -1;
 
         if (cfg is null)

--- a/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaProviderModule.cs
+++ b/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaProviderModule.cs
@@ -102,6 +102,20 @@ public sealed class AlpacaProviderModule : ConfigurableProviderModuleBase, IProv
 
             services.AddSingleton<IMarketDataClient>(sp =>
                 sp.GetRequiredService<AlpacaMarketDataClient>());
+
+            // Keep asset classes independently connectable. The host still selects the equities
+            // adapter as its compatibility default; operators and future routing can resolve the
+            // other streams without treating their entitlements as equivalent.
+            services.AddSingleton<AlpacaOptionsMarketDataClient>(sp => new(
+                sp.GetRequiredService<TradeDataCollector>(), sp.GetRequiredService<QuoteCollector>(), streamingOptions));
+            services.AddSingleton<AlpacaCryptoMarketDataClient>(sp => new(
+                sp.GetRequiredService<TradeDataCollector>(), sp.GetRequiredService<QuoteCollector>(), streamingOptions));
+            services.AddSingleton<AlpacaNewsMarketDataClient>(sp => new(
+                sp.GetRequiredService<TradeDataCollector>(), sp.GetRequiredService<QuoteCollector>(), streamingOptions));
+            services.AddSingleton<IAlpacaAssetStream>(sp => sp.GetRequiredService<AlpacaMarketDataClient>());
+            services.AddSingleton<IAlpacaAssetStream>(sp => sp.GetRequiredService<AlpacaOptionsMarketDataClient>());
+            services.AddSingleton<IAlpacaAssetStream>(sp => sp.GetRequiredService<AlpacaCryptoMarketDataClient>());
+            services.AddSingleton<IAlpacaAssetStream>(sp => sp.GetRequiredService<AlpacaNewsMarketDataClient>());
         }
 
         // ----------------------------------------------------------------

--- a/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaStreamProfiles.cs
+++ b/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaStreamProfiles.cs
@@ -1,0 +1,52 @@
+using Meridian.Core.Config;
+using Meridian.Infrastructure.Resilience;
+
+namespace Meridian.Infrastructure.Adapters.Alpaca;
+
+/// <summary>Known Alpaca stream endpoints and their entitlement semantics.</summary>
+internal static class AlpacaStreamProfiles
+{
+    public static IReadOnlyList<ProviderStreamDiagnostics> Create(
+        AlpacaOptions options,
+        WebSocketConnectionDiagnostics connection,
+        MarketDataAssetClass connectedAssetClass = MarketDataAssetClass.Equities)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var equityFeed = options.EquitiesFeed.Trim().ToLowerInvariant();
+        var equityIsIndicative = equityFeed is "iex" or "delayed_sip";
+        var optionsFeed = string.IsNullOrWhiteSpace(options.OptionsFeed)
+            ? "indicative"
+            : options.OptionsFeed.Trim().ToLowerInvariant();
+
+        return
+        [
+            new(MarketDataAssetClass.Equities, equityFeed, EquityEntitlement(equityFeed),
+                StateFor(MarketDataAssetClass.Equities), IsConnectedFor(MarketDataAssetClass.Equities), equityIsIndicative,
+                equityIsIndicative ? "Limited or delayed equity feed; not consolidated SIP data." : null),
+            new(MarketDataAssetClass.Options, optionsFeed, OptionsEntitlement(optionsFeed),
+                StateFor(MarketDataAssetClass.Options), IsConnectedFor(MarketDataAssetClass.Options), optionsFeed != "opra",
+                optionsFeed == "opra" ? "Options stream is configured but not connected." : "Indicative options data only; OPRA entitlement is not configured."),
+            new(MarketDataAssetClass.Crypto, options.CryptoFeed, "crypto-us", StateFor(MarketDataAssetClass.Crypto),
+                IsConnectedFor(MarketDataAssetClass.Crypto), false, "Crypto stream is configured separately and not connected."),
+            new(MarketDataAssetClass.News, options.NewsFeed, "news-basic", StateFor(MarketDataAssetClass.News),
+                IsConnectedFor(MarketDataAssetClass.News), true, "News stream is configured separately and not connected.")
+        ];
+
+        ProviderConnectionLifecycleState StateFor(MarketDataAssetClass assetClass) => assetClass == connectedAssetClass
+            ? connection.LifecycleState
+            : ProviderConnectionLifecycleState.NotConfigured;
+
+        bool IsConnectedFor(MarketDataAssetClass assetClass) => assetClass == connectedAssetClass && connection.IsConnected;
+    }
+
+    private static string EquityEntitlement(string feed) => feed switch
+    {
+        "sip" => "sip",
+        "delayed_sip" => "sip-delayed",
+        "iex" => "iex",
+        _ => feed
+    };
+
+    private static string OptionsEntitlement(string feed) => feed == "opra" ? "opra" : "indicative";
+}

--- a/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaSymbolSearchProvider.cs
+++ b/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaSymbolSearchProvider.cs
@@ -35,7 +35,7 @@ public sealed class AlpacaSymbolSearchProvider : BaseSymbolSearchProvider
     protected override TimeSpan RateLimitWindow => TimeSpan.FromMinutes(1);
     protected override TimeSpan MinRequestDelay => TimeSpan.FromMilliseconds(300);
 
-    public override IReadOnlyList<string> SupportedAssetTypes => new[] { "us_equity", "crypto" };
+    public override IReadOnlyList<string> SupportedAssetTypes => new[] { "us_equity", "crypto", "us_option", "fixed_income" };
     public override IReadOnlyList<string> SupportedExchanges => new[] { "NASDAQ", "NYSE", "ARCA", "AMEX", "BATS" };
 
     public AlpacaSymbolSearchProvider(
@@ -69,19 +69,17 @@ public sealed class AlpacaSymbolSearchProvider : BaseSymbolSearchProvider
     {
         var url = $"{BaseUrl}/assets?status=active";
 
-        if (!string.IsNullOrEmpty(assetType))
+        if (!string.IsNullOrWhiteSpace(assetType))
         {
             var assetClass = assetType.ToLowerInvariant() switch
             {
                 "us_equity" or "stock" or "equity" => "us_equity",
                 "crypto" => "crypto",
-                _ => "us_equity"
+                "us_option" or "option" or "options" => "us_option",
+                "fixed_income" or "bond" or "bonds" => "fixed_income",
+                _ => throw new ArgumentOutOfRangeException(nameof(assetType), assetType, "Unsupported Alpaca asset class.")
             };
             url += $"&asset_class={assetClass}";
-        }
-        else
-        {
-            url += "&asset_class=us_equity";
         }
 
         if (!string.IsNullOrEmpty(exchange))
@@ -157,7 +155,12 @@ public sealed class AlpacaSymbolSearchProvider : BaseSymbolSearchProvider
             Cusip: null,
             Source: Name,
             LastUpdated: DateTimeOffset.UtcNow
-        );
+        )
+        {
+            TradingEligibility = new SymbolTradingEligibility(asset.Tradable, asset.Marginable, asset.Shortable,
+                asset.EasyToBorrow, asset.Fractionable, asset.MaintenanceMarginRequirement, asset.MinOrderSize,
+                asset.MinTradeIncrement, asset.PriceIncrement, Name)
+        };
 
         return Task.FromResult<SymbolDetails?>(details);
     }
@@ -180,6 +183,8 @@ public sealed class AlpacaSymbolSearchProvider : BaseSymbolSearchProvider
         {
             "us_equity" => "Stock",
             "crypto" => "Crypto",
+            "us_option" => "Option",
+            "fixed_income" => "FixedIncome",
             _ => assetClass
         };
     }

--- a/src/Meridian.Infrastructure/Adapters/Core/WebSocketProviderBase.cs
+++ b/src/Meridian.Infrastructure/Adapters/Core/WebSocketProviderBase.cs
@@ -100,7 +100,7 @@ public abstract class WebSocketProviderBase :
     public abstract bool IsEnabled { get; }
 
     /// <inheritdoc/>
-    public WebSocketConnectionDiagnostics GetConnectionDiagnosticsSnapshot()
+    public virtual WebSocketConnectionDiagnostics GetConnectionDiagnosticsSnapshot()
     {
         var connection = _connectionManager.GetDiagnosticsSnapshot();
         var subscriptions = Subscriptions.GetSnapshot();

--- a/src/Meridian.Infrastructure/README.md
+++ b/src/Meridian.Infrastructure/README.md
@@ -40,6 +40,16 @@ transport-specific lifecycle evidence. For polling, raw-socket, simulation, and 
 diagnostics, `WebSocketState` is `None`. Consumers should use this contract instead of reaching
 into provider-specific transport internals.
 
+Alpaca streaming keeps equities, options, crypto, and news as explicit adapters with their own
+WebSocket endpoints. Its diagnostics carry a per-stream selected feed and entitlement (for
+example, IEX versus SIP and indicative versus OPRA), so a connected price socket cannot be
+misrepresented as consolidated or OPRA-entitled data.
+
+Alpaca reference-data search preserves broker-supplied marginability, shortability,
+easy-to-borrow, fractionability, and minimum/increment constraints on symbol details. Search no
+longer silently defaults omitted asset-class filters to equities; it can discover equities, crypto,
+options, and fixed-income assets when the configured Alpaca API entitlement exposes them.
+
 The public diagnostics interface, lifecycle/failure enums, and snapshot record retain their
 existing namespaces but are owned by ProviderSdk so plugin contracts do not depend on concrete
 Infrastructure. Infrastructure publishes type forwarders for adapters compiled against the former

--- a/src/Meridian.ProviderSdk/ConnectionDiagnosticsContracts.cs
+++ b/src/Meridian.ProviderSdk/ConnectionDiagnosticsContracts.cs
@@ -35,6 +35,28 @@ public enum ProviderFailureKind
     Cancelled = 8
 }
 
+/// <summary>Asset-class stream exposed by a market-data provider.</summary>
+public enum MarketDataAssetClass
+{
+    Equities = 0,
+    Options = 1,
+    Crypto = 2,
+    News = 3
+}
+
+/// <summary>
+/// Safe, operator-facing evidence for one provider stream. Feed and entitlement are deliberately
+/// explicit: a connected stream is not necessarily real-time consolidated market data.
+/// </summary>
+public sealed record ProviderStreamDiagnostics(
+    MarketDataAssetClass AssetClass,
+    string Feed,
+    string Entitlement,
+    ProviderConnectionLifecycleState LifecycleState,
+    bool IsConnected,
+    bool IsDegraded,
+    string? DegradationReason);
+
 /// <summary>
 /// Safe provider connection diagnostics. It intentionally excludes URIs, credentials,
 /// headers, account IDs, and payload data.
@@ -62,4 +84,5 @@ public sealed record WebSocketConnectionDiagnostics(
     int ActiveSubscriptions = 0,
     int FailedSubscriptions = 0,
     int RecoveringSubscriptions = 0,
-    DateTimeOffset? LastSubscriptionMessageAt = null);
+    DateTimeOffset? LastSubscriptionMessageAt = null,
+    IReadOnlyList<ProviderStreamDiagnostics>? Streams = null);

--- a/src/Meridian.ProviderSdk/README.md
+++ b/src/Meridian.ProviderSdk/README.md
@@ -37,6 +37,9 @@ report `Disabled`, `WebSocketState` is `None`, and no live connection is inferre
 connection supervisor should override the default event and snapshot with proven runtime state.
 The retained `WebSocketConnectionDiagnostics` name is transport-compatible; polling and raw-socket
 providers use `WebSocketState.None`.
+Connection snapshots may include `ProviderStreamDiagnostics` entries for independently entitled
+asset-class feeds. Consumers must present each stream's feed, entitlement, and degradation reason
+instead of inferring that a connected provider has consolidated or real-time coverage everywhere.
 `Backfill/BackfillJob.cs` owns the shared backfill job descriptors and `DataGranularity`
 conversion helpers.
 `PluginLoaderService` owns non-recursive provider plugin assembly scanning and registration against

--- a/src/Meridian.Ui.Shared/Endpoints/ProviderConnectionDiagnosticsProjection.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/ProviderConnectionDiagnosticsProjection.cs
@@ -22,7 +22,8 @@ internal sealed record ProviderConnectionDiagnosticsSummary(
     int ActiveSubscriptions,
     int FailedSubscriptions,
     int RecoveringSubscriptions,
-    DateTimeOffset? LastSubscriptionMessageAt);
+    DateTimeOffset? LastSubscriptionMessageAt,
+    IReadOnlyList<ProviderStreamDiagnostics>? Streams);
 
 internal static class ProviderConnectionDiagnosticsProjection
 {
@@ -101,7 +102,8 @@ internal static class ProviderConnectionDiagnosticsProjection
             ActiveSubscriptions: snapshot.ActiveSubscriptions,
             FailedSubscriptions: snapshot.FailedSubscriptions,
             RecoveringSubscriptions: snapshot.RecoveringSubscriptions,
-            LastSubscriptionMessageAt: snapshot.LastSubscriptionMessageAt);
+            LastSubscriptionMessageAt: snapshot.LastSubscriptionMessageAt,
+            Streams: snapshot.Streams);
 
     private static void AddIfPresent(
         IDictionary<string, ProviderConnectionDiagnosticsSummary> diagnostics,

--- a/src/Meridian.Ui.Shared/Endpoints/ProviderEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/ProviderEndpoints.cs
@@ -7,6 +7,7 @@ using Meridian.Identity.Auth;
 using Meridian.Contracts.Configuration;
 using Meridian.Infrastructure.Adapters.Core;
 using Meridian.Infrastructure.DataSources;
+using Meridian.Infrastructure.Resilience;
 using Meridian.Ui.Shared;
 using Meridian.Ui.Shared.Services;
 using Microsoft.AspNetCore.Builder;
@@ -418,7 +419,8 @@ public static class ProviderEndpoints
                     RecoveringSubscriptions: diagnostics?.RecoveringSubscriptions,
                     LastSubscriptionMessageAt: diagnostics?.LastSubscriptionMessageAt,
                     ConnectionState: connectionState,
-                    DiagnosticsAvailable: diagnostics is not null || realMetrics is not null
+                    DiagnosticsAvailable: diagnostics is not null || realMetrics is not null,
+                    Streams: ToStreamResponses(diagnostics?.Streams)
                 );
             }).ToList();
 
@@ -471,7 +473,8 @@ public static class ProviderEndpoints
                         RecoveringSubscriptions: diagnostics?.RecoveringSubscriptions,
                         LastSubscriptionMessageAt: diagnostics?.LastSubscriptionMessageAt,
                         ConnectionState: connectionState,
-                        DiagnosticsAvailable: diagnostics is not null));
+                        DiagnosticsAvailable: diagnostics is not null,
+                        Streams: ToStreamResponses(diagnostics?.Streams)));
                 }
             }
 
@@ -711,6 +714,13 @@ public static class ProviderEndpoints
         .Produces(StatusCodes.Status403Forbidden)
         .RequireRateLimiting(UiEndpoints.MutationRateLimitPolicy);
     }
+
+    private static IReadOnlyList<ProviderStreamStatusResponse>? ToStreamResponses(
+        IReadOnlyList<ProviderStreamDiagnostics>? streams)
+        => streams?.Select(stream => new ProviderStreamStatusResponse(
+            stream.AssetClass.ToString(), stream.Feed, stream.Entitlement,
+            stream.LifecycleState.ToString(), stream.IsConnected, stream.IsDegraded,
+            RuntimeDiagnosticRedactor.SanitizeText(stream.DegradationReason))).ToArray();
 
     internal static ProviderRegistrationReportDto CreateRegistrationReportDto(ProviderRegistrationReport report)
     {

--- a/tests/Meridian.Tests/Infrastructure/Providers/AlpacaStreamDiagnosticsTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/AlpacaStreamDiagnosticsTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using Meridian.Core.Config;
+using Meridian.Domain.Collectors;
+using Meridian.Infrastructure.Adapters.Alpaca;
+using Meridian.Infrastructure.Resilience;
+using Meridian.Tests.TestHelpers;
+using Xunit;
+
+namespace Meridian.Tests.Providers;
+
+public sealed class AlpacaStreamDiagnosticsTests
+{
+    [Fact]
+    public void ConnectionDiagnostics_ReportsEachAssetClassAndItsEntitlement()
+    {
+        var publisher = new TestMarketEventPublisher();
+        var client = new AlpacaMarketDataClient(
+            new TradeDataCollector(publisher),
+            new QuoteCollector(publisher),
+            new AlpacaOptions("key", "secret", Feed: "iex", OptionsFeed: "indicative"));
+
+        var streams = client.GetConnectionDiagnosticsSnapshot().Streams;
+
+        streams.Should().NotBeNull();
+        streams!.Should().ContainSingle(stream =>
+            stream.AssetClass == MarketDataAssetClass.Equities &&
+            stream.Feed == "iex" &&
+            stream.Entitlement == "iex" &&
+            stream.IsDegraded);
+        streams.Should().ContainSingle(stream =>
+            stream.AssetClass == MarketDataAssetClass.Options &&
+            stream.Feed == "indicative" &&
+            stream.Entitlement == "indicative" &&
+            stream.IsDegraded);
+        streams.Should().ContainSingle(stream => stream.AssetClass == MarketDataAssetClass.Crypto);
+        streams.Should().ContainSingle(stream => stream.AssetClass == MarketDataAssetClass.News);
+    }
+
+    [Fact]
+    public void ConnectionDiagnostics_SipAndOpraDoNotClaimIndicativeDegradation()
+    {
+        var publisher = new TestMarketEventPublisher();
+        var client = new AlpacaMarketDataClient(
+            new TradeDataCollector(publisher),
+            new QuoteCollector(publisher),
+            new AlpacaOptions("key", "secret", Feed: "sip", OptionsFeed: "opra"));
+
+        var streams = client.GetConnectionDiagnosticsSnapshot().Streams!;
+
+        var equities = streams.Single(stream => stream.AssetClass == MarketDataAssetClass.Equities);
+        equities.IsDegraded.Should().BeFalse();
+        equities.Entitlement.Should().Be("sip");
+
+        var options = streams.Single(stream => stream.AssetClass == MarketDataAssetClass.Options);
+        options.IsDegraded.Should().BeFalse();
+        options.Entitlement.Should().Be("opra");
+    }
+}


### PR DESCRIPTION
### Motivation

- Expose Alpaca's distinct asset-class streams (equities, options, crypto, news) independently so entitlements and connection state are reported per-stream rather than inferred from a single socket. 
- Preserve provider-supplied trading eligibility and increment/minimum constraints from symbol search and enrich trading-parameter responses for order validation and UI surfaces.
- Surface per-stream diagnostics in provider snapshots so the UI and operator tooling can display feed/entitlement and degradation reasons.

### Description

- Added contract-level types: `MarketDataAssetClass` enum and `ProviderStreamDiagnostics` record, and extended `WebSocketConnectionDiagnostics` to include a `Streams` field. 
- Extended UI/API DTOs with `ProviderStreamStatusResponse` and added a `Streams` list to `ProviderStatusResponse`, and mapped diagnostics into stream responses in `ProviderEndpoints`. 
- Broke out Alpaca asset-class adapters: introduced `IAlpacaAssetStream`, `AlpacaOptionsMarketDataClient`, `AlpacaCryptoMarketDataClient`, and `AlpacaNewsMarketDataClient`, and retained/backwards-compatible `AlpacaMarketDataClient` as the equities adapter. 
- Added `AlpacaOptions` configuration properties (`OptionsFeed`, `CryptoFeed`, `NewsFeed`) and compatibility property `EquitiesFeed`; added endpoint builders in `AlpacaEndpoints` and `AlpacaStreamProfiles` to produce per-stream diagnostics (feed, entitlement, degradation reasons). 
- Updated provider registration (`AlpacaProviderModule`) to register multiple Alpaca stream adapters and expose them as `IAlpacaAssetStream` services while keeping `IMarketDataClient` mapping for compatibility. 
- Enhanced `AlpacaSymbolSearchProvider` to support additional asset classes (`us_option`, `fixed_income`) and to populate a new `SymbolTradingEligibility` record on `SymbolDetails` carrying tradability, marginability, shortability, borrowability, fractionability, minimums, and increments. 
- Extended trading parameter plumbing: `TradingParametersDto` now includes read-only init properties (`IsMarginable`, `IsShortable`, `IsEasyToBorrow`, `IsFractionable`, `MinimumOrderSize`, `MinimumTradeIncrement`, `PriceIncrement`) and `SecurityMasterQueryService.GetTradingParametersAsync` reads these fields (with backward-compatible fallbacks for `LotSize`/`TickSize`). 
- Made `WebSocketProviderBase.GetConnectionDiagnosticsSnapshot` virtual and had `AlpacaMarketDataClient` override it to include per-stream diagnostics via `AlpacaStreamProfiles.Create`. 
- Documentation updates in `Infrastructure/README.md` and `ProviderSdk/README.md` describing the per-stream diagnostics and symbol-search behavior. 

### Testing

- Added unit tests `AlpacaStreamDiagnosticsTests` with two facts (`ConnectionDiagnostics_ReportsEachAssetClassAndItsEntitlement` and `ConnectionDiagnostics_SipAndOpraDoNotClaimIndicativeDegradation`). 
- Ran unit tests and build locally/CI; the new tests passed and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611221ad14832093b19e7af3998271)