### PR TITLE
Prevent stale cash balances from reconciling statements

### DIFF
--- a/src/Meridian.FinancialOperations/Reconciliation/StatementMatchingEngine.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementMatchingEngine.cs
@@ -493,7 +493,8 @@ public sealed class StatementMatchingEngine
         && statement.AsOfDate == internalPosition.AsOfDate;
 
     private static bool SameCashIdentity(NormalizedStatementCashBalance statement, InternalCashBalance internalCash) =>
-        SameText(statement.Account, internalCash.Account)
+        statement.IsForStatementPeriodEnd
+        && SameText(statement.Account, internalCash.Account)
         && SameText(statement.Currency, internalCash.Currency)
         && statement.AsOfDate == internalCash.AsOfDate;
 
@@ -614,7 +615,8 @@ public sealed record NormalizedStatementCashBalance(
     string Currency,
     decimal EndingBalance,
     string EvidenceReference,
-    DateOnly AsOfDate) : IStatementMatchItem
+    DateOnly AsOfDate,
+    bool IsForStatementPeriodEnd = true) : IStatementMatchItem
 {
     string IStatementMatchItem.MatchId => CashBalanceId;
 }

--- a/src/Meridian.FinancialOperations/Reconciliation/StatementRunMatcher.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementRunMatcher.cs
@@ -37,6 +37,9 @@ internal static class StatementRunMatcher
         var statementCash = new List<NormalizedStatementCashBalance>();
         var statementTransactions = new List<NormalizedStatementTransaction>();
         var rowByEvidence = new Dictionary<string, CanonicalStatementRow>(StringComparer.OrdinalIgnoreCase);
+        var statementPeriodEnd = import.StatementPeriodEnd == default
+            ? import.StatementDate
+            : import.StatementPeriodEnd;
 
         // A statement run reconciles a single custodian account, so the account dimension is a
         // run-level constant. Normalize the statement side to the run's external (custodian) account
@@ -57,7 +60,7 @@ internal static class StatementRunMatcher
                     statementPositions.Add(MapPosition(row, canonicalAccount, evidence, fxRateProvider, normalizedBase));
                     break;
                 case StatementRowKind.CashBalance:
-                    statementCash.Add(MapCash(row, canonicalAccount, evidence, fxRateProvider, normalizedBase));
+                    statementCash.Add(MapCash(row, canonicalAccount, evidence, statementPeriodEnd, fxRateProvider, normalizedBase));
                     break;
                 default:
                     statementTransactions.Add(MapTransaction(row, canonicalAccount, evidence, fxRateProvider, normalizedBase));
@@ -65,9 +68,8 @@ internal static class StatementRunMatcher
             }
         }
 
-        var asOf = import.StatementPeriodEnd == default ? import.StatementDate : import.StatementPeriodEnd;
         var internalCash = populations.CashBalances
-            .Select(cash => NormalizeInternalCash(cash, fxRateProvider, normalizedBase, asOf))
+            .Select(cash => NormalizeInternalCash(cash, fxRateProvider, normalizedBase, statementPeriodEnd))
             .ToArray();
         var internalTransactions = populations.LedgerTransactions
             .Select(transaction => NormalizeInternalTransaction(transaction, fxRateProvider, normalizedBase))
@@ -156,14 +158,23 @@ internal static class StatementRunMatcher
         CanonicalStatementRow row,
         string account,
         string evidence,
+        DateOnly statementPeriodEnd,
         IReconciliationFxRateProvider fxRateProvider,
         string baseCurrency)
     {
         var (currency, amount) = ToBaseCurrency(row.CashAmount, row.Currency, baseCurrency, row.TradeDate, fxRateProvider);
-        // Carry the statement balance's as-of date into the cash identity. The internal cash is the book's
-        // balance as of its own recorded date, and the engine now requires the two dates to agree, so a
-        // closing balance from the wrong period cannot exact-match a period-appropriate internal balance.
-        return new NormalizedStatementCashBalance(evidence, account, currency, amount, evidence, row.TradeDate);
+        // A cash balance is a closing balance only when it is dated at the run's closing period. Keep the
+        // source as-of date for evidence and mark an out-of-period row ineligible for matching. This
+        // prevents a stale cash row from reconciling if a faulty internal source happens to return the
+        // same stale snapshot instead of the requested period-end snapshot.
+        return new NormalizedStatementCashBalance(
+            evidence,
+            account,
+            currency,
+            amount,
+            evidence,
+            row.TradeDate,
+            IsForStatementPeriodEnd: row.TradeDate == statementPeriodEnd);
     }
 
     private static NormalizedStatementTransaction MapTransaction(

--- a/tests/Meridian.Tests/Reconciliation/StatementRunWorkflowServiceTests.cs
+++ b/tests/Meridian.Tests/Reconciliation/StatementRunWorkflowServiceTests.cs
@@ -72,26 +72,26 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task CreateAsync_WhenCashBalanceDateDiffersFromInternal_DoesNotMatchOnAmountAlone()
+    public async Task CreateAsync_WhenCashBalanceDateDiffersFromStatementPeriodEnd_DoesNotMatchEvenIfInternalSourceHasSameStaleDate()
     {
-        // The statement closing balance carries the same amount as the internal book but a different date
-        // (30 Apr vs the internal 31 May balance). A wrong-period closing balance must not exact-match the
-        // period-appropriate internal balance on account, currency, and amount alone; it surfaces as a break.
+        // The statement closing balance and a faulty internal source both carry 30 Apr, despite the run
+        // closing on 31 May. Date equality between the two sources alone is insufficient: a cash balance
+        // must be dated at the run's statement period end before it can be reconciled.
         var path = await WriteStatementAsync(
             "wrong-period-cash.csv",
             "FUND-1,,0,0,2500.25,cash,2026-04-30,,USD,,");
         var workflow = CreateWorkflow(Populations(new InternalReconciliationPopulations(
             [],
-            [new InternalCashBalance("i-cash", "EXT-1", "USD", 2500.25m, "internal:cash", new DateOnly(2026, 5, 31))],
+            [new InternalCashBalance("i-cash", "EXT-1", "USD", 2500.25m, "internal:cash", new DateOnly(2026, 4, 30))],
             [])));
 
         var result = await workflow.CreateAsync(Request(path), CancellationToken.None);
 
-        // Both sides are now unmatched — the wrong-period statement balance on one side and the
-        // period-end internal balance on the other — instead of a fabricated exact match on amount alone.
+        // Both sides are unmatched instead of producing a fabricated exact match solely because the
+        // stale statement and stale internal snapshot agree on account, currency, date, and amount.
         result.Breaks.Should().HaveCount(2);
         result.Breaks.Should().Contain(breakRecord => breakRecord.SourceReference == "internal:cash",
-            "the period-end internal balance has no same-date statement counterpart, so it is a one-sided internal break");
+            "the stale internal balance must remain visible as a one-sided internal break");
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation

- Prevent statement cash closing balances dated outside the run's closing period from exact-matching internal book snapshots and hiding genuine breaks.

### Description

- Gate cash matching on the run period end by computing `statementPeriodEnd` and carrying it into the normalized statement cash shape, and tag statement cash rows with `IsForStatementPeriodEnd` so out-of-period rows are ineligible for matching. (changes in `StatementRunMatcher.cs`)
- Require the statement cash to be both date-equal and flagged as the period-end before treating it as the same cash identity; extend the engine's cash identity check and cash record shape with `IsForStatementPeriodEnd`. (changes in `StatementMatchingEngine.cs`) 
- Update the end-to-end workflow test to assert that a stale statement cash row and a stale internal snapshot do not produce a fabricated exact match and instead surface both as breaks. (changes in `tests/Meridian.Tests/Reconciliation/StatementRunWorkflowServiceTests.cs`)

### Testing

- `git diff --check` passed locally.
- `dotnet test` for the targeted reconciliation tests could not be executed because this environment lacks the `dotnet` SDK (`dotnet: command not found`), so unit/integration test runs were not completed here. GitHub Actions remains the required integration-test authority and should run `bash scripts/ci.sh` as part of the PR validation.
- The changes were committed on branch `codex/fix-statement-cash-asof` with the message "Reject out-of-period statement cash balances"; please run CI to validate the updated reconciliation and workflow tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6115d4eaec8320bd4a1ba898292d52)