### PR TITLE
fix: harden direct Flex XML ingestion

### DIFF
--- a/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs
@@ -147,16 +147,9 @@ public sealed class StatementReconciliationService
     /// </summary>
     private static void ValidateFlexDocument(string sourcePath)
     {
-        var settings = new System.Xml.XmlReaderSettings
-        {
-            DtdProcessing = System.Xml.DtdProcessing.Prohibit,
-            XmlResolver = null,
-            CloseInput = true
-        };
-
         try
         {
-            using var reader = System.Xml.XmlReader.Create(File.OpenRead(sourcePath), settings);
+            using var reader = System.Xml.XmlReader.Create(File.OpenRead(sourcePath), CreateFlexReaderSettings());
             reader.MoveToContent();
             if (!string.Equals(reader.LocalName, "FlexQueryResponse", StringComparison.Ordinal))
             {
@@ -170,6 +163,21 @@ public sealed class StatementReconciliationService
         }
     }
 
+    private static System.Xml.Linq.XDocument LoadFlexDocument(string content)
+    {
+        using var textReader = new StringReader(content);
+        using var reader = System.Xml.XmlReader.Create(textReader, CreateFlexReaderSettings());
+        return System.Xml.Linq.XDocument.Load(reader);
+    }
+
+    private static System.Xml.XmlReaderSettings CreateFlexReaderSettings() => new()
+    {
+        DtdProcessing = System.Xml.DtdProcessing.Prohibit,
+        XmlResolver = null,
+        CloseInput = true,
+        MaxCharactersFromEntities = 0
+    };
+
     /// <summary>
     /// Reads an IB Flex report into normalized statement rows (one per Trade, OpenPosition,
     /// and CashTransaction element) so case intake matches Flex statements with the same
@@ -182,7 +190,7 @@ public sealed class StatementReconciliationService
         string sourcePath,
         string content)
     {
-        var document = System.Xml.Linq.XDocument.Parse(content);
+        var document = LoadFlexDocument(content);
         var rows = new List<NormalizedStatementRow>();
         var rowNumber = 0;
 
@@ -297,7 +305,9 @@ public sealed class StatementReconciliationService
         var content = await File.ReadAllTextAsync(sourcePath, ct).ConfigureAwait(false);
         var importId = DeterministicFingerprint.Compute($"{normalizedSourceKind}|{sourcePath}|{content}");
 
-        var document = System.Xml.Linq.XDocument.Parse(content);
+        // Import can be invoked without validation (for example, when resuming from a checkpoint),
+        // so parse with the same DTD-prohibiting settings as ValidateFlexDocument.
+        var document = LoadFlexDocument(content);
         var sourceRows = new List<StatementSourceRowReference>();
         var rowNumber = 0;
         foreach (var element in document.Descendants()

--- a/tests/Meridian.Tests/Reconciliation/IbFlexStatementServiceTests.cs
+++ b/tests/Meridian.Tests/Reconciliation/IbFlexStatementServiceTests.cs
@@ -319,6 +319,29 @@ public sealed class IbFlexStatementServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task StatementReconciliationService_ImportRejectsFlexDocumentWithDtd()
+    {
+        var service = new StatementReconciliationService();
+        var path = WriteFlexFile("""
+            <!DOCTYPE FlexQueryResponse [<!ENTITY symbol "AAPL">]>
+            <FlexQueryResponse>
+              <FlexStatements count="1">
+                <FlexStatement toDate="20260630">
+                  <Trades>
+                    <Trade symbol="&symbol;" tradeDate="20260615" quantity="1" tradePrice="1" />
+                  </Trades>
+                </FlexStatement>
+              </FlexStatements>
+            </FlexQueryResponse>
+            """, "dtd-flex-report.xml");
+
+        // ImportAsync can run without a prior validation stage, so it must reject DTDs itself.
+        var import = async () => await service.ImportAsync("ib-flex", path, null, CancellationToken.None);
+
+        await import.Should().ThrowAsync<System.Xml.XmlException>();
+    }
+
+    [Fact]
     public async Task StatementRunWorkflow_ImportsFlexStatementEndToEnd()
     {
         var workflow = new StatementRunWorkflowService(


### PR DESCRIPTION
### Motivation
- The direct IB Flex ingestion path parsed operator-supplied XML with `XDocument.Parse` without the hardened `XmlReaderSettings` used by validation, exposing a DTD/entity expansion resource-risk and inconsistent parsing behavior.
- The change ensures import and intake paths enforce the same DTD-prohibiting XML policy so validation cannot be bypassed by direct ingestion or resume flows.

### Description
- Add a shared `CreateFlexReaderSettings()` helper that sets `DtdProcessing = Prohibit`, `XmlResolver = null`, and `MaxCharactersFromEntities = 0` and use it for all Flex parsing paths.
- Introduce `LoadFlexDocument(string)` which loads an `XDocument` via an `XmlReader` created with the shared settings and replace `XDocument.Parse` calls with `LoadFlexDocument` in the import and row-reading code paths.
- Update `ValidateFlexDocument` to use the shared settings when checking the Flex root element so validation and import share the same hardening policy.
- Add a regression test `StatementReconciliationService_ImportRejectsFlexDocumentWithDtd` to verify that `ImportAsync` rejects a Flex document containing a DTD even when no prior validation stage ran.

### Testing
- Ran `git diff --check` and validated there are no whitespace/patch issues; the check passed.
- Ran `python3 build/python/cli/buildctl.py validation-status --summary` for local validation-status and it reported no active locks; the check passed.
- Attempted full CI with `bash scripts/ci.sh` and `dotnet`-based unit runs but the environment lacks the `.NET SDK` (`dotnet` not found), so repository unit tests could not be executed here; CI is expected to run in GitHub Actions where `dotnet` is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f39743c83209dd6fdbb5e6ca88c)