### PR TITLE
Fix redemption corporate action ledger proceeds

### DIFF
--- a/src/Meridian.Application/SecurityMaster/SecurityMasterLedgerBridge.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityMasterLedgerBridge.cs
@@ -205,7 +205,17 @@ public sealed class SecurityMasterLedgerBridge : ISecurityMasterLedgerBridge
                     break;
 
                 case CorporateActionLedgerPostingKind.RedemptionMemo when action.RedemptionPricePercentOfPar.HasValue:
-                    PostRedemptionMemo(ledger, action, normalizedTicker, ts, meta, eventType);
+                    if (postingContext.PositionQuantity <= 0m)
+                    {
+                        _logger.LogWarning(
+                            "SecurityMasterLedgerBridge skipped redemption {CorporateActionId} for {Ticker} because no held face amount was supplied.",
+                            action.CorpActId,
+                            normalizedTicker);
+                        break;
+                    }
+
+                    var redemptionProceeds = action.RedemptionPricePercentOfPar.Value / 100m * postingContext.PositionQuantity;
+                    PostRedemptionMemo(ledger, action, normalizedTicker, ts, meta, eventType, redemptionProceeds);
                     posted++;
                     break;
 
@@ -507,13 +517,11 @@ public sealed class SecurityMasterLedgerBridge : ISecurityMasterLedgerBridge
         string ticker,
         DateTimeOffset ts,
         JournalEntryMetadata meta,
-        string eventType)
+        string eventType,
+        decimal proceeds)
     {
-        // Contractual-flow view: the redemption price is expressed as percent of par (a
-        // per-100-par proxy amount); converting to actual cash against face-value lots is
-        // the durable ledger's job, the same as per-share dividend declarations.
-        var amount = action.RedemptionPricePercentOfPar!.Value;
-        var description = $"{eventType} {ticker} at {amount:N4}% of par, ex {action.ExDate:yyyy-MM-dd}";
+        var redemptionPricePercentOfPar = action.RedemptionPricePercentOfPar!.Value;
+        var description = $"{eventType} {ticker} at {redemptionPricePercentOfPar:N4}% of par, ex {action.ExDate:yyyy-MM-dd}";
 
         var entry = new JournalEntry(
             action.CorpActId,
@@ -521,9 +529,9 @@ public sealed class SecurityMasterLedgerBridge : ISecurityMasterLedgerBridge
             description,
             [
                 new LedgerEntry(Guid.NewGuid(), action.CorpActId, ts,
-                    LedgerAccounts.Cash, amount, 0m, description),
+                    LedgerAccounts.Cash, proceeds, 0m, description),
                 new LedgerEntry(Guid.NewGuid(), action.CorpActId, ts,
-                    LedgerAccounts.Securities(ticker), 0m, amount, description),
+                    LedgerAccounts.Securities(ticker), 0m, proceeds, description),
             ],
             meta);
 

--- a/tests/Meridian.Tests/SecurityMaster/CorporateActionLedgerKnownDefectTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/CorporateActionLedgerKnownDefectTests.cs
@@ -51,18 +51,6 @@ public sealed class CorporateActionLedgerKnownDefectTests
     }
 
     [Fact]
-    public async Task BondCall_CurrentBehavior_PercentOfParBookedAsCash_CA_DEF_005()
-    {
-        // TARGET (Idea #3): cash = 101.5% x par x 50,000 face quantity, with position
-        // close-out at the call price — not the percent-of-par proxy.
-        var (_, ledger) = await PostAsync("bond-call-101-5");
-
-        var entry = ledger.Journal.Should().ContainSingle().Subject;
-        entry.Lines.Single(static line => line.Account == LedgerAccounts.Cash).Debit.Should().Be(101.5m,
-            "CURRENT defective behavior: percent-of-par posts as literal proxy cash");
-    }
-
-    [Fact]
     public async Task Dividend_NoPositionContext_CurrentBehavior_SkippedEntirely_CA_DEF_006()
     {
         // TARGET (Idea #3): the record-date holdings seam supplies the position quantity;

--- a/tests/Meridian.Tests/SecurityMaster/SecurityMasterLedgerBridgeTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/SecurityMasterLedgerBridgeTests.cs
@@ -331,7 +331,36 @@ public sealed class SecurityMasterLedgerBridgeTests
     }
 
     [Fact]
-    public async Task PostCorporateActionsAsync_BondCall_PostsRedemptionMemo()
+    public async Task PostCorporateActionsAsync_BondCall_PostsRedemptionProceedsScaledByHeldFace()
+    {
+        var bondCall = MakeStockSplit(1m, new DateOnly(2026, 4, 15)) with
+        {
+            EventType = "BondCall",
+            SplitRatio = null,
+            RedemptionPricePercentOfPar = 101.25m
+        };
+        var queryService = Substitute.For<ISecurityMasterQueryService>();
+        queryService.GetCorporateActionsAsync(SecurityId, Arg.Any<CancellationToken>())
+            .Returns(new[] { bondCall });
+
+        var bridge = BuildBridge(queryService);
+        var ledger = new Meridian.Ledger.Ledger();
+
+        await bridge.PostCorporateActionsAsync(
+            SecurityId,
+            Ticker,
+            ledger,
+            new CorporateActionLedgerPostingContext(PositionQuantity: 1_000m));
+
+        var entry = ledger.Journal.Should().ContainSingle().Subject;
+        entry.IsBalanced.Should().BeTrue();
+        entry.Metadata.ActivityType.Should().Be("BondCall");
+        ledger.GetBalance(LedgerAccounts.Cash).Should().Be(1_012.50m);
+        ledger.GetBalance(LedgerAccounts.Securities(Ticker)).Should().Be(-1_012.50m);
+    }
+
+    [Fact]
+    public async Task PostCorporateActionsAsync_BondCallWithoutHeldFace_DoesNotPost()
     {
         var bondCall = MakeStockSplit(1m, new DateOnly(2026, 4, 15)) with
         {
@@ -348,11 +377,7 @@ public sealed class SecurityMasterLedgerBridgeTests
 
         await bridge.PostCorporateActionsAsync(SecurityId, Ticker, ledger);
 
-        var entry = ledger.Journal.Should().ContainSingle().Subject;
-        entry.IsBalanced.Should().BeTrue();
-        entry.Metadata.ActivityType.Should().Be("BondCall");
-        ledger.GetBalance(LedgerAccounts.Cash).Should().Be(101.25m);
-        ledger.GetBalance(LedgerAccounts.Securities(Ticker)).Should().Be(-101.25m);
+        ledger.Journal.Should().BeEmpty();
     }
 
     [Fact]

--- a/tests/fixtures/corporate-actions/golden/KNOWN-DEFECTS.md
+++ b/tests/fixtures/corporate-actions/golden/KNOWN-DEFECTS.md
@@ -17,7 +17,6 @@ dotnet test tests/Meridian.Backtesting.Tests -c Release /p:EnableWindowsTargetin
 |----|----------|---------------------------|-----------------|-------------|---------|
 | CA-DEF-001 | `src/Meridian.Backtesting/CorporateActionAdjustmentService.cs` (`BuildDividendFactors`) | Dividend factor silently skipped when no prior-close bar exists before an ex-date; series returned unadjusted with no signal | Explicit degradation: warning + machine-readable adjustment report | Idea #2 remainder (factor engine) | `dividend-missing-prior-bar.json` |
 | CA-DEF-002 | `src/Meridian.Application/SecurityMaster/SecurityMasterLedgerBridge.cs` (`PostNonCashLifecycleMemo`) | Spinoffs, mergers, and distributions post symbolic 1-unit memos; no basis allocation, lot conversion, or new position | Entitlement-driven position transformation with basis conservation | Idea #3 (entitlement engine) | `t-wbd-spinoff-2022.json`, `cash-stock-merger-2018.json` |
-| CA-DEF-005 | `src/Meridian.Application/SecurityMaster/SecurityMasterLedgerBridge.cs` (`PostRedemptionMemo`) | Percent-of-par redemption price posted as literal proxy cash | Cash = price% × par × face quantity | Idea #3 | `bond-call-101-5.json` |
 | CA-DEF-006 | `src/Meridian.Application/SecurityMaster/SecurityMasterLedgerBridge.cs` (dividend branch) | All dividends skipped with a warning when `CorporateActionLedgerPostingContext.PositionQuantity` is not supplied (defaults to 0) | Record-date holdings seam supplies the position quantity | Idea #3 | `dividend-no-position-context.json` |
 
 ## Fixture schema

--- a/tests/fixtures/corporate-actions/golden/bond-call-101-5.json
+++ b/tests/fixtures/corporate-actions/golden/bond-call-101-5.json
@@ -1,6 +1,6 @@
 {
   "scenarioId": "bond-call-101-5",
-  "description": "Issuer call at 101.5% of par. RedemptionPricePercentOfPar is a per-100-par proxy, not money: the bridge currently posts 101.5 as literal cash (CA-DEF-005, the code comment admits the proxy). Target: cash = price% x par x face quantity, position close-out at call price.",
+  "description": "Issuer call at 101.5% of par. The bridge calculates cash from the per-100-par price and the held face quantity.",
   "ticker": "XYZC29",
   "securityId": "a4000000-aaaa-4000-8000-000000000001",
   "actions": [
@@ -27,6 +27,5 @@
   ],
   "bars": [],
   "postingContext": { "positionQuantity": 50000, "withholdingTaxRate": 0, "financialAccountId": null },
-  "invariantTags": [ "journal-balanced" ],
-  "knownDefectIds": [ "CA-DEF-005" ]
+  "invariantTags": [ "journal-balanced" ]
 }


### PR DESCRIPTION
### Motivation
- Prevent incorrect ledger postings where a percent-of-par field was treated as literal cash and could create or misstate cash/securities balances.
- Ensure redemption postings are scaled by the held face/position quantity so proceeds reflect actual notional (percent × held face) rather than a percentage proxy.

### Description
- Require a positive `PositionQuantity` before posting a `RedemptionMemo` and skip with a warning when none is supplied.
- Compute proceeds as `RedemptionPricePercentOfPar / 100 * PositionQuantity` and pass the computed `proceeds` into `PostRedemptionMemo` so the Cash and Securities legs use the scaled amount.
- Update unit tests to assert the corrected behavior (scaled proceeds) and add a test ensuring redemptions without held face do not post, and update the golden fixture and known-defect registry entry for the resolved scenario.

### Testing
- `git diff --check` (sanity check) passed locally.
- `python build/python/cli/buildctl.py validation-status --summary` passed with no active locks or blockers in the environment.
- `python -m json.tool tests/fixtures/corporate-actions/golden/bond-call-101-5.json` validated the updated fixture successfully.
- `bash scripts/ci.sh` could not complete in this environment because the `.NET` SDK (`dotnet`) is not installed here, so full test execution and GitHub Actions remain the authoritative CI runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f3978548320b89b668528b5255d)