### PR TITLE
Add ProviderDataProvenance and attach provenance to provider read-models (IB adapter)

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.IBApi.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.IBApi.cs
@@ -1111,7 +1111,7 @@ public sealed partial class EnhancedIBConnectionManager : EWrapper, IDisposable
         var contract = contractDetails.Contract;
         var expiration = DateOnly.TryParse(contract.LastTradeDateOrContractMonth, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date) ? date : DateOnly.MinValue;
         if (expiration != DateOnly.MinValue && contract.Strike > 0 && !string.IsNullOrWhiteSpace(contract.Right))
-            OptionContractReceived?.Invoke(this, (reqId, new ProviderOptionContract(contract.Symbol, string.Empty, expiration, (decimal)contract.Strike, contract.Right, contract.Exchange, contract.TradingClass, contract.Multiplier, contract.ConId.ToString(CultureInfo.InvariantCulture))));
+            OptionContractReceived?.Invoke(this, (reqId, new ProviderOptionContract(contract.Symbol, string.Empty, expiration, (decimal)contract.Strike, contract.Right, contract.Exchange, contract.TradingClass, contract.Multiplier, contract.ConId.ToString(CultureInfo.InvariantCulture), ProviderDataProvenance.Unattributed(DateTimeOffset.UtcNow))));
 #endif
     }
     public void contractDetailsEnd(int reqId)

--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.IBApiVendorStubs.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.IBApiVendorStubs.cs
@@ -53,7 +53,7 @@ public sealed partial class EnhancedIBConnectionManager
     public void realtimeBar(int reqId, long date, double open, double high, double low, double close, decimal volume, decimal WAP, int count)
     {
         RecordMessageReceived();
-        RealTimeBarReceived?.Invoke(this, (reqId, new ProviderRealTimeBar(DateTimeOffset.FromUnixTimeSeconds(date), (decimal)open, (decimal)high, (decimal)low, (decimal)close, volume, WAP, count)));
+        RealTimeBarReceived?.Invoke(this, (reqId, new ProviderRealTimeBar(DateTimeOffset.FromUnixTimeSeconds(date), (decimal)open, (decimal)high, (decimal)low, (decimal)close, volume, WAP, count, ProviderDataProvenance.Unattributed(DateTimeOffset.FromUnixTimeSeconds(date)))));
     }
 
     public void scannerParameters(string xml)
@@ -64,7 +64,7 @@ public sealed partial class EnhancedIBConnectionManager
     {
         RecordMessageReceived();
         var contract = contractDetails.Contract;
-        ScannerResultReceived?.Invoke(this, (reqId, new ProviderScannerResult(rank, contract.Symbol, contract.Exchange, contract.ConId.ToString(), distance, benchmark, projection, legsStr)));
+        ScannerResultReceived?.Invoke(this, (reqId, new ProviderScannerResult(rank, contract.Symbol, contract.Exchange, contract.ConId.ToString(), distance, benchmark, projection, legsStr, ProviderDataProvenance.Unattributed(DateTimeOffset.UtcNow)));
     }
 
     public void scannerDataEnd(int reqId)
@@ -120,7 +120,7 @@ public sealed partial class EnhancedIBConnectionManager
         {
             if (!DateOnly.TryParseExact(expirationText, "yyyyMMdd", out var expiration)) continue;
             foreach (var strike in strikes)
-                OptionContractReceived?.Invoke(this, (reqId, new ProviderOptionContract(string.Empty, underlyingConId.ToString(), expiration, (decimal)strike, string.Empty, exchange, tradingClass, multiplier)));
+                OptionContractReceived?.Invoke(this, (reqId, new ProviderOptionContract(string.Empty, underlyingConId.ToString(), expiration, (decimal)strike, string.Empty, exchange, tradingClass, multiplier, null, ProviderDataProvenance.Unattributed(DateTimeOffset.UtcNow)));
         }
     }
 
@@ -166,26 +166,26 @@ public sealed partial class EnhancedIBConnectionManager
     {
         RecordMessageReceived();
         var requestId = _marketRuleRequests.TryRemove(marketRuleId, out var correlatedRequestId) ? correlatedRequestId : marketRuleId;
-        MarketRuleReceived?.Invoke(this, (requestId, priceIncrements.Select(static x => new ProviderMarketRuleIncrement((decimal)x.LowEdge, (decimal)x.Increment)).ToArray()));
+        MarketRuleReceived?.Invoke(this, (requestId, priceIncrements.Select(static x => new ProviderMarketRuleIncrement((decimal)x.LowEdge, (decimal)x.Increment, ProviderDataProvenance.Unattributed(DateTimeOffset.UtcNow))).ToArray()));
     }
 
     public void pnl(int reqId, double dailyPnL, double unrealizedPnL, double realizedPnL)
     {
         RecordMessageReceived();
-        PnlReceived?.Invoke(this, (reqId, new ProviderAccountPnl(string.Empty, null, (decimal)dailyPnL, (decimal)unrealizedPnL, (decimal)realizedPnL)));
+        PnlReceived?.Invoke(this, (reqId, new ProviderAccountPnl(string.Empty, null, (decimal)dailyPnL, (decimal)unrealizedPnL, (decimal)realizedPnL, null, null, ProviderDataProvenance.Unattributed(DateTimeOffset.UtcNow)));
     }
 
     public void pnlSingle(int reqId, decimal pos, double dailyPnL, double unrealizedPnL, double realizedPnL, double value)
     {
         RecordMessageReceived();
-        PnlReceived?.Invoke(this, (reqId, new ProviderAccountPnl(string.Empty, null, (decimal)dailyPnL, (decimal)unrealizedPnL, (decimal)realizedPnL, pos, (decimal)value)));
+        PnlReceived?.Invoke(this, (reqId, new ProviderAccountPnl(string.Empty, null, (decimal)dailyPnL, (decimal)unrealizedPnL, (decimal)realizedPnL, pos, (decimal)value, ProviderDataProvenance.Unattributed(DateTimeOffset.UtcNow)));
     }
 
     public void historicalTicks(int reqId, HistoricalTick[] ticks, bool done)
     {
         RecordMessageReceived();
         foreach (var tick in ticks)
-            HistoricalTickReceived?.Invoke(this, (reqId, new ProviderHistoricalTick(DateTimeOffset.FromUnixTimeSeconds(tick.Time), (decimal)tick.Price, tick.Size, "TRADES"), done));
+            HistoricalTickReceived?.Invoke(this, (reqId, new ProviderHistoricalTick(DateTimeOffset.FromUnixTimeSeconds(tick.Time), (decimal)tick.Price, tick.Size, "TRADES", null, null, null, ProviderDataProvenance.Unattributed(DateTimeOffset.FromUnixTimeSeconds(tick.Time))), done));
         if (done) RequestCompleted?.Invoke(this, reqId);
     }
 

--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.cs
@@ -18,7 +18,7 @@ namespace Meridian.Infrastructure.Adapters.InteractiveBrokers;
 /// - Unlimited retry attempts by default (configurable via maxRetries parameter)
 /// - See EnhancedIBConnectionManager.IBApi.cs and Infrastructure/Performance/ConnectionWarmUp.cs for implementation
 /// </summary>
-public sealed partial class EnhancedIBConnectionManager : IIBBrokerageClient, IIBDataServiceTransport, IIBDataLineageSource, IIBDataCallbackSource
+public sealed partial class EnhancedIBConnectionManager : IIBBrokerageClient, IIBDataServiceTransport, IIBDataLineageSource, IIBDataCallbackSource, IIBProviderConnectionIdentity
 {
 #if !IBAPI
     private readonly IBCallbackRouter _router;
@@ -130,4 +130,6 @@ public sealed partial class EnhancedIBConnectionManager : IIBBrokerageClient, II
     {
     }
 #endif
+
+    public string ProviderConnectionId => $"ib://{Host}:{Port}/client/{ClientId}";
 }

--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDataServices.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDataServices.cs
@@ -75,6 +75,12 @@ public interface IIBDataLineageSource
     event EventHandler<IBMarketDataTypeUpdate>? MarketDataTypeReceived;
 }
 
+/// <summary>Exposes the configured physical/logical IB connection identity for provenance.</summary>
+public interface IIBProviderConnectionIdentity
+{
+    string ProviderConnectionId { get; }
+}
+
 /// <summary>Callback bridge used to correlate vendor callbacks without exposing IB API types above Infrastructure.</summary>
 public interface IIBDataCallbackSource
 {
@@ -98,6 +104,8 @@ public sealed record IBMarketDataTypeUpdate(int RequestId, int MarketDataType);
 /// </summary>
 public sealed class IBDataServices : IProviderDataReadService, IDisposable
 {
+    private const string ProviderId = "interactive-brokers";
+    private readonly string _providerConnectionId;
     private readonly IIBDataServiceTransport _transport;
     private readonly IIBDataCallbackSource? _callbackSource;
     private readonly ConcurrentDictionary<int, IBDataLineage> _lineage = new();
@@ -106,9 +114,14 @@ public sealed class IBDataServices : IProviderDataReadService, IDisposable
         new BoundedChannelOptions(256) { SingleReader = false, SingleWriter = false, FullMode = BoundedChannelFullMode.DropOldest });
     private int _nextRequestId = 90_000;
 
-    public IBDataServices(IIBDataServiceTransport transport)
+    public IBDataServices(IIBDataServiceTransport transport, string providerConnectionId = "interactive-brokers/default")
     {
         _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+        _providerConnectionId = transport is IIBProviderConnectionIdentity identity
+            ? identity.ProviderConnectionId
+            : providerConnectionId;
+        if (string.IsNullOrWhiteSpace(_providerConnectionId))
+            throw new ArgumentException("Provider connection identity is required.", nameof(providerConnectionId));
         if (transport is IIBDataLineageSource source)
             source.MarketDataTypeReceived += OnMarketDataTypeReceived;
         if (transport is IIBDataCallbackSource callbacks)
@@ -234,7 +247,8 @@ public sealed class IBDataServices : IProviderDataReadService, IDisposable
             4 => IBMarketDataAvailability.DelayedFrozen,
             _ => IBMarketDataAvailability.Unknown
         };
-        Update(requestId, x => x with { Availability = availability, IsDelayed = availability is IBMarketDataAvailability.Delayed or IBMarketDataAvailability.DelayedFrozen, Status = "market-data-type", ObservedAt = DateTimeOffset.UtcNow });
+        var lineage = Update(requestId, x => x with { Availability = availability, IsDelayed = availability is IBMarketDataAvailability.Delayed or IBMarketDataAvailability.DelayedFrozen, Status = "market-data-type", ObservedAt = DateTimeOffset.UtcNow });
+        UpdateReadModel(requestId, current => current with { Provenance = CreateRequestProvenance(lineage) });
     }
 
     /// <summary>Records contract exchange and market-rule evidence returned by IB.</summary>
@@ -268,32 +282,32 @@ public sealed class IBDataServices : IProviderDataReadService, IDisposable
         UpdateReadModel(requestId, current => current with
         {
             Status = ProviderDataRequestStatus.Streaming,
-            OptionContracts = Append(current.OptionContracts, contract)
+            OptionContracts = Append(current.OptionContracts, contract with { Provenance = CreateObservationProvenance(current, contract.ProviderContractId ?? contract.Symbol, contract.Provenance.SourceTimestamp) })
         });
     }
 
     public void RecordScannerResult(int requestId, ProviderScannerResult result)
     {
         ArgumentNullException.ThrowIfNull(result);
-        UpdateReadModel(requestId, current => current with { Status = ProviderDataRequestStatus.Streaming, ScannerResults = Append(current.ScannerResults, result) });
+        UpdateReadModel(requestId, current => current with { Status = ProviderDataRequestStatus.Streaming, ScannerResults = Append(current.ScannerResults, result with { Provenance = CreateObservationProvenance(current, result.ProviderContractId ?? $"{result.Symbol}:{result.Rank}", result.Provenance.SourceTimestamp) }) });
     }
 
     public void RecordRealTimeBar(int requestId, ProviderRealTimeBar bar)
     {
         ArgumentNullException.ThrowIfNull(bar);
-        UpdateReadModel(requestId, current => current with { Status = ProviderDataRequestStatus.Streaming, RealTimeBars = Append(current.RealTimeBars, bar) });
+        UpdateReadModel(requestId, current => current with { Status = ProviderDataRequestStatus.Streaming, RealTimeBars = Append(current.RealTimeBars, bar with { Provenance = CreateObservationProvenance(current, $"{bar.Timestamp:O}:{bar.Open}:{bar.High}:{bar.Low}:{bar.Close}:{bar.Volume}:{bar.TradeCount}", bar.Timestamp) }) });
     }
 
     public void RecordHistoricalTick(int requestId, ProviderHistoricalTick tick, bool completed = false)
     {
         ArgumentNullException.ThrowIfNull(tick);
-        UpdateReadModel(requestId, current => current with { Status = completed ? ProviderDataRequestStatus.Completed : ProviderDataRequestStatus.Streaming, HistoricalTicks = Append(current.HistoricalTicks, tick) });
+        UpdateReadModel(requestId, current => current with { Status = completed ? ProviderDataRequestStatus.Completed : ProviderDataRequestStatus.Streaming, HistoricalTicks = Append(current.HistoricalTicks, tick with { Provenance = CreateObservationProvenance(current, $"{tick.Timestamp:O}:{tick.TickKind}:{tick.Price}:{tick.Size}", tick.Timestamp) }) });
     }
 
     public void RecordPnl(int requestId, ProviderAccountPnl pnl)
     {
         ArgumentNullException.ThrowIfNull(pnl);
-        UpdateReadModel(requestId, current => current with { Status = ProviderDataRequestStatus.Streaming, AccountId = pnl.AccountId, ModelAccountId = pnl.ModelAccountId, Pnl = pnl });
+        UpdateReadModel(requestId, current => current with { Status = ProviderDataRequestStatus.Streaming, AccountId = pnl.AccountId, ModelAccountId = pnl.ModelAccountId, Pnl = pnl with { Provenance = CreateObservationProvenance(current, $"{pnl.AccountId}:{pnl.ModelAccountId ?? string.Empty}", pnl.Provenance.SourceTimestamp) } });
     }
 
     public void RecordMarketRule(int requestId, IEnumerable<ProviderMarketRuleIncrement> increments)
@@ -301,7 +315,7 @@ public sealed class IBDataServices : IProviderDataReadService, IDisposable
         ArgumentNullException.ThrowIfNull(increments);
         var values = increments.ToArray();
         if (values.Length == 0) throw new ArgumentException("At least one market-rule increment is required.", nameof(increments));
-        UpdateReadModel(requestId, current => current with { Status = ProviderDataRequestStatus.Completed, MarketRuleIncrements = values });
+        UpdateReadModel(requestId, current => current with { Status = ProviderDataRequestStatus.Completed, MarketRuleIncrements = values.Select((value, index) => value with { Provenance = CreateObservationProvenance(current, $"{value.LowEdge}:{value.Increment}:{index}", value.Provenance.SourceTimestamp) }).ToArray() });
     }
 
     public void CompleteRequest(int requestId) => UpdateReadModel(requestId, current => current with { Status = ProviderDataRequestStatus.Completed });
@@ -349,7 +363,7 @@ public sealed class IBDataServices : IProviderDataReadService, IDisposable
         var requestId = Interlocked.Increment(ref _nextRequestId);
         var evidence = new IBDataLineage(requestId, service, symbol, exchange, null, null, subscription, IBMarketDataAvailability.Unknown, false, "requested", DateTimeOffset.UtcNow);
         if (!_lineage.TryAdd(requestId, evidence)) throw new InvalidOperationException($"Duplicate IB request id {requestId}.");
-        var projection = new ProviderDataRequestReadModel(requestId, "interactive-brokers", service, ProviderDataRequestStatus.Requested, evidence.ObservedAt);
+        var projection = new ProviderDataRequestReadModel(requestId, ProviderId, service, ProviderDataRequestStatus.Requested, evidence.ObservedAt, CreateRequestProvenance(evidence));
         _requests.TryAdd(requestId, projection);
         try { send(requestId); }
         catch { _lineage.TryRemove(requestId, out _); _requests.TryRemove(requestId, out _); throw; }
@@ -358,16 +372,40 @@ public sealed class IBDataServices : IProviderDataReadService, IDisposable
         return requestId;
     }
 
-    private void Update(int requestId, Func<IBDataLineage, IBDataLineage> update)
+    private IBDataLineage Update(int requestId, Func<IBDataLineage, IBDataLineage> update)
     {
         var updated = _lineage.AddOrUpdate(requestId, _ => throw new KeyNotFoundException($"Unknown IB request id {requestId}."), (_, current) => update(current));
         LineageUpdated?.Invoke(updated);
+        return updated;
     }
 
     private void UpdateReadModel(int requestId, Func<ProviderDataRequestReadModel, ProviderDataRequestReadModel> update)
     {
         var updated = _requests.AddOrUpdate(requestId, _ => throw new KeyNotFoundException($"Unknown IB request id {requestId}."), (_, current) => update(current) with { UpdatedAt = DateTimeOffset.UtcNow });
         Publish(updated);
+    }
+
+    private ProviderDataProvenance CreateRequestProvenance(IBDataLineage lineage)
+        => CreateProvenance(lineage, lineage.Symbol, lineage.ObservedAt);
+
+    private ProviderDataProvenance CreateObservationProvenance(ProviderDataRequestReadModel request, string providerNativeId, DateTimeOffset sourceTimestamp)
+    {
+        var lineage = _lineage.TryGetValue(request.RequestId, out var current)
+            ? current
+            : throw new KeyNotFoundException($"Unknown IB request id {request.RequestId}.");
+        return CreateProvenance(lineage, providerNativeId, sourceTimestamp);
+    }
+
+    private ProviderDataProvenance CreateProvenance(IBDataLineage lineage, string providerNativeId, DateTimeOffset sourceTimestamp)
+    {
+        var availability = lineage.Availability.ToString();
+        var descriptor = string.Join("|", lineage.Service, lineage.Symbol, lineage.Exchange ?? string.Empty, lineage.Subscription ?? string.Empty);
+        var correlationId = lineage.RequestId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var keyMaterial = string.Join("|", ProviderId, _providerConnectionId, providerNativeId, descriptor, correlationId);
+        var deduplicationKey = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(keyMaterial))).ToLowerInvariant();
+        return new ProviderDataProvenance(ProviderId, _providerConnectionId, sourceTimestamp, DateTimeOffset.UtcNow,
+            availability == nameof(IBMarketDataAvailability.Unknown) ? "unknown" : "reported", lineage.Subscription ?? "unspecified",
+            availability, descriptor, providerNativeId, correlationId, deduplicationKey);
     }
 
     private void Publish(ProviderDataRequestReadModel model)

--- a/src/Meridian.Infrastructure/README.md
+++ b/src/Meridian.Infrastructure/README.md
@@ -127,7 +127,9 @@ live/frozen/delayed status, exchange, market rules, and subscription descriptor 
 materialized observation; successful request submission is not evidence of a live entitlement.
 Its richer request callbacks publish bounded, request-correlated ProviderSdk read-model updates for
 option discovery, scanners, real-time bars, historical ticks, account/model-account P&L, and market
-rules. Vendor SDK absence remains simulation/fail-closed and cannot advertise live IB capability.
+rules. Each returned request and observation carries required provenance: provider and configured
+connection identity, source and receipt times, reported entitlement/feed/availability, request descriptor,
+provider-native identity, correlation, and a deterministic de-duplication key. Vendor SDK absence remains simulation/fail-closed and cannot advertise live IB capability.
 The brokerage gateway template remains an obsolete copy-target, but its scaffold behavior is
 deterministic: provider-discovery metadata, option-backed identity/capabilities, configurable
 connection readiness, option-backed account/position reads, and in-memory open-order tracking let

--- a/src/Meridian.ProviderSdk/IProviderDataReadService.cs
+++ b/src/Meridian.ProviderSdk/IProviderDataReadService.cs
@@ -2,78 +2,59 @@ using System.Runtime.CompilerServices;
 
 namespace Meridian.ProviderSdk;
 
-/// <summary>Provider-neutral lifecycle state for a correlated data request.</summary>
-public enum ProviderDataRequestStatus
+/// <summary>Immutable evidence describing the origin and availability posture of provider data.</summary>
+public sealed record ProviderDataProvenance(
+    string ProviderId,
+    string ProviderConnectionId,
+    DateTimeOffset SourceTimestamp,
+    DateTimeOffset ReceiptTimestamp,
+    string Entitlement,
+    string Feed,
+    string MarketDataAvailability,
+    string RequestOrSubscriptionDescriptor,
+    string ProviderNativeId,
+    string CorrelationId,
+    string StableDeduplicationKey)
 {
-    Requested,
-    Streaming,
-    Completed,
-    Cancelled,
-    TimedOut,
-    Rejected,
-    Failed
+    /// <summary>Creates explicit placeholder provenance for callback bridges before their request context is known.</summary>
+    public static ProviderDataProvenance Unattributed(DateTimeOffset sourceTimestamp) => new(
+        "unknown", "unknown", sourceTimestamp, DateTimeOffset.UtcNow, "unknown", "unknown", "unknown",
+        "unknown", "unknown", "unknown", "unknown");
 }
 
+/// <summary>Provider-neutral lifecycle state for a correlated data request.</summary>
+public enum ProviderDataRequestStatus { Requested, Streaming, Completed, Cancelled, TimedOut, Rejected, Failed }
+
 /// <summary>Provider-neutral evidence for a discovered option contract.</summary>
-public sealed record ProviderOptionContract(
-    string Symbol,
-    string UnderlyingSymbol,
-    DateOnly Expiration,
-    decimal Strike,
-    string Right,
-    string Exchange,
-    string? TradingClass = null,
-    string? Multiplier = null,
-    string? ProviderContractId = null);
+public sealed record ProviderOptionContract(string Symbol, string UnderlyingSymbol, DateOnly Expiration, decimal Strike, string Right, string Exchange, string? TradingClass, string? Multiplier, string? ProviderContractId, ProviderDataProvenance Provenance);
 
 /// <summary>Provider-neutral scanner row, retaining the source rank and optional metrics.</summary>
-public sealed record ProviderScannerResult(
-    int Rank,
-    string Symbol,
-    string? Exchange,
-    string? ProviderContractId,
-    string? Distance,
-    string? Benchmark,
-    string? Projection,
-    string? Legs);
+public sealed record ProviderScannerResult(int Rank, string Symbol, string? Exchange, string? ProviderContractId, string? Distance, string? Benchmark, string? Projection, string? Legs, ProviderDataProvenance Provenance);
 
 /// <summary>Provider-neutral real-time bar observation.</summary>
-public sealed record ProviderRealTimeBar(DateTimeOffset Timestamp, decimal Open, decimal High, decimal Low, decimal Close, decimal Volume, decimal WeightedAveragePrice, int TradeCount);
+public sealed record ProviderRealTimeBar(DateTimeOffset Timestamp, decimal Open, decimal High, decimal Low, decimal Close, decimal Volume, decimal WeightedAveragePrice, int TradeCount, ProviderDataProvenance Provenance);
 
 /// <summary>Provider-neutral historical tick observation.</summary>
-public sealed record ProviderHistoricalTick(DateTimeOffset Timestamp, decimal Price, decimal Size, string TickKind, decimal? Bid = null, decimal? Ask = null, string? Exchange = null);
+public sealed record ProviderHistoricalTick(DateTimeOffset Timestamp, decimal Price, decimal Size, string TickKind, decimal? Bid, decimal? Ask, string? Exchange, ProviderDataProvenance Provenance);
 
 /// <summary>Provider-neutral account or model-account P&amp;L observation.</summary>
-public sealed record ProviderAccountPnl(string AccountId, string? ModelAccountId, decimal Daily, decimal Unrealized, decimal Realized, decimal? Position = null, decimal? Value = null);
+public sealed record ProviderAccountPnl(string AccountId, string? ModelAccountId, decimal Daily, decimal Unrealized, decimal Realized, decimal? Position, decimal? Value, ProviderDataProvenance Provenance);
 
 /// <summary>One price-band increment in a provider market rule.</summary>
-public sealed record ProviderMarketRuleIncrement(decimal LowEdge, decimal Increment);
+public sealed record ProviderMarketRuleIncrement(decimal LowEdge, decimal Increment, ProviderDataProvenance Provenance);
 
-/// <summary>
-/// A correlated, presentation-safe snapshot of provider data. It deliberately contains no vendor
-/// transport objects so browser and desktop workstation services can consume the same seam.
-/// </summary>
+/// <summary>A correlated, presentation-safe snapshot of provider data.</summary>
 public sealed record ProviderDataRequestReadModel(
-    int RequestId,
-    string ProviderFamily,
-    string Capability,
-    ProviderDataRequestStatus Status,
-    DateTimeOffset UpdatedAt,
-    string? AccountId = null,
-    string? ModelAccountId = null,
-    string? ErrorCode = null,
-    string? ErrorMessage = null,
-    IReadOnlyList<ProviderOptionContract>? OptionContracts = null,
-    IReadOnlyList<ProviderScannerResult>? ScannerResults = null,
-    IReadOnlyList<ProviderRealTimeBar>? RealTimeBars = null,
-    IReadOnlyList<ProviderHistoricalTick>? HistoricalTicks = null,
-    ProviderAccountPnl? Pnl = null,
+    int RequestId, string ProviderFamily, string Capability, ProviderDataRequestStatus Status, DateTimeOffset UpdatedAt,
+    ProviderDataProvenance Provenance, string? AccountId = null, string? ModelAccountId = null, string? ErrorCode = null,
+    string? ErrorMessage = null, IReadOnlyList<ProviderOptionContract>? OptionContracts = null,
+    IReadOnlyList<ProviderScannerResult>? ScannerResults = null, IReadOnlyList<ProviderRealTimeBar>? RealTimeBars = null,
+    IReadOnlyList<ProviderHistoricalTick>? HistoricalTicks = null, ProviderAccountPnl? Pnl = null,
     IReadOnlyList<ProviderMarketRuleIncrement>? MarketRuleIncrements = null);
 
 /// <summary>Shared read-model seam for rich provider data requested by an operator workflow.</summary>
 public interface IProviderDataReadService
 {
     IReadOnlyList<ProviderDataRequestReadModel> GetRequests();
-
     IAsyncEnumerable<ProviderDataRequestReadModel> WatchAsync(CancellationToken cancellationToken = default);
 }

--- a/tests/Meridian.Tests/Infrastructure/Providers/IBDataServicesTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/IBDataServicesTests.cs
@@ -73,13 +73,68 @@ public sealed class IBDataServicesTests
         var first = services.RequestScanner(new IBScannerRequest("STK", "STK.US.MAJOR", "TOP_PERC_GAIN"));
         var second = services.RequestScanner(new IBScannerRequest("STK", "STK.US.MAJOR", "HOT_BY_VOLUME"));
 
-        services.RecordScannerResult(second, new ProviderScannerResult(0, "AAPL", "NASDAQ", "265598", null, null, null, null));
+        services.RecordScannerResult(second, new ProviderScannerResult(0, "AAPL", "NASDAQ", "265598", null, null, null, null, ProviderDataProvenance.Unattributed(DateTimeOffset.UtcNow)));
         services.CompleteRequest(second);
 
         services.GetRequests().Single(request => request.RequestId == first).Status.Should().Be(ProviderDataRequestStatus.Requested);
         var correlated = services.GetRequests().Single(request => request.RequestId == second);
         correlated.Status.Should().Be(ProviderDataRequestStatus.Completed);
         correlated.ScannerResults.Should().ContainSingle().Which.Symbol.Should().Be("AAPL");
+    }
+
+    [Fact]
+    public void ReturnedRecords_CarryCompleteProvenanceAndRepeatedCallbacksUseStableDeduplicationKeys()
+    {
+        var services = new IBDataServices(new RecordingTransport(), "ib-gateway:paper:17");
+        var scanner = services.RequestScanner(new IBScannerRequest("STK", "STK.US.MAJOR", "TOP_PERC_GAIN"));
+        var bars = services.SubscribeRealTimeBars(new IBRealTimeBarRequest(new SymbolConfig("AAPL")));
+        var ticks = services.RequestHistoricalTicks(new IBHistoricalTickRequest(new SymbolConfig("AAPL"), null, DateTimeOffset.UtcNow, 1));
+        var pnl = services.SubscribePnl("DU111", "model-a");
+        var marketRule = services.RequestMarketRule(26);
+        var options = services.RequestOptionChain(new SymbolConfig("SPY"));
+        services.RecordMarketDataType(scanner, 3);
+
+        var callbackTime = DateTimeOffset.Parse("2026-07-22T12:00:00+00:00");
+        var scannerRow = new ProviderScannerResult(0, "AAPL", "NASDAQ", "265598", null, null, null, null, ProviderDataProvenance.Unattributed(callbackTime));
+        services.RecordScannerResult(scanner, scannerRow);
+        services.RecordScannerResult(scanner, scannerRow);
+        services.RecordRealTimeBar(bars, new ProviderRealTimeBar(callbackTime, 1m, 2m, 1m, 2m, 10m, 1.5m, 3, ProviderDataProvenance.Unattributed(callbackTime)));
+        services.RecordHistoricalTick(ticks, new ProviderHistoricalTick(callbackTime, 2m, 10m, "TRADES", null, null, "NASDAQ", ProviderDataProvenance.Unattributed(callbackTime)));
+        services.RecordPnl(pnl, new ProviderAccountPnl("DU111", "model-a", 1m, 2m, 3m, null, null, ProviderDataProvenance.Unattributed(callbackTime)));
+        services.RecordMarketRule(marketRule, [new ProviderMarketRuleIncrement(0m, 0.01m, ProviderDataProvenance.Unattributed(callbackTime))]);
+        services.RecordOptionContract(options, new ProviderOptionContract("SPY", "SPY", new DateOnly(2026, 8, 21), 650m, "C", "SMART", null, null, "756733", ProviderDataProvenance.Unattributed(callbackTime)));
+
+        var records = services.GetRequests();
+        var observations = records.SelectMany(request => new object?[]
+        {
+            request.Provenance,
+            request.OptionContracts?.SingleOrDefault()?.Provenance,
+            request.RealTimeBars?.SingleOrDefault()?.Provenance,
+            request.HistoricalTicks?.SingleOrDefault()?.Provenance,
+            request.Pnl?.Provenance,
+            request.MarketRuleIncrements?.SingleOrDefault()?.Provenance
+        }).OfType<ProviderDataProvenance>().Concat(records.Single(x => x.RequestId == scanner).ScannerResults!.Select(x => x.Provenance));
+
+        foreach (var provenance in observations)
+        {
+            provenance.ProviderId.Should().Be("interactive-brokers");
+            provenance.ProviderConnectionId.Should().Be("ib-gateway:paper:17");
+            provenance.SourceTimestamp.Should().NotBe(default);
+            provenance.ReceiptTimestamp.Should().NotBe(default);
+            provenance.Entitlement.Should().NotBeNullOrWhiteSpace();
+            provenance.Feed.Should().NotBeNullOrWhiteSpace();
+            provenance.MarketDataAvailability.Should().NotBeNullOrWhiteSpace();
+            provenance.RequestOrSubscriptionDescriptor.Should().NotBeNullOrWhiteSpace();
+            provenance.ProviderNativeId.Should().NotBeNullOrWhiteSpace();
+            provenance.CorrelationId.Should().NotBeNullOrWhiteSpace();
+            provenance.StableDeduplicationKey.Should().NotBeNullOrWhiteSpace();
+        }
+
+        var scannerKeys = records.Single(x => x.RequestId == scanner).ScannerResults!.Select(x => x.Provenance.StableDeduplicationKey).ToArray();
+        scannerKeys.Should().HaveCount(2);
+        scannerKeys[0].Should().Be(scannerKeys[1], "identical provider callbacks must retain the same deduplication key");
+        records.Single(x => x.RequestId == bars).RealTimeBars!.Single().Provenance.SourceTimestamp.Should().Be(callbackTime);
+        records.Single(x => x.RequestId == scanner).ScannerResults!.Single().Provenance.MarketDataAvailability.Should().Be("Delayed");
     }
 
     [Fact]
@@ -102,8 +157,8 @@ public sealed class IBDataServicesTests
         var first = services.SubscribePnl("DU111", "growth");
         var second = services.SubscribePnl("DU222", "income");
 
-        services.RecordPnl(first, new ProviderAccountPnl("DU111", "growth", 10m, 4m, 6m));
-        services.RecordPnl(second, new ProviderAccountPnl("DU222", "income", 20m, 7m, 13m));
+        services.RecordPnl(first, new ProviderAccountPnl("DU111", "growth", 10m, 4m, 6m, null, null, ProviderDataProvenance.Unattributed(DateTimeOffset.UtcNow)));
+        services.RecordPnl(second, new ProviderAccountPnl("DU222", "income", 20m, 7m, 13m, null, null, ProviderDataProvenance.Unattributed(DateTimeOffset.UtcNow)));
 
         services.GetRequests().Single(x => x.RequestId == first).Pnl!.AccountId.Should().Be("DU111");
         services.GetRequests().Single(x => x.RequestId == second).Pnl!.ModelAccountId.Should().Be("income");


### PR DESCRIPTION
### Motivation

- Ensure every provider-originated record carries a required, shared provenance payload that records provider identity, configured connection identity, source/receipt times, entitlement/feed/availability, request descriptor, provider-native id, correlation id, and a deterministic de-duplication key.
- Make the IB adapter produce and enrich that provenance at request issuance and from entitlement/availability callbacks so downstream consumers can reason about source time, receipt time, and stable deduplication.

### Description

- Introduced a new `ProviderDataProvenance` record in `src/Meridian.ProviderSdk/IProviderDataReadService.cs` and extended all provider read-model record types to include a `Provenance` field.
- Updated `IBDataServices` (`src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDataServices.cs`) to carry a provider connection identity, create request-level provenance on `Issue(...)`, and derive observation provenance for each callback using a `CreateProvenance` helper that computes a SHA-256 stable de-duplication key from provider identity, configured connection id, provider-native id, request descriptor, and correlation id.
- Made `RecordMarketDataType(...)` refresh the request projection provenance when IB reports market-data-type (so availability/entitlement is preserved separately from receipt time), and wired observation provenance into all `Record*` functions that append/emit observations.
- Added `IIBProviderConnectionIdentity` and implemented `ProviderConnectionId` on the connection manager (`EnhancedIBConnectionManager`) so the configured connection identity is available for provenance construction; updated vendor callback bridges to attach unattributed placeholder provenance for initial callbacks where needed.
- Updated infrastructure README to document the provenance guarantee and added a new test `ReturnedRecords_CarryCompleteProvenanceAndRepeatedCallbacksUseStableDeduplicationKeys` in `tests/Meridian.Tests/Infrastructure/Providers/IBDataServicesTests.cs` that asserts provenance presence, preservation of source timestamps, delayed availability mapping, and stable deduplication keys across repeated identical callbacks.

### Testing

- Ran `git diff --check` to verify formatting and basic hygiene, which passed locally.
- Attempted to run the targeted test slice: `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~IBDataServicesTests" --no-restore --logger "console;verbosity=normal" /p:EnableWindowsTargeting=true /p:NodeReuse=false`, but the execution environment lacks the .NET SDK so the run was blocked and could not be completed.
- Attempted `bash scripts/ci.sh` as the repo's validation gate, but it also stopped early because `dotnet` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6122ac125083209277305f63d0c5ab)