### PR TITLE
Add capability-aware Alpaca asset-stream routing, news support, and entitlement-aware subscriptions

### DIFF
--- a/docs/source/generated/source-hash-manifest.json
+++ b/docs/source/generated/source-hash-manifest.json
@@ -191,8 +191,8 @@
       "id": "SRC-INFRASTRUCTURE",
       "path": "src/Meridian.Infrastructure",
       "readme": "src/Meridian.Infrastructure/README.md",
-      "readme_hash": "c6015eceed0be87a25be91e2d10f7010cb07faa75579bd8aaefeafc612563418",
-      "source_hash": "6251b39285d598cb1e4037406c36a52fc48fd42536d9563ebc7cdca36343766e"
+      "readme_hash": "d792fd5bd1d5e0112dd35beb34eba759da69a5e66d1a9cdde0c44aa447bd10be",
+      "source_hash": "3330096e44e2d90cd3061d6872fefb7064f368ded716317ce7770a7155ac6c39"
     },
     {
       "id": "SRC-LAUNCHER",

--- a/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaAssetStreamAdapters.cs
+++ b/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaAssetStreamAdapters.cs
@@ -1,63 +1,135 @@
+using Meridian.Contracts.Configuration;
+using Meridian.Contracts.Domain.Enums;
 using Meridian.Core.Config;
 using Meridian.Domain.Collectors;
+using Meridian.Infrastructure;
 using Meridian.Infrastructure.Resilience;
 
 namespace Meridian.Infrastructure.Adapters.Alpaca;
 
-/// <summary>Marker for independently connectable Alpaca asset-class stream adapters.</summary>
-public interface IAlpacaAssetStream
+/// <summary>Capability-aware contract for an independently connectable Alpaca market-data stream.</summary>
+public interface IAlpacaAssetStream : IMarketDataClient
 {
     MarketDataAssetClass AssetClass { get; }
+    IReadOnlyList<InstrumentType> SupportedInstrumentTypes { get; }
+    bool IsSubscriptionAvailable { get; }
+}
+
+/// <summary>Resolves an Alpaca stream only when its own entitlement permits subscriptions.</summary>
+public interface IAlpacaMarketDataRouter
+{
+    IAlpacaAssetStream Resolve(MarketDataAssetClass assetClass);
+    bool TryResolve(MarketDataAssetClass assetClass, out IAlpacaAssetStream? stream);
+}
+
+public sealed class AlpacaMarketDataRouter(IEnumerable<IAlpacaAssetStream> streams) : IAlpacaMarketDataRouter
+{
+    private readonly IReadOnlyDictionary<MarketDataAssetClass, IAlpacaAssetStream> _streams = streams
+        .GroupBy(static stream => stream.AssetClass)
+        .ToDictionary(static group => group.Key, static group => group.Single());
+
+    public IAlpacaAssetStream Resolve(MarketDataAssetClass assetClass) => TryResolve(assetClass, out var stream)
+        ? stream!
+        : throw new InvalidOperationException($"Alpaca {assetClass} streaming is not configured with a usable entitlement.");
+
+    public bool TryResolve(MarketDataAssetClass assetClass, out IAlpacaAssetStream? stream)
+    {
+        if (_streams.TryGetValue(assetClass, out stream) && stream.IsSubscriptionAvailable)
+            return true;
+
+        stream = null;
+        return false;
+    }
+}
+
+/// <summary>Normalized, provider-neutral-enough Alpaca news read model; never a trade or quote.</summary>
+public sealed record AlpacaNewsEvent(
+    string Id, string Headline, string Summary, string Url, string Source,
+    DateTimeOffset Timestamp, IReadOnlyList<string> Symbols);
+
+public interface IAlpacaNewsEventSink
+{
+    void Publish(AlpacaNewsEvent newsEvent);
+}
+
+/// <summary>In-memory bounded news read model for operator diagnostics and consumers.</summary>
+public sealed class AlpacaNewsEventBuffer : IAlpacaNewsEventSink
+{
+    private const int Capacity = 1024;
+    private readonly Queue<AlpacaNewsEvent> _events = new();
+    private readonly object _gate = new();
+    public IReadOnlyList<AlpacaNewsEvent> Events { get { lock (_gate) return _events.ToArray(); } }
+    public void Publish(AlpacaNewsEvent newsEvent)
+    {
+        lock (_gate)
+        {
+            _events.Enqueue(newsEvent);
+            while (_events.Count > Capacity) _events.Dequeue();
+        }
+    }
+}
+
+public interface IAlpacaNewsSubscriptionClient
+{
+    int SubscribeNews(SymbolConfig cfg);
+    void UnsubscribeNews(int subscriptionId);
 }
 
 /// <summary>Dedicated Alpaca US options WebSocket adapter.</summary>
 public sealed class AlpacaOptionsMarketDataClient : AlpacaMarketDataClient
 {
-    public AlpacaOptionsMarketDataClient(TradeDataCollector trades, QuoteCollector quotes, AlpacaOptions options)
-        : base(trades, quotes, options) { }
-
+    public AlpacaOptionsMarketDataClient(TradeDataCollector trades, QuoteCollector quotes, AlpacaOptions options) : base(trades, quotes, options) { }
     public override MarketDataAssetClass AssetClass => MarketDataAssetClass.Options;
+    public override IReadOnlyList<InstrumentType> SupportedInstrumentTypes => [InstrumentType.EquityOption, InstrumentType.IndexOption];
+    public override bool IsSubscriptionAvailable => string.Equals(Options.OptionsFeed, "opra", StringComparison.OrdinalIgnoreCase);
     public override string ProviderId => "alpaca-options-stream";
     public override string ProviderDisplayName => "Alpaca Options Streaming";
-
     protected override Uri BuildWebSocketUri() => AlpacaEndpoints.OptionsWssUri(Host);
-
     private string Host => Options.UseSandbox ? AlpacaEndpoints.SandboxHost : AlpacaEndpoints.LiveHost;
 }
 
 /// <summary>Dedicated Alpaca US crypto WebSocket adapter.</summary>
 public sealed class AlpacaCryptoMarketDataClient : AlpacaMarketDataClient
 {
-    public AlpacaCryptoMarketDataClient(TradeDataCollector trades, QuoteCollector quotes, AlpacaOptions options)
-        : base(trades, quotes, options) { }
-
+    public AlpacaCryptoMarketDataClient(TradeDataCollector trades, QuoteCollector quotes, AlpacaOptions options) : base(trades, quotes, options) { }
     public override MarketDataAssetClass AssetClass => MarketDataAssetClass.Crypto;
+    public override IReadOnlyList<InstrumentType> SupportedInstrumentTypes => [InstrumentType.Crypto];
+    public override bool IsSubscriptionAvailable => IsConfiguredFeed(Options.CryptoFeed);
     public override string ProviderId => "alpaca-crypto-stream";
     public override string ProviderDisplayName => "Alpaca Crypto Streaming";
-
     protected override Uri BuildWebSocketUri() => AlpacaEndpoints.CryptoWssUri(Host);
-
     private string Host => Options.UseSandbox ? AlpacaEndpoints.SandboxHost : AlpacaEndpoints.LiveHost;
 }
 
-/// <summary>
-/// Dedicated Alpaca news WebSocket adapter. News does not implement trade or quote subscriptions;
-/// callers can still connect and surface its entitlement independently from price streams.
-/// </summary>
-public sealed class AlpacaNewsMarketDataClient : AlpacaMarketDataClient
+/// <summary>Dedicated news endpoint with a normalized news sink, never price collectors.</summary>
+public sealed class AlpacaNewsMarketDataClient : AlpacaMarketDataClient, IAlpacaNewsSubscriptionClient
 {
-    public AlpacaNewsMarketDataClient(TradeDataCollector trades, QuoteCollector quotes, AlpacaOptions options)
-        : base(trades, quotes, options) { }
-
+    private readonly IAlpacaNewsEventSink _sink;
+    public AlpacaNewsMarketDataClient(TradeDataCollector trades, QuoteCollector quotes, AlpacaOptions options, IAlpacaNewsEventSink sink) : base(trades, quotes, options)
+        => _sink = sink ?? throw new ArgumentNullException(nameof(sink));
     public override MarketDataAssetClass AssetClass => MarketDataAssetClass.News;
+    public override IReadOnlyList<InstrumentType> SupportedInstrumentTypes => [];
+    public override bool IsSubscriptionAvailable => IsConfiguredFeed(Options.NewsFeed);
     public override string ProviderId => "alpaca-news-stream";
     public override string ProviderDisplayName => "Alpaca News Streaming";
-
     protected override Uri BuildWebSocketUri() => AlpacaEndpoints.NewsWssUri(Host);
-
-    public override int SubscribeTrades(Meridian.Contracts.Configuration.SymbolConfig cfg) => -1;
-
-    public override int SubscribeMarketDepth(Meridian.Contracts.Configuration.SymbolConfig cfg) => -1;
-
+    public override int SubscribeTrades(SymbolConfig cfg) => -1;
+    public override int SubscribeMarketDepth(SymbolConfig cfg) => -1;
+    public int SubscribeNews(SymbolConfig cfg) => Subscribe(cfg, "news");
+    public void UnsubscribeNews(int subscriptionId) => Unsubscribe(subscriptionId);
+    protected override string BuildSubscriptionPayload() => BuildNewsSubscriptionMessage(Subscriptions.GetSymbolsByKind("news"));
+    protected override void HandleMessage(System.Text.Json.JsonElement element)
+    {
+        if (!element.TryGetProperty("T", out var type) || type.GetString() != "n") return;
+        var timestamp = element.TryGetProperty("created_at", out var created) && DateTimeOffset.TryParse(created.GetString(), out var parsed) ? parsed : default;
+        var id = element.TryGetProperty("id", out var idProp) ? idProp.ValueKind == System.Text.Json.JsonValueKind.String ? idProp.GetString() : idProp.ToString() : null;
+        var headline = element.TryGetProperty("headline", out var headlineProp) ? headlineProp.GetString() : null;
+        if (timestamp == default || string.IsNullOrWhiteSpace(id) || string.IsNullOrWhiteSpace(headline)) return;
+        var symbols = element.TryGetProperty("symbols", out var symbolsProp) && symbolsProp.ValueKind == System.Text.Json.JsonValueKind.Array
+            ? symbolsProp.EnumerateArray().Select(static item => item.GetString()).Where(static symbol => !string.IsNullOrWhiteSpace(symbol)).Select(static symbol => symbol!).ToArray() : [];
+        _sink.Publish(new AlpacaNewsEvent(id!, headline!, element.TryGetProperty("summary", out var summary) ? summary.GetString() ?? string.Empty : string.Empty,
+            element.TryGetProperty("url", out var url) ? url.GetString() ?? string.Empty : string.Empty,
+            element.TryGetProperty("source", out var source) ? source.GetString() ?? string.Empty : string.Empty, timestamp, symbols));
+    }
     private string Host => Options.UseSandbox ? AlpacaEndpoints.SandboxHost : AlpacaEndpoints.LiveHost;
 }

--- a/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaMarketDataClient.cs
+++ b/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaMarketDataClient.cs
@@ -77,6 +77,12 @@ public class AlpacaMarketDataClient : WebSocketProviderBase, IAlpacaAssetStream
     /// <summary>The asset class served by this independent WebSocket adapter.</summary>
     public virtual MarketDataAssetClass AssetClass => MarketDataAssetClass.Equities;
 
+    /// <summary>Instrument types this stream is permitted to publish.</summary>
+    public virtual IReadOnlyList<Meridian.Contracts.Domain.Enums.InstrumentType> SupportedInstrumentTypes => [Meridian.Contracts.Domain.Enums.InstrumentType.Equity];
+
+    /// <summary>Whether this stream has a configured entitlement usable for subscription.</summary>
+    public virtual bool IsSubscriptionAvailable => IsConfiguredFeed(Options.EquitiesFeed);
+
     /// <inheritdoc/>
     public override string ProviderId => "alpaca";
 
@@ -195,9 +201,7 @@ public class AlpacaMarketDataClient : WebSocketProviderBase, IAlpacaAssetStream
             if (!Connected)
                 return;
 
-            var trades = Subscriptions.GetSymbolsByKind("trades");
-            var quotes = Subscriptions.GetSymbolsByKind("quotes");
-            var json = BuildSubscriptionMessage(Options.SubscribeQuotes, trades, quotes);
+            var json = BuildSubscriptionPayload();
             await SendAsync(json, ct).ConfigureAwait(false);
         }
         catch (Exception ex)
@@ -212,6 +216,8 @@ public class AlpacaMarketDataClient : WebSocketProviderBase, IAlpacaAssetStream
     /// <inheritdoc/>
     public override int SubscribeTrades(SymbolConfig cfg)
     {
+        if (!IsSubscriptionAvailable)
+            return -1;
         if (cfg is null)
             throw new ArgumentNullException(nameof(cfg));
         var id = Subscriptions.Subscribe(cfg.Symbol, "trades");
@@ -237,6 +243,8 @@ public class AlpacaMarketDataClient : WebSocketProviderBase, IAlpacaAssetStream
     /// <inheritdoc/>
     public override int SubscribeMarketDepth(SymbolConfig cfg)
     {
+        if (!IsSubscriptionAvailable)
+            return -1;
         // Not supported for stocks: Alpaca provides quotes, not full L2 depth updates.
         // If you later add QuoteCollector -> L2Snapshot mapping, wire it here.
         if (!Options.SubscribeQuotes)
@@ -263,6 +271,25 @@ public class AlpacaMarketDataClient : WebSocketProviderBase, IAlpacaAssetStream
                 .ObserveException(Log, $"Alpaca unsubscribe depth for {subscription.Symbol}");
         }
     }
+
+    protected virtual string BuildSubscriptionPayload() => BuildSubscriptionMessage(
+        Options.SubscribeQuotes, Subscriptions.GetSymbolsByKind("trades"), Subscriptions.GetSymbolsByKind("quotes"));
+
+    protected int Subscribe(SymbolConfig cfg, string kind)
+    {
+        ArgumentNullException.ThrowIfNull(cfg);
+        if (!IsSubscriptionAvailable) return -1;
+        var id = Subscriptions.Subscribe(cfg.Symbol, kind);
+        if (id != -1) ResubscribeAsync(CancellationToken.None).ObserveException(Log, $"Alpaca subscribe {kind} for {cfg.Symbol}");
+        return id;
+    }
+
+    protected void Unsubscribe(int subscriptionId)
+    {
+        if (Subscriptions.Unsubscribe(subscriptionId) is not null) ResubscribeAsync(CancellationToken.None).ObserveException(Log, "Alpaca unsubscribe");
+    }
+
+    protected static bool IsConfiguredFeed(string? feed) => !string.IsNullOrWhiteSpace(feed) && !string.Equals(feed, "none", StringComparison.OrdinalIgnoreCase) && !string.Equals(feed, "disabled", StringComparison.OrdinalIgnoreCase);
 
     internal static string BuildAuthenticationMessage(AlpacaOptions options)
     {
@@ -308,6 +335,16 @@ public class AlpacaMarketDataClient : WebSocketProviderBase, IAlpacaAssetStream
         });
     }
 
+    internal static string BuildNewsSubscriptionMessage(IReadOnlyList<string> symbols)
+    {
+        ArgumentNullException.ThrowIfNull(symbols);
+        return BuildJsonMessage(writer =>
+        {
+            writer.WriteString("action", "subscribe");
+            if (symbols.Count > 0) { writer.WritePropertyName("news"); writer.WriteStartArray(); foreach (var symbol in symbols) writer.WriteStringValue(symbol); writer.WriteEndArray(); }
+        });
+    }
+
     private static string BuildJsonMessage(Action<Utf8JsonWriter> writePayload)
     {
         ArgumentNullException.ThrowIfNull(writePayload);
@@ -323,7 +360,7 @@ public class AlpacaMarketDataClient : WebSocketProviderBase, IAlpacaAssetStream
 
 
 
-    private void HandleMessage(JsonElement el)
+    protected virtual void HandleMessage(JsonElement el)
     {
         // Trades: "T":"t" (per Alpaca docs)
         if (!el.TryGetProperty("T", out var tProp))

--- a/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaProviderModule.cs
+++ b/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaProviderModule.cs
@@ -110,12 +110,16 @@ public sealed class AlpacaProviderModule : ConfigurableProviderModuleBase, IProv
                 sp.GetRequiredService<TradeDataCollector>(), sp.GetRequiredService<QuoteCollector>(), streamingOptions));
             services.AddSingleton<AlpacaCryptoMarketDataClient>(sp => new(
                 sp.GetRequiredService<TradeDataCollector>(), sp.GetRequiredService<QuoteCollector>(), streamingOptions));
+            services.AddSingleton<AlpacaNewsEventBuffer>();
+            services.AddSingleton<IAlpacaNewsEventSink>(sp => sp.GetRequiredService<AlpacaNewsEventBuffer>());
             services.AddSingleton<AlpacaNewsMarketDataClient>(sp => new(
-                sp.GetRequiredService<TradeDataCollector>(), sp.GetRequiredService<QuoteCollector>(), streamingOptions));
+                sp.GetRequiredService<TradeDataCollector>(), sp.GetRequiredService<QuoteCollector>(), streamingOptions,
+                sp.GetRequiredService<IAlpacaNewsEventSink>()));
             services.AddSingleton<IAlpacaAssetStream>(sp => sp.GetRequiredService<AlpacaMarketDataClient>());
             services.AddSingleton<IAlpacaAssetStream>(sp => sp.GetRequiredService<AlpacaOptionsMarketDataClient>());
             services.AddSingleton<IAlpacaAssetStream>(sp => sp.GetRequiredService<AlpacaCryptoMarketDataClient>());
             services.AddSingleton<IAlpacaAssetStream>(sp => sp.GetRequiredService<AlpacaNewsMarketDataClient>());
+            services.AddSingleton<IAlpacaMarketDataRouter, AlpacaMarketDataRouter>();
         }
 
         // ----------------------------------------------------------------

--- a/src/Meridian.Infrastructure/Adapters/Core/ProviderCapabilityDescriptorCatalog.cs
+++ b/src/Meridian.Infrastructure/Adapters/Core/ProviderCapabilityDescriptorCatalog.cs
@@ -1,5 +1,6 @@
 using Meridian.Contracts.Domain.Enums;
 using Meridian.Execution.Sdk;
+using Meridian.Infrastructure.Resilience;
 using Meridian.Infrastructure.Adapters.Alpaca;
 using Meridian.Infrastructure.Adapters.Edgar;
 using Meridian.Infrastructure.Adapters.Polygon;
@@ -26,7 +27,8 @@ public static class ProviderCapabilityDescriptorCatalog
     public static IReadOnlyList<ProviderCapabilityDescriptor> Descriptors { get; } =
     [
         new("alpaca", typeof(AlpacaMarketDataClient), typeof(AlpacaHistoricalDataProvider), typeof(AlpacaSymbolSearchProvider), typeof(AlpacaCorporateActionProvider), typeof(AlpacaOptionsChainProvider), typeof(AlpacaBrokerageGateway),
-            InstrumentTypes: [InstrumentType.Equity, InstrumentType.EquityOption, InstrumentType.Crypto]),
+            InstrumentTypes: [InstrumentType.Equity, InstrumentType.EquityOption, InstrumentType.IndexOption, InstrumentType.Crypto],
+            StreamingAssetClasses: [MarketDataAssetClass.Equities, MarketDataAssetClass.Options, MarketDataAssetClass.Crypto, MarketDataAssetClass.News]),
         new("synthetic", Historical: typeof(SyntheticHistoricalDataProvider),
             InstrumentTypes: [InstrumentType.Equity]),
         new("ib", Streaming: typeof(IBMarketDataClient),
@@ -82,7 +84,8 @@ public sealed record ProviderCapabilityDescriptor(
     Type? CorporateActions = null,
     Type? Options = null,
     Type? Brokerage = null,
-    IReadOnlyList<InstrumentType>? InstrumentTypes = null)
+    IReadOnlyList<InstrumentType>? InstrumentTypes = null,
+    IReadOnlyList<MarketDataAssetClass>? StreamingAssetClasses = null)
 {
     /// <summary>
     /// Instrument types this provider is declared to cover. Declared here, next to the adapter
@@ -90,6 +93,8 @@ public sealed record ProviderCapabilityDescriptor(
     /// Defaults to equities when a provider has not declared broader coverage.
     /// </summary>
     public IReadOnlyList<InstrumentType> SupportedInstrumentTypes { get; } = InstrumentTypes ?? [InstrumentType.Equity];
+
+    public IReadOnlyList<MarketDataAssetClass> SupportedStreamingAssetClasses { get; } = StreamingAssetClasses ?? [];
 
     public bool HasStreaming => Streaming is not null;
     public bool HasHistorical => Historical is not null;

--- a/src/Meridian.Infrastructure/README.md
+++ b/src/Meridian.Infrastructure/README.md
@@ -41,7 +41,8 @@ diagnostics, `WebSocketState` is `None`. Consumers should use this contract inst
 into provider-specific transport internals.
 
 Alpaca streaming keeps equities, options, crypto, and news as explicit adapters with their own
-WebSocket endpoints. Its diagnostics carry a per-stream selected feed and entitlement (for
+WebSocket endpoints. Consumers resolve them through the capability-aware Alpaca asset-stream router, which
+fails closed when a requested stream has no usable entitlement rather than falling back to equities. Its diagnostics carry a per-stream selected feed and entitlement (for
 example, IEX versus SIP and indicative versus OPRA), so a connected price socket cannot be
 misrepresented as consolidated or OPRA-entitled data.
 

--- a/tests/Meridian.Tests/Infrastructure/Providers/AlpacaAssetStreamRoutingTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/AlpacaAssetStreamRoutingTests.cs
@@ -1,0 +1,149 @@
+using System.Reflection;
+using System.Text.Json;
+using FluentAssertions;
+using Meridian.Contracts.Configuration;
+using Meridian.Contracts.Domain.Enums;
+using Meridian.Core.Config;
+using Meridian.Domain.Collectors;
+using Meridian.Infrastructure.Adapters.Alpaca;
+using Meridian.Infrastructure.Resilience;
+using Meridian.Infrastructure.DataSources;
+using Microsoft.Extensions.DependencyInjection;
+using Meridian.Tests.TestHelpers;
+using Xunit;
+
+namespace Meridian.Tests.Infrastructure.Providers;
+
+public sealed class AlpacaAssetStreamRoutingTests
+{
+    private static AlpacaOptions Options(string? optionsFeed = "opra", string cryptoFeed = "us", string newsFeed = "basic") =>
+        new(KeyId: "key", SecretKey: "secret", OptionsFeed: optionsFeed, CryptoFeed: cryptoFeed, NewsFeed: newsFeed);
+
+    private static (TradeDataCollector Trades, QuoteCollector Quotes) Collectors()
+    {
+        var publisher = new TestMarketEventPublisher();
+        return (new TradeDataCollector(publisher), new QuoteCollector(publisher));
+    }
+
+    [Fact]
+    public void Router_ResolvesEachEntitledAssetClass_WithItsOwnInstrumentClass()
+    {
+        var (trades, quotes) = Collectors();
+        var options = Options();
+        var streams = new IAlpacaAssetStream[]
+        {
+            new AlpacaMarketDataClient(trades, quotes, options),
+            new AlpacaOptionsMarketDataClient(trades, quotes, options),
+            new AlpacaCryptoMarketDataClient(trades, quotes, options),
+            new AlpacaNewsMarketDataClient(trades, quotes, options, new AlpacaNewsEventBuffer())
+        };
+        var router = new AlpacaMarketDataRouter(streams);
+
+        router.Resolve(MarketDataAssetClass.Options).SupportedInstrumentTypes.Should().Contain(InstrumentType.EquityOption);
+        router.Resolve(MarketDataAssetClass.Crypto).SupportedInstrumentTypes.Should().ContainSingle().Which.Should().Be(InstrumentType.Crypto);
+        router.Resolve(MarketDataAssetClass.News).Should().BeOfType<AlpacaNewsMarketDataClient>();
+    }
+
+    [Fact]
+    public void Router_UnavailableOptionsEntitlement_FailsClosed_WithoutEquitiesFallback()
+    {
+        var (trades, quotes) = Collectors();
+        var options = Options(optionsFeed: "indicative");
+        var router = new AlpacaMarketDataRouter([
+            new AlpacaMarketDataClient(trades, quotes, options),
+            new AlpacaOptionsMarketDataClient(trades, quotes, options)]);
+
+        router.TryResolve(MarketDataAssetClass.Options, out var stream).Should().BeFalse();
+        stream.Should().BeNull();
+        var action = () => router.Resolve(MarketDataAssetClass.Options);
+        action.Should().Throw<InvalidOperationException>().WithMessage("*Options*");
+    }
+
+
+    [Fact]
+    public void ReconnectSubscriptionPayload_RetainsOnlyTheAssetStreamSubscriptions()
+    {
+        var (trades, quotes) = Collectors();
+        var client = new TestAlpacaClient(trades, quotes, Options());
+        client.SubscribeTrades(new SymbolConfig("BTC/USD")).Should().BeGreaterThan(0);
+
+        using var doc = JsonDocument.Parse(client.ReconnectSubscriptionPayload());
+        doc.RootElement.GetProperty("trades").EnumerateArray().Select(x => x.GetString())
+            .Should().ContainSingle().Which.Should().Be("BTC/USD");
+        doc.RootElement.TryGetProperty("news", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void NewsSubscription_UsesNewsChannel_AndNewsDoesNotExposeTradeOrQuoteSubscriptions()
+    {
+        var (trades, quotes) = Collectors();
+        var client = new AlpacaNewsMarketDataClient(trades, quotes, Options(), new AlpacaNewsEventBuffer());
+        client.SubscribeTrades(new SymbolConfig("AAPL")).Should().Be(-1);
+        client.SubscribeMarketDepth(new SymbolConfig("AAPL")).Should().Be(-1);
+        client.SubscribeNews(new SymbolConfig("AAPL")).Should().BeGreaterThan(0);
+
+        using var doc = JsonDocument.Parse(AlpacaMarketDataClient.BuildNewsSubscriptionMessage(["AAPL"]));
+        doc.RootElement.GetProperty("news").EnumerateArray().Select(x => x.GetString()).Should().ContainSingle().Which.Should().Be("AAPL");
+        doc.RootElement.TryGetProperty("trades", out _).Should().BeFalse();
+        doc.RootElement.TryGetProperty("quotes", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void NewsMessage_NormalizesIntoNewsSink_WithoutPublishingPriceEvents()
+    {
+        var (trades, quotes) = Collectors();
+        var sink = new AlpacaNewsEventBuffer();
+        var client = new AlpacaNewsMarketDataClient(trades, quotes, Options(), sink);
+        var method = typeof(AlpacaNewsMarketDataClient).GetMethod("HandleMessage", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        using var doc = JsonDocument.Parse("""{"T":"n","id":123,"headline":"Earnings beat","summary":"Results","url":"https://news","source":"wire","created_at":"2025-01-02T03:04:05Z","symbols":["AAPL"]}""");
+
+        method.Invoke(client, [doc.RootElement]);
+
+        sink.Events.Should().ContainSingle().Which.Should().BeEquivalentTo(new AlpacaNewsEvent("123", "Earnings beat", "Results", "https://news", "wire", DateTimeOffset.Parse("2025-01-02T03:04:05Z"), ["AAPL"]));
+    }
+
+
+    [Fact]
+    public void ProviderModule_RegistersCapabilityRouterAndAllAssetStreams()
+    {
+        var previousKey = Environment.GetEnvironmentVariable("ALPACA_KEY_ID");
+        var previousSecret = Environment.GetEnvironmentVariable("ALPACA_SECRET_KEY");
+        try
+        {
+            Environment.SetEnvironmentVariable("ALPACA_KEY_ID", "key");
+            Environment.SetEnvironmentVariable("ALPACA_SECRET_KEY", "secret");
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddHttpClient();
+            var publisher = new TestMarketEventPublisher();
+            services.AddSingleton<Meridian.Domain.Events.IMarketEventPublisher>(publisher);
+            services.AddSingleton(new TradeDataCollector(publisher));
+            services.AddSingleton(new QuoteCollector(publisher));
+            new AlpacaProviderModule().Register(services, new DataSourceRegistry());
+
+            using var provider = services.BuildServiceProvider();
+            provider.GetServices<IAlpacaAssetStream>().Select(stream => stream.AssetClass).Should().BeEquivalentTo(
+                [MarketDataAssetClass.Equities, MarketDataAssetClass.Options, MarketDataAssetClass.Crypto, MarketDataAssetClass.News]);
+            provider.GetRequiredService<IAlpacaMarketDataRouter>().Resolve(MarketDataAssetClass.Crypto)
+                .Should().BeOfType<AlpacaCryptoMarketDataClient>();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("ALPACA_KEY_ID", previousKey);
+            Environment.SetEnvironmentVariable("ALPACA_SECRET_KEY", previousSecret);
+        }
+    }
+
+    private sealed class TestAlpacaClient(TradeDataCollector trades, QuoteCollector quotes, AlpacaOptions options)
+        : AlpacaMarketDataClient(trades, quotes, options)
+    {
+        public string ReconnectSubscriptionPayload() => BuildSubscriptionPayload();
+    }
+
+    [Fact]
+    public void CapabilityCatalog_DeclaresAllAlpacaStreamingAssetClasses()
+    {
+        var alpaca = Meridian.Infrastructure.Adapters.Core.ProviderCapabilityDescriptorCatalog.Descriptors.Single(x => x.ProviderId == "alpaca");
+        alpaca.SupportedStreamingAssetClasses.Should().BeEquivalentTo([MarketDataAssetClass.Equities, MarketDataAssetClass.Options, MarketDataAssetClass.Crypto, MarketDataAssetClass.News]);
+    }
+}


### PR DESCRIPTION
### Motivation

- Surface Alpaca asset classes (equities, options, crypto, news) as first-class, entitlement-aware streams so consumers can resolve and subscribe to the correct stream instead of silently falling back to equities. 
- Treat news as its own normalized event surface (not trades/quotes) and provide a bounded read model for operator diagnostics and downstream reads. 
- Make provider capability metadata and routing selection aware of asset-class coverage so routing and entitlement checks can be used by provider-selection logic.

### Description

- Introduce a capability-aware contract and router by adding `IAlpacaAssetStream`, `IAlpacaMarketDataRouter`, and `AlpacaMarketDataRouter` in `src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaAssetStreamAdapters.cs`. 
- Add a normalized news event model `AlpacaNewsEvent`, an in-memory `AlpacaNewsEventBuffer`, and `IAlpacaNewsEventSink`, plus `IAlpacaNewsSubscriptionClient` and `AlpacaNewsMarketDataClient` that publish news to the sink and never surface news as trades/quotes. 
- Extend `AlpacaMarketDataClient` to include per-stream metadata and entitlement-aware subscription behavior by adding `SupportedInstrumentTypes`, `IsSubscriptionAvailable`, a `BuildSubscriptionPayload` hook, `BuildNewsSubscriptionMessage`, and safer `Subscribe`/`Unsubscribe` helpers; also make message handler overridable for asset-specific parsing. 
- Register streams, the news sink, and the router in DI via `AlpacaProviderModule` so each asset-class client is individually resolvable and the router is available to consumers. 
- Extend provider metadata by adding `StreamingAssetClasses` to `ProviderCapabilityDescriptor` and declaring Alpaca streaming asset classes in `src/Meridian.Infrastructure/Adapters/Core/ProviderCapabilityDescriptorCatalog.cs`. 
- Add focused tests in `tests/Meridian.Tests/Infrastructure/Providers/AlpacaAssetStreamRoutingTests.cs` that cover DI registration, router selection, entitlement fail-closed behavior, news subscription payloads, reconnect payload retention, and news normalization. 
- Update `src/Meridian.Infrastructure/README.md` to document the router behavior and refresh the infrastructure source-hash manifest (`docs/source/generated/source-hash-manifest.json`).

### Testing

- Ran `git diff --check` to validate whitespace/merge issues and it reported no problems. 
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --write-module SRC-INFRASTRUCTURE --summary` which refreshed the infra module manifest successfully. 
- Attempted to run the full CI script `bash scripts/ci.sh` and targeted `dotnet` tests, but the environment lacks the .NET SDK (`dotnet: command not found`), so `dotnet test` could not be executed locally here; the added unit tests are present and should pass under the repository CI when `dotnet` is available. 
- The change set includes new unit tests that validate DI registration, routing selection, per-stream subscription JSON, parser normalization, reconnect/resubscribe payload behavior, and the fail-closed entitlement rule (see `tests/Meridian.Tests/Infrastructure/Providers/AlpacaAssetStreamRoutingTests.cs`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611d00ee0c83208398b7a51d3a144a)