### PR TITLE
Fix BAI2 blank account-section rejection

### DIFF
--- a/src/Meridian.FinancialOperations/Reconciliation/Connectors/Bai2/Bai2StatementConnector.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/Connectors/Bai2/Bai2StatementConnector.cs
@@ -42,7 +42,7 @@ public sealed class Bai2StatementConnector : IStatementConnector
 
         var groupCurrency = "USD";
         DateOnly? asOfDate = null;
-        var account = "unknown-account";
+        string? account = null;
         var accountCurrency = groupCurrency;
         var rowNumber = 0;
 
@@ -91,14 +91,16 @@ public sealed class Bai2StatementConnector : IStatementConnector
                         hasBlankAccountId = true;
                     }
 
-                    account = string.IsNullOrWhiteSpace(accountId) ? "unknown-account" : accountId.Trim();
+                    account = string.IsNullOrWhiteSpace(accountId) ? null : accountId.Trim();
                     accountCurrency = NormalizeCurrency(FieldAt(fields, 2), groupCurrency);
-                    if (TryResolveClosingBalance(fields, out var balanceMinorUnits) && asOfDate is { } balanceDate)
+                    if (account is { } identifiedAccount &&
+                        TryResolveClosingBalance(fields, out var balanceMinorUnits) &&
+                        asOfDate is { } balanceDate)
                     {
                         rowNumber++;
                         records.Add(new StatementCanonicalRecord(
                             StatementRecordKind.CashBalance,
-                            account,
+                            identifiedAccount,
                             Symbol: string.Empty,
                             Quantity: 0m,
                             Price: 0m,
@@ -123,6 +125,15 @@ public sealed class Bai2StatementConnector : IStatementConnector
                         break;
                     }
 
+                    // Do not construct canonical rows under a shared placeholder account. The parse
+                    // result is rejected below, but keeping malformed sections out of records also
+                    // prevents a future validation-path change from accidentally exposing them.
+                    if (account is not { } identifiedTransactionAccount)
+                    {
+                        hasBlankAccountId = true;
+                        break;
+                    }
+
                     if (asOfDate is not { } transactionDate)
                     {
                         issues.Add(StatementParseIssue.Warning("BAI2_NO_ASOF_DATE", "Transaction detail appeared before a group as-of date; skipped.", rowNumber + 1));
@@ -140,7 +151,7 @@ public sealed class Bai2StatementConnector : IStatementConnector
                     var signedAmount = SignByTypeCode(ToMajorUnits(amountMinorUnits, accountCurrency), typeCode);
                     records.Add(new StatementCanonicalRecord(
                         StatementRecordKind.Transaction,
-                        account,
+                        identifiedTransactionAccount,
                         Symbol: string.Empty,
                         Quantity: 0m,
                         Price: 0m,

--- a/tests/Meridian.Tests/Reconciliation/Connectors/Bai2StatementConnectorTests.cs
+++ b/tests/Meridian.Tests/Reconciliation/Connectors/Bai2StatementConnectorTests.cs
@@ -97,7 +97,7 @@ public sealed class Bai2StatementConnectorTests
     }
 
     [Fact]
-    public async Task Parse_Bai2_WithBlankAccountIdentifier_IsRejected()
+    public async Task Parse_Bai2_WithMultipleBlankAccountIdentifiers_IsRejected()
     {
         // Two 03 account sections whose required account-number field is blank. Both would otherwise share
         // the "unknown-account" placeholder, collapsing to one distinct account and slipping past the


### PR DESCRIPTION
### Motivation
- Prevent malformed BAI2 files with blank `03` account identifiers from collapsing to a shared placeholder account and being accepted for a single-account statement run.
- Treat a missing `03` account number as a parse error so separate blank account sections cannot combine and silently reconcile against the selected Meridian account.

### Description
- Replace the parser's shared `"unknown-account"` placeholder with a nullable `account` state and only materialize canonical records after a `03` record provides an account number in `Bai2StatementConnector.cs`.
- Stop constructing cash-balance rows and transactions when the current account is unset, and mark the parse as having blank account identifiers so the existing fail-closed `BAI2_MISSING_ACCOUNT_ID` error path remains intact.
- Keep the existing structural trailer/group/multi-account checks and rejection behaviors while preventing malformed sections from being added to `records`.
- Rename the focused regression test to `Parse_Bai2_WithMultipleBlankAccountIdentifiers_IsRejected` in `Bai2StatementConnectorTests.cs` to reflect the exact scenario covered.

### Testing
- `git diff --check` passed locally.
- Attempted `dotnet test` for the Bai2 connector tests but could not run because the environment lacks the .NET SDK (`dotnet: command not found`).
- Running `bash scripts/ci.sh` was blocked at the same SDK verification step, so CI/test suites were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6115df0fe4832087bf7b388866df0c)