### PR TITLE
Add shared provider data projections

### DIFF
--- a/src/Meridian.Contracts/Api/UiApiRoutes.cs
+++ b/src/Meridian.Contracts/Api/UiApiRoutes.cs
@@ -79,6 +79,7 @@ public static class UiApiRoutes
     public const string BackfillProviderConfigAudit = "/api/backfill/providers/audit";
 
     // Provider endpoints
+    public const string ProviderDataProjection = "/api/providers/data-projection";
     public const string ProviderComparison = "/api/providers/comparison";
     public const string ProviderStatus = "/api/providers/status";
     public const string ProviderMetrics = "/api/providers/metrics";

--- a/src/Meridian.ProviderSdk/IProviderDataReadService.cs
+++ b/src/Meridian.ProviderSdk/IProviderDataReadService.cs
@@ -77,3 +77,67 @@ public interface IProviderDataReadService
 
     IAsyncEnumerable<ProviderDataRequestReadModel> WatchAsync(CancellationToken cancellationToken = default);
 }
+
+/// <summary>Presentation-safe provider news item supplied by providers that support news.</summary>
+public sealed record ProviderNewsItem(
+    string NewsId,
+    string Headline,
+    DateTimeOffset PublishedAt,
+    string? Symbol = null,
+    string? Source = null,
+    string? Url = null);
+
+/// <summary>Presentation-safe trading-calendar event supplied by providers that support calendars.</summary>
+public sealed record ProviderCalendarEvent(
+    string EventId,
+    string Market,
+    DateTimeOffset StartsAt,
+    DateTimeOffset EndsAt,
+    string EventType,
+    string? Description = null);
+
+/// <summary>Presentation-safe instrument discovery result supplied by providers that support search.</summary>
+public sealed record ProviderInstrumentDiscoveryResult(
+    string InstrumentId,
+    string Symbol,
+    string DisplayName,
+    string? Exchange = null,
+    string? AssetClass = null);
+
+/// <summary>
+/// Provider availability and entitlement evidence. Implement this optional interface instead of
+/// leaking adapter connection objects into workstation projections.
+/// </summary>
+public sealed record ProviderDataAvailability(
+    string ProviderFamily,
+    bool IsAvailable,
+    string ConnectionState,
+    DateTimeOffset ObservedAt,
+    string? Entitlement = null,
+    string? Detail = null);
+
+public interface IProviderDataAvailabilityReadService
+{
+    IReadOnlyList<ProviderDataAvailability> GetAvailability();
+}
+
+public interface IProviderNewsReadService
+{
+    string ProviderFamily { get; }
+    IReadOnlyList<ProviderNewsItem> GetNews();
+    IAsyncEnumerable<ProviderNewsItem> WatchNewsAsync(CancellationToken cancellationToken = default);
+}
+
+public interface IProviderCalendarReadService
+{
+    string ProviderFamily { get; }
+    IReadOnlyList<ProviderCalendarEvent> GetCalendarEvents();
+    IAsyncEnumerable<ProviderCalendarEvent> WatchCalendarEventsAsync(CancellationToken cancellationToken = default);
+}
+
+public interface IProviderInstrumentDiscoveryReadService
+{
+    string ProviderFamily { get; }
+    IReadOnlyList<ProviderInstrumentDiscoveryResult> GetInstruments();
+    IAsyncEnumerable<ProviderInstrumentDiscoveryResult> WatchInstrumentsAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Meridian.Ui.Shared/Endpoints/ProviderDataProjectionEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/ProviderDataProjectionEndpoints.cs
@@ -1,0 +1,24 @@
+using System.Text.Json;
+using Meridian.Contracts.Api;
+using Meridian.Ui.Shared.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Meridian.Ui.Shared.Endpoints;
+
+/// <summary>Exposes one provider-neutral projection for every workstation client.</summary>
+public static class ProviderDataProjectionEndpoints
+{
+    public static void MapProviderDataProjectionEndpoints(this WebApplication app, JsonSerializerOptions jsonOptions)
+    {
+        app.MapGet(UiApiRoutes.ProviderDataProjection, ([FromServices] ProviderDataReadModelService service) =>
+            Results.Json(CreateProjection(service), jsonOptions))
+            .WithName("GetProviderDataProjection")
+            .WithTags("Providers")
+            .Produces<ProviderDataProjectionSnapshot>(StatusCodes.Status200OK);
+    }
+
+    public static ProviderDataProjectionSnapshot CreateProjection(ProviderDataReadModelService service) =>
+        (service ?? throw new ArgumentNullException(nameof(service))).GetProjection();
+}

--- a/src/Meridian.Ui.Shared/Endpoints/UiEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/UiEndpoints.cs
@@ -158,6 +158,7 @@ public static class UiEndpoints
         app.MapMessagingEndpoints(jsonOptions);
         app.MapOmsIntegrationEndpoints(jsonOptions);
         app.MapProviderExtendedEndpoints(jsonOptions);
+        app.MapProviderDataProjectionEndpoints(jsonOptions);
         app.MapProviderModuleEndpoints(jsonOptions);
         app.MapIndexEndpoints(jsonOptions);
 

--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -44,8 +44,7 @@ compatibility across `src/Meridian.Ui.Services`, `src/Meridian.Ui/dashboard`, an
 
 ## Important workflows
 
-`ProviderDataReadModelService` projects `IProviderDataReadService` records for both workstation
-lanes, keeping provider option/scanner/bar/tick/P&L/market-rule data outside provider-specific UI code.
+`ProviderDataReadModelService` aggregates optional provider read interfaces into one typed, live-updating projection for both workstation lanes. Each news, scanner, P&L, calendar, market-rule, and instrument row retains a stable provenance key plus provider connection and entitlement evidence, keeping adapter-specific state outside UI code.
 
 The lifecycle control plane publishes unauthenticated, sanitized `/livez`, `/readyz`, `/startupz`,
 and `/startup` surfaces for local process supervision and pre-login progress. Authenticated browser

--- a/src/Meridian.Ui.Shared/Services/ProviderDataReadModelService.cs
+++ b/src/Meridian.Ui.Shared/Services/ProviderDataReadModelService.cs
@@ -1,23 +1,137 @@
+using System.Threading.Channels;
 using Meridian.ProviderSdk;
 
 namespace Meridian.Ui.Shared.Services;
 
+/// <summary>Stable source identity for an operator-visible provider datum.</summary>
+public sealed record ProviderProjectionProvenance(
+    string Key,
+    string ProviderFamily,
+    int RequestId,
+    string Capability,
+    DateTimeOffset ObservedAt);
+
+/// <summary>Connection and entitlement evidence retained alongside every projection row.</summary>
+public sealed record ProviderProjectionAvailability(
+    bool IsAvailable,
+    string ConnectionState,
+    string? Entitlement,
+    string? Detail);
+
+public sealed record ProviderNewsReadModel(ProviderProjectionProvenance Provenance, ProviderProjectionAvailability Availability, ProviderNewsItem Item);
+public sealed record ProviderScannerReadModel(ProviderProjectionProvenance Provenance, ProviderProjectionAvailability Availability, ProviderScannerResult Item);
+public sealed record ProviderPnlReadModel(ProviderProjectionProvenance Provenance, ProviderProjectionAvailability Availability, ProviderAccountPnl Item);
+public sealed record ProviderCalendarReadModel(ProviderProjectionProvenance Provenance, ProviderProjectionAvailability Availability, ProviderCalendarEvent Item);
+public sealed record ProviderMarketRuleReadModel(ProviderProjectionProvenance Provenance, ProviderProjectionAvailability Availability, ProviderMarketRuleIncrement Item);
+public sealed record ProviderInstrumentDiscoveryReadModel(ProviderProjectionProvenance Provenance, ProviderProjectionAvailability Availability, ProviderInstrumentDiscoveryResult Item);
+
+/// <summary>Shared, typed snapshot consumed unchanged by browser endpoints and WPF view models.</summary>
+public sealed record ProviderDataProjectionSnapshot(
+    IReadOnlyList<ProviderNewsReadModel> News,
+    IReadOnlyList<ProviderScannerReadModel> ScannerResults,
+    IReadOnlyList<ProviderPnlReadModel> PnlStreams,
+    IReadOnlyList<ProviderCalendarReadModel> Calendars,
+    IReadOnlyList<ProviderMarketRuleReadModel> MarketRules,
+    IReadOnlyList<ProviderInstrumentDiscoveryReadModel> Instruments);
+
 /// <summary>
-/// Shared workstation projection seam for provider discovery, market-data, P&amp;L, and tick-rule
-/// read models. UI hosts depend only on ProviderSdk records, never on a vendor adapter.
+/// Aggregates provider-neutral read interfaces. Rows are de-duplicated by the stable provenance
+/// key (<c>provider-family/request-id/capability/item-id</c>), so repeated live snapshots replace
+/// older evidence rather than making either workstation show duplicate vendor data.
 /// </summary>
 public sealed class ProviderDataReadModelService
 {
     private readonly IReadOnlyList<IProviderDataReadService> _providers;
+    private readonly IReadOnlyList<IProviderNewsReadService> _newsProviders;
+    private readonly IReadOnlyList<IProviderCalendarReadService> _calendarProviders;
+    private readonly IReadOnlyList<IProviderInstrumentDiscoveryReadService> _instrumentProviders;
+    private readonly IReadOnlyList<IProviderDataAvailabilityReadService> _availabilityProviders;
 
-    public ProviderDataReadModelService(IEnumerable<IProviderDataReadService> providers)
+    public ProviderDataReadModelService(
+        IEnumerable<IProviderDataReadService> providers,
+        IEnumerable<IProviderNewsReadService>? newsProviders = null,
+        IEnumerable<IProviderCalendarReadService>? calendarProviders = null,
+        IEnumerable<IProviderInstrumentDiscoveryReadService>? instrumentProviders = null,
+        IEnumerable<IProviderDataAvailabilityReadService>? availabilityProviders = null)
     {
         _providers = providers?.ToArray() ?? throw new ArgumentNullException(nameof(providers));
+        _newsProviders = newsProviders?.ToArray() ?? [];
+        _calendarProviders = calendarProviders?.ToArray() ?? [];
+        _instrumentProviders = instrumentProviders?.ToArray() ?? [];
+        _availabilityProviders = availabilityProviders?.ToArray() ?? [];
     }
 
-    public IReadOnlyList<ProviderDataRequestReadModel> GetRequests()
-        => _providers.SelectMany(static provider => provider.GetRequests())
-            .OrderByDescending(static request => request.UpdatedAt)
-            .ThenBy(static request => request.RequestId)
-            .ToArray();
+    public IReadOnlyList<ProviderDataRequestReadModel> GetRequests() => _providers
+        .SelectMany(static provider => provider.GetRequests())
+        .OrderByDescending(static request => request.UpdatedAt)
+        .ThenBy(static request => request.RequestId)
+        .ToArray();
+
+    /// <summary>Emits the initial projection and a refreshed snapshot after any optional provider stream changes.</summary>
+    public async IAsyncEnumerable<ProviderDataProjectionSnapshot> WatchAsync([System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        yield return GetProjection();
+        var updates = Channel.CreateUnbounded<bool>();
+        var pumps = new List<Task>();
+        pumps.AddRange(_providers.Select(provider => Pump(provider.WatchAsync(cancellationToken), updates.Writer, cancellationToken)));
+        pumps.AddRange(_newsProviders.Select(provider => Pump(provider.WatchNewsAsync(cancellationToken), updates.Writer, cancellationToken)));
+        pumps.AddRange(_calendarProviders.Select(provider => Pump(provider.WatchCalendarEventsAsync(cancellationToken), updates.Writer, cancellationToken)));
+        pumps.AddRange(_instrumentProviders.Select(provider => Pump(provider.WatchInstrumentsAsync(cancellationToken), updates.Writer, cancellationToken)));
+        _ = Task.WhenAll(pumps).ContinueWith(_ => updates.Writer.TryComplete(), CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
+
+        await foreach (var _ in updates.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+            yield return GetProjection();
+    }
+
+    private static async Task Pump<T>(IAsyncEnumerable<T> stream, ChannelWriter<bool> updates, CancellationToken cancellationToken)
+    {
+        await foreach (var _ in stream.WithCancellation(cancellationToken).ConfigureAwait(false))
+            await updates.WriteAsync(true, cancellationToken).ConfigureAwait(false);
+    }
+
+    public ProviderDataProjectionSnapshot GetProjection()
+    {
+        var availability = _availabilityProviders.SelectMany(static provider => provider.GetAvailability())
+            .GroupBy(static item => item.ProviderFamily, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(static group => group.Key, static group => group.OrderByDescending(x => x.ObservedAt).First(), StringComparer.OrdinalIgnoreCase);
+        var requests = GetRequests();
+
+        var news = _newsProviders.SelectMany(provider => provider.GetNews().Select(item => (provider.ProviderFamily, item))).Select((entry, index) =>
+            new ProviderNewsReadModel(CreateOptionalProvenance(entry.ProviderFamily, "news", entry.item.NewsId, entry.item.PublishedAt, index), OptionalAvailability(entry.ProviderFamily, entry.item.PublishedAt, availability), entry.item));
+        var calendars = _calendarProviders.SelectMany(provider => provider.GetCalendarEvents().Select(item => (provider.ProviderFamily, item))).Select((entry, index) =>
+            new ProviderCalendarReadModel(CreateOptionalProvenance(entry.ProviderFamily, "calendar", entry.item.EventId, entry.item.StartsAt, index), OptionalAvailability(entry.ProviderFamily, entry.item.StartsAt, availability), entry.item));
+        var instruments = _instrumentProviders.SelectMany(provider => provider.GetInstruments().Select(item => (provider.ProviderFamily, item))).Select((entry, index) =>
+            new ProviderInstrumentDiscoveryReadModel(CreateOptionalProvenance(entry.ProviderFamily, "instrument-discovery", entry.item.InstrumentId, DateTimeOffset.MinValue, index), OptionalAvailability(entry.ProviderFamily, DateTimeOffset.MinValue, availability), entry.item));
+
+        return new ProviderDataProjectionSnapshot(
+            Deduplicate(news, x => x.Provenance.Key, x => x.Provenance.ObservedAt),
+            Deduplicate(requests.Where(x => x.ScannerResults is not null).SelectMany(request => request.ScannerResults!.Select((item, index) => new ProviderScannerReadModel(Provenance(request, $"scanner:{item.Symbol}:{item.Rank}:{index}"), Availability(request, availability), item))), x => x.Provenance.Key, x => x.Provenance.ObservedAt),
+            Deduplicate(requests.Where(x => x.Pnl is not null).Select(request => new ProviderPnlReadModel(Provenance(request, $"pnl:{request.Pnl!.AccountId}:{request.Pnl.ModelAccountId}"), Availability(request, availability), request.Pnl!)), x => x.Provenance.Key, x => x.Provenance.ObservedAt),
+            Deduplicate(calendars, x => x.Provenance.Key, x => x.Provenance.ObservedAt),
+            Deduplicate(requests.Where(x => x.MarketRuleIncrements is not null).SelectMany(request => request.MarketRuleIncrements!.Select((item, index) => new ProviderMarketRuleReadModel(Provenance(request, $"market-rule:{item.LowEdge}:{item.Increment}:{index}"), Availability(request, availability), item))), x => x.Provenance.Key, x => x.Provenance.ObservedAt),
+            Deduplicate(instruments, x => x.Provenance.Key, x => x.Provenance.ObservedAt));
+    }
+
+    private static IReadOnlyList<T> Deduplicate<T>(IEnumerable<T> rows, Func<T, string> key, Func<T, DateTimeOffset> observedAt) => rows
+        .GroupBy(key, StringComparer.Ordinal)
+        .Select(group => group.OrderByDescending(observedAt).First())
+        .OrderByDescending(observedAt)
+        .ThenBy(key, StringComparer.Ordinal)
+        .ToArray();
+
+    private static ProviderProjectionProvenance Provenance(ProviderDataRequestReadModel request, string itemKey) =>
+        new($"{request.ProviderFamily}/{request.RequestId}/{request.Capability}/{itemKey}", request.ProviderFamily, request.RequestId, request.Capability, request.UpdatedAt);
+
+    private static ProviderProjectionProvenance CreateOptionalProvenance(string providerFamily, string capability, string itemKey, DateTimeOffset observedAt, int index) =>
+        new($"{providerFamily}/{index}/{capability}/{itemKey}", providerFamily, index, capability, observedAt);
+
+    private static ProviderProjectionAvailability Availability(ProviderDataRequestReadModel request, IReadOnlyDictionary<string, ProviderDataAvailability> availability) =>
+        availability.TryGetValue(request.ProviderFamily, out var item)
+            ? new(item.IsAvailable, item.ConnectionState, item.Entitlement, item.Detail)
+            : new(request.Status is ProviderDataRequestStatus.Streaming or ProviderDataRequestStatus.Completed, request.Status.ToString(), null, request.ErrorMessage);
+
+    private static ProviderProjectionAvailability OptionalAvailability(string providerFamily, DateTimeOffset observedAt, IReadOnlyDictionary<string, ProviderDataAvailability> availability) =>
+        availability.TryGetValue(providerFamily, out var item)
+            ? new(item.IsAvailable, item.ConnectionState, item.Entitlement, item.Detail)
+            : new(true, "Available", null, null);
 }

--- a/src/Meridian.Wpf/Features/Data/DataFeatureModule.cs
+++ b/src/Meridian.Wpf/Features/Data/DataFeatureModule.cs
@@ -73,6 +73,8 @@ public sealed class DataFeatureModule : IDesktopFeatureModule
         services.AddTransient<DataWorkspaceShellViewModel>();
         services.AddTransient<DataWorkspaceShellPage>();
         services.AddTransient<DataCalendarService>();
+        services.TryAddSingleton<ProviderDataReadModelService>();
+        services.AddTransient<ProviderDataProjectionViewModel>();
         services.AddTransient<SecurityMasterViewModel>();
         services.AddTransient<QualityArchivePage>();
         services.AddTransient<ClusterStatusPage>();

--- a/src/Meridian.Wpf/ViewModels/ProviderDataProjectionViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/ProviderDataProjectionViewModel.cs
@@ -1,0 +1,41 @@
+using System.Collections.ObjectModel;
+using Meridian.Ui.Shared.Services;
+
+namespace Meridian.Wpf.ViewModels;
+
+/// <summary>Desktop presentation shell over the provider-neutral shared projection.</summary>
+public sealed class ProviderDataProjectionViewModel : BindableBase
+{
+    private readonly ProviderDataReadModelService _providerData;
+    private ProviderDataProjectionSnapshot? _projection;
+
+    public ProviderDataProjectionViewModel(ProviderDataReadModelService providerData)
+    {
+        _providerData = providerData ?? throw new ArgumentNullException(nameof(providerData));
+    }
+
+    public ObservableCollection<ProviderNewsReadModel> News { get; } = [];
+    public ObservableCollection<ProviderScannerReadModel> ScannerResults { get; } = [];
+    public ObservableCollection<ProviderPnlReadModel> PnlStreams { get; } = [];
+    public ObservableCollection<ProviderCalendarReadModel> Calendars { get; } = [];
+    public ObservableCollection<ProviderMarketRuleReadModel> MarketRules { get; } = [];
+    public ObservableCollection<ProviderInstrumentDiscoveryReadModel> Instruments { get; } = [];
+    public ProviderDataProjectionSnapshot? Projection { get => _projection; private set => SetProperty(ref _projection, value); }
+
+    public void Refresh()
+    {
+        Projection = _providerData.GetProjection();
+        Replace(News, Projection.News);
+        Replace(ScannerResults, Projection.ScannerResults);
+        Replace(PnlStreams, Projection.PnlStreams);
+        Replace(Calendars, Projection.Calendars);
+        Replace(MarketRules, Projection.MarketRules);
+        Replace(Instruments, Projection.Instruments);
+    }
+
+    private static void Replace<T>(ObservableCollection<T> target, IReadOnlyList<T> source)
+    {
+        target.Clear();
+        foreach (var item in source) target.Add(item);
+    }
+}

--- a/tests/Meridian.Tests/Ui/ProviderDataProjectionEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/ProviderDataProjectionEndpointsTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using Meridian.ProviderSdk;
+using Meridian.Ui.Shared.Endpoints;
+using Meridian.Ui.Shared.Services;
+using Xunit;
+
+namespace Meridian.Tests.Ui;
+
+public sealed class ProviderDataProjectionEndpointsTests
+{
+    [Fact]
+    public void CreateProjection_DeduplicatesLiveRowsAndRetainsAvailabilityAndLineage()
+    {
+        var service = new ProviderDataReadModelService(
+            [new Requests()],
+            [new News()],
+            [new Calendar()],
+            [new Instruments()],
+            [new Availability()]);
+
+        var projection = ProviderDataProjectionEndpoints.CreateProjection(service);
+
+        projection.ScannerResults.Should().ContainSingle();
+        projection.ScannerResults[0].Provenance.Key.Should().Be("ib/42/scanner/scanner:MSFT:1:0");
+        projection.ScannerResults[0].Availability.Entitlement.Should().Be("US equities");
+        projection.ScannerResults[0].Availability.ConnectionState.Should().Be("Connected");
+        projection.PnlStreams.Should().ContainSingle();
+        projection.MarketRules.Should().ContainSingle();
+        projection.News.Should().ContainSingle().Which.Provenance.ProviderFamily.Should().Be("ib");
+        projection.Calendars.Should().ContainSingle().Which.Availability.IsAvailable.Should().BeTrue();
+        projection.Instruments.Should().ContainSingle().Which.Provenance.Capability.Should().Be("instrument-discovery");
+    }
+
+    private sealed class Requests : IProviderDataReadService
+    {
+        public IReadOnlyList<ProviderDataRequestReadModel> GetRequests() =>
+        [
+            new(42, "ib", "scanner", ProviderDataRequestStatus.Streaming, new DateTimeOffset(2026, 7, 22, 10, 0, 0, TimeSpan.Zero), ScannerResults: [new(1, "MSFT", "NASDAQ", null, null, null, null, null)], Pnl: new("DU1", null, 1m, 2m, 3m), MarketRuleIncrements: [new(0m, .01m)]),
+            new(42, "ib", "scanner", ProviderDataRequestStatus.Streaming, new DateTimeOffset(2026, 7, 22, 9, 0, 0, TimeSpan.Zero), ScannerResults: [new(1, "MSFT", "NASDAQ", null, null, null, null, null)])
+        ];
+        public async IAsyncEnumerable<ProviderDataRequestReadModel> WatchAsync([System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default) { yield break; }
+    }
+    private sealed class Availability : IProviderDataAvailabilityReadService { public IReadOnlyList<ProviderDataAvailability> GetAvailability() => [new("ib", true, "Connected", DateTimeOffset.UtcNow, "US equities", "gateway healthy")]; }
+    private sealed class News : IProviderNewsReadService { public string ProviderFamily => "ib"; public IReadOnlyList<ProviderNewsItem> GetNews() => [new("n1", "Results", DateTimeOffset.UtcNow, "MSFT")]; public async IAsyncEnumerable<ProviderNewsItem> WatchNewsAsync([System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default) { yield break; } }
+    private sealed class Calendar : IProviderCalendarReadService { public string ProviderFamily => "ib"; public IReadOnlyList<ProviderCalendarEvent> GetCalendarEvents() => [new("c1", "NYSE", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddHours(1), "halt")]; public async IAsyncEnumerable<ProviderCalendarEvent> WatchCalendarEventsAsync([System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default) { yield break; } }
+    private sealed class Instruments : IProviderInstrumentDiscoveryReadService { public string ProviderFamily => "ib"; public IReadOnlyList<ProviderInstrumentDiscoveryResult> GetInstruments() => [new("i1", "MSFT", "Microsoft")]; public async IAsyncEnumerable<ProviderInstrumentDiscoveryResult> WatchInstrumentsAsync([System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default) { yield break; } }
+}

--- a/tests/Meridian.Wpf.Tests/ViewModels/ProviderDataProjectionViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/ProviderDataProjectionViewModelTests.cs
@@ -1,0 +1,32 @@
+using FluentAssertions;
+using Meridian.ProviderSdk;
+using Meridian.Ui.Shared.Services;
+using Meridian.Wpf.ViewModels;
+using Xunit;
+
+namespace Meridian.Wpf.Tests.ViewModels;
+
+public sealed class ProviderDataProjectionViewModelTests
+{
+    [Fact]
+    public void Refresh_RendersTheSharedProjectionWithoutAdapterSpecificState()
+    {
+        var service = new ProviderDataReadModelService([new Requests()], availabilityProviders: [new Availability()]);
+        var viewModel = new ProviderDataProjectionViewModel(service);
+
+        viewModel.Refresh();
+
+        viewModel.PnlStreams.Should().ContainSingle();
+        viewModel.PnlStreams[0].Provenance.Key.Should().Be("ib/7/pnl/pnl:DU123:");
+        viewModel.PnlStreams[0].Availability.Entitlement.Should().Be("real-time P&L");
+        viewModel.PnlStreams[0].Availability.ConnectionState.Should().Be("Connected");
+        viewModel.Projection!.PnlStreams.Should().BeEquivalentTo(service.GetProjection().PnlStreams);
+    }
+
+    private sealed class Requests : IProviderDataReadService
+    {
+        public IReadOnlyList<ProviderDataRequestReadModel> GetRequests() => [new(7, "ib", "pnl", ProviderDataRequestStatus.Streaming, DateTimeOffset.UtcNow, Pnl: new("DU123", null, 11m, 12m, 13m))];
+        public async IAsyncEnumerable<ProviderDataRequestReadModel> WatchAsync([System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default) { yield break; }
+    }
+    private sealed class Availability : IProviderDataAvailabilityReadService { public IReadOnlyList<ProviderDataAvailability> GetAvailability() => [new("ib", true, "Connected", DateTimeOffset.UtcNow, "real-time P&L")]; }
+}


### PR DESCRIPTION
### Motivation
- Provide a single, typed projection seam that both browser endpoints and WPF view models can consume so UI lanes do not duplicate or leak adapter-specific state.
- Aggregate optional provider surfaces (news, scanner rows, P&L streams, calendars, market rules, instrument discovery) into a stable projection with provenance and availability/evidence.
- Ensure live updates replace older evidence (stable de-duplication) and preserve provider/connection/entitlement lineage for operator visibility.

### Description
- Added optional presentation-safe provider contracts and read interfaces in `src/Meridian.ProviderSdk/IProviderDataReadService.cs` for news, calendar events, instrument discovery, and provider availability (`ProviderNewsItem`, `ProviderCalendarEvent`, `ProviderInstrumentDiscoveryResult`, `ProviderDataAvailability`, and new `IProvider*ReadService` and `IProviderDataAvailabilityReadService`).
- Replaced/extended the shared read-model service with `ProviderDataReadModelService` in `src/Meridian.Ui.Shared/Services/ProviderDataReadModelService.cs` that produces typed read models and a `ProviderDataProjectionSnapshot`; rows include `ProviderProjectionProvenance` and `ProviderProjectionAvailability`, and live updates are observed via `WatchAsync` with stable de-duplication keyed by provenance.
- Exposed the projection through a browser endpoint at `UiApiRoutes.ProviderDataProjection = "/api/providers/data-projection"` and `ProviderDataProjectionEndpoints` in `src/Meridian.Ui.Shared/Endpoints/ProviderDataProjectionEndpoints.cs` which returns the `ProviderDataProjectionSnapshot`.
- Added a WPF consumer `ProviderDataProjectionViewModel` in `src/Meridian.Wpf/ViewModels/ProviderDataProjectionViewModel.cs` that consumes `ProviderDataReadModelService` and renders the projection without adapter-specific UI state, and registered the view model/service in the Data feature DI graph (`src/Meridian.Wpf/Features/Data/DataFeatureModule.cs`).
- Added unit tests demonstrating projection parity and evidence retention: `tests/Meridian.Tests/Ui/ProviderDataProjectionEndpointsTests.cs` and `tests/Meridian.Wpf.Tests/ViewModels/ProviderDataProjectionViewModelTests.cs`.

### Testing
- Ran `git diff --cached --check` locally and the staged changes passed the pre-commit checks.
- Attempted to run the repository validation script `bash scripts/ci.sh`, but the local environment lacks the .NET SDK so the run was blocked with `dotnet: command not found` and full `dotnet` build/test could not be executed here.
- The change adds targeted tests under `tests/Meridian.Tests/Ui/` and `tests/Meridian.Wpf.Tests/` that exercise the projection creation and WPF view-model rendering; these tests were added to the branch but could not be executed locally due to the missing `dotnet` runtime (GitHub Actions remains the authoritative test runner).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6122b01c008320b2f8f7d814b460f5)