### PR TITLE
fix(storage): preserve corrupt WAL segments during truncation

### DIFF
--- a/src/Meridian.Storage/Archival/WriteAheadLog.cs
+++ b/src/Meridian.Storage/Archival/WriteAheadLog.cs
@@ -459,9 +459,8 @@ public sealed class WriteAheadLog : IAsyncDisposable
                 {
                     // Name-derived bound: every record in this segment has a sequence at or
                     // below the successor segment's embedded base, so committed-ness is a
-                    // metadata comparison. A corrupt record cannot raise a sequence above the
-                    // bound, so no header/content inspection is required before removal (and
-                    // ArchiveAfterTruncate preserves the raw bytes regardless).
+                    // metadata comparison. Record scanning is not required, but deletion still
+                    // requires a valid header so corrupt segments remain available for recovery.
                     fullyCommitted = upperBound <= throughSequence;
                 }
                 else
@@ -474,17 +473,17 @@ public sealed class WriteAheadLog : IAsyncDisposable
                     }
 
                     fullyCommitted = maxSequence <= throughSequence;
+                }
 
-                    // A corrupt header makes the enumeration above yield zero records, which is
-                    // indistinguishable from "fully committed". Never delete such a file — it may
-                    // still hold the only copy of unreplayed records.
-                    if (fullyCommitted && !await HasValidHeaderAsync(walFile, ct))
-                    {
-                        _log.Error(
-                            "Refusing to truncate WAL file {File}: header is invalid; file preserved for inspection",
-                            walFile);
-                        continue;
-                    }
+                // A corrupt header can make the scan fallback enumerate zero records, and segment
+                // metadata cannot prove that a corrupt file is safe to remove. Never delete such
+                // a file — it may still hold the only copy of unreplayed records.
+                if (fullyCommitted && !await HasValidHeaderAsync(walFile, ct))
+                {
+                    _log.Error(
+                        "Refusing to truncate WAL file {File}: header is invalid; file preserved for inspection",
+                        walFile);
+                    continue;
                 }
 
                 if (fullyCommitted)

--- a/tests/Meridian.Tests/Storage/WriteAheadLogFuzzTests.cs
+++ b/tests/Meridian.Tests/Storage/WriteAheadLogFuzzTests.cs
@@ -241,9 +241,10 @@ public sealed class WriteAheadLogFuzzTests : TempDirectoryAsyncTestBase
     [Fact]
     public async Task Truncate_InvalidHeaderWalFile_IsNeverDeleted()
     {
-        // A corrupt-header file enumerates as zero records, which looks "fully committed"
-        // to TruncateAsync. The truncate path must refuse to delete it.
-        var corruptPath = Path.Combine(TestDataRoot, "20200101T000000Z_000.wal");
+        // This follows the generated segment-name convention, so truncation uses the metadata
+        // fast path rather than the record-scan fallback. The corrupt header must still prevent
+        // deletion.
+        var corruptPath = Path.Combine(TestDataRoot, "wal_20200101_000000_000000000000.wal");
         await File.WriteAllTextAsync(
             corruptPath,
             "NOTAWAL|garbage\n1|2026-01-01T00:00:00Z|trade|deadbeef|{\"p\":1}\n");


### PR DESCRIPTION
### Motivation
- A metadata-only fast path in `TruncateAsync` could mark generated-name WAL segments as fully committed without validating the WAL header, allowing a corrupt-header segment to be deleted and breaking recovery assumptions.
- The change restores the prior safety invariant that invalid-header WAL files are preserved for inspection and recovery even when filename metadata indicates they are eligible for truncation.

### Description
- Ensure `TruncateAsync` always validates the WAL header by calling `HasValidHeaderAsync` before deleting a file, including when the file was deemed `fullyCommitted` via `TryInferSegmentUpperBounds` (metadata fast path).
- Preserve existing archive/delete workflow and `ArchiveAfterTruncate` semantics while adding the header-preservation guard.
- Update the regression test `Truncate_InvalidHeaderWalFile_IsNeverDeleted` to use a generated, parseable WAL filename (the `wal_yyyyMMdd_HHmmss_############.wal` pattern) so the metadata fast path is exercised.
- Small comment and log-message adjustments to document the safety rationale for the header check.

### Testing
- Ran `git diff --check` to validate whitespace/patch hygiene; check passed.
- Ran `python build/python/cli/buildctl.py validation-status --summary` for local validation status; the command reported no blocking build locks and completed successfully.
- Ran `bash scripts/ci.sh` to invoke the CI validation script, but it failed at SDK verification because `dotnet` is not installed in the environment (`dotnet: command not found`), so full unit test suites could not be executed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f39e8dc83208b41dd1654335c5f)