### PR TITLE
Add provider-neutral IB data read models, callback correlation, and ui projection seam

### DIFF
--- a/docs/source/generated/source-hash-manifest.json
+++ b/docs/source/generated/source-hash-manifest.json
@@ -191,8 +191,8 @@
       "id": "SRC-INFRASTRUCTURE",
       "path": "src/Meridian.Infrastructure",
       "readme": "src/Meridian.Infrastructure/README.md",
-      "readme_hash": "c6015eceed0be87a25be91e2d10f7010cb07faa75579bd8aaefeafc612563418",
-      "source_hash": "6251b39285d598cb1e4037406c36a52fc48fd42536d9563ebc7cdca36343766e"
+      "readme_hash": "8b7f74c8ba3b98f757131f3df03d893100c8d29274eea312e964edee8aed41b7",
+      "source_hash": "ebda0c14391a2040dbacc8e09eeca8efaadb28c2d0a937ac020c440061adc588"
     },
     {
       "id": "SRC-LAUNCHER",
@@ -226,8 +226,8 @@
       "id": "SRC-PROVIDER-SDK",
       "path": "src/Meridian.ProviderSdk",
       "readme": "src/Meridian.ProviderSdk/README.md",
-      "readme_hash": "d5df4a0781396f4a42b05b6ae080182dd38361100fa5116ce7a3f3e634fc201b",
-      "source_hash": "d81e051d4dfb35049b8bc1d2bec4b8ba44c24312564fe3900e6f1f5f99aff1b9"
+      "readme_hash": "bd19b96994842ab6c25b38b1350b052ce8b0c4fb2fd7f4e50b378c3957558ae1",
+      "source_hash": "237272157b29d3a4e0fc8ce5dac9ce4142a3f79a5b853026e7cc13bc1612979d"
     },
     {
       "id": "SRC-QUANTSCRIPT",
@@ -282,8 +282,8 @@
       "id": "SRC-UI-SHARED",
       "path": "src/Meridian.Ui.Shared",
       "readme": "src/Meridian.Ui.Shared/README.md",
-      "readme_hash": "bd6d18dd8ed568560f90f37d7c3c46679d12efb1621e16c76c939cd5775552a5",
-      "source_hash": "5357fef9f3b7dd97ebb04aacaf77968ba86a06e34199c0dfcd55609ba9d4eac1"
+      "readme_hash": "72d3011283608d57658a13ec10fe853760588139983e6dcf4e950ef6ec06f1e5",
+      "source_hash": "d82e1591432b0dfef67f3e6330d617b1125cf3f01db506a9aa4892cb956cff24"
     },
     {
       "id": "SRC-WPF",

--- a/src/Meridian.Infrastructure/Adapters/Core/ProviderCapabilityDescriptorCatalog.cs
+++ b/src/Meridian.Infrastructure/Adapters/Core/ProviderCapabilityDescriptorCatalog.cs
@@ -29,14 +29,8 @@ public static class ProviderCapabilityDescriptorCatalog
             InstrumentTypes: [InstrumentType.Equity, InstrumentType.EquityOption, InstrumentType.Crypto]),
         new("synthetic", Historical: typeof(SyntheticHistoricalDataProvider),
             InstrumentTypes: [InstrumentType.Equity]),
-        new("ib", Streaming: typeof(IBMarketDataClient),
-            InstrumentTypes:
-            [
-                InstrumentType.Equity, InstrumentType.EquityOption, InstrumentType.IndexOption,
-                InstrumentType.Future, InstrumentType.FuturesOption, InstrumentType.Forex,
-                InstrumentType.Bond, InstrumentType.CFD, InstrumentType.Warrant, InstrumentType.Index
-            ]),
-        new("ibkr", Historical: typeof(IBHistoricalDataProvider),
+        new("ibkr", Streaming: typeof(IBMarketDataClient), Historical: typeof(IBHistoricalDataProvider), Brokerage: typeof(IBBrokerageGateway),
+            ExecutionMode: IBProviderCapabilityExecutionMode.SimulationWhenVendorSdkUnavailable,
             InstrumentTypes:
             [
                 InstrumentType.Equity, InstrumentType.EquityOption, InstrumentType.IndexOption,
@@ -82,6 +76,7 @@ public sealed record ProviderCapabilityDescriptor(
     Type? CorporateActions = null,
     Type? Options = null,
     Type? Brokerage = null,
+    IBProviderCapabilityExecutionMode ExecutionMode = IBProviderCapabilityExecutionMode.NotApplicable,
     IReadOnlyList<InstrumentType>? InstrumentTypes = null)
 {
     /// <summary>
@@ -113,4 +108,12 @@ public sealed record ProviderCapabilityDescriptor(
         if (Brokerage is not null)
             yield return Brokerage;
     }
+}
+
+/// <summary>Catalog-level readiness signal; inventory cannot promote a guidance build to live routing.</summary>
+public enum IBProviderCapabilityExecutionMode
+{
+    NotApplicable,
+    SimulationWhenVendorSdkUnavailable,
+    VendorRuntimeRequiredForLive
 }

--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.IBApi.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.IBApi.cs
@@ -11,6 +11,7 @@ using Meridian.Core.Logging;
 using Meridian.Core.Performance;
 using Meridian.Execution.Sdk;
 using Meridian.Infrastructure.Resilience;
+using Meridian.ProviderSdk;
 using Serilog;
 
 namespace Meridian.Infrastructure.Adapters.InteractiveBrokers;
@@ -45,6 +46,7 @@ public sealed partial class EnhancedIBConnectionManager : EWrapper, IDisposable
     private readonly ConcurrentDictionary<int, TaskCompletionSource<List<IBApi.Bar>>> _historicalDataRequests = new();
     private readonly ConcurrentDictionary<int, List<IBApi.Bar>> _historicalDataBuffers = new();
     private int _nextBrokerRequestId = 50_000;
+    private readonly ConcurrentDictionary<int, int> _marketRuleRequests = new();
 
     // Performance monitoring
     private readonly ConnectionWarmUp _warmUp;
@@ -151,6 +153,14 @@ public sealed partial class EnhancedIBConnectionManager : EWrapper, IDisposable
     public event EventHandler? PositionsCompleted;
     public event EventHandler<IBAccountSummaryUpdate>? AccountSummaryReceived;
     public event EventHandler<int>? AccountSummaryCompleted;
+    public event EventHandler<(int RequestId, ProviderOptionContract Contract)>? OptionContractReceived;
+    public event EventHandler<(int RequestId, ProviderScannerResult Result)>? ScannerResultReceived;
+    public event EventHandler<(int RequestId, ProviderRealTimeBar Bar)>? RealTimeBarReceived;
+    public event EventHandler<(int RequestId, ProviderHistoricalTick Tick, bool Completed)>? HistoricalTickReceived;
+    public event EventHandler<(int RequestId, ProviderAccountPnl Pnl)>? PnlReceived;
+    public event EventHandler<(int RequestId, IReadOnlyList<ProviderMarketRuleIncrement> Increments)>? MarketRuleReceived;
+    public event EventHandler<int>? RequestCompleted;
+    public event EventHandler<(int RequestId, string Code, string Message)>? RequestRejected;
 
     public async Task ConnectAsync(CancellationToken ct = default)
     {
@@ -833,6 +843,7 @@ public sealed partial class EnhancedIBConnectionManager : EWrapper, IDisposable
     public void RequestMarketRule(int requestId, int marketRuleId)
     {
         ThrowIfNotConnected();
+        _marketRuleRequests[marketRuleId] = requestId;
         _clientSocket.reqMarketRule(marketRuleId);
     }
 
@@ -840,6 +851,58 @@ public sealed partial class EnhancedIBConnectionManager : EWrapper, IDisposable
     {
         ThrowIfNotConnected();
         _clientSocket.reqMktDepthExchanges();
+    }
+
+    /// <summary>Starts a correlated, five-second real-time bar stream.</summary>
+    public void RequestRealTimeBars(int requestId, IBRealTimeBarRequest request)
+    {
+        ThrowIfNotConnected();
+#if IBAPI_VENDOR
+        _clientSocket.reqRealTimeBars(requestId, ContractFactory.Create(request.Contract), 5, request.WhatToShow, request.UseRegularTradingHours, []);
+#else
+        throw new NotSupportedException("Real-time bars require the official Interactive Brokers vendor SDK.");
+#endif
+    }
+
+    /// <summary>Requests a bounded historical-tick page with explicit time bounds.</summary>
+    public void RequestHistoricalTicks(int requestId, IBHistoricalTickRequest request)
+    {
+        ThrowIfNotConnected();
+#if IBAPI_VENDOR
+        _clientSocket.reqHistoricalTicks(requestId, ContractFactory.Create(request.Contract),
+            request.Start?.UtcDateTime.ToString("yyyyMMdd-HH:mm:ss", CultureInfo.InvariantCulture) ?? string.Empty,
+            request.End?.UtcDateTime.ToString("yyyyMMdd-HH:mm:ss", CultureInfo.InvariantCulture) ?? string.Empty,
+            request.NumberOfTicks, request.WhatToShow, request.UseRegularTradingHours ? 1 : 0, false, []);
+#else
+        throw new NotSupportedException("Historical ticks require the official Interactive Brokers vendor SDK.");
+#endif
+    }
+
+    /// <summary>Cancels the associated vendor stream when its request lifetime ends.</summary>
+    public void CancelDataRequest(int requestId, string capability)
+    {
+        if (!IsConnected) return;
+        switch (capability)
+        {
+            case "scanner":
+#if IBAPI_VENDOR
+                _clientSocket.cancelScannerSubscription(requestId);
+#endif
+                break;
+            case "tick-by-tick": _clientSocket.cancelTickByTickData(requestId); break;
+            case "pnl":
+#if IBAPI_VENDOR
+                _clientSocket.cancelPnL(requestId);
+#endif
+                break;
+            case "real-time-bars":
+#if IBAPI_VENDOR
+                _clientSocket.cancelRealTimeBars(requestId);
+#endif
+                break;
+            case "historical-ticks":
+                break; // IB historical ticks are bounded and complete from their terminal callback.
+        }
     }
 
     // -----------------------
@@ -931,6 +994,8 @@ public sealed partial class EnhancedIBConnectionManager : EWrapper, IDisposable
         }
 
         ErrorOccurred?.Invoke(this, new IBApiError(id, errorCode, errorMsg, advancedOrderRejectJson));
+        if (id > 0)
+            RequestRejected?.Invoke(this, (id, errorCode.ToString(CultureInfo.InvariantCulture), errorMsg));
     }
 
     public void connectionClosed()
@@ -1039,8 +1104,21 @@ public sealed partial class EnhancedIBConnectionManager : EWrapper, IDisposable
         RecordMessageReceived();
         MarketDataTypeReceived?.Invoke(this, new IBMarketDataTypeUpdate(reqId, marketDataType));
     }
-    public void contractDetails(int reqId, ContractDetails contractDetails) { }
-    public void contractDetailsEnd(int reqId) { }
+    public void contractDetails(int reqId, ContractDetails contractDetails)
+    {
+        RecordMessageReceived();
+#if IBAPI_VENDOR
+        var contract = contractDetails.Contract;
+        var expiration = DateOnly.TryParse(contract.LastTradeDateOrContractMonth, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date) ? date : DateOnly.MinValue;
+        if (expiration != DateOnly.MinValue && contract.Strike > 0 && !string.IsNullOrWhiteSpace(contract.Right))
+            OptionContractReceived?.Invoke(this, (reqId, new ProviderOptionContract(contract.Symbol, string.Empty, expiration, (decimal)contract.Strike, contract.Right, contract.Exchange, contract.TradingClass, contract.Multiplier, contract.ConId.ToString(CultureInfo.InvariantCulture))));
+#endif
+    }
+    public void contractDetailsEnd(int reqId)
+    {
+        RecordMessageReceived();
+        RequestCompleted?.Invoke(this, reqId);
+    }
     public void symbolSamples(int reqId, ContractDescription[] contractDescriptions) { }
     public void reqMktDepthExchanges(DepthMktDataDescription[] depthMktDataDescriptions) { }
     public void tickReqParams(int tickerId, double minTick, string bboExchange, int snapshotPermissions) { }

--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.IBApiVendorStubs.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.IBApiVendorStubs.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using IBApi;
 using Pb = IBApi.protobuf;
+using Meridian.ProviderSdk;
 
 namespace Meridian.Infrastructure.Adapters.InteractiveBrokers;
 
@@ -51,6 +52,8 @@ public sealed partial class EnhancedIBConnectionManager
 
     public void realtimeBar(int reqId, long date, double open, double high, double low, double close, decimal volume, decimal WAP, int count)
     {
+        RecordMessageReceived();
+        RealTimeBarReceived?.Invoke(this, (reqId, new ProviderRealTimeBar(DateTimeOffset.FromUnixTimeSeconds(date), (decimal)open, (decimal)high, (decimal)low, (decimal)close, volume, WAP, count)));
     }
 
     public void scannerParameters(string xml)
@@ -59,10 +62,15 @@ public sealed partial class EnhancedIBConnectionManager
 
     public void scannerData(int reqId, int rank, ContractDetails contractDetails, string distance, string benchmark, string projection, string legsStr)
     {
+        RecordMessageReceived();
+        var contract = contractDetails.Contract;
+        ScannerResultReceived?.Invoke(this, (reqId, new ProviderScannerResult(rank, contract.Symbol, contract.Exchange, contract.ConId.ToString(), distance, benchmark, projection, legsStr)));
     }
 
     public void scannerDataEnd(int reqId)
     {
+        RecordMessageReceived();
+        RequestCompleted?.Invoke(this, reqId);
     }
 
     public void receiveFA(int faDataType, string faXmlData)
@@ -107,10 +115,19 @@ public sealed partial class EnhancedIBConnectionManager
 
     public void securityDefinitionOptionParameter(int reqId, string exchange, int underlyingConId, string tradingClass, string multiplier, HashSet<string> expirations, HashSet<double> strikes)
     {
+        RecordMessageReceived();
+        foreach (var expirationText in expirations)
+        {
+            if (!DateOnly.TryParseExact(expirationText, "yyyyMMdd", out var expiration)) continue;
+            foreach (var strike in strikes)
+                OptionContractReceived?.Invoke(this, (reqId, new ProviderOptionContract(string.Empty, underlyingConId.ToString(), expiration, (decimal)strike, string.Empty, exchange, tradingClass, multiplier)));
+        }
     }
 
     public void securityDefinitionOptionParameterEnd(int reqId)
     {
+        RecordMessageReceived();
+        RequestCompleted?.Invoke(this, reqId);
     }
 
     public void softDollarTiers(int reqId, SoftDollarTier[] tiers)
@@ -147,18 +164,29 @@ public sealed partial class EnhancedIBConnectionManager
 
     public void marketRule(int marketRuleId, PriceIncrement[] priceIncrements)
     {
+        RecordMessageReceived();
+        var requestId = _marketRuleRequests.TryRemove(marketRuleId, out var correlatedRequestId) ? correlatedRequestId : marketRuleId;
+        MarketRuleReceived?.Invoke(this, (requestId, priceIncrements.Select(static x => new ProviderMarketRuleIncrement((decimal)x.LowEdge, (decimal)x.Increment)).ToArray()));
     }
 
     public void pnl(int reqId, double dailyPnL, double unrealizedPnL, double realizedPnL)
     {
+        RecordMessageReceived();
+        PnlReceived?.Invoke(this, (reqId, new ProviderAccountPnl(string.Empty, null, (decimal)dailyPnL, (decimal)unrealizedPnL, (decimal)realizedPnL)));
     }
 
     public void pnlSingle(int reqId, decimal pos, double dailyPnL, double unrealizedPnL, double realizedPnL, double value)
     {
+        RecordMessageReceived();
+        PnlReceived?.Invoke(this, (reqId, new ProviderAccountPnl(string.Empty, null, (decimal)dailyPnL, (decimal)unrealizedPnL, (decimal)realizedPnL, pos, (decimal)value)));
     }
 
     public void historicalTicks(int reqId, HistoricalTick[] ticks, bool done)
     {
+        RecordMessageReceived();
+        foreach (var tick in ticks)
+            HistoricalTickReceived?.Invoke(this, (reqId, new ProviderHistoricalTick(DateTimeOffset.FromUnixTimeSeconds(tick.Time), (decimal)tick.Price, tick.Size, "TRADES"), done));
+        if (done) RequestCompleted?.Invoke(this, reqId);
     }
 
     public void historicalTicksBidAsk(int reqId, HistoricalTickBidAsk[] ticks, bool done)

--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.cs
@@ -18,7 +18,7 @@ namespace Meridian.Infrastructure.Adapters.InteractiveBrokers;
 /// - Unlimited retry attempts by default (configurable via maxRetries parameter)
 /// - See EnhancedIBConnectionManager.IBApi.cs and Infrastructure/Performance/ConnectionWarmUp.cs for implementation
 /// </summary>
-public sealed partial class EnhancedIBConnectionManager : IIBBrokerageClient, IIBDataServiceTransport, IIBDataLineageSource
+public sealed partial class EnhancedIBConnectionManager : IIBBrokerageClient, IIBDataServiceTransport, IIBDataLineageSource, IIBDataCallbackSource
 {
 #if !IBAPI
     private readonly IBCallbackRouter _router;
@@ -59,6 +59,14 @@ public sealed partial class EnhancedIBConnectionManager : IIBBrokerageClient, II
     public event EventHandler<int>? AccountSummaryCompleted;
     public event EventHandler<IBApiError>? ErrorOccurred;
     public event EventHandler<IBMarketDataTypeUpdate>? MarketDataTypeReceived;
+    public event EventHandler<(int RequestId, Meridian.ProviderSdk.ProviderOptionContract Contract)>? OptionContractReceived;
+    public event EventHandler<(int RequestId, Meridian.ProviderSdk.ProviderScannerResult Result)>? ScannerResultReceived;
+    public event EventHandler<(int RequestId, Meridian.ProviderSdk.ProviderRealTimeBar Bar)>? RealTimeBarReceived;
+    public event EventHandler<(int RequestId, Meridian.ProviderSdk.ProviderHistoricalTick Tick, bool Completed)>? HistoricalTickReceived;
+    public event EventHandler<(int RequestId, Meridian.ProviderSdk.ProviderAccountPnl Pnl)>? PnlReceived;
+    public event EventHandler<(int RequestId, IReadOnlyList<Meridian.ProviderSdk.ProviderMarketRuleIncrement> Increments)>? MarketRuleReceived;
+    public event EventHandler<int>? RequestCompleted;
+    public event EventHandler<(int RequestId, string Code, string Message)>? RequestRejected;
 #pragma warning restore CS0067
 
     /// <summary>
@@ -114,6 +122,9 @@ public sealed partial class EnhancedIBConnectionManager : IIBBrokerageClient, II
     public void RequestPnl(int requestId, string account, string? modelCode) => throw ThrowPlatformNotSupported();
     public void RequestMarketRule(int requestId, int marketRuleId) => throw ThrowPlatformNotSupported();
     public void RequestDepthExchanges(int requestId) => throw ThrowPlatformNotSupported();
+    public void RequestRealTimeBars(int requestId, IBRealTimeBarRequest request) => throw ThrowPlatformNotSupported();
+    public void RequestHistoricalTicks(int requestId, IBHistoricalTickRequest request) => throw ThrowPlatformNotSupported();
+    public void CancelDataRequest(int requestId, string capability) => throw ThrowPlatformNotSupported();
 
     public void Dispose()
     {

--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBBrokerageGateway.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBBrokerageGateway.cs
@@ -20,7 +20,7 @@ namespace Meridian.Infrastructure.Adapters.InteractiveBrokers;
 /// Interactive Brokers brokerage gateway for live or paper order execution via the TWS/Gateway API.
 /// Uses the native IB socket path when the official vendor SDK is available.
 /// </summary>
-[DataSource("ib-brokerage", "Interactive Brokers Brokerage", DataSourceType.Realtime, DataSourceCategory.Broker,
+[DataSource("ibkr", "Interactive Brokers Brokerage", DataSourceType.Realtime, DataSourceCategory.Broker,
     Priority = 5, Description = "Interactive Brokers TWS/Gateway order execution")]
 [ImplementsAdr("ADR-001", "IB brokerage provider implementation")]
 [ImplementsAdr("ADR-004", "All async methods support CancellationToken")]
@@ -79,7 +79,7 @@ public sealed class IBBrokerageGateway :
     }
 
     /// <inheritdoc />
-    public string GatewayId => "ib";
+    public string GatewayId => "ibkr";
 
     /// <inheritdoc />
     public bool IsConnected => _connected && _client.IsConnected;

--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDataServices.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDataServices.cs
@@ -1,5 +1,7 @@
 using System.Collections.Concurrent;
+using System.Threading.Channels;
 using Meridian.Contracts.Configuration;
+using Meridian.ProviderSdk;
 
 namespace Meridian.Infrastructure.Adapters.InteractiveBrokers;
 
@@ -39,6 +41,12 @@ public sealed record IBScannerRequest(
     string? AbovePrice = null,
     string? AboveVolume = null);
 
+/// <summary>Explicit parameters for a five-second IB real-time-bar stream.</summary>
+public sealed record IBRealTimeBarRequest(SymbolConfig Contract, string WhatToShow = "TRADES", bool UseRegularTradingHours = true);
+
+/// <summary>Explicit parameters for an IB historical-tick request.</summary>
+public sealed record IBHistoricalTickRequest(SymbolConfig Contract, DateTimeOffset? Start, DateTimeOffset? End, int NumberOfTicks, string WhatToShow = "TRADES", bool UseRegularTradingHours = true);
+
 /// <summary>
 /// Compile-neutral IB data-service transport. The connection manager supplies the vendor calls in
 /// an IBAPI build; tests can supply a deterministic transport without an official SDK assembly.
@@ -56,12 +64,28 @@ public interface IIBDataServiceTransport
     void RequestPnl(int requestId, string account, string? modelCode);
     void RequestMarketRule(int requestId, int marketRuleId);
     void RequestDepthExchanges(int requestId);
+    void RequestRealTimeBars(int requestId, IBRealTimeBarRequest request) => throw new NotSupportedException("The configured IB transport does not support real-time bars.");
+    void RequestHistoricalTicks(int requestId, IBHistoricalTickRequest request) => throw new NotSupportedException("The configured IB transport does not support historical ticks.");
+    void CancelDataRequest(int requestId, string capability) { }
 }
 
 /// <summary>Optional runtime callback source for automatically captured IB entitlement evidence.</summary>
 public interface IIBDataLineageSource
 {
     event EventHandler<IBMarketDataTypeUpdate>? MarketDataTypeReceived;
+}
+
+/// <summary>Callback bridge used to correlate vendor callbacks without exposing IB API types above Infrastructure.</summary>
+public interface IIBDataCallbackSource
+{
+    event EventHandler<(int RequestId, ProviderOptionContract Contract)>? OptionContractReceived;
+    event EventHandler<(int RequestId, ProviderScannerResult Result)>? ScannerResultReceived;
+    event EventHandler<(int RequestId, ProviderRealTimeBar Bar)>? RealTimeBarReceived;
+    event EventHandler<(int RequestId, ProviderHistoricalTick Tick, bool Completed)>? HistoricalTickReceived;
+    event EventHandler<(int RequestId, ProviderAccountPnl Pnl)>? PnlReceived;
+    event EventHandler<(int RequestId, IReadOnlyList<ProviderMarketRuleIncrement> Increments)>? MarketRuleReceived;
+    event EventHandler<int>? RequestCompleted;
+    event EventHandler<(int RequestId, string Code, string Message)>? RequestRejected;
 }
 
 /// <summary>IB's actual live/frozen/delayed classification for a request.</summary>
@@ -72,10 +96,14 @@ public sealed record IBMarketDataTypeUpdate(int RequestId, int MarketDataType);
 /// while retaining request lineage. This surface never fabricates availability: callers begin at
 /// <see cref="IBMarketDataAvailability.Unknown"/> until TWS/Gateway reports a data type.
 /// </summary>
-public sealed class IBDataServices
+public sealed class IBDataServices : IProviderDataReadService, IDisposable
 {
     private readonly IIBDataServiceTransport _transport;
+    private readonly IIBDataCallbackSource? _callbackSource;
     private readonly ConcurrentDictionary<int, IBDataLineage> _lineage = new();
+    private readonly ConcurrentDictionary<int, ProviderDataRequestReadModel> _requests = new();
+    private readonly Channel<ProviderDataRequestReadModel> _updates = Channel.CreateBounded<ProviderDataRequestReadModel>(
+        new BoundedChannelOptions(256) { SingleReader = false, SingleWriter = false, FullMode = BoundedChannelFullMode.DropOldest });
     private int _nextRequestId = 90_000;
 
     public IBDataServices(IIBDataServiceTransport transport)
@@ -83,13 +111,36 @@ public sealed class IBDataServices
         _transport = transport ?? throw new ArgumentNullException(nameof(transport));
         if (transport is IIBDataLineageSource source)
             source.MarketDataTypeReceived += OnMarketDataTypeReceived;
+        if (transport is IIBDataCallbackSource callbacks)
+        {
+            _callbackSource = callbacks;
+            callbacks.OptionContractReceived += OnOptionContractReceived;
+            callbacks.ScannerResultReceived += OnScannerResultReceived;
+            callbacks.RealTimeBarReceived += OnRealTimeBarReceived;
+            callbacks.HistoricalTickReceived += OnHistoricalTickReceived;
+            callbacks.PnlReceived += OnPnlReceived;
+            callbacks.MarketRuleReceived += OnMarketRuleReceived;
+            callbacks.RequestCompleted += OnRequestCompleted;
+            callbacks.RequestRejected += OnRequestRejected;
+        }
     }
 
     /// <summary>Raised after request, status, or contract-lineage evidence changes.</summary>
     public event Action<IBDataLineage>? LineageUpdated;
 
+    /// <summary>Raised when a provider-neutral request projection changes.</summary>
+    public event Action<ProviderDataRequestReadModel>? ReadModelUpdated;
+
     /// <summary>Returns the current lineage evidence in stable request-id order.</summary>
     public IReadOnlyList<IBDataLineage> GetLineage() => _lineage.Values.OrderBy(x => x.RequestId).ToArray();
+
+    public IReadOnlyList<ProviderDataRequestReadModel> GetRequests() => _requests.Values.OrderBy(x => x.RequestId).ToArray();
+
+    public async IAsyncEnumerable<ProviderDataRequestReadModel> WatchAsync([System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await foreach (var update in _updates.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+            yield return update;
+    }
 
     public int RequestScanner(IBScannerRequest request, CancellationToken ct = default)
     {
@@ -149,6 +200,20 @@ public sealed class IBDataServices
         return Issue("pnl", account, null, modelCode, id => _transport.RequestPnl(id, account, modelCode), ct);
     }
 
+    public int SubscribeRealTimeBars(IBRealTimeBarRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return Issue("real-time-bars", RequireSymbol(request.Contract), request.Contract.Exchange, request.WhatToShow, id => _transport.RequestRealTimeBars(id, request), ct);
+    }
+
+    public int RequestHistoricalTicks(IBHistoricalTickRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (request.NumberOfTicks is < 1 or > 1000) throw new ArgumentOutOfRangeException(nameof(request), "IB historical-tick requests must contain 1 to 1,000 ticks.");
+        if (request.Start.HasValue && request.End.HasValue && request.Start > request.End) throw new ArgumentException("Historical tick start must not be after end.", nameof(request));
+        return Issue("historical-ticks", RequireSymbol(request.Contract), request.Contract.Exchange, request.WhatToShow, id => _transport.RequestHistoricalTicks(id, request), ct);
+    }
+
     public int RequestMarketRule(int marketRuleId, CancellationToken ct = default)
     {
         if (marketRuleId <= 0) throw new ArgumentOutOfRangeException(nameof(marketRuleId));
@@ -196,11 +261,87 @@ public sealed class IBDataServices
         Update(requestId, x => x with { Status = status, ObservedAt = DateTimeOffset.UtcNow });
     }
 
+    /// <summary>Correlates an option-discovery callback to its originating request.</summary>
+    public void RecordOptionContract(int requestId, ProviderOptionContract contract)
+    {
+        ArgumentNullException.ThrowIfNull(contract);
+        UpdateReadModel(requestId, current => current with
+        {
+            Status = ProviderDataRequestStatus.Streaming,
+            OptionContracts = Append(current.OptionContracts, contract)
+        });
+    }
+
+    public void RecordScannerResult(int requestId, ProviderScannerResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        UpdateReadModel(requestId, current => current with { Status = ProviderDataRequestStatus.Streaming, ScannerResults = Append(current.ScannerResults, result) });
+    }
+
+    public void RecordRealTimeBar(int requestId, ProviderRealTimeBar bar)
+    {
+        ArgumentNullException.ThrowIfNull(bar);
+        UpdateReadModel(requestId, current => current with { Status = ProviderDataRequestStatus.Streaming, RealTimeBars = Append(current.RealTimeBars, bar) });
+    }
+
+    public void RecordHistoricalTick(int requestId, ProviderHistoricalTick tick, bool completed = false)
+    {
+        ArgumentNullException.ThrowIfNull(tick);
+        UpdateReadModel(requestId, current => current with { Status = completed ? ProviderDataRequestStatus.Completed : ProviderDataRequestStatus.Streaming, HistoricalTicks = Append(current.HistoricalTicks, tick) });
+    }
+
+    public void RecordPnl(int requestId, ProviderAccountPnl pnl)
+    {
+        ArgumentNullException.ThrowIfNull(pnl);
+        UpdateReadModel(requestId, current => current with { Status = ProviderDataRequestStatus.Streaming, AccountId = pnl.AccountId, ModelAccountId = pnl.ModelAccountId, Pnl = pnl });
+    }
+
+    public void RecordMarketRule(int requestId, IEnumerable<ProviderMarketRuleIncrement> increments)
+    {
+        ArgumentNullException.ThrowIfNull(increments);
+        var values = increments.ToArray();
+        if (values.Length == 0) throw new ArgumentException("At least one market-rule increment is required.", nameof(increments));
+        UpdateReadModel(requestId, current => current with { Status = ProviderDataRequestStatus.Completed, MarketRuleIncrements = values });
+    }
+
+    public void CompleteRequest(int requestId) => UpdateReadModel(requestId, current => current with { Status = ProviderDataRequestStatus.Completed });
+
+    public void CancelRequest(int requestId) => UpdateReadModel(requestId, current => current with { Status = ProviderDataRequestStatus.Cancelled });
+
+    /// <summary>Cancels the vendor request and marks only its correlated read model as cancelled.</summary>
+    public void CancelRequest(int requestId, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+        if (!_requests.TryGetValue(requestId, out var request)) throw new KeyNotFoundException($"Unknown IB request id {requestId}.");
+        _transport.CancelDataRequest(requestId, request.Capability);
+        CancelRequest(requestId);
+    }
+
+    /// <summary>Fails closed on a local timeout and stops a cancellable vendor stream.</summary>
+    public void TimeoutRequest(int requestId)
+    {
+        if (!_requests.TryGetValue(requestId, out var request)) throw new KeyNotFoundException($"Unknown IB request id {requestId}.");
+        _transport.CancelDataRequest(requestId, request.Capability);
+        UpdateReadModel(requestId, current => current with { Status = ProviderDataRequestStatus.TimedOut, ErrorCode = "timeout", ErrorMessage = "The provider callback did not complete before the request timeout." });
+    }
+
+    public void RejectRequest(int requestId, string code, string message)
+        => UpdateReadModel(requestId, current => current with { Status = ProviderDataRequestStatus.Rejected, ErrorCode = code, ErrorMessage = message });
+
     private void OnMarketDataTypeReceived(object? sender, IBMarketDataTypeUpdate update)
     {
         if (_lineage.ContainsKey(update.RequestId))
             RecordMarketDataType(update.RequestId, update.MarketDataType);
     }
+
+    private void OnOptionContractReceived(object? sender, (int RequestId, ProviderOptionContract Contract) value) => RecordOptionContract(value.RequestId, value.Contract);
+    private void OnScannerResultReceived(object? sender, (int RequestId, ProviderScannerResult Result) value) => RecordScannerResult(value.RequestId, value.Result);
+    private void OnRealTimeBarReceived(object? sender, (int RequestId, ProviderRealTimeBar Bar) value) => RecordRealTimeBar(value.RequestId, value.Bar);
+    private void OnHistoricalTickReceived(object? sender, (int RequestId, ProviderHistoricalTick Tick, bool Completed) value) => RecordHistoricalTick(value.RequestId, value.Tick, value.Completed);
+    private void OnPnlReceived(object? sender, (int RequestId, ProviderAccountPnl Pnl) value) => RecordPnl(value.RequestId, value.Pnl);
+    private void OnMarketRuleReceived(object? sender, (int RequestId, IReadOnlyList<ProviderMarketRuleIncrement> Increments) value) => RecordMarketRule(value.RequestId, value.Increments);
+    private void OnRequestCompleted(object? sender, int requestId) => CompleteRequest(requestId);
+    private void OnRequestRejected(object? sender, (int RequestId, string Code, string Message) value) => RejectRequest(value.RequestId, value.Code, value.Message);
 
     private int Issue(string service, string symbol, string? exchange, string? subscription, Action<int> send, CancellationToken ct)
     {
@@ -208,9 +349,12 @@ public sealed class IBDataServices
         var requestId = Interlocked.Increment(ref _nextRequestId);
         var evidence = new IBDataLineage(requestId, service, symbol, exchange, null, null, subscription, IBMarketDataAvailability.Unknown, false, "requested", DateTimeOffset.UtcNow);
         if (!_lineage.TryAdd(requestId, evidence)) throw new InvalidOperationException($"Duplicate IB request id {requestId}.");
+        var projection = new ProviderDataRequestReadModel(requestId, "interactive-brokers", service, ProviderDataRequestStatus.Requested, evidence.ObservedAt);
+        _requests.TryAdd(requestId, projection);
         try { send(requestId); }
-        catch { _lineage.TryRemove(requestId, out _); throw; }
+        catch { _lineage.TryRemove(requestId, out _); _requests.TryRemove(requestId, out _); throw; }
         LineageUpdated?.Invoke(evidence);
+        Publish(projection);
         return requestId;
     }
 
@@ -218,6 +362,39 @@ public sealed class IBDataServices
     {
         var updated = _lineage.AddOrUpdate(requestId, _ => throw new KeyNotFoundException($"Unknown IB request id {requestId}."), (_, current) => update(current));
         LineageUpdated?.Invoke(updated);
+    }
+
+    private void UpdateReadModel(int requestId, Func<ProviderDataRequestReadModel, ProviderDataRequestReadModel> update)
+    {
+        var updated = _requests.AddOrUpdate(requestId, _ => throw new KeyNotFoundException($"Unknown IB request id {requestId}."), (_, current) => update(current) with { UpdatedAt = DateTimeOffset.UtcNow });
+        Publish(updated);
+    }
+
+    private void Publish(ProviderDataRequestReadModel model)
+    {
+        _updates.Writer.TryWrite(model);
+        ReadModelUpdated?.Invoke(model);
+    }
+
+    private static IReadOnlyList<T> Append<T>(IReadOnlyList<T>? existing, T value)
+        => existing is null ? [value] : [.. existing, value];
+
+    public void Dispose()
+    {
+        if (_transport is IIBDataLineageSource source)
+            source.MarketDataTypeReceived -= OnMarketDataTypeReceived;
+        if (_callbackSource is { } callbacks)
+        {
+            callbacks.OptionContractReceived -= OnOptionContractReceived;
+            callbacks.ScannerResultReceived -= OnScannerResultReceived;
+            callbacks.RealTimeBarReceived -= OnRealTimeBarReceived;
+            callbacks.HistoricalTickReceived -= OnHistoricalTickReceived;
+            callbacks.PnlReceived -= OnPnlReceived;
+            callbacks.MarketRuleReceived -= OnMarketRuleReceived;
+            callbacks.RequestCompleted -= OnRequestCompleted;
+            callbacks.RequestRejected -= OnRequestRejected;
+        }
+        _updates.Writer.TryComplete();
     }
 
     private static string RequireSymbol(SymbolConfig contract)

--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBMarketDataClient.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBMarketDataClient.cs
@@ -17,7 +17,7 @@ namespace Meridian.Infrastructure.Adapters.InteractiveBrokers;
 /// - Without IBAPI defined, delegates to IBSimulationClient (generates synthetic data for testing).
 /// - With IBAPI defined, uses EnhancedIBConnectionManager + IBCallbackRouter for real TWS/Gateway.
 /// </summary>
-[DataSource("ib", "Interactive Brokers", Infrastructure.DataSources.DataSourceType.Realtime, DataSourceCategory.Broker,
+[DataSource("ibkr", "Interactive Brokers", Infrastructure.DataSources.DataSourceType.Realtime, DataSourceCategory.Broker,
     Priority = 1, Description = "Interactive Brokers TWS/Gateway for real-time market data")]
 [ImplementsAdr("ADR-001", "Interactive Brokers streaming data provider implementation")]
 [ImplementsAdr("ADR-004", "All async methods support CancellationToken")]
@@ -41,7 +41,7 @@ public sealed class IBMarketDataClient :
     {
         _streamingRateLimits = new ProviderRateLimitTracker();
         _streamingRateLimits.RegisterProvider(
-            "ib",
+            "ibkr",
             maxRequestsPerWindow: 50,
             window: TimeSpan.FromSeconds(1),
             minDelay: TimeSpan.FromMilliseconds(20));
@@ -92,7 +92,7 @@ public sealed class IBMarketDataClient :
 
 
     /// <inheritdoc/>
-    public string ProviderId => "ib";
+    public string ProviderId => "ibkr";
 
     /// <inheritdoc/>
     public string ProviderDisplayName => "Interactive Brokers";

--- a/src/Meridian.Infrastructure/README.md
+++ b/src/Meridian.Infrastructure/README.md
@@ -125,6 +125,9 @@ contract details, option chains, news, fundamentals, tick-by-tick data, account 
 and depth-exchange metadata. Its request lineage begins `Unknown` and must retain the actual IB
 live/frozen/delayed status, exchange, market rules, and subscription descriptor alongside any
 materialized observation; successful request submission is not evidence of a live entitlement.
+Its richer request callbacks publish bounded, request-correlated ProviderSdk read-model updates for
+option discovery, scanners, real-time bars, historical ticks, account/model-account P&L, and market
+rules. Vendor SDK absence remains simulation/fail-closed and cannot advertise live IB capability.
 The brokerage gateway template remains an obsolete copy-target, but its scaffold behavior is
 deterministic: provider-discovery metadata, option-backed identity/capabilities, configurable
 connection readiness, option-backed account/position reads, and in-memory open-order tracking let

--- a/src/Meridian.ProviderSdk/IProviderDataReadService.cs
+++ b/src/Meridian.ProviderSdk/IProviderDataReadService.cs
@@ -1,0 +1,79 @@
+using System.Runtime.CompilerServices;
+
+namespace Meridian.ProviderSdk;
+
+/// <summary>Provider-neutral lifecycle state for a correlated data request.</summary>
+public enum ProviderDataRequestStatus
+{
+    Requested,
+    Streaming,
+    Completed,
+    Cancelled,
+    TimedOut,
+    Rejected,
+    Failed
+}
+
+/// <summary>Provider-neutral evidence for a discovered option contract.</summary>
+public sealed record ProviderOptionContract(
+    string Symbol,
+    string UnderlyingSymbol,
+    DateOnly Expiration,
+    decimal Strike,
+    string Right,
+    string Exchange,
+    string? TradingClass = null,
+    string? Multiplier = null,
+    string? ProviderContractId = null);
+
+/// <summary>Provider-neutral scanner row, retaining the source rank and optional metrics.</summary>
+public sealed record ProviderScannerResult(
+    int Rank,
+    string Symbol,
+    string? Exchange,
+    string? ProviderContractId,
+    string? Distance,
+    string? Benchmark,
+    string? Projection,
+    string? Legs);
+
+/// <summary>Provider-neutral real-time bar observation.</summary>
+public sealed record ProviderRealTimeBar(DateTimeOffset Timestamp, decimal Open, decimal High, decimal Low, decimal Close, decimal Volume, decimal WeightedAveragePrice, int TradeCount);
+
+/// <summary>Provider-neutral historical tick observation.</summary>
+public sealed record ProviderHistoricalTick(DateTimeOffset Timestamp, decimal Price, decimal Size, string TickKind, decimal? Bid = null, decimal? Ask = null, string? Exchange = null);
+
+/// <summary>Provider-neutral account or model-account P&amp;L observation.</summary>
+public sealed record ProviderAccountPnl(string AccountId, string? ModelAccountId, decimal Daily, decimal Unrealized, decimal Realized, decimal? Position = null, decimal? Value = null);
+
+/// <summary>One price-band increment in a provider market rule.</summary>
+public sealed record ProviderMarketRuleIncrement(decimal LowEdge, decimal Increment);
+
+/// <summary>
+/// A correlated, presentation-safe snapshot of provider data. It deliberately contains no vendor
+/// transport objects so browser and desktop workstation services can consume the same seam.
+/// </summary>
+public sealed record ProviderDataRequestReadModel(
+    int RequestId,
+    string ProviderFamily,
+    string Capability,
+    ProviderDataRequestStatus Status,
+    DateTimeOffset UpdatedAt,
+    string? AccountId = null,
+    string? ModelAccountId = null,
+    string? ErrorCode = null,
+    string? ErrorMessage = null,
+    IReadOnlyList<ProviderOptionContract>? OptionContracts = null,
+    IReadOnlyList<ProviderScannerResult>? ScannerResults = null,
+    IReadOnlyList<ProviderRealTimeBar>? RealTimeBars = null,
+    IReadOnlyList<ProviderHistoricalTick>? HistoricalTicks = null,
+    ProviderAccountPnl? Pnl = null,
+    IReadOnlyList<ProviderMarketRuleIncrement>? MarketRuleIncrements = null);
+
+/// <summary>Shared read-model seam for rich provider data requested by an operator workflow.</summary>
+public interface IProviderDataReadService
+{
+    IReadOnlyList<ProviderDataRequestReadModel> GetRequests();
+
+    IAsyncEnumerable<ProviderDataRequestReadModel> WatchAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Meridian.ProviderSdk/README.md
+++ b/src/Meridian.ProviderSdk/README.md
@@ -56,6 +56,9 @@ entries project this contract rather than maintaining a separate UI capability i
 chart-of-accounts, journal-entry, trial-balance, and reconciliation-preview evidence. It is
 read-oriented by default; write/posting support must be exposed explicitly by provider capabilities
 before any service or client can offer export actions.
+`IProviderDataReadService` owns vendor-neutral, request-correlated read models for option discovery,
+scanner rows, real-time bars, historical ticks, account/model-account P&L, and market-rule increments;
+operator surfaces consume this seam rather than vendor callback types.
 
 ## Diagrams
 

--- a/src/Meridian.Ui.Shared/Meridian.Ui.Shared.csproj
+++ b/src/Meridian.Ui.Shared/Meridian.Ui.Shared.csproj
@@ -51,6 +51,7 @@
     <ProjectReference Include="..\Meridian.Reporting\Meridian.Reporting.csproj" />
     <ProjectReference Include="..\Meridian.Risk\Meridian.Risk.csproj" />
     <ProjectReference Include="..\Meridian.Storage\Meridian.Storage.csproj" />
+    <ProjectReference Include="..\Meridian.ProviderSdk\Meridian.ProviderSdk.csproj" />
     <ProjectReference Include="..\Meridian.Strategies\Meridian.Strategies.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -44,6 +44,9 @@ compatibility across `src/Meridian.Ui.Services`, `src/Meridian.Ui/dashboard`, an
 
 ## Important workflows
 
+`ProviderDataReadModelService` projects `IProviderDataReadService` records for both workstation
+lanes, keeping provider option/scanner/bar/tick/P&L/market-rule data outside provider-specific UI code.
+
 The lifecycle control plane publishes unauthenticated, sanitized `/livez`, `/readyz`, `/startupz`,
 and `/startup` surfaces for local process supervision and pre-login progress. Authenticated browser
 and WPF operator controls use the loopback-only `/api/system/lifecycle`,

--- a/src/Meridian.Ui.Shared/Services/ProviderDataReadModelService.cs
+++ b/src/Meridian.Ui.Shared/Services/ProviderDataReadModelService.cs
@@ -1,0 +1,23 @@
+using Meridian.ProviderSdk;
+
+namespace Meridian.Ui.Shared.Services;
+
+/// <summary>
+/// Shared workstation projection seam for provider discovery, market-data, P&amp;L, and tick-rule
+/// read models. UI hosts depend only on ProviderSdk records, never on a vendor adapter.
+/// </summary>
+public sealed class ProviderDataReadModelService
+{
+    private readonly IReadOnlyList<IProviderDataReadService> _providers;
+
+    public ProviderDataReadModelService(IEnumerable<IProviderDataReadService> providers)
+    {
+        _providers = providers?.ToArray() ?? throw new ArgumentNullException(nameof(providers));
+    }
+
+    public IReadOnlyList<ProviderDataRequestReadModel> GetRequests()
+        => _providers.SelectMany(static provider => provider.GetRequests())
+            .OrderByDescending(static request => request.UpdatedAt)
+            .ThenBy(static request => request.RequestId)
+            .ToArray();
+}

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -80,6 +80,7 @@ public static class WorkstationServiceCollectionExtensions
         // Unified persistence config must resolve before the reporting/scoped-access
         // registrations below read the per-domain connection-string variables.
         Meridian.Storage.MeridianDatabaseEnvironment.ApplyUnifiedDatabaseUrl();
+        services.TryAddSingleton<ProviderDataReadModelService>();
 
         var isProductionComposition = ProductionServiceRegistrationPolicy.IsProductionComposition(services);
 

--- a/tests/Meridian.Tests/Infrastructure/Providers/IBBrokerageGatewayTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/IBBrokerageGatewayTests.cs
@@ -22,7 +22,7 @@ public sealed class IBBrokerageGatewayTests
     {
         var sut = CreateSut(new FakeIbBrokerageClient());
 
-        sut.GatewayId.Should().Be("ib");
+        sut.GatewayId.Should().Be("ibkr");
         sut.BrokerDisplayName.Should().Contain("Interactive Brokers");
         sut.BrokerageCapabilities.SupportedAssetClasses.Should().Contain(["equity", "bond"]);
         sut.BrokerageCapabilities.SupportedOrderTypes.Should().NotContain(OrderType.MarketOnOpen);

--- a/tests/Meridian.Tests/Infrastructure/Providers/IBDataServicesTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/IBDataServicesTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Meridian.Contracts.Configuration;
 using Meridian.Infrastructure.Adapters.InteractiveBrokers;
+using Meridian.ProviderSdk;
 
 namespace Meridian.Tests.Infrastructure.Providers;
 
@@ -65,6 +66,76 @@ public sealed class IBDataServicesTests
         services.GetLineage().Single().Subscription.Should().Be("456,258");
     }
 
+    [Fact]
+    public void CallbackCorrelation_OnlyUpdatesItsOriginatingRequest()
+    {
+        var services = new IBDataServices(new RecordingTransport());
+        var first = services.RequestScanner(new IBScannerRequest("STK", "STK.US.MAJOR", "TOP_PERC_GAIN"));
+        var second = services.RequestScanner(new IBScannerRequest("STK", "STK.US.MAJOR", "HOT_BY_VOLUME"));
+
+        services.RecordScannerResult(second, new ProviderScannerResult(0, "AAPL", "NASDAQ", "265598", null, null, null, null));
+        services.CompleteRequest(second);
+
+        services.GetRequests().Single(request => request.RequestId == first).Status.Should().Be(ProviderDataRequestStatus.Requested);
+        var correlated = services.GetRequests().Single(request => request.RequestId == second);
+        correlated.Status.Should().Be(ProviderDataRequestStatus.Completed);
+        correlated.ScannerResults.Should().ContainSingle().Which.Symbol.Should().Be("AAPL");
+    }
+
+    [Fact]
+    public void Cancellation_MarksOnlyTheRequestedStreamAndCallsTransportCancellation()
+    {
+        var transport = new RecordingTransport();
+        var services = new IBDataServices(transport);
+        var requestId = services.SubscribePnl("DU123", "model-a");
+
+        services.CancelRequest(requestId, CancellationToken.None);
+
+        services.GetRequests().Single().Status.Should().Be(ProviderDataRequestStatus.Cancelled);
+        transport.Calls.Should().Contain($"cancel:{requestId}:pnl");
+    }
+
+    [Fact]
+    public void PnlCallbacks_RetainAccountAndModelIsolation()
+    {
+        var services = new IBDataServices(new RecordingTransport());
+        var first = services.SubscribePnl("DU111", "growth");
+        var second = services.SubscribePnl("DU222", "income");
+
+        services.RecordPnl(first, new ProviderAccountPnl("DU111", "growth", 10m, 4m, 6m));
+        services.RecordPnl(second, new ProviderAccountPnl("DU222", "income", 20m, 7m, 13m));
+
+        services.GetRequests().Single(x => x.RequestId == first).Pnl!.AccountId.Should().Be("DU111");
+        services.GetRequests().Single(x => x.RequestId == second).Pnl!.ModelAccountId.Should().Be("income");
+    }
+
+    [Fact]
+    public void UnavailableMarketDataPermission_RejectsCorrelatedRequestWithoutClaimingLiveData()
+    {
+        var services = new IBDataServices(new RecordingTransport());
+        var requestId = services.SubscribeRealTimeBars(new IBRealTimeBarRequest(new SymbolConfig("AAPL")));
+
+        services.RejectRequest(requestId, "354", "Requested market data is not subscribed.");
+
+        var request = services.GetRequests().Single();
+        request.Status.Should().Be(ProviderDataRequestStatus.Rejected);
+        request.ErrorCode.Should().Be("354");
+        request.RealTimeBars.Should().BeNull();
+    }
+
+    [Fact]
+    public void PacingViolation_RejectsOnlyTheCorrelatedHistoricalTickRequest()
+    {
+        var services = new IBDataServices(new RecordingTransport());
+        var first = services.RequestHistoricalTicks(new IBHistoricalTickRequest(new SymbolConfig("AAPL"), null, DateTimeOffset.UtcNow, 100));
+        var second = services.RequestHistoricalTicks(new IBHistoricalTickRequest(new SymbolConfig("MSFT"), null, DateTimeOffset.UtcNow, 100));
+
+        services.RejectRequest(first, IBApiLimits.ErrorPacingViolation.ToString(), "Historical data query pacing violation.");
+
+        services.GetRequests().Single(request => request.RequestId == first).Status.Should().Be(ProviderDataRequestStatus.Rejected);
+        services.GetRequests().Single(request => request.RequestId == second).Status.Should().Be(ProviderDataRequestStatus.Requested);
+    }
+
     private sealed class RecordingTransport : IIBDataServiceTransport
     {
         public List<string> Calls { get; } = [];
@@ -79,5 +150,6 @@ public sealed class IBDataServicesTests
         public void RequestPnl(int requestId, string account, string? modelCode) => Calls.Add($"pnl:{requestId}:{account}");
         public void RequestMarketRule(int requestId, int marketRuleId) => Calls.Add($"market-rule:{requestId}:{marketRuleId}");
         public void RequestDepthExchanges(int requestId) => Calls.Add($"depth-exchanges:{requestId}");
+        public void CancelDataRequest(int requestId, string capability) => Calls.Add($"cancel:{requestId}:{capability}");
     }
 }

--- a/tests/Meridian.Tests/Infrastructure/Providers/IBMarketDataClientContractTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/IBMarketDataClientContractTests.cs
@@ -37,6 +37,17 @@ public sealed class IBMarketDataClientContractTests : MarketDataClientContractTe
 public sealed class IBMarketDataClientDiagnosticsTests
 {
     [Fact]
+    public void NonVendorBuild_DoesNotClaimLiveInteractiveBrokersCapability()
+    {
+#if !IBAPI_VENDOR
+        IBMarketDataClient.IsSimulationBuild.Should().BeTrue();
+        var descriptor = Meridian.Infrastructure.Adapters.Core.ProviderCapabilityDescriptorCatalog.Descriptors
+            .Single(static value => value.ProviderId == "ibkr");
+        descriptor.ExecutionMode.Should().Be(Meridian.Infrastructure.Adapters.Core.IBProviderCapabilityExecutionMode.SimulationWhenVendorSdkUnavailable);
+#endif
+    }
+
+    [Fact]
     public async Task Diagnostics_TrackConnectAndDisconnectHonestly()
     {
         var publisher = new TestMarketEventPublisher();

--- a/tests/Meridian.Tests/Providers/ProviderCapabilityDescriptorCatalogTests.cs
+++ b/tests/Meridian.Tests/Providers/ProviderCapabilityDescriptorCatalogTests.cs
@@ -118,10 +118,11 @@ public sealed class ProviderCapabilityDescriptorCatalogTests
         robinhood.CorporateActions.Should().BeNull(
             "Robinhood has no dedicated ICorporateActionProvider implementation in the runtime catalog");
 
-        var ibkr = descriptorsById["ib"];
+        var ibkr = descriptorsById["ibkr"];
         ibkr.Streaming.Should().Be(typeof(IBMarketDataClient));
         ibkr.Historical.Should().Be(typeof(IBHistoricalDataProvider));
         ibkr.Brokerage.Should().Be(typeof(IBBrokerageGateway));
+        ibkr.ExecutionMode.Should().Be(IBProviderCapabilityExecutionMode.SimulationWhenVendorSdkUnavailable);
 
         descriptorsById.Keys.Should().Contain("edgar");
         var edgar = descriptorsById["edgar"];
@@ -133,15 +134,8 @@ public sealed class ProviderCapabilityDescriptorCatalogTests
         edgar.CorporateActions.Should().BeNull(
             "EDGAR corporate-action support is routed through Security Master/reference-data workflows, not an ICorporateActionProvider implementation");
 
-        var ibStreaming = descriptorsById["ib"];
-        ibStreaming.Streaming.Should().Be(typeof(IBMarketDataClient));
-        ibStreaming.Historical.Should().BeNull(
-            "the IBKR historical adapter registers under its actual ibkr provider identity");
-
-        var ibHistorical = descriptorsById["ibkr"];
-        ibHistorical.Historical.Should().Be(typeof(IBHistoricalDataProvider));
-        ibHistorical.Streaming.Should().BeNull(
-            "the TWS/Gateway streaming adapter registers under its actual ib provider identity");
+        descriptorsById.Keys.Should().NotContain("ib",
+            "the IB family uses one provider identifier across streaming, historical, and brokerage capabilities");
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- Provide explicit, provider-SDK read models and request-correlated evidence for high-value IB capabilities (option discovery, scanners, real-time bars, historical ticks, account/model P&L, and market-rule increments).
- Replace no-op IB callback stubs with correlated completion paths and bounded streaming publishers so consumers can observe request lifecycle, entitlement, pacing, cancellation, and timeouts without depending on vendor types.
- Keep non-vendor/smoke builds simulation/fail-closed and expose provider-neutral read models to UI surfaces rather than leaking vendor transport types into workstation code.

### Description
- Add `IProviderDataReadService` and a set of provider-neutral read-model records (`ProviderDataRequestReadModel`, `ProviderOptionContract`, `ProviderScannerResult`, `ProviderRealTimeBar`, `ProviderHistoricalTick`, `ProviderAccountPnl`, `ProviderMarketRuleIncrement`) in `src/Meridian.ProviderSdk/IProviderDataReadService.cs` so application and UI can consume a stable, transport-neutral seam.
- Extend `IBDataServices` to implement `IProviderDataReadService`, add a bounded `Channel<ProviderDataRequestReadModel>` publisher, a request projection store, and methods to record correlated events (option contracts, scanner rows, real-time bars, historical ticks, P&L, market rules) plus cancellation, timeout, rejection, and completion flows in `src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDataServices.cs`.
- Introduce `IIBDataCallbackSource` callback bridge and wire enhanced events on the connection manager so vendor callbacks are correlated and transformed into `ProviderSdk` records; update `EnhancedIBConnectionManager` and vendor stubs to emit these events (real-time bars, scanner rows, option-definition parameters, historical ticks, PnL, market rules, request-complete/rejected). Vendor-only calls remain behind `#if IBAPI_VENDOR` guards where appropriate.
- Add explicit request methods for richer IB services (`RequestRealTimeBars`, `RequestHistoricalTicks`) and `CancelDataRequest` on the transport/connection manager with vendor-conditional implementations.
- Consolidate IB capability wiring under a single provider family id `ibkr`, advertise `IBBrokerageGateway` alongside streaming/historical adapters, and add an `ExecutionMode` readiness signal (`SimulationWhenVendorSdkUnavailable`) so non-vendor builds do not claim live routing.
- Provide a workstation projection seam `ProviderDataReadModelService` in `src/Meridian.Ui.Shared/Services/ProviderDataReadModelService.cs` and register it in DI so browser/WPF surfaces consume provider read models without vendor types.
- Add and update focused contract tests in `tests/.../IBDataServicesTests.cs`, `IBMarketDataClientContractTests.cs`, and `ProviderCapabilityDescriptorCatalogTests.cs` to verify callback correlation, cancellation, pacing rejection isolation, account/model P&L isolation, unavailable-permission rejection behavior, and non-vendor capability signaling.

### Testing
- Ran `git diff --check` and code hygiene checks which passed (`git diff --check`).
- Ran documentation validation and manifest updates: `python3 build/scripts/docs/validate-source-readmes.py --summary` (passed) and `python3 build/scripts/docs/validate-doc-hashes.py --write-module SRC-PROVIDER-SDK --summary` / `--write-module SRC-INFRASTRUCTURE` / `--write-module SRC-UI-SHARED` (passed; refreshed scoped doc hash manifest entries where needed).
- Attempted full CI local invocation `bash scripts/ci.sh` and targeted `dotnet` tests but the environment lacks the .NET SDK; `dotnet`-based test runs (e.g. `dotnet test --filter FullyQualifiedName~IBDataServicesTests`) were blocked with `dotnet: command not found` and could not be executed here.
- Added/updated xUnit tests exercising the new read-model behaviors and DI/catalog assertions; these tests were committed and are ready to run in a CI environment that has `dotnet` installed and GitHub Actions validation enabled.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611d0376108320a2e2082051e9c1e2)