### PR TITLE
Reject BAI2 files without account sections

### DIFF
--- a/src/Meridian.FinancialOperations/Reconciliation/Connectors/Bai2/Bai2StatementConnector.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/Connectors/Bai2/Bai2StatementConnector.cs
@@ -199,6 +199,25 @@ public sealed class Bai2StatementConnector : IStatementConnector
                 fingerprint));
         }
 
+        // A structurally complete file with a group but no account section cannot be associated with
+        // the account selected for the run. Do not accept it merely because it has no 16 records: it
+        // is still an unidentifiable statement, and accepting it would report a misleading successful
+        // import with no usable account evidence.
+        if (accountCount == 0)
+        {
+            issues.Add(StatementParseIssue.Error(
+                "BAI2_MISSING_ACCOUNT_SECTION",
+                "The BAI2 file has no 03 account identifier record; a statement run must contain at least one identified account section. Repair the file before importing."));
+            return Task.FromResult(new StatementParseResult(
+                ConnectorId,
+                ProfileId: null,
+                detectedColumns,
+                ColumnMappings: [],
+                [],
+                issues,
+                fingerprint));
+        }
+
         // Every 03 account-identifier record must carry its account number. A blank one cannot identify
         // the account being reconciled and would share the "unknown-account" placeholder with any other
         // blank section, so reject the file rather than reconcile an unidentifiable account.

--- a/tests/Meridian.Tests/Reconciliation/Connectors/Bai2StatementConnectorTests.cs
+++ b/tests/Meridian.Tests/Reconciliation/Connectors/Bai2StatementConnectorTests.cs
@@ -148,6 +148,28 @@ public sealed class Bai2StatementConnectorTests
     }
 
     [Fact]
+    public async Task Parse_Bai2_WithoutAccountSection_IsRejected()
+    {
+        // An empty custody statement with a valid group and trailers still must identify the account it
+        // covers. Otherwise import would succeed without account evidence and operators could mistake it
+        // for an empty statement for the selected Meridian account.
+        const string bai2 = """
+            01,CITIBANK,MERIDIAN,260531,0800,1,,,2/
+            02,MERIDIAN,CITIBANK,1,260531,,USD,2/
+            98,0,1,2/
+            99,0,1,4/
+            """;
+        var document = new StatementSourceDocument("missing-account-section.bai", Encoding.UTF8.GetBytes(bai2));
+
+        _connector.CanHandle(document).Should().BeTrue();
+        var result = await _connector.ParseAsync(document);
+
+        result.HasErrors.Should().BeTrue();
+        result.Records.Should().BeEmpty("a BAI2 statement must identify an account even when it has no activity");
+        result.Issues.Should().Contain(issue => issue.Code == "BAI2_MISSING_ACCOUNT_SECTION");
+    }
+
+    [Fact]
     public async Task Parse_Bai2_ScalesAmountsByDeclaredCurrencyExponent()
     {
         // JPY has no minor unit, so a BAI2 amount of 10000 is 10000 yen, not 100. Assuming cents would


### PR DESCRIPTION
### Motivation
- Prevent accepting BAI2 documents that contain a group (02) but no `03` account-identifier records, which could cause transactions or empty groups to be attributed to an `unknown-account` and mistakenly reconciled against the wrong Meridian account.

### Description
- Add a fail-closed validation in `Bai2StatementConnector.ParseAsync` that returns an error `BAI2_MISSING_ACCOUNT_SECTION` when the file contains no `03` account section, preserving the existing rejection for `16` transactions outside an account section; update `src/Meridian.FinancialOperations/Reconciliation/Connectors/Bai2/Bai2StatementConnector.cs` accordingly.
- Add a regression test `Parse_Bai2_WithoutAccountSection_IsRejected` in `tests/Meridian.Tests/Reconciliation/Connectors/Bai2StatementConnectorTests.cs` that asserts the connector rejects a trailered group with no account section.

### Testing
- Ran `git diff --check`, which passed.
- Attempted to run the narrowed unit tests with `dotnet test` filtered to `Bai2StatementConnectorTests`, but `dotnet` is not available in this execution environment so the tests could not be executed locally; `bash scripts/ci.sh` likewise could not run here due to the same missing SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6115d497088320994c8d205df66369)