### PR TITLE
Add optional provider routing capabilities and provider-neutral service contracts

### DIFF
--- a/src/Meridian.Application/ProviderRouting/ProviderRoutingEngine.cs
+++ b/src/Meridian.Application/ProviderRouting/ProviderRoutingEngine.cs
@@ -528,6 +528,13 @@ internal sealed class ProviderFamilyCatalogService : IProviderFamilyCatalogServi
             family.RegisterCapability(new ProviderCapabilityDescriptor(ProviderCapabilityKind.FactorSchedule, "Factor schedule provider"), () => corporateActions);
         }
 
+        RegisterOptionalCapability<IProviderNewsService>(families, ProviderCapabilityKind.News, "Provider news service");
+        RegisterOptionalCapability<IProviderScannerService>(families, ProviderCapabilityKind.Scanner, "Provider scanner service");
+        RegisterOptionalCapability<IProviderPnlStream>(families, ProviderCapabilityKind.PnLStream, "Provider P&L stream", requiresAccountBinding: true, supportsFailover: false);
+        RegisterOptionalCapability<ITradingCalendarProvider>(families, ProviderCapabilityKind.TradingCalendar, "Trading calendar provider");
+        RegisterOptionalCapability<IMarketRuleProvider>(families, ProviderCapabilityKind.MarketRules, "Market rule provider");
+        RegisterOptionalCapability<IProviderInstrumentDiscoveryService>(families, ProviderCapabilityKind.InstrumentDiscovery, "Instrument discovery provider");
+
         return families.Values.Cast<IProviderFamilyAdapter>().ToArray();
     }
 
@@ -547,6 +554,28 @@ internal sealed class ProviderFamilyCatalogService : IProviderFamilyCatalogServi
         }
 
         return adapter;
+    }
+
+    private void RegisterOptionalCapability<TProvider>(
+        IDictionary<string, MutableProviderFamilyAdapter> families,
+        ProviderCapabilityKind capability,
+        string description,
+        bool requiresAccountBinding = false,
+        bool supportsFailover = true)
+        where TProvider : class, IProviderMetadata
+    {
+        foreach (var provider in _providerRegistry.GetProviders<TProvider>())
+        {
+            var family = GetOrCreate(
+                families,
+                provider.ProviderId,
+                provider.ProviderDisplayName,
+                provider.ProviderDescription);
+
+            family.RegisterCapability(
+                new ProviderCapabilityDescriptor(capability, description, requiresAccountBinding, supportsFailover),
+                () => provider);
+        }
     }
 
     private static IEnumerable<ProviderCapabilityDescriptor> Describe(ProviderCatalogEntry entry)

--- a/src/Meridian.ProviderSdk/IMarketRuleProvider.cs
+++ b/src/Meridian.ProviderSdk/IMarketRuleProvider.cs
@@ -1,0 +1,15 @@
+using Meridian.Infrastructure.Adapters.Core;
+
+namespace Meridian.ProviderSdk;
+
+/// <summary>Provider-neutral request for price increment rules.</summary>
+public sealed record MarketRuleRequest(string MarketRuleId, string? Symbol = null, string? Exchange = null);
+
+/// <summary>Provider-neutral market rule with ordered price-band increments.</summary>
+public sealed record ProviderMarketRule(string MarketRuleId, IReadOnlyList<ProviderMarketRuleIncrement> Increments);
+
+/// <summary>Optional provider capability for market-rule and price-increment retrieval.</summary>
+public interface IMarketRuleProvider : IProviderMetadata
+{
+    Task<ProviderMarketRule?> GetMarketRuleAsync(MarketRuleRequest request, CancellationToken ct = default);
+}

--- a/src/Meridian.ProviderSdk/IProviderInstrumentDiscoveryService.cs
+++ b/src/Meridian.ProviderSdk/IProviderInstrumentDiscoveryService.cs
@@ -1,0 +1,25 @@
+using Meridian.Infrastructure.Adapters.Core;
+
+namespace Meridian.ProviderSdk;
+
+/// <summary>Provider-neutral request for discoverable instruments and contracts.</summary>
+public sealed record ProviderInstrumentDiscoveryRequest(
+    string Query,
+    string? AssetClass = null,
+    string? Market = null,
+    int? Limit = null);
+
+/// <summary>Provider-neutral instrument identity returned by discovery.</summary>
+public sealed record ProviderInstrument(
+    string Symbol,
+    string Name,
+    string AssetClass,
+    string? Exchange = null,
+    string? Currency = null,
+    string? ProviderInstrumentId = null);
+
+/// <summary>Optional provider capability for instrument and contract discovery.</summary>
+public interface IProviderInstrumentDiscoveryService : IProviderMetadata
+{
+    Task<IReadOnlyList<ProviderInstrument>> DiscoverAsync(ProviderInstrumentDiscoveryRequest request, CancellationToken ct = default);
+}

--- a/src/Meridian.ProviderSdk/IProviderNewsService.cs
+++ b/src/Meridian.ProviderSdk/IProviderNewsService.cs
@@ -1,0 +1,27 @@
+using Meridian.Infrastructure.Adapters.Core;
+
+namespace Meridian.ProviderSdk;
+
+/// <summary>Provider-neutral request for news associated with instruments or topics.</summary>
+public sealed record ProviderNewsRequest(
+    IReadOnlyList<string> Symbols,
+    DateTimeOffset? From = null,
+    DateTimeOffset? To = null,
+    IReadOnlyList<string>? Topics = null,
+    int? Limit = null);
+
+/// <summary>Provider-neutral news item suitable for routing and workstation consumption.</summary>
+public sealed record ProviderNewsArticle(
+    string Headline,
+    DateTimeOffset PublishedAt,
+    string Source,
+    string? Summary = null,
+    string? Url = null,
+    IReadOnlyList<string>? Symbols = null,
+    string? ProviderArticleId = null);
+
+/// <summary>Optional provider capability for retrieving market news.</summary>
+public interface IProviderNewsService : IProviderMetadata
+{
+    Task<IReadOnlyList<ProviderNewsArticle>> GetNewsAsync(ProviderNewsRequest request, CancellationToken ct = default);
+}

--- a/src/Meridian.ProviderSdk/IProviderPnlStream.cs
+++ b/src/Meridian.ProviderSdk/IProviderPnlStream.cs
@@ -1,0 +1,15 @@
+using Meridian.Infrastructure.Adapters.Core;
+
+namespace Meridian.ProviderSdk;
+
+/// <summary>Provider-neutral request for an account or model-account P&amp;L stream.</summary>
+public sealed record ProviderPnlStreamRequest(string AccountId, string? ModelAccountId = null);
+
+/// <summary>Timestamped account P&amp;L update emitted by a provider-neutral stream.</summary>
+public sealed record ProviderPnlUpdate(DateTimeOffset ObservedAt, ProviderAccountPnl Pnl);
+
+/// <summary>Optional provider capability for streaming account and model-account P&amp;L.</summary>
+public interface IProviderPnlStream : IProviderMetadata
+{
+    IAsyncEnumerable<ProviderPnlUpdate> StreamAsync(ProviderPnlStreamRequest request, CancellationToken ct = default);
+}

--- a/src/Meridian.ProviderSdk/IProviderScannerService.cs
+++ b/src/Meridian.ProviderSdk/IProviderScannerService.cs
@@ -1,0 +1,17 @@
+using Meridian.Infrastructure.Adapters.Core;
+
+namespace Meridian.ProviderSdk;
+
+/// <summary>Provider-neutral request for a ranked market scanner query.</summary>
+public sealed record ProviderScannerRequest(
+    string ScanCode,
+    string? Instrument = null,
+    string? Location = null,
+    int? Limit = null,
+    IReadOnlyDictionary<string, string>? Filters = null);
+
+/// <summary>Optional provider capability for retrieving scanner results.</summary>
+public interface IProviderScannerService : IProviderMetadata
+{
+    Task<IReadOnlyList<ProviderScannerResult>> ScanAsync(ProviderScannerRequest request, CancellationToken ct = default);
+}

--- a/src/Meridian.ProviderSdk/ITradingCalendarProvider.cs
+++ b/src/Meridian.ProviderSdk/ITradingCalendarProvider.cs
@@ -1,0 +1,20 @@
+using Meridian.Infrastructure.Adapters.Core;
+
+namespace Meridian.ProviderSdk;
+
+/// <summary>Provider-neutral request for venue trading sessions.</summary>
+public sealed record TradingCalendarRequest(string Market, DateOnly From, DateOnly To, string? AssetClass = null);
+
+/// <summary>One provider-neutral trading session, including closed or shortened sessions.</summary>
+public sealed record TradingSession(
+    DateOnly Date,
+    bool IsOpen,
+    DateTimeOffset? OpensAt = null,
+    DateTimeOffset? ClosesAt = null,
+    string? Name = null);
+
+/// <summary>Optional provider capability for venue trading calendars.</summary>
+public interface ITradingCalendarProvider : IProviderMetadata
+{
+    Task<IReadOnlyList<TradingSession>> GetSessionsAsync(TradingCalendarRequest request, CancellationToken ct = default);
+}

--- a/src/Meridian.ProviderSdk/ProviderRoutingModels.cs
+++ b/src/Meridian.ProviderSdk/ProviderRoutingModels.cs
@@ -24,7 +24,13 @@ public enum ProviderCapabilityKind : byte
     CashTransactions = 13,
     BankStatements = 14,
     ReconciliationFeed = 15,
-    FactorSchedule = 16
+    FactorSchedule = 16,
+    News = 17,
+    Scanner = 18,
+    PnLStream = 19,
+    TradingCalendar = 20,
+    MarketRules = 21,
+    InstrumentDiscovery = 22
 }
 
 /// <summary>

--- a/tests/Meridian.Tests/Application/ProviderRouting/ProviderRoutingServiceTests.cs
+++ b/tests/Meridian.Tests/Application/ProviderRouting/ProviderRoutingServiceTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Meridian.Core.Config;
 using Meridian.Application.ProviderRouting;
 using Meridian.Application.UI;
+using Meridian.Infrastructure.Adapters.Core;
 using Meridian.ProviderSdk;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
@@ -206,6 +207,46 @@ public sealed class ProviderRoutingServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task ProviderFamilyCatalog_RegistersAndResolvesEachOptionalTypedCapabilityIndependently()
+    {
+        using var registry = new ProviderRegistry();
+        var provider = new OptionalCapabilitiesProvider();
+        registry.Register(provider);
+
+        var catalog = new ProviderFamilyCatalogService(
+            registry,
+            Array.Empty<IOptionsChainProvider>(),
+            Array.Empty<ICorporateActionProvider>());
+
+        var family = catalog.GetFamily(provider.ProviderId);
+
+        family.Should().NotBeNull();
+        foreach (var (capability, serviceType) in OptionalCapabilities)
+        {
+            family!.CapabilityDescriptors.Should().ContainSingle(descriptor => descriptor.Kind == capability);
+
+            var resolved = await family.ResolveCapabilityAsync(capability);
+            resolved.Should().BeSameAs(provider);
+            serviceType.IsInstanceOfType(resolved).Should().BeTrue();
+        }
+    }
+
+    [Fact]
+    public void ProviderFamilyCatalog_DoesNotInferOptionalCapabilitiesFromMetadataAlone()
+    {
+        using var registry = new ProviderRegistry();
+        var provider = new MetadataOnlyProvider();
+        registry.Register(provider);
+
+        var catalog = new ProviderFamilyCatalogService(
+            registry,
+            Array.Empty<IOptionsChainProvider>(),
+            Array.Empty<ICorporateActionProvider>());
+
+        catalog.GetFamily(provider.ProviderId).Should().BeNull();
+    }
+
+    [Fact]
     public async Task RouteAsync_RebuildsCachedSnapshotWhenConfigChanges()
     {
         await SaveConfigAsync(new AppConfig(
@@ -330,6 +371,69 @@ public sealed class ProviderRoutingServiceTests : IDisposable
 
         public IProviderFamilyAdapter? GetFamily(string providerFamilyId)
             => new FakeAdapter(providerFamilyId);
+    }
+
+    private static readonly (ProviderCapabilityKind Capability, Type ServiceType)[] OptionalCapabilities =
+    [
+        (ProviderCapabilityKind.News, typeof(IProviderNewsService)),
+        (ProviderCapabilityKind.Scanner, typeof(IProviderScannerService)),
+        (ProviderCapabilityKind.PnLStream, typeof(IProviderPnlStream)),
+        (ProviderCapabilityKind.TradingCalendar, typeof(ITradingCalendarProvider)),
+        (ProviderCapabilityKind.MarketRules, typeof(IMarketRuleProvider)),
+        (ProviderCapabilityKind.InstrumentDiscovery, typeof(IProviderInstrumentDiscoveryService))
+    ];
+
+    private sealed class OptionalCapabilitiesProvider :
+        IProviderNewsService,
+        IProviderScannerService,
+        IProviderPnlStream,
+        ITradingCalendarProvider,
+        IMarketRuleProvider,
+        IProviderInstrumentDiscoveryService
+    {
+        public string ProviderId => "optional-capabilities";
+
+        public string ProviderDisplayName => "Optional capabilities";
+
+        public string ProviderDescription => "Test provider for optional routing capabilities";
+
+        public int ProviderPriority => 100;
+
+        public ProviderCapabilities ProviderCapabilities => ProviderCapabilities.None;
+
+        public Task<IReadOnlyList<ProviderNewsArticle>> GetNewsAsync(ProviderNewsRequest request, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<ProviderNewsArticle>>([]);
+
+        public Task<IReadOnlyList<ProviderScannerResult>> ScanAsync(ProviderScannerRequest request, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<ProviderScannerResult>>([]);
+
+        public async IAsyncEnumerable<ProviderPnlUpdate> StreamAsync(ProviderPnlStreamRequest request, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        public Task<IReadOnlyList<TradingSession>> GetSessionsAsync(TradingCalendarRequest request, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<TradingSession>>([]);
+
+        public Task<ProviderMarketRule?> GetMarketRuleAsync(MarketRuleRequest request, CancellationToken ct = default)
+            => Task.FromResult<ProviderMarketRule?>(null);
+
+        public Task<IReadOnlyList<ProviderInstrument>> DiscoverAsync(ProviderInstrumentDiscoveryRequest request, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<ProviderInstrument>>([]);
+    }
+
+    private sealed class MetadataOnlyProvider : IProviderMetadata
+    {
+        public string ProviderId => "metadata-only";
+
+        public string ProviderDisplayName => "Metadata only";
+
+        public string ProviderDescription => "Does not implement an optional capability interface";
+
+        public int ProviderPriority => 100;
+
+        public ProviderCapabilities ProviderCapabilities => ProviderCapabilities.None;
     }
 
     private sealed class FakeAdapter : IProviderFamilyAdapter


### PR DESCRIPTION
### Motivation
- Expose additional provider capabilities (News, Scanner, PnLStream, TradingCalendar, MarketRules, InstrumentDiscovery) so adapters can opt-in to richer routing and operator workflows without changing existing capability values. 
- Provide provider-neutral request/output contracts for these optional surfaces so Application and UI layers consume stable types rather than vendor transport objects.
- Ensure provider-family discovery registers those capabilities only when a registered adapter actually implements the typed optional interface, preserving `ProviderCapabilityKind` as the canonical routing and workflow gate.

### Description
- Added new capability enum values to `ProviderCapabilityKind` in `src/Meridian.ProviderSdk/ProviderRoutingModels.cs` for `News`, `Scanner`, `PnLStream`, `TradingCalendar`, `MarketRules`, and `InstrumentDiscovery` while keeping existing values unchanged.
- Introduced provider-neutral optional interfaces and their request/output models under `src/Meridian.ProviderSdk/`: `IProviderNewsService`, `IProviderScannerService`, `IProviderPnlStream`, `ITradingCalendarProvider`, `IMarketRuleProvider`, and `IProviderInstrumentDiscoveryService` (each file defines typed request/read models and the interface contract).
- Updated provider-family discovery in `src/Meridian.Application/ProviderRouting/ProviderRoutingEngine.cs` to register an optional `ProviderCapabilityDescriptor` only when a registered provider implements the corresponding typed interface via a new helper `RegisterOptionalCapability<TProvider>`, and set the `PnLStream` descriptor to require account binding and disable failover.
- Added catalog/routing tests in `tests/Meridian.Tests/Application/ProviderRouting/ProviderRoutingServiceTests.cs` that verify each typed interface produces the correct capability descriptor and resolves to the provider instance, and a negative test to ensure metadata-only providers do not infer optional capabilities.

### Testing
- `git diff --check` passed locally with no whitespace errors.
- Attempted to run the focused unit tests with: `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~ProviderRoutingServiceTests" --logger "console;verbosity=normal" /p:EnableWindowsTargeting=true /p:NodeReuse=false`, but the environment lacks the `dotnet` SDK so tests could not be executed here.
- Attempted to run the repository CI via `bash scripts/ci.sh` but it could not complete because `dotnet` is not available in this environment; CI/test execution should be verified in the normal CI environment (GitHub Actions) where the .NET SDK is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6122ab64408320a6a6fc379339ba6e)