### PR TITLE
Pass provisioning loaded flags into saved sample pack and add regression test

### DIFF
--- a/src/Meridian.Ui.Shared/Services/FirstRunExperienceService.cs
+++ b/src/Meridian.Ui.Shared/Services/FirstRunExperienceService.cs
@@ -168,7 +168,9 @@ public sealed class FirstRunExperienceService(
             version = SamplePackVersion,
             label = "Sample · Paper",
             generatedAtUtc = DateTimeOffset.UtcNow,
-            workspace = DemoTenantBlueprint.BuildSampleWorkspace(),
+            workspace = DemoTenantBlueprint.BuildSampleWorkspace(
+                provisioning?.ReconciliationLoaded ?? true,
+                provisioning?.StrategyRunLoaded ?? true),
             provisioning
         };
         return AtomicFileWriter.WriteAsync(SamplePath(username), JsonSerializer.Serialize(pack, _json), ct);

--- a/tests/Meridian.Tests/Ui/FirstRunExperienceServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/FirstRunExperienceServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using FluentAssertions;
 using Meridian.Contracts.Workstation;
 using Meridian.Core.Config;
@@ -75,6 +76,25 @@ public sealed class FirstRunExperienceServiceTests
         status.SampleWorkspace!.Highlights.Should().BeEmpty();
         // The illustrative sample portfolio preview is still shown.
         status.SampleWorkspace.Holdings.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task CompleteAsync_SampleMode_WhenProvisioningLoadsNothing_PersistsNoDeskHighlights()
+    {
+        using var artifacts = TestArtifactDirectory.Create(nameof(CompleteAsync_SampleMode_WhenProvisioningLoadsNothing_PersistsNoDeskHighlights));
+        var config = new ConfigStore(Path.Combine(artifacts.RootPath, "appsettings.json"));
+        await config.SaveAsync(new AppConfig(DataRoot: artifacts.RootPath));
+        // During a demo-store outage, the durable sample artifact must agree with the Ready screen
+        // and must not advertise desks that remain empty.
+        var service = new FirstRunExperienceService(config, new DemoTenantProvisioner());
+
+        await service.CompleteAsync("local-admin", new CompleteFirstRunRequestDto(
+            "monitor-investments", "personal-portfolio", "sample", true));
+
+        var packPath = Path.Combine(artifacts.RootPath, "workspaces", "local-admin", "sample-pack.json");
+        using var pack = JsonDocument.Parse(await File.ReadAllTextAsync(packPath));
+
+        pack.RootElement.GetProperty("workspace").GetProperty("highlights").GetArrayLength().Should().Be(0);
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- The persisted `sample-pack.json` could advertise reconciliation/strategy surfaces as loaded even when demo provisioning failed or no desk stores were available, creating a misleading onboarding artifact.
- The Ready-screen already used the recorded provisioning flags but the sample-pack creation omitted them, so the saved manifest could diverge from the actual provisioning outcome.

### Description
- Update `FirstRunExperienceService.ProvisionSamplePackAsync` to pass the provisioning outcomes into `DemoTenantBlueprint.BuildSampleWorkspace` via `provisioning?.ReconciliationLoaded ?? true` and `provisioning?.StrategyRunLoaded ?? true` so the saved workspace reflects the real loaded-state.
- Add a regression test `CompleteAsync_SampleMode_WhenProvisioningLoadsNothing_PersistsNoDeskHighlights` in `tests/Meridian.Tests/Ui/FirstRunExperienceServiceTests.cs` that provisions with a no-store `DemoTenantProvisioner`, reads the produced `sample-pack.json`, and asserts the `workspace.highlights` array is empty.
- Add a `using System.Text.Json;` import to the test to parse the persisted pack with `JsonDocument`.

### Testing
- Ran `git diff --check` and a small static assertion script to confirm the `BuildSampleWorkspace` call now receives the provisioning flags; these checks passed.  
- The new unit test `CompleteAsync_SampleMode_WhenProvisioningLoadsNothing_PersistsNoDeskHighlights` is added to `tests/Meridian.Tests`; it is intended to be run by the repository test suite.  
- Attempted to run the focused `dotnet` test via `buildctl` and `bash scripts/ci.sh` in the local environment, but execution was blocked because `dotnet` is not installed here (so executable .NET validation could not be completed locally).  
- Recommend CI (GitHub Actions) run the full test matrix; the change is minimal and guarded by the new regression test to prevent recurrence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f39881c8320bc784f90ad8003c5)