### PR TITLE
Follow-up: preserve statement source account identity

### DIFF
--- a/src/Meridian.FinancialOperations/Reconciliation/StatementRunMatcher.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementRunMatcher.cs
@@ -38,15 +38,16 @@ internal static class StatementRunMatcher
         var statementTransactions = new List<NormalizedStatementTransaction>();
         var rowByEvidence = new Dictionary<string, CanonicalStatementRow>(StringComparer.OrdinalIgnoreCase);
 
-        // A statement run reconciles a single custodian account. Before replacing the source-row
-        // account with the run-level key, reject any populated source account that names a different
-        // custodian account. Otherwise a statement for account B could be normalized to account A and
-        // falsely reconcile against A's internal book. Account aliases must be resolved before this
-        // boundary; this matcher never silently treats distinct account identifiers as equivalent.
+        // A statement run reconciles a single custodian account. Preserve the identifier supplied by
+        // the statement rather than replacing it with the operator's run-level key: connectors often
+        // supply a bank-native account number or IBAN while the run uses Meridian's external key.
+        // Rewriting that identifier could make a statement for account B falsely reconcile against
+        // account A's internal book. A multi-account statement remains invalid, but a single source
+        // identifier need not equal the run-level external key.
         var canonicalAccount = string.IsNullOrWhiteSpace(import.ExternalAccountId)
             ? import.FundAccountId.Trim()
             : import.ExternalAccountId.Trim();
-        ValidateStatementAccounts(rows, canonicalAccount);
+        ValidateSingleStatementAccount(rows);
 
         foreach (var row in rows)
         {
@@ -55,13 +56,13 @@ internal static class StatementRunMatcher
             switch (Classify(row.ActivityType))
             {
                 case StatementRowKind.Position:
-                    statementPositions.Add(MapPosition(row, canonicalAccount, evidence, fxRateProvider, normalizedBase));
+                    statementPositions.Add(MapPosition(row, StatementAccount(row, canonicalAccount), evidence, fxRateProvider, normalizedBase));
                     break;
                 case StatementRowKind.CashBalance:
-                    statementCash.Add(MapCash(row, canonicalAccount, evidence, fxRateProvider, normalizedBase));
+                    statementCash.Add(MapCash(row, StatementAccount(row, canonicalAccount), evidence, fxRateProvider, normalizedBase));
                     break;
                 default:
-                    statementTransactions.Add(MapTransaction(row, canonicalAccount, evidence, fxRateProvider, normalizedBase));
+                    statementTransactions.Add(MapTransaction(row, StatementAccount(row, canonicalAccount), evidence, fxRateProvider, normalizedBase));
                     break;
             }
         }
@@ -123,26 +124,24 @@ internal static class StatementRunMatcher
         return new StatementRunMatchResult(breaks, matchCount);
     }
 
-    private static void ValidateStatementAccounts(
-        IReadOnlyList<CanonicalStatementRow> rows,
-        string canonicalAccount)
+    private static void ValidateSingleStatementAccount(IReadOnlyList<CanonicalStatementRow> rows)
     {
-        foreach (var row in rows)
-        {
-            if (string.IsNullOrWhiteSpace(row.Account))
-            {
-                continue;
-            }
+        var accounts = rows
+            .Where(static row => !string.IsNullOrWhiteSpace(row.Account))
+            .Select(static row => row.Account.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Take(2)
+            .ToArray();
 
-            var sourceAccount = row.Account.Trim();
-            if (!string.Equals(sourceAccount, canonicalAccount, StringComparison.OrdinalIgnoreCase))
-            {
-                throw new InvalidDataException(
-                    $"Statement row {row.SourceRowNumber} identifies account '{sourceAccount}', " +
-                    $"which does not match the requested external account '{canonicalAccount}'.");
-            }
+        if (accounts.Length > 1)
+        {
+            throw new InvalidDataException(
+                "Statement contains rows for different accounts; a statement run reconciles a single account.");
         }
     }
+
+    private static string StatementAccount(CanonicalStatementRow row, string fallbackAccount) =>
+        string.IsNullOrWhiteSpace(row.Account) ? fallbackAccount : row.Account.Trim();
 
     private static NormalizedStatementPosition MapPosition(
         CanonicalStatementRow row,

--- a/src/Meridian.FinancialOperations/Reconciliation/StatementRunWorkflowService.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementRunWorkflowService.cs
@@ -41,7 +41,14 @@ public sealed class StatementRunWorkflowService(
         // fail the run before ImportAsync persists it; otherwise the stored import would be left with no
         // breaks or cases and the duplicate-source guard would reject a corrected retry of the same file.
         var toleranceProfile = await ResolveToleranceProfileAsync(normalizedRequest.ToleranceProfileId, cancellationToken).ConfigureAwait(false);
-        var imported = await brokerStatementService.ImportAsync(ToImportRequest(normalizedRequest), cancellationToken).ConfigureAwait(false);
+        var importRequest = ToImportRequest(normalizedRequest);
+        var importValidation = await brokerStatementService.ValidateAsync(importRequest, cancellationToken).ConfigureAwait(false);
+        if (!importValidation.IsValid)
+        {
+            throw new InvalidDataException($"Statement cannot be imported: {string.Join(" ", importValidation.Errors)}");
+        }
+
+        var imported = await brokerStatementService.ImportAsync(importRequest, cancellationToken).ConfigureAwait(false);
 
         // Reconcile the imported statement against Meridian's own book. The population provider
         // supplies the internal positions, cash, and ledger for this fund account and period; the

--- a/src/Meridian.Infrastructure/Reconciliation/BrokerStatementInfrastructure.cs
+++ b/src/Meridian.Infrastructure/Reconciliation/BrokerStatementInfrastructure.cs
@@ -147,7 +147,8 @@ public sealed class CsvBrokerStatementService(ICanonicalStatementStore store) : 
         try
         {
             var rows = await ParseFileAsync(request.SourcePath, request, importId: "validation", ct).ConfigureAwait(false);
-            return new BrokerStatementValidationResult(true, errors, rows.Count);
+            AddSingleAccountError(rows, errors);
+            return new BrokerStatementValidationResult(errors.Count == 0, errors, rows.Count);
         }
         catch (InvalidDataException ex)
         {
@@ -174,6 +175,7 @@ public sealed class CsvBrokerStatementService(ICanonicalStatementStore store) : 
         var importId = duplicateKey;
         var normalizedRequest = request.WithSourceFileHash(sourceFileHash);
         var rows = await ParseFileAsync(request.SourcePath, normalizedRequest, importId, ct).ConfigureAwait(false);
+        EnsureSingleAccount(rows);
         var import = new CanonicalStatementImport(
             importId,
             normalizedRequest.Broker,
@@ -324,6 +326,30 @@ public sealed class CsvBrokerStatementService(ICanonicalStatementStore store) : 
 
         return rows;
     }
+
+    private static void AddSingleAccountError(IReadOnlyList<CanonicalStatementRow> rows, ICollection<string> errors)
+    {
+        if (HasMultipleAccounts(rows))
+        {
+            errors.Add("Statement contains rows for different accounts; a statement run reconciles a single account.");
+        }
+    }
+
+    private static void EnsureSingleAccount(IReadOnlyList<CanonicalStatementRow> rows)
+    {
+        if (HasMultipleAccounts(rows))
+        {
+            throw new InvalidDataException(
+                "Statement contains rows for different accounts; a statement run reconciles a single account.");
+        }
+    }
+
+    private static bool HasMultipleAccounts(IReadOnlyList<CanonicalStatementRow> rows) =>
+        rows.Where(static row => !string.IsNullOrWhiteSpace(row.Account))
+            .Select(static row => row.Account.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Skip(1)
+            .Any();
 
     private static IReadOnlyList<string> ParseCsvLine(string line, int rowNumber)
     {

--- a/tests/Meridian.Tests/Reconciliation/StatementRunWorkflowServiceTests.cs
+++ b/tests/Meridian.Tests/Reconciliation/StatementRunWorkflowServiceTests.cs
@@ -236,11 +236,10 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task CreateAsync_WhenStatementAccountDiffersFromRequestedExternalAccount_FailsClosed()
+    public async Task CreateAsync_WhenStatementAccountDiffersFromRequestedExternalAccount_PreservesSourceAccountAndCreatesBreaks()
     {
-        // The internal book belongs to EXT-1 and would exactly match this row if the matcher rewrote
-        // its retained source account. The run must instead reject a populated account B before that
-        // normalization can turn this into a false reconciliation for account A.
+        // Connector imports can use a bank-native account number while the run uses Meridian's
+        // external key. Preserve that source account so it cannot falsely match EXT-1's internal book.
         var path = await WriteStatementAsync(
             "wrong-account.csv",
             "EXT-B,SPY,10,500,5000,position,2026-05-28,,USD,,");
@@ -249,10 +248,29 @@ public sealed class StatementRunWorkflowServiceTests : IDisposable
             [],
             [])));
 
+        var result = await workflow.CreateAsync(Request(path), CancellationToken.None);
+
+        result.Breaks.Should().HaveCount(2);
+        result.Breaks.Should().Contain(breakRecord => breakRecord.SourceReference.EndsWith(":2", StringComparison.Ordinal));
+        result.Breaks.Should().Contain(breakRecord => breakRecord.SourceReference == "internal:pos:spy");
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenStatementContainsMultipleAccounts_FailsBeforePersistingImport()
+    {
+        var path = await WriteStatementAsync(
+            "multiple-accounts.csv",
+            "EXT-1,SPY,10,500,5000,position,2026-05-28,,USD,,",
+            "EXT-B,MSFT,5,20,100,position,2026-05-28,,USD,,");
+        var workflow = CreateWorkflow();
+
         var act = async () => await workflow.CreateAsync(Request(path), CancellationToken.None);
 
         await act.Should().ThrowAsync<InvalidDataException>()
-            .WithMessage("*account 'EXT-B'*requested external account 'EXT-1'*");
+            .WithMessage("*different accounts*");
+
+        var imports = await new JsonCanonicalStatementStore(_root).ListImportsAsync();
+        imports.Should().BeEmpty("multi-account validation must complete before the import claims its duplicate key");
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation

- Prevent silently rewriting a statement row's bank-native account identifier into the run-level external account and accidentally reconciling a statement for account B against account A.  
- Fail invalid imports (multi-account or otherwise malformed canonical CSV) before the import claims its duplicate key so a corrected retry is not blocked by a partially persisted run.  

### Description

- Preserve populated source statement account identifiers during matching in `StatementRunMatcher` by using the row's `Account` when present and adding `StatementAccount` helper logic.  
- Add `ValidateSingleStatementAccount` in `StatementRunMatcher` to reject multi-account statement rows with an `InvalidDataException`.  
- Validate the broker import before persisting by calling `brokerStatementService.ValidateAsync` in `StatementRunWorkflowService.CreateAsync` and throw `InvalidDataException` when validation fails.  
- Extend the canonical CSV importer (`CsvBrokerStatementService` / `BrokerStatementInfrastructure`) to report multi-account errors in `ValidateAsync` and to run `EnsureSingleAccount` in `ImportAsync` (helpers: `AddSingleAccountError`, `EnsureSingleAccount`, `HasMultipleAccounts`).  
- Update regression tests in `tests/Meridian.Tests/Reconciliation/StatementRunWorkflowServiceTests.cs` to assert that a preserved source account produces breaks rather than a false match, and to assert that a multi-account CSV is rejected before persistence.  

### Testing

- Ran `git diff --check` with no issues.  
- Ran `python3 build/python/cli/buildctl.py validation-status --summary` which reported `blocked=false` and no active build processes.  
- Attempted `dotnet test` for the focused reconciliation tests and `bash scripts/ci.sh`, but both could not run in this environment because `dotnet` is not installed, so the updated unit tests were not executed locally.  
- The change adds/updates unit tests for the reconciliation workflow; full test and CI validation should be verified by GitHub Actions (`bash scripts/ci.sh`) in the PR run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611a1de690832086a5da7c99ad8f05)