### PR TITLE
Fix unbounded evidence vault review lock cache

### DIFF
--- a/src/Meridian.Ui.Shared/Evidence/FileEvidenceArtifactStore.cs
+++ b/src/Meridian.Ui.Shared/Evidence/FileEvidenceArtifactStore.cs
@@ -655,6 +655,15 @@ public sealed partial class FileEvidenceArtifactStore : IEvidenceArtifactStore
         var normalizedDocumentId = RequireTrimmed(documentId, nameof(documentId));
         var reviewer = RequireTrimmed(request.Reviewer, nameof(request.Reviewer));
 
+        // Avoid retaining a process-lifetime lock for a vault that does not exist. The identity is
+        // read again after acquiring the lock so a concurrent review still operates on the latest
+        // persisted state.
+        var indexPath = Path.Combine(_rootDirectory, "_vault", $"{safeVaultId}.json");
+        if (await TryReadVaultIdentityAsync(indexPath, ct).ConfigureAwait(false) is null)
+        {
+            return null;
+        }
+
         var vaultLock = _vaultWriteLocks.GetOrAdd(safeVaultId, static _ => new SemaphoreSlim(1, 1));
         await vaultLock.WaitAsync(ct).ConfigureAwait(false);
         try

--- a/tests/Meridian.Tests/Ui/EvidenceWorkflowFabricTests.cs
+++ b/tests/Meridian.Tests/Ui/EvidenceWorkflowFabricTests.cs
@@ -1,5 +1,7 @@
+using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Http.Json;
+using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -2753,6 +2755,30 @@ public sealed class EvidenceWorkflowFabricTests
             cts.Token);
         await unconfirmedReview.Should().ThrowAsync<ArgumentException>()
             .WithMessage("*require at least one human-confirmed field*");
+    }
+
+    [Fact]
+    public async Task FileEvidenceArtifactStore_DuringMissingVaultDocumentReviews_DoesNotRetainVaultLocks()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"evidence-vault-missing-review-{Guid.NewGuid():N}");
+        var store = new FileEvidenceArtifactStore(root, NullLogger<FileEvidenceArtifactStore>.Instance);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        for (var index = 0; index < 32; index++)
+        {
+            var result = await store.ReviewDocumentAsync(
+                $"ev-{index:x24}",
+                "missing-document",
+                new EvidenceVaultDocumentReviewRequestDto(EvidenceDocumentReviewStatusDto.Rejected, "controller"),
+                cts.Token);
+
+            result.Should().BeNull();
+        }
+
+        var locks = (ConcurrentDictionary<string, SemaphoreSlim>)typeof(FileEvidenceArtifactStore)
+            .GetField("_vaultWriteLocks", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(store)!;
+        locks.Should().BeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- Prevent an unbounded memory growth/DoS where syntactically valid but non-existent evidence vault IDs could cause a `ConcurrentDictionary<string, SemaphoreSlim>` to accumulate process-lifetime entries when `ReviewDocumentAsync` created a lock before checking the vault exists.

### Description
- In `FileEvidenceArtifactStore.ReviewDocumentAsync` verify the vault index exists by calling `TryReadVaultIdentityAsync` for the computed `indexPath` before calling `_vaultWriteLocks.GetOrAdd(...)`, returning `null` immediately for missing vaults to avoid creating a persistent lock entry.
- Preserve the existing locked-path behavior by keeping the in-lock `ReviewDocumentUnderLockAsync` call so concurrent reviews still serialize on the vault manifest once the vault is known to exist.
- Add a regression test `FileEvidenceArtifactStore_DuringMissingVaultDocumentReviews_DoesNotRetainVaultLocks` that issues multiple `ReviewDocumentAsync` calls with distinct, syntactically valid non-existent vault IDs and asserts each returns `null` and that `_vaultWriteLocks` remains empty after the calls.
- Files changed: `src/Meridian.Ui.Shared/Evidence/FileEvidenceArtifactStore.cs` and `tests/Meridian.Tests/Ui/EvidenceWorkflowFabricTests.cs`.

### Testing
- Static checks: `git diff --check` and repository diff verification passed locally.
- Unit test added: `FullyQualifiedName~EvidenceWorkflowFabricTests.FileEvidenceArtifactStore_DuringMissingVaultDocumentReviews_DoesNotRetainVaultLocks` was added to the test suite and prepared for execution, but running the .NET test runner was blocked because `dotnet` is not available in this environment so the focused test could not be executed here.
- CI: running `bash scripts/ci.sh` is blocked in this environment for the same reason (`dotnet` not present), so full CI results must be observed on GitHub Actions. Please run the repository test matrix (or `bash scripts/ci.sh`) in an environment with the .NET SDK to validate the new test and ensure no regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f3c81a883208515df2c170b6e7e)