### PR TITLE
Add durable IB data result materialization and storage seam

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDataResultMaterializer.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDataResultMaterializer.cs
@@ -1,0 +1,41 @@
+using System.Text.Json;
+using System.Threading.Channels;
+using Meridian.ProviderSdk;
+
+namespace Meridian.Infrastructure.Adapters.InteractiveBrokers;
+
+/// <summary>
+/// Composition-boundary reader that durably materializes IB updates before exposing them to
+/// operator readers. Register this, rather than the transport-facing service, as the read seam.
+/// </summary>
+public sealed class IBDataResultMaterializer : IProviderDataReadService
+{
+    private readonly IProviderDataReadService _source;
+    private readonly IIBDataResultStore _store;
+    private readonly Channel<ProviderDataRequestReadModel> _published = Channel.CreateUnbounded<ProviderDataRequestReadModel>();
+
+    public IBDataResultMaterializer(IProviderDataReadService source, IIBDataResultStore store)
+    {
+        _source = source ?? throw new ArgumentNullException(nameof(source));
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+    }
+
+    public IReadOnlyList<ProviderDataRequestReadModel> GetRequests() => _source.GetRequests();
+    public IAsyncEnumerable<ProviderDataRequestReadModel> WatchAsync(CancellationToken cancellationToken = default) => _published.Reader.ReadAllAsync(cancellationToken);
+
+    public async Task MaterializeAsync(CancellationToken cancellationToken = default)
+    {
+        await foreach (var update in _source.WatchAsync(cancellationToken).ConfigureAwait(false))
+        {
+            var lineage = update.Lineage ?? throw new InvalidOperationException($"IB update {update.RequestId} was missing lineage.");
+            var capturedAt = update.UpdatedAt;
+            var requestIdentity = lineage.RequestId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            var result = new IBDataResult(
+                $"interactive-brokers:{requestIdentity}:{update.Capability}", update.ProviderFamily,
+                update.Capability, requestIdentity, lineage.Subscription, lineage.Symbol, update.AccountId,
+                capturedAt, update.Status, JsonSerializer.Serialize(update), lineage);
+            await _store.UpsertAsync(result, cancellationToken).ConfigureAwait(false);
+            await _published.Writer.WriteAsync(update, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDataServices.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDataServices.cs
@@ -5,33 +5,6 @@ using Meridian.ProviderSdk;
 
 namespace Meridian.Infrastructure.Adapters.InteractiveBrokers;
 
-/// <summary>IB data access class returned by TWS/Gateway for a request.</summary>
-public enum IBMarketDataAvailability
-{
-    Unknown = 0,
-    Live = 1,
-    Frozen = 2,
-    Delayed = 3,
-    DelayedFrozen = 4
-}
-
-/// <summary>
-/// Immutable, entitlement-aware evidence for an IB request or subscription. Persist this with
-/// downstream observations: exchange and data availability are part of the meaning of IB data.
-/// </summary>
-public sealed record IBDataLineage(
-    int RequestId,
-    string Service,
-    string Symbol,
-    string? Exchange,
-    string? MarketRuleIds,
-    string? MinimumIncrements,
-    string? Subscription,
-    IBMarketDataAvailability Availability,
-    bool IsDelayed,
-    string Status,
-    DateTimeOffset ObservedAt);
-
 /// <summary>Scanner criteria intentionally limited to IB's stable scanner subscription fields.</summary>
 public sealed record IBScannerRequest(
     string Instrument,
@@ -349,7 +322,7 @@ public sealed class IBDataServices : IProviderDataReadService, IDisposable
         var requestId = Interlocked.Increment(ref _nextRequestId);
         var evidence = new IBDataLineage(requestId, service, symbol, exchange, null, null, subscription, IBMarketDataAvailability.Unknown, false, "requested", DateTimeOffset.UtcNow);
         if (!_lineage.TryAdd(requestId, evidence)) throw new InvalidOperationException($"Duplicate IB request id {requestId}.");
-        var projection = new ProviderDataRequestReadModel(requestId, "interactive-brokers", service, ProviderDataRequestStatus.Requested, evidence.ObservedAt);
+        var projection = new ProviderDataRequestReadModel(requestId, "interactive-brokers", service, ProviderDataRequestStatus.Requested, evidence.ObservedAt, Lineage: evidence);
         _requests.TryAdd(requestId, projection);
         try { send(requestId); }
         catch { _lineage.TryRemove(requestId, out _); _requests.TryRemove(requestId, out _); throw; }
@@ -362,11 +335,13 @@ public sealed class IBDataServices : IProviderDataReadService, IDisposable
     {
         var updated = _lineage.AddOrUpdate(requestId, _ => throw new KeyNotFoundException($"Unknown IB request id {requestId}."), (_, current) => update(current));
         LineageUpdated?.Invoke(updated);
+        UpdateReadModel(requestId, current => current with { Lineage = updated });
     }
 
     private void UpdateReadModel(int requestId, Func<ProviderDataRequestReadModel, ProviderDataRequestReadModel> update)
     {
-        var updated = _requests.AddOrUpdate(requestId, _ => throw new KeyNotFoundException($"Unknown IB request id {requestId}."), (_, current) => update(current) with { UpdatedAt = DateTimeOffset.UtcNow });
+        var lineage = _lineage.TryGetValue(requestId, out var currentLineage) ? currentLineage : null;
+        var updated = _requests.AddOrUpdate(requestId, _ => throw new KeyNotFoundException($"Unknown IB request id {requestId}."), (_, current) => update(current) with { UpdatedAt = DateTimeOffset.UtcNow, Lineage = lineage });
         Publish(updated);
     }
 

--- a/src/Meridian.Infrastructure/README.md
+++ b/src/Meridian.Infrastructure/README.md
@@ -124,7 +124,9 @@ The IB vendor runtime also exposes an entitlement-aware `IBDataServices` seam fo
 contract details, option chains, news, fundamentals, tick-by-tick data, account P&L, market rules,
 and depth-exchange metadata. Its request lineage begins `Unknown` and must retain the actual IB
 live/frozen/delayed status, exchange, market rules, and subscription descriptor alongside any
-materialized observation; successful request submission is not evidence of a live entitlement.
+materialized result. `IBDataResultMaterializer` is the Infrastructure-to-storage composition seam:
+it commits each `WatchAsync` update to `IIBDataResultStore` before making that update available to
+operator readers; successful request submission is not evidence of a live entitlement.
 Its richer request callbacks publish bounded, request-correlated ProviderSdk read-model updates for
 option discovery, scanners, real-time bars, historical ticks, account/model-account P&L, and market
 rules. Vendor SDK absence remains simulation/fail-closed and cannot advertise live IB capability.

--- a/src/Meridian.ProviderSdk/IProviderDataReadService.cs
+++ b/src/Meridian.ProviderSdk/IProviderDataReadService.cs
@@ -14,6 +14,15 @@ public enum ProviderDataRequestStatus
     Failed
 }
 
+/// <summary>IB's reported market-data availability; unknown is never treated as live data.</summary>
+public enum IBMarketDataAvailability { Unknown = 0, Live = 1, Frozen = 2, Delayed = 3, DelayedFrozen = 4 }
+
+/// <summary>Complete, entitlement-aware lineage for an Interactive Brokers request or subscription.</summary>
+public sealed record IBDataLineage(
+    int RequestId, string Service, string Symbol, string? Exchange, string? MarketRuleIds,
+    string? MinimumIncrements, string? Subscription, IBMarketDataAvailability Availability,
+    bool IsDelayed, string Status, DateTimeOffset ObservedAt);
+
 /// <summary>Provider-neutral evidence for a discovered option contract.</summary>
 public sealed record ProviderOptionContract(
     string Symbol,
@@ -68,7 +77,43 @@ public sealed record ProviderDataRequestReadModel(
     IReadOnlyList<ProviderRealTimeBar>? RealTimeBars = null,
     IReadOnlyList<ProviderHistoricalTick>? HistoricalTicks = null,
     ProviderAccountPnl? Pnl = null,
-    IReadOnlyList<ProviderMarketRuleIncrement>? MarketRuleIncrements = null);
+    IReadOnlyList<ProviderMarketRuleIncrement>? MarketRuleIncrements = null,
+    IBDataLineage? Lineage = null);
+
+/// <summary>
+/// Storage-facing, normalized provider result. Snapshot identities are stable across retries and
+/// restarts; <see cref="NormalizedPayload"/> is the portable serialized read model and lineage is
+/// retained separately so consumers need not recover it from an opaque payload.
+/// </summary>
+public sealed record IBDataResult(
+    string ResultIdentity,
+    string ProviderFamily,
+    string Capability,
+    string RequestIdentity,
+    string? SubscriptionIdentity,
+    string? Symbol,
+    string? AccountId,
+    DateTimeOffset CapturedAt,
+    ProviderDataRequestStatus LifecycleStatus,
+    string NormalizedPayload,
+    IBDataLineage Lineage);
+
+/// <summary>Bounded filter for durable IB materialized results.</summary>
+public sealed record IBDataResultQuery(
+    string? Capability = null,
+    string? RequestIdentity = null,
+    string? Symbol = null,
+    string? AccountId = null,
+    DateTimeOffset? CapturedFrom = null,
+    DateTimeOffset? CapturedTo = null,
+    int Limit = 500);
+
+/// <summary>Durable read/write seam for materialized IB observations and snapshots.</summary>
+public interface IIBDataResultStore
+{
+    ValueTask UpsertAsync(IBDataResult result, CancellationToken cancellationToken = default);
+    ValueTask<IReadOnlyList<IBDataResult>> QueryAsync(IBDataResultQuery query, CancellationToken cancellationToken = default);
+}
 
 /// <summary>Shared read-model seam for rich provider data requested by an operator workflow.</summary>
 public interface IProviderDataReadService

--- a/src/Meridian.ProviderSdk/README.md
+++ b/src/Meridian.ProviderSdk/README.md
@@ -58,7 +58,9 @@ read-oriented by default; write/posting support must be exposed explicitly by pr
 before any service or client can offer export actions.
 `IProviderDataReadService` owns vendor-neutral, request-correlated read models for option discovery,
 scanner rows, real-time bars, historical ticks, account/model-account P&L, and market-rule increments;
-operator surfaces consume this seam rather than vendor callback types.
+operator surfaces consume this seam rather than vendor callback types. `IIBDataResultStore` is the
+storage-facing companion seam: every materialized IB snapshot carries normalized payload, stable
+request/subscription identity, lifecycle state, capture time, and complete `IBDataLineage` evidence.
 
 ## Diagrams
 

--- a/src/Meridian.Storage/Store/JsonFileIBDataResultStore.cs
+++ b/src/Meridian.Storage/Store/JsonFileIBDataResultStore.cs
@@ -1,0 +1,71 @@
+using System.Text.Json;
+using Meridian.ProviderSdk;
+using Meridian.Storage.Archival;
+
+namespace Meridian.Storage.Store;
+
+public sealed record IBDataResultStoreOptions
+{
+    public required string DataRoot { get; init; }
+}
+
+/// <summary>
+/// Crash-safe IB result store. Each upsert replaces one complete atomic snapshot, so an interrupted
+/// write leaves either the previous valid result set or the new valid result set available at restart.
+/// </summary>
+public sealed class JsonFileIBDataResultStore : IIBDataResultStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web) { WriteIndented = false };
+    private readonly string _path;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public JsonFileIBDataResultStore(IBDataResultStoreOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.DataRoot);
+        _path = Path.Combine(options.DataRoot, "provider-results", "interactive-brokers", "results.json");
+    }
+
+    public async ValueTask UpsertAsync(IBDataResult result, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        ArgumentException.ThrowIfNullOrWhiteSpace(result.ResultIdentity);
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var values = await ReadUnsafeAsync(cancellationToken).ConfigureAwait(false);
+            values[result.ResultIdentity] = result;
+            var ordered = values.Values.OrderBy(x => x.CapturedAt).ThenBy(x => x.ResultIdentity, StringComparer.Ordinal).ToArray();
+            await AtomicFileWriter.WriteAsync(_path, JsonSerializer.Serialize(ordered, JsonOptions), cancellationToken).ConfigureAwait(false);
+        }
+        finally { _gate.Release(); }
+    }
+
+    public async ValueTask<IReadOnlyList<IBDataResult>> QueryAsync(IBDataResultQuery query, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        if (query.Limit < 1) throw new ArgumentOutOfRangeException(nameof(query), "Limit must be positive.");
+        if (query.CapturedFrom > query.CapturedTo) throw new ArgumentException("CapturedFrom must not be after CapturedTo.", nameof(query));
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return (await ReadUnsafeAsync(cancellationToken).ConfigureAwait(false)).Values
+                .Where(x => query.Capability is null || string.Equals(x.Capability, query.Capability, StringComparison.OrdinalIgnoreCase))
+                .Where(x => query.RequestIdentity is null || string.Equals(x.RequestIdentity, query.RequestIdentity, StringComparison.Ordinal))
+                .Where(x => query.Symbol is null || string.Equals(x.Symbol, query.Symbol, StringComparison.OrdinalIgnoreCase))
+                .Where(x => query.AccountId is null || string.Equals(x.AccountId, query.AccountId, StringComparison.OrdinalIgnoreCase))
+                .Where(x => !query.CapturedFrom.HasValue || x.CapturedAt >= query.CapturedFrom)
+                .Where(x => !query.CapturedTo.HasValue || x.CapturedAt <= query.CapturedTo)
+                .OrderBy(x => x.CapturedAt).ThenBy(x => x.ResultIdentity, StringComparer.Ordinal).Take(query.Limit).ToArray();
+        }
+        finally { _gate.Release(); }
+    }
+
+    private async Task<Dictionary<string, IBDataResult>> ReadUnsafeAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_path)) return new(StringComparer.Ordinal);
+        await using var stream = new FileStream(_path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, FileOptions.Asynchronous | FileOptions.SequentialScan);
+        var values = await JsonSerializer.DeserializeAsync<IBDataResult[]>(stream, JsonOptions, cancellationToken).ConfigureAwait(false) ?? [];
+        return values.ToDictionary(x => x.ResultIdentity, StringComparer.Ordinal);
+    }
+}

--- a/tests/Meridian.Tests/Infrastructure/Providers/IBDataServicesTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/IBDataServicesTests.cs
@@ -2,11 +2,42 @@ using FluentAssertions;
 using Meridian.Contracts.Configuration;
 using Meridian.Infrastructure.Adapters.InteractiveBrokers;
 using Meridian.ProviderSdk;
+using Meridian.Storage.Store;
 
 namespace Meridian.Tests.Infrastructure.Providers;
 
 public sealed class IBDataServicesTests
 {
+    [Fact]
+    public async Task Materializer_PersistsAnUpdateBeforePublishingItToOperatorReaders()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "meridian-ib-materializer", Guid.NewGuid().ToString("N"));
+        try
+        {
+            using var services = new IBDataServices(new RecordingTransport());
+            var store = new JsonFileIBDataResultStore(new IBDataResultStoreOptions { DataRoot = root });
+            var materializer = new IBDataResultMaterializer(services, store);
+            using var cts = new CancellationTokenSource();
+            var worker = materializer.MaterializeAsync(cts.Token);
+            await Task.Delay(25);
+
+            var requestId = services.RequestScanner(new IBScannerRequest("STK", "STK.US.MAJOR", "TOP_PERC_GAIN"));
+            await using var enumerator = materializer.WatchAsync(cts.Token).GetAsyncEnumerator();
+            (await enumerator.MoveNextAsync()).Should().BeTrue();
+
+            var persisted = await store.QueryAsync(new IBDataResultQuery(RequestIdentity: requestId.ToString(), Limit: 1));
+            persisted.Should().ContainSingle();
+            persisted[0].Lineage.RequestId.Should().Be(requestId);
+            persisted[0].NormalizedPayload.Should().Contain("interactive-brokers");
+            cts.Cancel();
+            await worker.ContinueWith(_ => { });
+        }
+        finally
+        {
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+
     [Fact]
     public void RequestContractDetails_TracksExchangeAndMarketRuleLineage()
     {

--- a/tests/Meridian.Tests/Storage/JsonFileIBDataResultStoreTests.cs
+++ b/tests/Meridian.Tests/Storage/JsonFileIBDataResultStoreTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using Meridian.ProviderSdk;
+using Meridian.Storage.Store;
+
+namespace Meridian.Tests.Storage;
+
+public sealed class JsonFileIBDataResultStoreTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "meridian-ib-results", Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public async Task UpsertAndRestart_RetainsCompleteLineageAndUsesStableOrdering()
+    {
+        var store = new JsonFileIBDataResultStore(new IBDataResultStoreOptions { DataRoot = _root });
+        await store.UpsertAsync(Result("two", 2, "MSFT", DateTimeOffset.UnixEpoch.AddMinutes(2)));
+        await store.UpsertAsync(Result("one", 1, "AAPL", DateTimeOffset.UnixEpoch.AddMinutes(1)));
+        await store.UpsertAsync(Result("one", 1, "AAPL", DateTimeOffset.UnixEpoch.AddMinutes(3), status: ProviderDataRequestStatus.Completed));
+
+        var restarted = new JsonFileIBDataResultStore(new IBDataResultStoreOptions { DataRoot = _root });
+        var values = await restarted.QueryAsync(new IBDataResultQuery(Capability: "scanner", CapturedFrom: DateTimeOffset.UnixEpoch, Limit: 10));
+
+        values.Select(x => x.ResultIdentity).Should().Equal("two", "one");
+        values.Should().HaveCount(2);
+        values.Last().LifecycleStatus.Should().Be(ProviderDataRequestStatus.Completed);
+        values.Last().Lineage.Should().Be(Result("one", 1, "AAPL", DateTimeOffset.UnixEpoch).Lineage);
+        values.Last().NormalizedPayload.Should().Be("{\"kind\":\"scanner\"}");
+    }
+
+    [Fact]
+    public async Task Query_BoundsByRequestSymbolAccountAndTime()
+    {
+        var store = new JsonFileIBDataResultStore(new IBDataResultStoreOptions { DataRoot = _root });
+        await store.UpsertAsync(Result("a", 1, "AAPL", DateTimeOffset.UnixEpoch, account: "DU1"));
+        await store.UpsertAsync(Result("b", 2, "MSFT", DateTimeOffset.UnixEpoch.AddMinutes(1), account: "DU2"));
+
+        var values = await store.QueryAsync(new IBDataResultQuery(RequestIdentity: "2", Symbol: "MSFT", AccountId: "DU2", CapturedFrom: DateTimeOffset.UnixEpoch.AddSeconds(30), Limit: 1));
+
+        values.Should().ContainSingle().Which.ResultIdentity.Should().Be("b");
+    }
+
+    private static IBDataResult Result(string identity, int requestId, string symbol, DateTimeOffset capturedAt, string? account = null, ProviderDataRequestStatus status = ProviderDataRequestStatus.Streaming)
+    {
+        var lineage = new IBDataLineage(requestId, "scanner", symbol, "NASDAQ", "26", "0.01", "TOP", IBMarketDataAvailability.Delayed, true, "streaming", DateTimeOffset.UnixEpoch);
+        return new IBDataResult(identity, "interactive-brokers", "scanner", requestId.ToString(), "TOP", symbol, account, capturedAt, status, "{\"kind\":\"scanner\"}", lineage);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a storage-facing materialization contract so persisted IB observations include normalized payload, stable request/subscription identity, capture timestamp, lifecycle status, and the full `IBDataLineage` instead of only a request id.
- Ensure updates from the IB composition boundary are durably persisted before being published to operator readers, supporting restart recovery and idempotent append/upsert semantics.

### Description
- Added `IBMarketDataAvailability`, `IBDataLineage`, `IBDataResult`, `IBDataResultQuery`, and the `IIBDataResultStore` seam to `src/Meridian.ProviderSdk/IProviderDataReadService.cs` and extended `ProviderDataRequestReadModel` with a `Lineage` field.
- Updated `IBDataServices` (`src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDataServices.cs`) to attach and retain complete lineage on initial request projections and to propagate lineage changes into the published read model.
- Implemented a crash-safe JSON-backed result store `JsonFileIBDataResultStore` at `src/Meridian.Storage/Store/JsonFileIBDataResultStore.cs` using the repository `AtomicFileWriter`, supporting idempotent upserts, bounded queries by capability/request/symbol/account/time, stable ordering, and restart recovery.
- Introduced `IBDataResultMaterializer` at `src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDataResultMaterializer.cs` which consumes `WatchAsync`, persists each update to `IIBDataResultStore` before publishing to operator readers.
- Added tests: `tests/Meridian.Tests/Storage/JsonFileIBDataResultStoreTests.cs` (upsert/restart, ordering, query bounds) and extended `tests/Meridian.Tests/Infrastructure/Providers/IBDataServicesTests.cs` with a materializer persistence test; updated README notes in `src/Meridian.ProviderSdk/README.md` and `src/Meridian.Infrastructure/README.md`.

### Testing
- `git diff --cached --check` passed locally.
- Attempted `dotnet test` filtered to `IBDataServicesTests` and `JsonFileIBDataResultStoreTests`, but the environment lacks the `dotnet` executable so tests could not be executed here.
- `bash scripts/ci.sh` could not be run for the same reason; CI/GitHub Actions remains the authoritative test run and must be used to validate the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6122c084a08320a5e426b6d31a8dfe)