### PR TITLE
fix(ci): restore reporting governance test coverage

### DIFF
--- a/build/scripts/ci/run-dotnet-ci-tests.py
+++ b/build/scripts/ci/run-dotnet-ci-tests.py
@@ -107,20 +107,10 @@ DEFAULT_TEST_PROJECTS = [
             "FullyQualifiedName~Meridian.Tests.ExponentialBackoffTests|FullyQualifiedName~Meridian.Tests.CircuitBreakerTests"
         ),
     ),
-    # QUARANTINE (tracked): ReportingSecureDistributionAuthorizationTests and
-    # ReportingGovernanceCanonicalValidationTests (37 tests, 7 currently failing) carry
-    # assertions whose expected exception messages/sequencing drifted from the hardened
-    # product behaviour while the namespace ran in no CI lane. Both classes are excluded
-    # here (not silently skipped — this comment is the record) until the governance
-    # semantics are re-adjudicated; the remaining 68 Reporting tests gate every PR.
     (
         "core-reporting",
         "tests/Meridian.Tests/Meridian.Tests.csproj",
-        (
-            "FullyQualifiedName~Meridian.Tests.Reporting"
-            "&FullyQualifiedName!~Meridian.Tests.Reporting.ReportingSecureDistributionAuthorizationTests"
-            "&FullyQualifiedName!~Meridian.Tests.Reporting.ReportingGovernanceCanonicalValidationTests"
-        ),
+        "FullyQualifiedName~Meridian.Tests.Reporting",
     ),
     ("fsharp", "tests/Meridian.FSharp.Tests/Meridian.FSharp.Tests.fsproj", None),
     ("ui", "tests/Meridian.Ui.Tests/Meridian.Ui.Tests.csproj", None),

--- a/tests/scripts/test_run_dotnet_ci_tests.py
+++ b/tests/scripts/test_run_dotnet_ci_tests.py
@@ -43,6 +43,12 @@ class RunDotnetCiTestsTests(unittest.TestCase):
         self.assertTrue(projects[0].filter_expression)
         self.assertTrue(projects[-1].filter_expression, "core-remainder must carry the catch-all filter")
 
+    def test_core_reporting_shard_includes_all_reporting_governance_tests(self):
+        projects = MODULE.parse_project_entries([])
+        reporting = next(project for project in projects if project.name == "core-reporting")
+
+        self.assertEqual(reporting.filter_expression, "FullyQualifiedName~Meridian.Tests.Reporting")
+
     def test_core_remainder_filter_excludes_every_explicit_core_prefix(self):
         remainder = MODULE.build_core_remainder_filter(MODULE.DEFAULT_TEST_PROJECTS[:-1])
 


### PR DESCRIPTION
### Motivation
- Close a CI assurance gap where two security- and governance-focused tests in `Meridian.Tests.Reporting` were being excluded from the default PR lane, leaving critical authorization and governance assertions ungated.

### Description
- Restore the `core-reporting` CI shard to use the unqualified filter `FullyQualifiedName~Meridian.Tests.Reporting` by updating `build/scripts/ci/run-dotnet-ci-tests.py` so the reporting authorization and governance classes are no longer excluded.
- Remove the class-level negative filters that quarantined `ReportingSecureDistributionAuthorizationTests` and `ReportingGovernanceCanonicalValidationTests` from the default reporting shard.
- Add a regression unit test `test_core_reporting_shard_includes_all_reporting_governance_tests` in `tests/scripts/test_run_dotnet_ci_tests.py` to assert `core-reporting` keeps the unqualified `Meridian.Tests.Reporting` filter and to prevent reintroduction of class-level exclusions.

### Testing
- Ran `python3 -m unittest tests/scripts/test_run_dotnet_ci_tests.py -v`, and all unit tests passed.
- Executed `python3 build/scripts/ci/run-dotnet-ci-tests.py --dry-run ...` and confirmed the generated `core-reporting` command uses `FullyQualifiedName~Meridian.Tests.Reporting` without exclusions, and the dry-run completed successfully.
- Ran `python3 build/python/cli/buildctl.py validation-status --summary`, which completed without blocking state.
- Tried `bash scripts/ci.sh` but it failed in this environment because the .NET SDK is not installed (`dotnet: command not found`), so a full CI run could not be executed here; the PR relies on GitHub Actions to validate the restored test coverage on the official runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f3a0b588320a804aa9c510597b8)