### PR TITLE
Add provenance-aware provider trading calendar contract and split local operational calendar

### DIFF
--- a/src/Meridian.Contracts/README.md
+++ b/src/Meridian.Contracts/README.md
@@ -61,8 +61,8 @@ or provider implementations.
 - `FundStructure/` - fund-structure command, query, DTO, ownership lifecycle, and graph-validation payloads.
 - `Plaid/` - Plaid provider, account-link, transaction, investment, identity, webhook, and transfer DTOs.
 - `Services/` - cross-module service contracts such as backtest preflight and Security Master
-  validation gates, fund-structure graph/query orchestration, operational scheduling/trading
-  calendar coordination, plus Environment Design draft/publish/runtime projection contracts that
+  validation gates, fund-structure graph/query orchestration, operational scheduling/deterministic local trading-calendar
+  coordination, plus Environment Design draft/publish/runtime projection contracts that
   must be injectable without depending on Application implementation types.
 - `Etl/` - shared ETL DTOs, the job-definition store contract, and the SFTP publisher port used by
   Application orchestration, Data Integration ETL services, Infrastructure adapters, and
@@ -732,8 +732,9 @@ Application-layer dependencies. Runtime pipeline statistics live in `Pipeline/` 
 `PipelineStatistics` contract-owned so Platform backpressure alerting can observe Application
 pipeline state without referencing Application implementation assemblies.
 Operational scheduler contracts live in `Services/`. Keep `IOperationalScheduler`,
-`ITradingCalendarProvider`, operation types, resource requirements, scheduling decisions, slots,
-trading sessions, and maintenance-window records contract-owned so scheduling behavior can be
+`IOperationalTradingCalendar` (plus the obsolete `ITradingCalendarProvider` compatibility alias),
+operation types, resource requirements, scheduling decisions, slots, trading sessions, and
+maintenance-window records contract-owned so deterministic local scheduling behavior can be
 implemented in Platform while tests, future hosts, and operator surfaces consume the same
 scheduler shape.
 Evidence Vault identities also expose retained artifact metadata, grouped request lists, and

--- a/src/Meridian.Contracts/Services/IOperationalScheduler.cs
+++ b/src/Meridian.Contracts/Services/IOperationalScheduler.cs
@@ -207,9 +207,10 @@ public interface IOperationalScheduler
 }
 
 /// <summary>
-/// Provides trading calendar information.
+/// Provides the deterministic trading-calendar policy used by local operational scheduling.
+/// This is intentionally separate from provider-supplied calendar data.
 /// </summary>
-public interface ITradingCalendarProvider
+public interface IOperationalTradingCalendar
 {
     /// <summary>
     /// Checks if a specific date is a trading day.
@@ -242,4 +243,16 @@ public interface ITradingCalendarProvider
     /// <param name="market">Market to check.</param>
     /// <returns>List of holiday dates.</returns>
     IReadOnlyList<DateOnly> GetHolidays(int year, string market = "US");
+}
+
+
+/// <summary>
+/// Compatibility alias for the former local scheduling calendar contract.
+/// New local scheduling code must use <see cref="IOperationalTradingCalendar"/>; provider
+/// adapters must use <c>Meridian.ProviderSdk.ITradingCalendarProvider</c> so their calendar
+/// output retains provider provenance.
+/// </summary>
+[Obsolete("Use IOperationalTradingCalendar for local scheduling or Meridian.ProviderSdk.ITradingCalendarProvider for provider data.")]
+public interface ITradingCalendarProvider : IOperationalTradingCalendar
+{
 }

--- a/src/Meridian.Platform/README.md
+++ b/src/Meridian.Platform/README.md
@@ -67,7 +67,7 @@ This module belongs to the Design Module layer. Keep changes within that ownersh
 - `Scheduling/OperationalScheduler.cs` - trading-hours-aware runtime scheduling policy for
   maintenance, backfill, reporting, health, credential refresh, and other operational work.
 - `Scheduling/TradingCalendar.cs` - US-market trading-day, holiday, half-day, session-status, and
-  `ITradingCalendarProvider` implementation used by runtime scheduling and calendar endpoints.
+  deterministic `IOperationalTradingCalendar` implementation used by runtime scheduling and calendar endpoints; provider-supplied calendar data uses the ProviderSdk contract.
 - `Tracing/EventTraceContext.cs` - cross-thread activity context capture used by the Application
   event pipeline to preserve trace parent/correlation IDs across queued market events.
 - `Tracing/OpenTelemetrySetup.cs` - host OpenTelemetry setup, exporter configuration, and

--- a/src/Meridian.Platform/Scheduling/OperationalScheduler.cs
+++ b/src/Meridian.Platform/Scheduling/OperationalScheduler.cs
@@ -10,7 +10,7 @@ namespace Meridian.Platform.Scheduling;
 /// </summary>
 public sealed class OperationalScheduler : IOperationalScheduler
 {
-    private readonly ITradingCalendarProvider _calendarProvider;
+    private readonly IOperationalTradingCalendar _calendarProvider;
     private readonly List<MaintenanceWindow> _maintenanceWindows = new();
     private readonly object _windowLock = new();
 
@@ -54,7 +54,7 @@ public sealed class OperationalScheduler : IOperationalScheduler
             Priority: 5)
     };
 
-    public OperationalScheduler(ITradingCalendarProvider calendarProvider)
+    public OperationalScheduler(IOperationalTradingCalendar calendarProvider)
     {
         _calendarProvider = calendarProvider ?? throw new ArgumentNullException(nameof(calendarProvider));
     }

--- a/src/Meridian.Platform/Scheduling/TradingCalendar.cs
+++ b/src/Meridian.Platform/Scheduling/TradingCalendar.cs
@@ -9,7 +9,7 @@ namespace Meridian.Platform.Scheduling;
 /// - Regular, pre-market, and after-hours session times
 /// - Timezone-aware market status queries
 /// </summary>
-public sealed class TradingCalendar : ITradingCalendarProvider
+public sealed class TradingCalendar : IOperationalTradingCalendar, ITradingCalendarProvider
 {
     private readonly TimeZoneInfo _easternTimeZone;
 

--- a/src/Meridian.ProviderSdk/ITradingCalendarProvider.cs
+++ b/src/Meridian.ProviderSdk/ITradingCalendarProvider.cs
@@ -1,0 +1,93 @@
+using Meridian.Contracts.Operations;
+using Meridian.Infrastructure.Adapters.Core;
+
+namespace Meridian.ProviderSdk;
+
+/// <summary>
+/// Provider-facing source of exchange trading-calendar data. Implementations return data with
+/// retained provider provenance; this contract is not the deterministic local scheduling calendar.
+/// </summary>
+public interface ITradingCalendarProvider : IProviderMetadata
+{
+    /// <summary>
+    /// Retrieves provider-supplied sessions and closures for the requested market and date range.
+    /// </summary>
+    Task<ProviderTradingCalendarResponse> GetTradingCalendarAsync(
+        ProviderTradingCalendarRequest request,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Specifies the market and inclusive date range requested from a calendar provider.
+/// </summary>
+public sealed record ProviderTradingCalendarRequest(
+    string Market,
+    DateOnly StartDate,
+    DateOnly EndDate)
+{
+    /// <summary>Validates that the request has a market and an ordered range.</summary>
+    public void EnsureValid()
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(Market);
+        if (EndDate < StartDate)
+            throw new ArgumentOutOfRangeException(nameof(EndDate), "The end date must not precede the start date.");
+    }
+}
+
+/// <summary>
+/// A session supplied by a calendar provider.
+/// </summary>
+public sealed record ProviderTradingSession(
+    string Exchange,
+    string Market,
+    string SessionType,
+    DateTimeOffset OpenTime,
+    DateTimeOffset CloseTime);
+
+/// <summary>
+/// A provider-supplied full-day or partial-day market closure.
+/// </summary>
+public sealed record ProviderTradingCalendarClosure(
+    DateOnly Date,
+    string Market,
+    string Reason,
+    bool IsEarlyClose = false);
+
+/// <summary>
+/// Required provenance for provider calendar output. <see cref="DataProvenance"/> carries the
+/// shared real/simulated/seeded/sample classification used throughout Meridian.
+/// </summary>
+public sealed record ProviderCalendarProvenance(
+    string ProviderId,
+    string SourceReference,
+    DateTimeOffset RetrievedAtUtc,
+    DateTimeOffset? SourceAsOfUtc,
+    DataProvenance DataProvenance)
+{
+    /// <summary>Throws when provider output cannot be traced to its source and observation time.</summary>
+    public void EnsureComplete()
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(ProviderId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(SourceReference);
+        if (RetrievedAtUtc == default)
+            throw new ArgumentOutOfRangeException(nameof(RetrievedAtUtc), "Provider output must include its retrieval time.");
+        if (!Enum.IsDefined(DataProvenance))
+            throw new ArgumentOutOfRangeException(nameof(DataProvenance), "Provider output must include a recognized data provenance.");
+    }
+}
+
+/// <summary>
+/// Provider calendar output and its required provenance envelope.
+/// </summary>
+public sealed record ProviderTradingCalendarResponse(
+    IReadOnlyList<ProviderTradingSession> Sessions,
+    IReadOnlyList<ProviderTradingCalendarClosure> Closures,
+    ProviderCalendarProvenance Provenance)
+{
+    /// <summary>Throws when the provider output omits required shared provenance.</summary>
+    public void EnsureProvenanceComplete()
+    {
+        ArgumentNullException.ThrowIfNull(Provenance);
+        Provenance.EnsureComplete();
+    }
+}

--- a/src/Meridian.ProviderSdk/ProviderRoutingModels.cs
+++ b/src/Meridian.ProviderSdk/ProviderRoutingModels.cs
@@ -24,7 +24,10 @@ public enum ProviderCapabilityKind : byte
     CashTransactions = 13,
     BankStatements = 14,
     ReconciliationFeed = 15,
-    FactorSchedule = 16
+    FactorSchedule = 16,
+
+    /// <summary>Provider-supplied exchange sessions, closures, and early-close calendar data.</summary>
+    TradingCalendar = 17
 }
 
 /// <summary>

--- a/src/Meridian.ProviderSdk/README.md
+++ b/src/Meridian.ProviderSdk/README.md
@@ -14,7 +14,7 @@ last_reviewed: 2026-07-15
 ## Purpose
 
 ProviderSdk defines provider-facing abstractions for streaming, historical, symbol-search, backfill
-job descriptors, dynamic provider plugin discovery, and accounting-system integrations.
+job descriptors, dynamic provider plugin discovery, accounting-system integrations, and provenance-complete provider trading-calendar data.
 
 ## Layer responsibility
 
@@ -45,6 +45,7 @@ conversion helpers.
 `PluginLoaderService` owns non-recursive provider plugin assembly scanning and registration against
 `DataSourceRegistry` under the `Meridian.ProviderSdk` namespace; WPF and host composition consume that ProviderSdk-owned loader rather than
 keeping reflection-based provider discovery in Application.
+Provider trading-calendar output is requested through `ITradingCalendarProvider` and must include `ProviderCalendarProvenance`, including the shared `DataProvenance` classification, provider identifier, source reference, and retrieval time. Local `IOperationalTradingCalendar` policy remains deterministic and is not a provider adapter.
 Provider routing capabilities are contract-level workflow gates; `FactorSchedule` is distinct from
 generic `CorporateActions` so accounting workflows can degrade fixed-income, structured-credit,
 amortization, and paydown evidence when a provider cannot route the required factor/coupon feed.

--- a/tests/Meridian.Tests/Application/Services/OperationalSchedulerTests.cs
+++ b/tests/Meridian.Tests/Application/Services/OperationalSchedulerTests.cs
@@ -8,13 +8,25 @@ namespace Meridian.Tests.Application.Services;
 
 public sealed class OperationalSchedulerTests
 {
-    private readonly Mock<ITradingCalendarProvider> _calendarMock;
+    private readonly Mock<IOperationalTradingCalendar> _calendarMock;
     private readonly OperationalScheduler _scheduler;
 
     public OperationalSchedulerTests()
     {
-        _calendarMock = new Mock<ITradingCalendarProvider>();
+        _calendarMock = new Mock<IOperationalTradingCalendar>();
         _scheduler = new OperationalScheduler(_calendarMock.Object);
+    }
+
+
+    [Fact]
+    public void Constructor_AcceptsTheDeterministicLocalTradingCalendar()
+    {
+        IOperationalTradingCalendar localCalendar = new TradingCalendar();
+
+        var scheduler = new OperationalScheduler(localCalendar);
+
+        scheduler.Should().NotBeNull();
+        localCalendar.IsTradingDay(new DateOnly(2024, 7, 4)).Should().BeFalse();
     }
 
     [Fact]

--- a/tests/Meridian.Tests/Application/Services/ProviderTradingCalendarContractsTests.cs
+++ b/tests/Meridian.Tests/Application/Services/ProviderTradingCalendarContractsTests.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using Meridian.Contracts.Operations;
+using Meridian.ProviderSdk;
+using Xunit;
+
+namespace Meridian.Tests.Application.Services;
+
+public sealed class ProviderTradingCalendarContractsTests
+{
+    [Fact]
+    public void ProviderCalendarResponse_AcceptsCompleteSharedProvenance()
+    {
+        var response = new ProviderTradingCalendarResponse(
+            Sessions:
+            [
+                new ProviderTradingSession(
+                    "NYSE",
+                    "US",
+                    "Regular",
+                    new DateTimeOffset(2026, 7, 2, 13, 30, 0, TimeSpan.Zero),
+                    new DateTimeOffset(2026, 7, 2, 20, 0, 0, TimeSpan.Zero))
+            ],
+            Closures: [],
+            Provenance: new ProviderCalendarProvenance(
+                ProviderId: "calendar-vendor",
+                SourceReference: "calendar-vendor/us/2026-07-02",
+                RetrievedAtUtc: new DateTimeOffset(2026, 7, 1, 12, 0, 0, TimeSpan.Zero),
+                SourceAsOfUtc: new DateTimeOffset(2026, 7, 1, 0, 0, 0, TimeSpan.Zero),
+                DataProvenance: DataProvenance.Real));
+
+        response.EnsureProvenanceComplete();
+        response.Provenance.DataProvenance.Should().Be(DataProvenance.Real);
+        ProviderCapabilityKind.TradingCalendar.Should().Be((ProviderCapabilityKind)17);
+    }
+
+    [Fact]
+    public void ProviderCalendarResponse_RejectsIncompleteProvenance()
+    {
+        var response = new ProviderTradingCalendarResponse(
+            Sessions: [],
+            Closures: [],
+            Provenance: new ProviderCalendarProvenance(
+                ProviderId: "calendar-vendor",
+                SourceReference: "",
+                RetrievedAtUtc: default,
+                SourceAsOfUtc: null,
+                DataProvenance: DataProvenance.Real));
+
+        var action = response.EnsureProvenanceComplete;
+
+        action.Should().Throw<ArgumentException>();
+    }
+}


### PR DESCRIPTION
### Motivation
- Preserve deterministic local scheduling behavior while enabling providers to supply calendar data that includes required provenance for downstream trust and auditing.
- Make provider calendar outputs provenance-complete so provider-supplied sessions/closures can be validated and routed by `ProviderCapabilityKind`.

### Description
- Add a provider-facing `ITradingCalendarProvider` in `src/Meridian.ProviderSdk` with request/response models (`ProviderTradingCalendarRequest`, `ProviderTradingSession`, `ProviderTradingCalendarClosure`, `ProviderTradingCalendarResponse`) and a `ProviderCalendarProvenance` envelope that enforces `DataProvenance`, provider id, source reference, and retrieval time via `EnsureProvenanceComplete`.
- Register `ProviderCapabilityKind.TradingCalendar` in `src/Meridian.ProviderSdk/ProviderRoutingModels.cs` so trading-calendar is a routable provider capability.
- Introduce a deterministic local scheduling abstraction `IOperationalTradingCalendar` in `src/Meridian.Contracts/Services/IOperationalScheduler.cs` and keep the previous `ITradingCalendarProvider` name as an `[Obsolete]` compatibility alias that inherits `IOperationalTradingCalendar`.
- Update `TradingCalendar` to implement both `IOperationalTradingCalendar` (local policy) and `ITradingCalendarProvider` (compatibility), and change `OperationalScheduler` to depend on `IOperationalTradingCalendar` so local scheduling remains deterministic.
- Add tests: `ProviderTradingCalendarContractsTests` (provenance-complete and incomplete cases) and a constructor test in `OperationalSchedulerTests` validating the local `TradingCalendar` can be used by `OperationalScheduler`, and update related README entries to document the separation.

### Testing
- Ran `git diff --check` and code-style checks locally (passed).
- Attempted `dotnet test` for the focused tests (`FullyQualifiedName~OperationalSchedulerTests|FullyQualifiedName~ProviderTradingCalendarContractsTests`) but the environment lacked `dotnet` so the tests were not executed here (not run: `dotnet: command not found`).
- Ran `bash scripts/ci.sh` which is blocked in this environment at the .NET SDK verification step (`dotnet: command not found`).
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary` which reported existing repository documentation hash drift (36 entries including touched modules); this is repository baseline noise and not caused by these changes alone.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6122b375948320aaff109f905b8b26)