### PR TITLE
Require typed spine for non-canonical instrument proof lineage

### DIFF
--- a/docs/architecture/event-accounting-architecture.md
+++ b/docs/architecture/event-accounting-architecture.md
@@ -135,9 +135,11 @@ adjusters may call projection calculators, but they do not establish production 
 Consistent with that boundary, the shared instrument-to-journal proof
 (`FinancialRecordExplorerReadService.InstrumentJournalProof.cs`) reconstructs the source-event ->
 role/position -> projection -> posting-candidate -> approval -> immutable-journal chain for any
-position whose projection lineage is authoritative and self-consistent, regardless of model key. It
-no longer special-cases the factor-paydown model, so "prove the number" is demonstrable on any
-security and any of the eight canonical asset accounting event kinds; the source-evidence label is
+position whose projection lineage is authoritative, self-consistent, and triggered by one of the
+eight canonical asset-accounting event kinds, regardless of model key. It no longer special-cases
+the factor-paydown model, so "prove the number" is demonstrable on any security and any canonical
+asset accounting event kind; non-canonical projection producers require a validated typed spine
+before they can establish accounting proof material. The source-evidence label is
 derived from the triggering event kind (for example "Corporate Action Evidence" or "Income
 Evidence") rather than fixed to factor-paydown wording.
 

--- a/src/Meridian.Ui.Shared/Services/FinancialRecordExplorerReadService.InstrumentJournalProof.cs
+++ b/src/Meridian.Ui.Shared/Services/FinancialRecordExplorerReadService.InstrumentJournalProof.cs
@@ -21,11 +21,9 @@ public sealed partial class FinancialRecordExplorerReadService
                 continue;
             }
 
-            // The instrument-to-journal proof is model-agnostic: any position whose projection
-            // lineage is authoritative and self-consistent (see IsAuthoritativeProjectionLineage)
-            // can reconstruct its chain, not just the MBS factor-paydown calculator. The downstream
-            // spine and durable-journal matching validate the lineage against its own model key, so
-            // "prove the number" is demonstrable on any security and any asset accounting event kind.
+            // The instrument-to-journal proof is model-agnostic across the canonical Asset
+            // Accounting event kinds. A self-consistent lineage from another projection producer
+            // cannot establish an accounting proof without the typed event spine.
             var lineage = new[] { position.ProjectionLineage }
                 .Concat(operations.ProjectionLineages)
                 .Where(static candidate => candidate is not null)
@@ -72,6 +70,11 @@ public sealed partial class FinancialRecordExplorerReadService
                 {
                     spine = null;
                 }
+            }
+
+            if (!IsCanonicalAssetAccountingEvent(lineage) && spine is null)
+            {
+                continue;
             }
 
             LedgerJournalEntryRecord? journal = null;
@@ -426,6 +429,9 @@ public sealed partial class FinancialRecordExplorerReadService
            HasText(lineage.TriggerEvent.SourceDomain) &&
            HasText(lineage.TriggerEvent.SourceEntityId) &&
            HasText(lineage.TriggerEvent.SourceContentHash);
+
+    private static bool IsCanonicalAssetAccountingEvent(ProjectionLineageDto lineage)
+        => AssetAccountingEventTypeNames.TryParse(lineage.TriggerEvent.EventType, out _);
 
     private static bool IsAuthoritativeProjectionScope(
         BookPositionDto position,

--- a/tests/Meridian.Tests/Ui/WorkstationFinancialRecordExplorerEndpointTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationFinancialRecordExplorerEndpointTests.cs
@@ -455,6 +455,35 @@ public sealed partial class WorkstationEndpointsTests
     }
 
     [Fact]
+    public async Task MapWorkstationEndpoints_SecurityInstrumentExplorer_ShouldExcludeNonCanonicalProjectionLineageWithoutTypedSpine()
+    {
+        await using var app = await CreateAppAsync(services => RegisterFinancialRecordExplorerTestServices(services));
+        app.Services.GetRequiredService<FinancialRecordExplorerAssetOperationsQueryService>().ProjectionEventType =
+            "ThirdPartyUnregisteredPnLMark";
+        app.Services.GetRequiredService<FinancialRecordExplorerAssetAccountingEventSpineService>().ReturnSpine = false;
+
+        var store = app.Services.GetRequiredService<IStrategyRepository>();
+        await store.RecordRunAsync(BuildActivePaperRun("financial-record-explorer-unregistered-lineage", withBreaks: false));
+
+        var explorer = await app.GetTestClient().GetFromJsonAsync<FinancialRecordExplorerDto>(
+            "/api/workstation/financial-record-explorers/security-instrument",
+            ServerJsonOptions);
+
+        var row = explorer!.Rows.Single(item => item.RecordId == $"security:{FinancialRecordExplorerAaplSecurityId:D}");
+        row.Detail.Fields.Should().NotContain(static field =>
+            field.Label is "Source Evidence" or "Corporate Action Evidence" or "Role / Position");
+        row.Detail.Impacts.Should().NotContain(static impact =>
+            impact.RelationshipId is "factor-evidence" or "instrument-role-position" or "economic-projection");
+        row.Detail.UsedIn.Should().NotContain(static relationship =>
+            relationship.RelationshipId == "accounting-projection-proof");
+        explorer.RecordGraph.Nodes.Should().NotContain(static node =>
+            node.Label is "Source evidence" or "Role / position");
+        explorer.RecordGraph.Edges.Should().NotContain(static edge =>
+            edge.Label is "supports" or "projects");
+        app.Services.GetRequiredService<FinancialRecordExplorerJournalStore>().LastQuery.Should().BeNull();
+    }
+
+    [Fact]
     public async Task MapWorkstationEndpoints_ReportLineProvenanceExplorer_ShouldExcludeApprovedButUnpublishedRecords()
     {
         await using var app = await CreateAppAsync(services => RegisterFinancialRecordExplorerTestServices(services));
@@ -702,8 +731,10 @@ public sealed partial class WorkstationEndpointsTests
         services.AddSingleton<ReportPackDeliveryService>();
         services.AddSingleton<ISecurityMasterWorkbenchQueryService>(
             new FinancialRecordExplorerSecurityMasterWorkbenchQueryService(FinancialRecordExplorerAaplSecurityId));
-        services.AddSingleton<IAssetOperationsQueryService>(
+        services.AddSingleton<FinancialRecordExplorerAssetOperationsQueryService>(
             new FinancialRecordExplorerAssetOperationsQueryService(FinancialRecordExplorerAaplSecurityId));
+        services.AddSingleton<IAssetOperationsQueryService>(sp =>
+            sp.GetRequiredService<FinancialRecordExplorerAssetOperationsQueryService>());
         services.AddSingleton<FinancialRecordExplorerJournalStore>();
         services.AddSingleton<ILedgerJournalStore>(sp => sp.GetRequiredService<FinancialRecordExplorerJournalStore>());
         services.AddSingleton<FinancialRecordExplorerAssetAccountingEventSpineService>();
@@ -918,6 +949,8 @@ public sealed partial class WorkstationEndpointsTests
     {
         private readonly DateTimeOffset _now = new(2026, 3, 22, 15, 0, 0, TimeSpan.Zero);
 
+        public string ProjectionEventType { get; set; } = AssetAccountingEventTypeNames.For(AssetAccountingEventKindDto.CorporateAction);
+
         public Task<AssetOperationsDetailDto?> GetOperationsAsync(Guid requestedSecurityId, CancellationToken ct = default)
             => Task.FromResult<AssetOperationsDetailDto?>(requestedSecurityId == securityId ? CreateDetail() : null);
 
@@ -1037,7 +1070,7 @@ public sealed partial class WorkstationEndpointsTests
             var roleId = Guid.Parse("11111111-1111-1111-1111-111111111115");
             var economicEvent = new EconomicEventReferenceDto(
                 FinancialRecordExplorerEventId,
-                AssetAccountingEventTypeNames.For(AssetAccountingEventKindDto.CorporateAction),
+                ProjectionEventType,
                 1,
                 new DateOnly(2026, 3, 22),
                 _now,


### PR DESCRIPTION
### Motivation
- Prevent unregistered/third-party projection producers from surfacing as accounting proof material in the Financial Record Explorer UI unless a validated typed Asset Accounting event spine exists. 
- Preserve existing projection-only proof behavior for the eight canonical asset-accounting event kinds while closing the UI integrity gap introduced by widening lineage acceptance. 

### Description
- Fail closed in `BuildInstrumentJournalProofsAsync` by continuing when a selected lineage is non-canonical and no validated typed `AssetAccountingEventSpineDto` was found, so non-canonical producers cannot emit evidence/graph/journal artifacts without a spine.  
- Add `IsCanonicalAssetAccountingEvent(ProjectionLineageDto)` helper that validates lineage event types via `AssetAccountingEventTypeNames.TryParse`. 
- Add an endpoint regression test `MapWorkstationEndpoints_SecurityInstrumentExplorer_ShouldExcludeNonCanonicalProjectionLineageWithoutTypedSpine` that sets a test projection event type to an unregistered value and asserts no evidence, impacts, proof relationships, graph nodes/edges, or journal queries are emitted. 
- Adjust the test fixture to expose a configurable projection event type and register the concrete test `FinancialRecordExplorerAssetOperationsQueryService` so the new regression scenario can be exercised, and update `docs/architecture/event-accounting-architecture.md` to clarify the boundary for non-canonical producers. 

### Testing
- Ran `git diff --check` and found no whitespace or diff-check issues.  
- Ran `python3 build/python/cli/buildctl.py validation-status --summary` which reported `blocked=false` and no active build processes.  
- Added an xUnit endpoint regression test but could not run `dotnet test` locally because `dotnet` is not available in this environment, so the new test was not executed here.  
- `bash scripts/ci.sh` could not complete local CI because the environment lacks the .NET SDK; CI must be run in the repository CI environment (GitHub Actions) to validate the change end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f398ff083209a64dab02a10174a)