### PR TITLE
fix(reconciliation): require symbols for trades

### DIFF
--- a/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs
@@ -492,11 +492,10 @@ public sealed class StatementReconciliationService
             var sourceActivityType = mapped.GetRequired(StatementCanonicalField.ActivityType, currentRowNumber);
             var activityType = profile.MapActivityType(sourceActivityType);
             var rowKind = ToStatementRowKind(activityType);
-            // Position rows must carry a security identifier so the matching engine can compare
-            // them against internal positions by security; a blank one is a mapping error, not a
-            // matchable position. Account-level cash/fee/dividend and other activity rows may omit
-            // it, matching the prior positional importer.
-            var symbol = rowKind == StatementRowKind.Position
+            // Security-bearing positions and transactions must carry an identifier so downstream
+            // matching and resolution retain a security reference. Only account-level cash, fee,
+            // and dividend rows may omit it, matching the prior positional importer.
+            var symbol = rowKind is StatementRowKind.Position or StatementRowKind.Transaction
                 ? mapped.GetRequired(StatementCanonicalField.SecurityIdentifier, currentRowNumber)
                 : mapped.GetOptional(StatementCanonicalField.SecurityIdentifier) ?? string.Empty;
             var quantity = mapped.GetRequiredDecimal(StatementCanonicalField.Quantity, currentRowNumber);
@@ -579,9 +578,10 @@ public sealed class StatementReconciliationService
             var account = mapped.GetRequired(StatementCanonicalField.Account, rowNumber);
             var activityType = profile.MapActivityType(mapped.GetRequired(StatementCanonicalField.ActivityType, rowNumber));
             var rowKind = ToStatementRowKind(activityType);
-            // Position rows must carry a security identifier (see import path); account-level
-            // cash/fee/dividend and other activity rows may omit it. Kept consistent across both paths.
-            var symbol = rowKind == StatementRowKind.Position
+            // Security-bearing positions and transactions must carry an identifier (see import
+            // path); only account-level cash, fee, and dividend rows may omit it. Kept consistent
+            // across both paths.
+            var symbol = rowKind is StatementRowKind.Position or StatementRowKind.Transaction
                 ? mapped.GetRequired(StatementCanonicalField.SecurityIdentifier, rowNumber)
                 : mapped.GetOptional(StatementCanonicalField.SecurityIdentifier) ?? string.Empty;
             var quantity = mapped.GetRequiredDecimal(StatementCanonicalField.Quantity, rowNumber);

--- a/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
+++ b/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
@@ -575,6 +575,30 @@ public sealed class StatementReconciliationServiceTests
     }
 
     [Fact]
+    public async Task ImportAsync_SymbolLessTradeRow_Throws()
+    {
+        var svc = new StatementReconciliationService();
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            // A trade is security-bearing and must not bypass downstream security-resolution
+            // evidence merely because it is normalized as a transaction rather than a position.
+            await File.WriteAllLinesAsync(filePath,
+            [
+                "account,symbol,quantity,price,cashAmount,activityType,tradeDate",
+                "EXT-1,,10,500,0,trade,2026-05-29"
+            ]);
+
+            await Assert.ThrowsAsync<InvalidDataException>(() =>
+                svc.ImportAsync("broker", filePath, CancellationToken.None));
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    [Fact]
     public async Task ImportAsync_BlankOptionalColumns_ApplyDefaults()
     {
         var svc = new StatementReconciliationService();


### PR DESCRIPTION
### Motivation
- Prevent importing security-bearing rows (positions and trades/transactions) without any security identity, which allowed downstream consumers to receive records with neither `SecurityId` nor `UnresolvedIdentifier` and no `StatementSecurityReference` for resolution.
- Preserve prior behavior that allowed account-level cash, fee, and dividend rows to omit the `SecurityIdentifier` while tightening validation for security-bearing rows.

### Description
- In `StatementReconciliationService.cs` require `SecurityIdentifier` for both `StatementRowKind.Position` and `StatementRowKind.Transaction` when normalizing CSV/profile-driven imports by using `rowKind is StatementRowKind.Position or StatementRowKind.Transaction` before calling `GetRequired` for the symbol.
- Mirror the same requirement in the canonical CSV parsing path so typed imports and case-intake parsing remain consistent.
- Add a regression test `ImportAsync_SymbolLessTradeRow_Throws` to `tests/Meridian.Tests/StatementReconciliationServiceTests.cs` that asserts a symbol-less trade row is rejected during a typed `broker` import.

### Testing
- Ran `git diff --check` which passed with no whitespace or patch problems.
- Ran `python build/python/cli/buildctl.py validation-status --summary` which reported `blocked=false` and returned normally.
- Attempted targeted unit test run `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~StatementReconciliationServiceTests"`, but it could not be executed in this environment because `dotnet` is not installed (blocked).
- Ran `bash scripts/ci.sh` locally but it was blocked at the .NET SDK verification step for the same reason; full GitHub Actions CI remains required to validate the .NET test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f3b14c88320afc911fd78b45c16)