### PR TITLE
Fix statement-account validation on #2364

### DIFF
--- a/src/Meridian.FinancialOperations/Reconciliation/StatementRunMatcher.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementRunMatcher.cs
@@ -38,14 +38,15 @@ internal static class StatementRunMatcher
         var statementTransactions = new List<NormalizedStatementTransaction>();
         var rowByEvidence = new Dictionary<string, CanonicalStatementRow>(StringComparer.OrdinalIgnoreCase);
 
-        // A statement run reconciles a single custodian account, so the account dimension is a
-        // run-level constant. Normalize the statement side to the run's external (custodian) account
-        // key — the same key the internal populations use — so institutional statements whose per-row
-        // account column carries an IBAN or bank id (camt.053, BAI2) still reconcile instead of
-        // breaking on an account-string mismatch.
+        // A statement run reconciles a single custodian account. Before replacing the source-row
+        // account with the run-level key, reject any populated source account that names a different
+        // custodian account. Otherwise a statement for account B could be normalized to account A and
+        // falsely reconcile against A's internal book. Account aliases must be resolved before this
+        // boundary; this matcher never silently treats distinct account identifiers as equivalent.
         var canonicalAccount = string.IsNullOrWhiteSpace(import.ExternalAccountId)
-            ? import.FundAccountId
+            ? import.FundAccountId.Trim()
             : import.ExternalAccountId.Trim();
+        ValidateStatementAccounts(rows, canonicalAccount);
 
         foreach (var row in rows)
         {
@@ -120,6 +121,27 @@ internal static class StatementRunMatcher
         }
 
         return new StatementRunMatchResult(breaks, matchCount);
+    }
+
+    private static void ValidateStatementAccounts(
+        IReadOnlyList<CanonicalStatementRow> rows,
+        string canonicalAccount)
+    {
+        foreach (var row in rows)
+        {
+            if (string.IsNullOrWhiteSpace(row.Account))
+            {
+                continue;
+            }
+
+            var sourceAccount = row.Account.Trim();
+            if (!string.Equals(sourceAccount, canonicalAccount, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidDataException(
+                    $"Statement row {row.SourceRowNumber} identifies account '{sourceAccount}', " +
+                    $"which does not match the requested external account '{canonicalAccount}'.");
+            }
+        }
     }
 
     private static NormalizedStatementPosition MapPosition(

--- a/tests/Meridian.Tests/Reconciliation/StatementRunWorkflowServiceTests.cs
+++ b/tests/Meridian.Tests/Reconciliation/StatementRunWorkflowServiceTests.cs
@@ -37,9 +37,9 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
     {
         var path = await WriteStatementAsync(
             "empty-book.csv",
-            "FUND-1,SPY,10,500,5000,position,2026-05-28,,USD,,",
-            "FUND-1,,0,0,2500.25,cash,2026-05-28,,USD,,",
-            "FUND-1,MSFT,5,20,100,trade,2026-05-28,,USD,,EXT-9");
+            "EXT-1,SPY,10,500,5000,position,2026-05-28,,USD,,",
+            "EXT-1,,0,0,2500.25,cash,2026-05-28,,USD,,",
+            "EXT-1,MSFT,5,20,100,trade,2026-05-28,,USD,,EXT-9");
         var workflow = CreateWorkflow();
 
         var result = await workflow.CreateAsync(Request(path), CancellationToken.None);
@@ -57,9 +57,9 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
     {
         var path = await WriteStatementAsync(
             "matched.csv",
-            "FUND-1,SPY,10,500,5000,position,2026-05-28,,USD,,",
-            "FUND-1,,0,0,2500.25,cash,2026-05-28,,USD,,",
-            "FUND-1,MSFT,5,20,-100,trade,2026-05-28,2026-05-30,USD,,EXT-9");
+            "EXT-1,SPY,10,500,5000,position,2026-05-28,,USD,,",
+            "EXT-1,,0,0,2500.25,cash,2026-05-28,,USD,,",
+            "EXT-1,MSFT,5,20,-100,trade,2026-05-28,2026-05-30,USD,,EXT-9");
         var workflow = CreateWorkflow(Populations(new InternalReconciliationPopulations(
             [new InternalPortfolioPosition("i-spy", "EXT-1", "SPY", new DateOnly(2026, 5, 28), 10m, 5000m, "internal:pos:spy")],
             [new InternalCashBalance("i-cash", "EXT-1", "USD", 2500.25m, "internal:cash", new DateOnly(2026, 5, 28))],
@@ -79,7 +79,7 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
         // period-appropriate internal balance on account, currency, and amount alone; it surfaces as a break.
         var path = await WriteStatementAsync(
             "wrong-period-cash.csv",
-            "FUND-1,,0,0,2500.25,cash,2026-04-30,,USD,,");
+            "EXT-1,,0,0,2500.25,cash,2026-04-30,,USD,,");
         var workflow = CreateWorkflow(Populations(new InternalReconciliationPopulations(
             [],
             [new InternalCashBalance("i-cash", "EXT-1", "USD", 2500.25m, "internal:cash", new DateOnly(2026, 5, 31))],
@@ -100,7 +100,7 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
         // 1,000 EUR converts to 1,085 USD at 1.085; the internal book holds 1,085 USD for the account.
         var path = await WriteStatementAsync(
             "fx.csv",
-            "FUND-1,,0,0,1000,cash,2026-05-28,,EUR,,");
+            "EXT-1,,0,0,1000,cash,2026-05-28,,EUR,,");
         var workflow = CreateWorkflow(
             Populations(new InternalReconciliationPopulations(
                 [],
@@ -118,7 +118,7 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
     {
         var path = await WriteStatementAsync(
             "fx-missing.csv",
-            "FUND-1,,0,0,1000,cash,2026-05-28,,EUR,,");
+            "EXT-1,,0,0,1000,cash,2026-05-28,,EUR,,");
         var workflow = CreateWorkflow(Populations(new InternalReconciliationPopulations(
             [],
             [new InternalCashBalance("i-cash", "FUND-1", "USD", 1085m, "internal:cash", new DateOnly(2026, 5, 28))],
@@ -136,7 +136,7 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
     {
         var path = await WriteStatementAsync(
             "internal-only.csv",
-            "FUND-1,SPY,10,500,5000,position,2026-05-28,,USD,,");
+            "EXT-1,SPY,10,500,5000,position,2026-05-28,,USD,,");
         var workflow = CreateWorkflow(Populations(new InternalReconciliationPopulations(
             [
                 new InternalPortfolioPosition("i-spy", "EXT-1", "SPY", new DateOnly(2026, 5, 28), 10m, 5000m, "internal:pos:spy"),
@@ -171,7 +171,7 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
         // profile, not a hard-coded default, drives the thresholds.
         var path = await WriteStatementAsync(
             "tolerance-default.csv",
-            "FUND-1,,0,0,1000.50,cash,2026-05-28,,USD,,");
+            "EXT-1,,0,0,1000.50,cash,2026-05-28,,USD,,");
         var workflow = CreateWorkflow(Populations(new InternalReconciliationPopulations(
             [],
             [new InternalCashBalance("i-cash", "EXT-1", "USD", 1000m, "internal:cash", new DateOnly(2026, 5, 28))],
@@ -190,7 +190,7 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
         // ToleranceProfileId threads into the matcher instead of always using the default thresholds.
         var path = await WriteStatementAsync(
             "tolerance-loose.csv",
-            "FUND-1,,0,0,1000.50,cash,2026-05-28,,USD,,");
+            "EXT-1,,0,0,1000.50,cash,2026-05-28,,USD,,");
         var looseProfile = new StatementToleranceProfile(
             "statement-loose",
             1,
@@ -220,7 +220,7 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
         // id, so the persisted profile is always the profile actually applied.
         var path = await WriteStatementAsync(
             "unknown-tolerance.csv",
-            "FUND-1,,0,0,1000,cash,2026-05-28,,USD,,");
+            "EXT-1,,0,0,1000,cash,2026-05-28,,USD,,");
         var workflow = CreateWorkflow();
 
         var act = async () => await workflow.CreateAsync(
@@ -236,6 +236,26 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task CreateAsync_WhenStatementAccountDiffersFromRequestedExternalAccount_FailsClosed()
+    {
+        // The internal book belongs to EXT-1 and would exactly match this row if the matcher rewrote
+        // its retained source account. The run must instead reject a populated account B before that
+        // normalization can turn this into a false reconciliation for account A.
+        var path = await WriteStatementAsync(
+            "wrong-account.csv",
+            "EXT-B,SPY,10,500,5000,position,2026-05-28,,USD,,");
+        var workflow = CreateWorkflow(Populations(new InternalReconciliationPopulations(
+            [new InternalPortfolioPosition("i-spy", "EXT-1", "SPY", new DateOnly(2026, 5, 28), 10m, 5000m, "internal:pos:spy")],
+            [],
+            [])));
+
+        var act = async () => await workflow.CreateAsync(Request(path), CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidDataException>()
+            .WithMessage("*account 'EXT-B'*requested external account 'EXT-1'*");
+    }
+
+    [Fact]
     public async Task CreateAsync_WithMalformedSettlementDate_FailsClosed()
     {
         // A nonblank but unparsable optional settlement date must be rejected, not silently dropped to
@@ -243,7 +263,7 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
         // could exact-match a same-day ledger transaction instead of blocking the import.
         var path = await WriteStatementAsync(
             "bad-settlement.csv",
-            "FUND-1,MSFT,5,20,-100,trade,2026-05-28,not-a-date,USD,,EXT-9");
+            "EXT-1,MSFT,5,20,-100,trade,2026-05-28,not-a-date,USD,,EXT-9");
         var workflow = CreateWorkflow();
 
         var act = async () => await workflow.CreateAsync(Request(path), CancellationToken.None);


### PR DESCRIPTION
### Motivation

- Prevent normalizing a source statement row from one custodian account to the run's requested external account and accidentally reconciling it against the wrong internal book. This must fail closed so operators cannot upload a statement for account B and have it be reconciled against account A.

### Description

- Add a `ValidateStatementAccounts` check in `src/Meridian.FinancialOperations/Reconciliation/StatementRunMatcher.cs` that rejects any populated `CanonicalStatementRow.Account` which does not case-insensitively match the run's `ExternalAccountId` (or trimmed `FundAccountId` when `ExternalAccountId` is blank).
- Trim `FundAccountId` when deriving the run-level `canonicalAccount` and call the new validator before normalizing rows for matching.
- Throw `InvalidDataException` on mismatched accounts so account-alias resolution must happen before this matcher boundary.
- Update `tests/Meridian.Tests/Reconciliation/StatementRunWorkflowServiceTests.cs` fixtures to use the run `ExternalAccountId` (`EXT-1`) and add a regression test `CreateAsync_WhenStatementAccountDiffersFromRequestedExternalAccount_FailsClosed` proving a statement for `EXT-B` is rejected rather than falsely matching `EXT-1`.

### Testing

- Ran `python build/python/cli/buildctl.py validation-status --summary` which reported the workspace is not blocked and no active build processes were found.
- Ran `git diff --check` to validate changes; no whitespace or diff issues reported.
- Attempted `dotnet test` and `bash scripts/ci.sh` locally but could not run because `dotnet` is not installed in this environment, so the updated unit tests were not executed here; GitHub Actions remains the authoritative integration test runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6115d5f7d48320a3fb768a9b570e53)