### PR TITLE
Follow-up: preserve source statement accounts

### DIFF
--- a/src/Meridian.FinancialOperations/Reconciliation/StatementRunMatcher.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementRunMatcher.cs
@@ -38,30 +38,33 @@ internal static class StatementRunMatcher
         var statementTransactions = new List<NormalizedStatementTransaction>();
         var rowByEvidence = new Dictionary<string, CanonicalStatementRow>(StringComparer.OrdinalIgnoreCase);
 
-        // A statement run reconciles a single custodian account. Before replacing the source-row
-        // account with the run-level key, reject any populated source account that names a different
-        // custodian account. Otherwise a statement for account B could be normalized to account A and
-        // falsely reconcile against A's internal book. Account aliases must be resolved before this
-        // boundary; this matcher never silently treats distinct account identifiers as equivalent.
-        var canonicalAccount = string.IsNullOrWhiteSpace(import.ExternalAccountId)
+        // Keep the requested run account only as a fallback for source formats that do not carry an
+        // account identifier. A source statement account is evidence from the custodian, and it can
+        // legitimately differ from Meridian's configured external key (for example, BAI2 account
+        // numbers and camt.053 IBANs). Replacing it with the run key would let account B match
+        // account A's internal book. Keeping it instead makes the account difference surface as
+        // ordinary statement and internal breaks until an explicit alias-resolution seam is wired.
+        var fallbackAccount = string.IsNullOrWhiteSpace(import.ExternalAccountId)
             ? import.FundAccountId.Trim()
             : import.ExternalAccountId.Trim();
-        ValidateStatementAccounts(rows, canonicalAccount);
 
         foreach (var row in rows)
         {
+            var statementAccount = string.IsNullOrWhiteSpace(row.Account)
+                ? fallbackAccount
+                : row.Account.Trim();
             var evidence = $"{import.ImportId}:{row.SourceRowNumber}";
             rowByEvidence[evidence] = row;
             switch (Classify(row.ActivityType))
             {
                 case StatementRowKind.Position:
-                    statementPositions.Add(MapPosition(row, canonicalAccount, evidence, fxRateProvider, normalizedBase));
+                    statementPositions.Add(MapPosition(row, statementAccount, evidence, fxRateProvider, normalizedBase));
                     break;
                 case StatementRowKind.CashBalance:
-                    statementCash.Add(MapCash(row, canonicalAccount, evidence, fxRateProvider, normalizedBase));
+                    statementCash.Add(MapCash(row, statementAccount, evidence, fxRateProvider, normalizedBase));
                     break;
                 default:
-                    statementTransactions.Add(MapTransaction(row, canonicalAccount, evidence, fxRateProvider, normalizedBase));
+                    statementTransactions.Add(MapTransaction(row, statementAccount, evidence, fxRateProvider, normalizedBase));
                     break;
             }
         }
@@ -121,27 +124,6 @@ internal static class StatementRunMatcher
         }
 
         return new StatementRunMatchResult(breaks, matchCount);
-    }
-
-    private static void ValidateStatementAccounts(
-        IReadOnlyList<CanonicalStatementRow> rows,
-        string canonicalAccount)
-    {
-        foreach (var row in rows)
-        {
-            if (string.IsNullOrWhiteSpace(row.Account))
-            {
-                continue;
-            }
-
-            var sourceAccount = row.Account.Trim();
-            if (!string.Equals(sourceAccount, canonicalAccount, StringComparison.OrdinalIgnoreCase))
-            {
-                throw new InvalidDataException(
-                    $"Statement row {row.SourceRowNumber} identifies account '{sourceAccount}', " +
-                    $"which does not match the requested external account '{canonicalAccount}'.");
-            }
-        }
     }
 
     private static NormalizedStatementPosition MapPosition(

--- a/tests/Meridian.Tests/Reconciliation/StatementRunWorkflowServiceTests.cs
+++ b/tests/Meridian.Tests/Reconciliation/StatementRunWorkflowServiceTests.cs
@@ -236,11 +236,13 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task CreateAsync_WhenStatementAccountDiffersFromRequestedExternalAccount_FailsClosed()
+    public async Task CreateAsync_WhenStatementAccountDiffersFromRequestedExternalAccount_PreservesSourceAccountAndCreatesBreaks()
     {
         // The internal book belongs to EXT-1 and would exactly match this row if the matcher rewrote
-        // its retained source account. The run must instead reject a populated account B before that
-        // normalization can turn this into a false reconciliation for account A.
+        // its retained source account. The source account must remain EXT-B so it produces a
+        // statement-only break and leaves EXT-1 as an internal-only break. This also accepts bank
+        // source identifiers (such as BAI2 account numbers and camt.053 IBANs) that differ from a
+        // Meridian run-level external key without creating a partial persisted import.
         var path = await WriteStatementAsync(
             "wrong-account.csv",
             "EXT-B,SPY,10,500,5000,position,2026-05-28,,USD,,");
@@ -249,10 +251,15 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
             [],
             [])));
 
-        var act = async () => await workflow.CreateAsync(Request(path), CancellationToken.None);
+        var result = await workflow.CreateAsync(Request(path), CancellationToken.None);
 
-        await act.Should().ThrowAsync<InvalidDataException>()
-            .WithMessage("*account 'EXT-B'*requested external account 'EXT-1'*");
+        result.Breaks.Should().HaveCount(2);
+        result.Breaks.Should().Contain(breakRecord => breakRecord.SourceReference.EndsWith(":2", StringComparison.Ordinal));
+        result.Breaks.Should().Contain(breakRecord => breakRecord.SourceReference == "internal:pos:spy");
+        result.Cases.Should().HaveCount(2);
+
+        var imports = await new JsonCanonicalStatementStore(_root).ListImportsAsync();
+        imports.Should().ContainSingle("the accepted source-account difference is materialized as a complete reconciliation run");
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation

- Preserve bank-statement account identifiers provided by the source instead of overwriting them with the run-level external key so BAI2/camt.053 imports (and other connector sources) are not rejected or falsely reconciled. 
- Avoid throwing after the import is persisted so a source/run account difference materializes as normal statement/internal breaks instead of leaving a partial persisted import that blocks retries.

### Description

- Change `StatementRunMatcher.Match` to use the source row `Account` when populated and to use the run `ExternalAccountId`/`FundAccountId` only as a fallback for rows with no account. 
- Remove the pre-match `ValidateStatementAccounts` rejection that threw `InvalidDataException` on mismatched accounts so source account differences are treated as reconciliation evidence rather than exceptions. 
- Thread the derived `statementAccount` into `MapPosition`, `MapCash`, and `MapTransaction` so normalized statement rows keep their source account identity. 
- Update unit test `tests/Meridian.Tests/Reconciliation/StatementRunWorkflowServiceTests.cs` to replace the prior mismatch-exception assertion with a regression test (`CreateAsync_WhenStatementAccountDiffersFromRequestedExternalAccount_PreservesSourceAccountAndCreatesBreaks`) that asserts a statement-only break and an internal-only break are produced and that the canonical import is persisted.

### Testing

- Ran `git diff --check` to validate whitespace/diff issues and it passed. 
- Ran `python build/python/cli/buildctl.py validation-status --summary` which reported the workspace is not blocked and no active build processes were found. 
- Attempted to run focused unit tests with `dotnet test ... --filter

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61190845608320bc3746eab705b733)