### PR TITLE
Add durable Interactive Brokers workstation result queries

### DIFF
--- a/src/Meridian.Contracts/Api/UiApiRoutes.cs
+++ b/src/Meridian.Contracts/Api/UiApiRoutes.cs
@@ -144,6 +144,7 @@ public static class UiApiRoutes
     public const string IBStatus = "/api/providers/ib/status";
     public const string IBErrorCodes = "/api/providers/ib/error-codes";
     public const string IBLimits = "/api/providers/ib/limits";
+    public const string IBResults = "/api/workstation/ib/results";
 
     // Failover endpoints
     public const string FailoverConfig = "/api/failover/config";

--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDataServices.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDataServices.cs
@@ -100,15 +100,17 @@ public sealed class IBDataServices : IProviderDataReadService, IDisposable
 {
     private readonly IIBDataServiceTransport _transport;
     private readonly IIBDataCallbackSource? _callbackSource;
+    private readonly IBDataResultMaterializer? _materializer;
     private readonly ConcurrentDictionary<int, IBDataLineage> _lineage = new();
     private readonly ConcurrentDictionary<int, ProviderDataRequestReadModel> _requests = new();
     private readonly Channel<ProviderDataRequestReadModel> _updates = Channel.CreateBounded<ProviderDataRequestReadModel>(
         new BoundedChannelOptions(256) { SingleReader = false, SingleWriter = false, FullMode = BoundedChannelFullMode.DropOldest });
     private int _nextRequestId = 90_000;
 
-    public IBDataServices(IIBDataServiceTransport transport)
+    public IBDataServices(IIBDataServiceTransport transport, IBDataResultMaterializer? materializer = null)
     {
         _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+        _materializer = materializer;
         if (transport is IIBDataLineageSource source)
             source.MarketDataTypeReceived += OnMarketDataTypeReceived;
         if (transport is IIBDataCallbackSource callbacks)
@@ -362,6 +364,7 @@ public sealed class IBDataServices : IProviderDataReadService, IDisposable
     {
         var updated = _lineage.AddOrUpdate(requestId, _ => throw new KeyNotFoundException($"Unknown IB request id {requestId}."), (_, current) => update(current));
         LineageUpdated?.Invoke(updated);
+        if (_requests.TryGetValue(requestId, out var request)) _materializer?.Materialize(request, updated);
     }
 
     private void UpdateReadModel(int requestId, Func<ProviderDataRequestReadModel, ProviderDataRequestReadModel> update)
@@ -374,6 +377,7 @@ public sealed class IBDataServices : IProviderDataReadService, IDisposable
     {
         _updates.Writer.TryWrite(model);
         ReadModelUpdated?.Invoke(model);
+        _materializer?.Materialize(model, _lineage.TryGetValue(model.RequestId, out var lineage) ? lineage : null);
     }
 
     private static IReadOnlyList<T> Append<T>(IReadOnlyList<T>? existing, T value)

--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDurableResultStore.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDurableResultStore.cs
@@ -1,0 +1,74 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Meridian.ProviderSdk;
+
+namespace Meridian.Infrastructure.Adapters.InteractiveBrokers;
+
+/// <summary>A persisted, request-correlated IB result.  Tenant is part of the durable key.</summary>
+public sealed record IBDurableResult(string TenantId, ProviderDataRequestReadModel Request, IBDataLineage? Lineage);
+
+/// <summary>Durable query seam; callers must always supply the tenant they are authorized to read.</summary>
+public interface IBDurableResultStore
+{
+    void Upsert(string tenantId, ProviderDataRequestReadModel request, IBDataLineage? lineage);
+    IReadOnlyList<IBDurableResult> Get(string tenantId, string? capability = null, string? accountId = null, string? modelAccountId = null);
+}
+
+/// <summary>
+/// Small atomic JSON result store used until an installation supplies a database projection. It is
+/// deliberately keyed by tenant + request id, so a process restart never turns an in-memory IB
+/// callback cache into a cross-tenant read surface.
+/// </summary>
+public sealed class JsonIBDurableResultStore : IBDurableResultStore
+{
+    private readonly string _path;
+    private readonly object _gate = new();
+    private Dictionary<string, IBDurableResult>? _results;
+
+    public JsonIBDurableResultStore(string path) => _path = path ?? throw new ArgumentNullException(nameof(path));
+
+    public void Upsert(string tenantId, ProviderDataRequestReadModel request, IBDataLineage? lineage)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+        ArgumentNullException.ThrowIfNull(request);
+        lock (_gate)
+        {
+            var results = Load();
+            results[$"{tenantId}:{request.RequestId}"] = new IBDurableResult(tenantId, request, lineage);
+            Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
+            var temporary = _path + ".tmp";
+            File.WriteAllText(temporary, JsonSerializer.Serialize(results.Values));
+            File.Move(temporary, _path, overwrite: true);
+        }
+    }
+
+    public IReadOnlyList<IBDurableResult> Get(string tenantId, string? capability = null, string? accountId = null, string? modelAccountId = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+        lock (_gate)
+            return Load().Values.Where(x => x.TenantId == tenantId)
+                .Where(x => capability is null || string.Equals(x.Request.Capability, capability, StringComparison.OrdinalIgnoreCase))
+                .Where(x => accountId is null || string.Equals(x.Request.AccountId, accountId, StringComparison.Ordinal))
+                .Where(x => modelAccountId is null || string.Equals(x.Request.ModelAccountId, modelAccountId, StringComparison.Ordinal))
+                .OrderByDescending(x => x.Request.UpdatedAt).ToArray();
+    }
+
+    private Dictionary<string, IBDurableResult> Load()
+    {
+        if (_results is not null) return _results;
+        if (!File.Exists(_path)) return _results = new();
+        var values = JsonSerializer.Deserialize<List<IBDurableResult>>(File.ReadAllText(_path)) ?? [];
+        return _results = values.ToDictionary(x => $"{x.TenantId}:{x.Request.RequestId}", StringComparer.Ordinal);
+    }
+}
+
+/// <summary>Materializes callback updates without treating a submitted request as live entitlement.</summary>
+public sealed class IBDataResultMaterializer
+{
+    private readonly IBDurableResultStore _store;
+    private readonly Func<string> _tenantResolver;
+    public IBDataResultMaterializer(IBDurableResultStore store, Func<string>? tenantResolver = null)
+    { _store = store; _tenantResolver = tenantResolver ?? (() => "system"); }
+    public void Materialize(ProviderDataRequestReadModel request, IBDataLineage? lineage)
+        => _store.Upsert(_tenantResolver(), request, lineage);
+}

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.IBResults.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.IBResults.cs
@@ -1,0 +1,31 @@
+using Meridian.Contracts.Api;
+using Meridian.Ui.Shared.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Meridian.Ui.Shared.Endpoints;
+
+public static partial class WorkstationEndpoints
+{
+    private static void MapIBResultEndpoints(RouteGroupBuilder group, System.Text.Json.JsonSerializerOptions jsonOptions)
+    {
+        group.MapGet(WorkstationSubroute(UiApiRoutes.IBResults), (
+            string? family, string? accountId, string? modelAccountId,
+            IWorkstationTenantContextAccessor tenantContext, IBResultQueryService results) =>
+        {
+            var tenant = tenantContext.GetRequired();
+            var items = results.Get(tenant.TenantId!, family, accountId, modelAccountId)
+                .Select(x => new
+                {
+                    request = x.Request,
+                    lineage = x.Lineage,
+                    availability = x.Lineage?.Availability.ToString(),
+                    delayed = x.Lineage?.IsDelayed ?? false,
+                    subscriptionEvidence = x.Lineage?.Subscription,
+                    terminalStatus = x.Request.Status.ToString(),
+                    requestErrors = new { x.Request.ErrorCode, x.Request.ErrorMessage }
+                });
+            return Results.Json(new { provider = "interactive-brokers", results = items }, jsonOptions);
+        }).WithName("GetWorkstationIBResults").Produces(200).Produces(403);
+    }
+}

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -127,6 +127,7 @@ public static partial class WorkstationEndpoints
         MapDataOperationsAssuranceEndpoints(group);
         MapStatementConnectorEndpoints(group, jsonOptions);
         MapProviderIntegrationEndpoints(group, jsonOptions);
+        MapIBResultEndpoints(group, jsonOptions);
 
         group.MapGet(WorkstationSubroute(UiApiRoutes.WorkstationWorkflowSummary), async (
             bool? hasOperatingContext,

--- a/src/Meridian.Ui.Shared/Services/IBResultQueryService.cs
+++ b/src/Meridian.Ui.Shared/Services/IBResultQueryService.cs
@@ -1,0 +1,12 @@
+using Meridian.Infrastructure.Adapters.InteractiveBrokers;
+
+namespace Meridian.Ui.Shared.Services;
+
+/// <summary>Shared, tenant-scoped query service for typed, durable IB callback results.</summary>
+public sealed class IBResultQueryService
+{
+    private readonly IBDurableResultStore _store;
+    public IBResultQueryService(IBDurableResultStore store) => _store = store;
+    public IReadOnlyList<IBDurableResult> Get(string tenantId, string? family, string? accountId, string? modelAccountId)
+        => _store.Get(tenantId, family, accountId, modelAccountId);
+}

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -38,6 +38,7 @@ using Meridian.FinancialOperations.OperationsContinuity;
 using Meridian.FinancialOperations.PrivateCapital;
 using Meridian.FinancialOperations.Reconciliation;
 using Meridian.Infrastructure.Adapters.Plaid;
+using Meridian.Infrastructure.Adapters.InteractiveBrokers;
 using Meridian.Infrastructure.Adapters.Core;
 using Meridian.Identity;
 using Meridian.Instruments.AssetOperations;
@@ -81,6 +82,13 @@ public static class WorkstationServiceCollectionExtensions
         // registrations below read the per-domain connection-string variables.
         Meridian.Storage.MeridianDatabaseEnvironment.ApplyUnifiedDatabaseUrl();
         services.TryAddSingleton<ProviderDataReadModelService>();
+        // Persisted evidence does not enable live IB access in a guidance/non-vendor build.
+        services.TryAddSingleton<IBDurableResultStore>(sp =>
+        {
+            var root = sp.GetRequiredService<StorageOptions>().RootPath;
+            return new JsonIBDurableResultStore(Path.Combine(root, "providers", "interactive-brokers", "results.json"));
+        });
+        services.TryAddSingleton<IBResultQueryService>();
 
         var isProductionComposition = ProductionServiceRegistrationPolicy.IsProductionComposition(services);
 

--- a/src/Meridian/HostedBrokerageGatewayServiceCollectionExtensions.cs
+++ b/src/Meridian/HostedBrokerageGatewayServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using Meridian.Infrastructure.Adapters.Robinhood;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Meridian.ProviderSdk;
 
 namespace Meridian;
 
@@ -36,6 +37,18 @@ internal static class HostedBrokerageGatewayServiceCollectionExtensions
             var logger = sp.GetRequiredService<ILogger<IBBrokerageGateway>>();
             return new IBBrokerageGateway(options, logger);
         });
+#if IBAPI
+        // Only an official-vendor build wires a transport; non-vendor builds remain fail-closed.
+        services.TryAddSingleton<EnhancedIBConnectionManager>(sp =>
+        {
+            var options = sp.GetService<Meridian.Core.Config.IBOptions>() ?? new Meridian.Core.Config.IBOptions();
+            return new EnhancedIBConnectionManager(new IBCallbackRouter(), options.Host, options.Port, options.ClientId);
+        });
+        services.TryAddSingleton<IBDataServices>(sp => new IBDataServices(
+            sp.GetRequiredService<EnhancedIBConnectionManager>(),
+            new IBDataResultMaterializer(sp.GetRequiredService<IBDurableResultStore>())));
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IProviderDataReadService>(sp => sp.GetRequiredService<IBDataServices>()));
+#endif
         services.AddBrokerageGateway("ib", sp => sp.GetRequiredService<IBBrokerageGateway>());
         services.AddBrokerageGateway("ibkr", sp => sp.GetRequiredService<IBBrokerageGateway>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IBrokerageAccountCatalog>(sp => sp.GetRequiredService<IBBrokerageGateway>()));


### PR DESCRIPTION
### Motivation

- Provide a durable, tenant-scoped read surface for Interactive Brokers request/read-model results so workstation clients can query historical callback evidence across restarts without inferring live entitlement from a submitted request. 
- Preserve the existing fail-closed behavior when the official IB vendor SDK or entitlement is not available by keeping live transport wiring conditional on the IBAPI build symbol.

### Description

- Add a tenant-keyed, atomic JSON result store and durable model record types in `src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDurableResultStore.cs` and a small `IBDataResultMaterializer` that writes read-model updates into the store. 
- Materialize persisted evidence from `IBDataServices` by injecting an optional `IBDataResultMaterializer` and calling it on lineage/read-model updates so persisted evidence always reflects vendor callbacks rather than request submission. (`src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDataServices.cs`).
- Register the JSON-backed store and a shared query service in the workstation composition: `JsonIBDurableResultStore` + `IBResultQueryService` in `src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs` so endpoints and UI hosts can query tenant-isolated results.
- Add a tenant-scoped workstation endpoint at `GET /api/workstation/ib/results` (`src/Meridian.Contracts/Api/UiApiRoutes.cs` + `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.IBResults.cs`) that returns the typed request payload, lineage, availability/delayed flag, subscription evidence, terminal status, and request error fields with each item.
- Keep runtime wiring of the live IB transport and `IBDataServices` conditional on the official SDK with `#if IBAPI` inside `HostedBrokerageGatewayServiceCollectionExtensions.cs`, preserving non-vendor guidance builds as fail-closed and exposing only persisted historical evidence in those builds.

### Testing

- Ran `git diff --check` and created a local commit for the change; that check passed.
- Attempted to run `dotnet build` on `src/Meridian.Ui.Shared` and `src/Meridian` but `dotnet` is not available in this environment, so builds could not be executed here.
- This environment has no configured `origin` remote so the feature branch could not be pushed from here; CI/GitHub Actions should be used to run the full `bash scripts/ci.sh`/GitHub checks and confirm integration tests and compilation succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6122c19d808320994332ad6c6a4c08)