### PR TITLE
Fix atomic tax-lot asset account validation

### DIFF
--- a/src/Meridian.FinancialOperations/Ledger/AccountingPostingCandidatePostService.cs
+++ b/src/Meridian.FinancialOperations/Ledger/AccountingPostingCandidatePostService.cs
@@ -1208,6 +1208,14 @@ public sealed class AccountingPostingCandidatePostService : IAccountingPostingCa
         var durable = entry.Lines[indexes[0]];
         if (durable.Debit != eventAmount || durable.Credit != 0m)
             throw new InvalidOperationException("Acquisition asset-account journal line does not match the retained acquisition amount.");
+        if (retainedCandidate.GeneratedPostingLines.Count(line =>
+                string.Equals(line.AccountPath, accountId, StringComparison.Ordinal)) != 1 ||
+            entry.Lines.Count(line => line.Account == durable.Account) != 1)
+        {
+            throw new InvalidOperationException(
+                "Acquisition asset-account journal movement must be limited to the retained lot-cost debit.");
+        }
+
         return durable.Account;
     }
 
@@ -1233,6 +1241,10 @@ public sealed class AccountingPostingCandidatePostService : IAccountingPostingCa
         var durableRelief = durableEntry.Lines[assetReliefIndexes[0]];
         RequireAssetAssertion(durableRelief.Credit == expectedCostBasis && durableRelief.Debit == 0m,
             "Durable disposal asset-relief line does not equal selected-lot cost basis.");
+        RequireAssetAssertion(retainedCandidate.GeneratedPostingLines.Count(line =>
+                                  string.Equals(line.AccountPath, assetAccountId, StringComparison.Ordinal)) == 1 &&
+                              durableEntry.Lines.Count(line => line.Account == durableRelief.Account) == 1,
+            "Disposal asset-account journal movement must be limited to the selected-lot cost-basis relief.");
 
         var totalDebits = durableEntry.Lines.Sum(static line => line.Debit);
         var totalCredits = durableEntry.Lines.Sum(static line => line.Credit);

--- a/src/Meridian.FinancialOperations/Ledger/AssetAccountingEventSpineService.cs
+++ b/src/Meridian.FinancialOperations/Ledger/AssetAccountingEventSpineService.cs
@@ -885,9 +885,12 @@ public sealed class AssetAccountingEventSpineService : IAssetAccountingEventSpin
         {
             var acquisition = requested?.Acquisition
                 ?? throw new InvalidOperationException("Acquisition requires a retained lot instruction.");
-            RequireAssertion(source.ProjectedEffect!.Lines.Count(line =>
-                    string.Equals(line.AccountId, acquisition.AccountId, StringComparison.Ordinal) &&
-                    line.Debit == source.EventAmount && line.Credit == 0m) == 1,
+            var assetLines = source.ProjectedEffect!.Lines
+                .Where(line => string.Equals(line.AccountId, acquisition.AccountId, StringComparison.Ordinal))
+                .ToArray();
+            RequireAssertion(assetLines.Length == 1 &&
+                             assetLines[0].Debit == source.EventAmount &&
+                             assetLines[0].Credit == 0m,
                 "Acquisition projected accounting must contain exactly one authorized asset-account debit for the lot cost.");
             return requested;
         }
@@ -950,9 +953,12 @@ public sealed class AssetAccountingEventSpineService : IAssetAccountingEventSpin
         }
 
         var aggregateCostBasis = canonicalSelections.Sum(static selection => selection.ExpectedCostBasis);
-        RequireAssertion(source.ProjectedEffect!.Lines.Count(line =>
-                string.Equals(line.AccountId, instruction.AssetAccountId, StringComparison.Ordinal) &&
-                line.Credit == aggregateCostBasis && line.Debit == 0m) == 1,
+        var assetLines = source.ProjectedEffect!.Lines
+            .Where(line => string.Equals(line.AccountId, instruction.AssetAccountId, StringComparison.Ordinal))
+            .ToArray();
+        RequireAssertion(assetLines.Length == 1 &&
+                         assetLines[0].Credit == aggregateCostBasis &&
+                         assetLines[0].Debit == 0m,
             "Disposal projected accounting must contain exactly one authoritative asset-relief credit for selected-lot cost basis.");
         RequireAssertion(position.SecurityId == source.Scope.SecurityId &&
                          position.PositionId == source.Scope.BookPositionId,

--- a/src/Meridian.Storage/Ledger/PostgresLedgerJournalStore.AtomicTaxLots.cs
+++ b/src/Meridian.Storage/Ledger/PostgresLedgerJournalStore.AtomicTaxLots.cs
@@ -1225,13 +1225,14 @@ public sealed partial class PostgresLedgerJournalStore
         }
 
         var expectedCostBasis = mutations.Sum(static mutation => mutation.CostBasis);
-        var matchingLines = command.Journal.Entry.Lines
+        var assetLines = command.Journal.Entry.Lines
             .Where(line => line.Account == assetAccounts[0])
-            .Where(line => command.MutationKind == AtomicTaxLotMutationKind.Acquisition
-                ? line.Debit == expectedCostBasis && line.Credit == 0m
-                : line.Credit == expectedCostBasis && line.Debit == 0m)
             .ToArray();
-        if (expectedCostBasis <= 0m || matchingLines.Length != 1)
+        var hasExpectedMovement = assetLines.Length == 1 &&
+            (command.MutationKind == AtomicTaxLotMutationKind.Acquisition
+                ? assetLines[0].Debit == expectedCostBasis && assetLines[0].Credit == 0m
+                : assetLines[0].Credit == expectedCostBasis && assetLines[0].Debit == 0m);
+        if (expectedCostBasis <= 0m || !hasExpectedMovement)
         {
             var side = command.MutationKind == AtomicTaxLotMutationKind.Acquisition
                 ? "debit"

--- a/tests/Meridian.Tests/Storage/AtomicTaxLotJournalStoreTests.cs
+++ b/tests/Meridian.Tests/Storage/AtomicTaxLotJournalStoreTests.cs
@@ -383,6 +383,47 @@ public sealed class AtomicTaxLotJournalStoreTests
             ledgerBookId,
             periodId,
             expectedPeriodVersion: period.Version);
+        var acquisitionAssetLine = acquisition.Journal.Entry.Lines[0];
+        var offsettingAcquisition = (acquisition with
+        {
+            Journal = acquisition.Journal with
+            {
+                Entry = new JournalEntry(
+                    acquisition.Journal.Entry.JournalEntryId,
+                    acquisition.Journal.Entry.Timestamp,
+                    acquisition.Journal.Entry.Description,
+                    [
+                        .. acquisition.Journal.Entry.Lines,
+                        new LedgerEntry(
+                            Guid.NewGuid(),
+                            acquisitionAssetLine.JournalEntryId,
+                            acquisitionAssetLine.Timestamp,
+                            acquisitionAssetLine.Account,
+                            debit: 0m,
+                            credit: acquisitionAssetLine.Debit,
+                            description: acquisitionAssetLine.Description,
+                            dimensions: acquisitionAssetLine.Dimensions,
+                            currency: new LedgerEntryCurrency(
+                                "USD", "USD", 0m, acquisitionAssetLine.Debit, 1m)),
+                        new LedgerEntry(
+                            Guid.NewGuid(),
+                            acquisition.Journal.Entry.Lines[1].JournalEntryId,
+                            acquisition.Journal.Entry.Lines[1].Timestamp,
+                            acquisition.Journal.Entry.Lines[1].Account,
+                            debit: acquisitionAssetLine.Debit,
+                            credit: 0m,
+                            description: acquisition.Journal.Entry.Lines[1].Description,
+                            dimensions: acquisition.Journal.Entry.Lines[1].Dimensions,
+                            currency: new LedgerEntryCurrency(
+                                "USD", "USD", acquisitionAssetLine.Debit, 0m, 1m))
+                    ],
+                    acquisition.Journal.Entry.Metadata)
+            }
+        }).WithComputedFingerprint();
+        var offsettingAcquisitionAct = () => database.JournalStore.AppendAssetPostingAsync(offsettingAcquisition);
+        await offsettingAcquisitionAct.Should().ThrowAsync<LedgerValidationException>()
+            .WithMessage("*one exact asset-account debit*");
+
         var acquired = await database.JournalStore.AppendAssetPostingAsync(acquisition);
 
         acquired.IsExactReplay.Should().BeFalse();


### PR DESCRIPTION
### Motivation
- The atomic tax-lot posting path previously required a matching asset-account line equal to the lot cost but did not ensure that this was the only movement touching that asset account, allowing balanced but malicious offsetting lines to neutralize net ledger impact while mutating tax lots. 
- The change hardens projection, candidate, and durable-store validations so the authoritative asset-account movement is exclusive and equal to the tax-lot cost basis.

### Description
- Require the projected acquisition asset-account to have exactly one line and that line must be the debit equal to `EventAmount` in `src/Meridian.FinancialOperations/Ledger/AssetAccountingEventSpineService.cs`.
- Require the projected disposal asset-account to have exactly one line and that line must be the credit equal to the selected-lot aggregate cost basis in `src/Meridian.FinancialOperations/Ledger/AssetAccountingEventSpineService.cs`.
- Reject posting candidates whose generated or durable journals include additional lines affecting the same asset account in `src/Meridian.FinancialOperations/Ledger/AccountingPostingCandidatePostService.cs`.
- Enforce the same exclusive asset-account movement invariant in the durable atomic store by verifying the journal contains only one asset-account line and that it carries the expected debit/credit in `src/Meridian.Storage/Ledger/PostgresLedgerJournalStore.AtomicTaxLots.cs`.
- Add an integration regression case that constructs a balanced acquisition with offsetting extra asset-account lines and asserts the append is rejected in `tests/Meridian.Tests/Storage/AtomicTaxLotJournalStoreTests.cs`.

### Testing
- Ran `git diff --check` and repository diff check (passed). 
- Ran targeted invariant/source checks (small Python verification over the modified enforcement points) and they passed. 
- Attempted the repository validation command `bash scripts/ci.sh` but it could not complete in this environment because `dotnet` is not available (`dotnet: command not found`).
- Added a defensive integration assertion in `tests/Meridian.Tests/Storage/AtomicTaxLotJournalStoreTests.cs` to exercise the new rejection behavior, but full `dotnet`-based test execution was blocked by the environment; CI/GitHub Actions will run the test suite when the branch is pushed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f396e308320b93fa37004a274ab)