### PR TITLE
Fix journal template audit integrity

### DIFF
--- a/src/Meridian.FinancialOperations/FundAdministration/FundAdministrationControlService.cs
+++ b/src/Meridian.FinancialOperations/FundAdministration/FundAdministrationControlService.cs
@@ -60,6 +60,7 @@ public sealed class FundAdministrationControlService
     {
         ArgumentNullException.ThrowIfNull(template);
         RequireActor(actor);
+        var definition = DescribeJournalTemplate(template);
 
         lock (_gate)
         {
@@ -78,7 +79,7 @@ public sealed class FundAdministrationControlService
                     // sides, amounts, factors, dimensions, required parameters, or book scope produces a
                     // distinct (hashed) registration event — recurring schedules resolve the current
                     // template at materialization, so the chain must preserve which version was approved.
-                    ["definition"] = DescribeJournalTemplate(template),
+                    ["definition"] = definition,
                 });
         }
 
@@ -87,9 +88,14 @@ public sealed class FundAdministrationControlService
 
     private static string DescribeJournalTemplate(JournalTemplate template)
     {
-        var lines = string.Join(";", template.Lines.Select(line =>
-            $"{line.Account.Name}:{line.Account.AccountType}:{line.Account.FinancialAccountId}" +
-            $"|{line.Side}|p={line.AmountParameter}|f={line.FixedAmount}|x={line.Factor}|d={line.Dimensions}|m={line.Memo}"));
+        var lines = string.Join(";", template.Lines.Select((line, index) =>
+        {
+            ArgumentNullException.ThrowIfNull(line, $"{nameof(template)}.{nameof(template.Lines)}[{index}]");
+            ArgumentNullException.ThrowIfNull(line.Account, $"{nameof(template)}.{nameof(template.Lines)}[{index}].{nameof(line.Account)}");
+
+            return $"{line.Account.Name}:{line.Account.AccountType}:{line.Account.FinancialAccountId}" +
+                   $"|{line.Side}|p={line.AmountParameter}|f={line.FixedAmount}|x={line.Factor}|d={line.Dimensions}|m={line.Memo}";
+        }));
         var requiredParameters = string.Join(",", template.RequiredParameters);
         return $"book={template.LedgerBook};params={requiredParameters};lines={lines}";
     }

--- a/tests/Meridian.Tests/FinancialOperations/FundAdministrationControlServiceTests.cs
+++ b/tests/Meridian.Tests/FinancialOperations/FundAdministrationControlServiceTests.cs
@@ -160,6 +160,26 @@ public sealed class FundAdministrationControlServiceTests
     }
 
     [Fact]
+    public void RegisterJournalTemplate_MalformedReplacement_PreservesApprovedTemplateAndAuditTrail()
+    {
+        var service = new FundAdministrationControlService();
+        var approvedTemplate = FeeTemplate();
+        service.RegisterJournalTemplate(approvedTemplate, "controller");
+        var malformedReplacement = new JournalTemplate(
+            "fee",
+            "Malformed Fee Accrual",
+            "An invalid replacement.",
+            [new JournalTemplateLine(null!, JournalTemplateSide.Debit, "fee")]);
+
+        var act = () => service.RegisterJournalTemplate(malformedReplacement, "controller");
+
+        act.Should().Throw<ArgumentNullException>();
+        service.RegisteredJournalTemplates.Should().ContainSingle().Which.Should().BeSameAs(approvedTemplate);
+        service.EventLog.EventsOfKind(FundAdministrationEventKind.JournalTemplateRegistered).Should().ContainSingle();
+        service.EventLog.VerifyIntegrity().Should().BeTrue();
+    }
+
+    [Fact]
     public void ApplyOnboardingTemplate_ResolvesPlaceholdersAndRecords()
     {
         var service = new FundAdministrationControlService();


### PR DESCRIPTION
### Motivation
- Prevent a malformed `JournalTemplate` replacement from mutating the in-memory template registry before the governance event is constructed and appended, which could leave an unaudited active template in place.

### Description
- Precompute the audit definition by calling `DescribeJournalTemplate(template)` before any registry mutation so descriptor construction cannot throw after `_templates.Register` has replaced the approved template. 
- Harden `DescribeJournalTemplate` to validate each `line` and `line.Account` with `ArgumentNullException` checks to fail fast on malformed lines/accounts. 
- Add a regression test `RegisterJournalTemplate_MalformedReplacement_PreservesApprovedTemplateAndAuditTrail` that asserts a malformed same-id replacement throws and preserves the previously approved template and the existing registration event. 
- Changed files: `src/Meridian.FinancialOperations/FundAdministration/FundAdministrationControlService.cs` and `tests/Meridian.Tests/FinancialOperations/FundAdministrationControlServiceTests.cs`.

### Testing
- Ran `git diff --check` to verify no whitespace/check issues and it passed. 
- Ran `python3 build/python/cli/buildctl.py validation-status --summary` and it returned `blocked=false` indicating no local validation blockers. 
- Attempted to run the targeted tests with `dotnet test ... FullyQualifiedName~FundAdministrationControlServiceTests` but the environment has no `dotnet` SDK so the test run could not be executed locally. 
- Running `bash scripts/ci.sh` was blocked at its .NET SDK preflight for the same missing `dotnet`, so CI must run the added test matrix to fully validate the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f3964a08320be8c5a91d6d9ad49)