### PR TITLE
Add provenance to provider data records

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDataServices.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDataServices.cs
@@ -249,7 +249,7 @@ public sealed class IBDataServices : IProviderDataReadService, IDisposable
             _ => IBMarketDataAvailability.Unknown
         };
         var lineage = Update(requestId, x => x with { Availability = availability, IsDelayed = availability is IBMarketDataAvailability.Delayed or IBMarketDataAvailability.DelayedFrozen, Status = "market-data-type", ObservedAt = DateTimeOffset.UtcNow });
-        UpdateReadModel(requestId, current => current with { Provenance = CreateRequestProvenance(lineage) });
+        UpdateReadModel(requestId, current => RefreshProvenance(current, lineage));
     }
 
     /// <summary>Records contract exchange and market-rule evidence returned by IB.</summary>
@@ -397,14 +397,30 @@ public sealed class IBDataServices : IProviderDataReadService, IDisposable
         return CreateProvenance(lineage, providerNativeId, sourceTimestamp);
     }
 
-    private ProviderDataProvenance CreateProvenance(IBDataLineage lineage, string providerNativeId, DateTimeOffset sourceTimestamp)
+    private ProviderDataRequestReadModel RefreshProvenance(ProviderDataRequestReadModel request, IBDataLineage lineage)
+        => request with
+        {
+            Provenance = RefreshProvenance(lineage, request.Provenance),
+            OptionContracts = request.OptionContracts?.Select(contract => contract with { Provenance = RefreshProvenance(lineage, contract.Provenance) }).ToArray(),
+            ScannerResults = request.ScannerResults?.Select(result => result with { Provenance = RefreshProvenance(lineage, result.Provenance) }).ToArray(),
+            RealTimeBars = request.RealTimeBars?.Select(bar => bar with { Provenance = RefreshProvenance(lineage, bar.Provenance) }).ToArray(),
+            HistoricalTicks = request.HistoricalTicks?.Select(tick => tick with { Provenance = RefreshProvenance(lineage, tick.Provenance) }).ToArray(),
+            Pnl = request.Pnl is { } pnl ? pnl with { Provenance = RefreshProvenance(lineage, pnl.Provenance) } : null,
+            MarketRuleIncrements = request.MarketRuleIncrements?.Select(increment => increment with { Provenance = RefreshProvenance(lineage, increment.Provenance) }).ToArray()
+        };
+
+    private ProviderDataProvenance RefreshProvenance(IBDataLineage lineage, ProviderDataProvenance provenance)
+        => CreateProvenance(lineage, provenance.ProviderNativeId, provenance.SourceTimestamp, provenance.ReceiptTimestamp);
+
+    private ProviderDataProvenance CreateProvenance(IBDataLineage lineage, string providerNativeId, DateTimeOffset sourceTimestamp, DateTimeOffset? receiptTimestamp = null)
     {
+        providerNativeId = string.IsNullOrWhiteSpace(providerNativeId) ? lineage.Symbol : providerNativeId;
         var availability = lineage.Availability.ToString();
         var descriptor = string.Join("|", lineage.Service, lineage.Symbol, lineage.Exchange ?? string.Empty, lineage.Subscription ?? string.Empty);
         var correlationId = lineage.RequestId.ToString(System.Globalization.CultureInfo.InvariantCulture);
         var keyMaterial = string.Join("|", ProviderId, _providerConnectionId, providerNativeId, descriptor, correlationId);
         var deduplicationKey = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(keyMaterial))).ToLowerInvariant();
-        return new ProviderDataProvenance(ProviderId, _providerConnectionId, sourceTimestamp, DateTimeOffset.UtcNow,
+        return new ProviderDataProvenance(ProviderId, _providerConnectionId, sourceTimestamp, receiptTimestamp ?? DateTimeOffset.UtcNow,
             availability == nameof(IBMarketDataAvailability.Unknown) ? "unknown" : "reported", lineage.Subscription ?? "unspecified",
             availability, descriptor, providerNativeId, correlationId, deduplicationKey);
     }

--- a/src/Meridian.ProviderSdk/IMarketRuleProvider.cs
+++ b/src/Meridian.ProviderSdk/IMarketRuleProvider.cs
@@ -6,7 +6,7 @@ namespace Meridian.ProviderSdk;
 public sealed record MarketRuleRequest(string MarketRuleId, string? Symbol = null, string? Exchange = null);
 
 /// <summary>Provider-neutral market rule with ordered price-band increments.</summary>
-public sealed record ProviderMarketRule(string MarketRuleId, IReadOnlyList<ProviderMarketRuleIncrement> Increments);
+public sealed record ProviderMarketRule(string MarketRuleId, IReadOnlyList<ProviderMarketRuleIncrement> Increments, ProviderDataProvenance Provenance);
 
 /// <summary>Optional provider capability for market-rule and price-increment retrieval.</summary>
 public interface IMarketRuleProvider : IProviderMetadata

--- a/src/Meridian.ProviderSdk/IProviderDataReadService.cs
+++ b/src/Meridian.ProviderSdk/IProviderDataReadService.cs
@@ -64,9 +64,14 @@ public sealed record ProviderNewsItem(
     string NewsId,
     string Headline,
     DateTimeOffset PublishedAt,
-    string? Symbol = null,
-    string? Source = null,
-    string? Url = null);
+    string? Symbol,
+    string? Source,
+    string? Url,
+    ProviderDataProvenance Provenance)
+{
+    public ProviderNewsItem(string newsId, string headline, DateTimeOffset publishedAt, string? symbol = null, string? source = null, string? url = null)
+        : this(newsId, headline, publishedAt, symbol, source, url, ProviderDataProvenance.Unattributed(publishedAt)) { }
+}
 
 /// <summary>Presentation-safe trading-calendar event supplied by providers that support calendars.</summary>
 public sealed record ProviderCalendarEvent(
@@ -75,15 +80,25 @@ public sealed record ProviderCalendarEvent(
     DateTimeOffset StartsAt,
     DateTimeOffset EndsAt,
     string EventType,
-    string? Description = null);
+    string? Description,
+    ProviderDataProvenance Provenance)
+{
+    public ProviderCalendarEvent(string eventId, string market, DateTimeOffset startsAt, DateTimeOffset endsAt, string eventType, string? description = null)
+        : this(eventId, market, startsAt, endsAt, eventType, description, ProviderDataProvenance.Unattributed(startsAt)) { }
+}
 
 /// <summary>Presentation-safe instrument discovery result supplied by providers that support search.</summary>
 public sealed record ProviderInstrumentDiscoveryResult(
     string InstrumentId,
     string Symbol,
     string DisplayName,
-    string? Exchange = null,
-    string? AssetClass = null);
+    string? Exchange,
+    string? AssetClass,
+    ProviderDataProvenance Provenance)
+{
+    public ProviderInstrumentDiscoveryResult(string instrumentId, string symbol, string displayName, string? exchange = null, string? assetClass = null)
+        : this(instrumentId, symbol, displayName, exchange, assetClass, ProviderDataProvenance.Unattributed(DateTimeOffset.UtcNow)) { }
+}
 
 /// <summary>
 /// Provider availability and entitlement evidence. Implement this optional interface instead of
@@ -94,8 +109,13 @@ public sealed record ProviderDataAvailability(
     bool IsAvailable,
     string ConnectionState,
     DateTimeOffset ObservedAt,
-    string? Entitlement = null,
-    string? Detail = null);
+    string? Entitlement,
+    string? Detail,
+    ProviderDataProvenance Provenance)
+{
+    public ProviderDataAvailability(string providerFamily, bool isAvailable, string connectionState, DateTimeOffset observedAt, string? entitlement = null, string? detail = null)
+        : this(providerFamily, isAvailable, connectionState, observedAt, entitlement, detail, ProviderDataProvenance.Unattributed(observedAt)) { }
+}
 
 public interface IProviderDataAvailabilityReadService
 {

--- a/src/Meridian.ProviderSdk/IProviderInstrumentDiscoveryService.cs
+++ b/src/Meridian.ProviderSdk/IProviderInstrumentDiscoveryService.cs
@@ -14,9 +14,10 @@ public sealed record ProviderInstrument(
     string Symbol,
     string Name,
     string AssetClass,
-    string? Exchange = null,
-    string? Currency = null,
-    string? ProviderInstrumentId = null);
+    string? Exchange,
+    string? Currency,
+    string? ProviderInstrumentId,
+    ProviderDataProvenance Provenance);
 
 /// <summary>Optional provider capability for instrument and contract discovery.</summary>
 public interface IProviderInstrumentDiscoveryService : IProviderMetadata

--- a/src/Meridian.ProviderSdk/IProviderNewsService.cs
+++ b/src/Meridian.ProviderSdk/IProviderNewsService.cs
@@ -15,10 +15,11 @@ public sealed record ProviderNewsArticle(
     string Headline,
     DateTimeOffset PublishedAt,
     string Source,
-    string? Summary = null,
-    string? Url = null,
-    IReadOnlyList<string>? Symbols = null,
-    string? ProviderArticleId = null);
+    string? Summary,
+    string? Url,
+    IReadOnlyList<string>? Symbols,
+    string? ProviderArticleId,
+    ProviderDataProvenance Provenance);
 
 /// <summary>Optional provider capability for retrieving market news.</summary>
 public interface IProviderNewsService : IProviderMetadata

--- a/src/Meridian.ProviderSdk/IProviderPnlStream.cs
+++ b/src/Meridian.ProviderSdk/IProviderPnlStream.cs
@@ -6,7 +6,7 @@ namespace Meridian.ProviderSdk;
 public sealed record ProviderPnlStreamRequest(string AccountId, string? ModelAccountId = null);
 
 /// <summary>Timestamped account P&amp;L update emitted by a provider-neutral stream.</summary>
-public sealed record ProviderPnlUpdate(DateTimeOffset ObservedAt, ProviderAccountPnl Pnl);
+public sealed record ProviderPnlUpdate(DateTimeOffset ObservedAt, ProviderAccountPnl Pnl, ProviderDataProvenance Provenance);
 
 /// <summary>Optional provider capability for streaming account and model-account P&amp;L.</summary>
 public interface IProviderPnlStream : IProviderMetadata

--- a/tests/Meridian.Tests/Infrastructure/Providers/IBDataServicesTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/IBDataServicesTests.cs
@@ -92,7 +92,6 @@ public sealed class IBDataServicesTests
         var pnl = services.SubscribePnl("DU111", "model-a");
         var marketRule = services.RequestMarketRule(26);
         var options = services.RequestOptionChain(new SymbolConfig("SPY"));
-        services.RecordMarketDataType(scanner, 3);
 
         var callbackTime = DateTimeOffset.Parse("2026-07-22T12:00:00+00:00");
         var scannerRow = new ProviderScannerResult(0, "AAPL", "NASDAQ", "265598", null, null, null, null, ProviderDataProvenance.Unattributed(callbackTime));
@@ -103,6 +102,7 @@ public sealed class IBDataServicesTests
         services.RecordPnl(pnl, new ProviderAccountPnl("DU111", "model-a", 1m, 2m, 3m, null, null, ProviderDataProvenance.Unattributed(callbackTime)));
         services.RecordMarketRule(marketRule, [new ProviderMarketRuleIncrement(0m, 0.01m, ProviderDataProvenance.Unattributed(callbackTime))]);
         services.RecordOptionContract(options, new ProviderOptionContract("SPY", "SPY", new DateOnly(2026, 8, 21), 650m, "C", "SMART", null, null, "756733", ProviderDataProvenance.Unattributed(callbackTime)));
+        services.RecordMarketDataType(scanner, 3);
 
         var records = services.GetRequests();
         var observations = records.SelectMany(request => new object?[]
@@ -134,7 +134,27 @@ public sealed class IBDataServicesTests
         scannerKeys.Should().HaveCount(2);
         scannerKeys[0].Should().Be(scannerKeys[1], "identical provider callbacks must retain the same deduplication key");
         records.Single(x => x.RequestId == bars).RealTimeBars!.Single().Provenance.SourceTimestamp.Should().Be(callbackTime);
+        records.Single(x => x.RequestId == bars).RealTimeBars!.Single().Provenance.ReceiptTimestamp.Should().NotBe(callbackTime);
         records.Single(x => x.RequestId == scanner).ScannerResults!.Single().Provenance.MarketDataAvailability.Should().Be("Delayed");
+    }
+
+    [Fact]
+    public void CallbackBridge_EnrichesPreviouslyReceivedObservationsWithEntitlementEvidence()
+    {
+        var transport = new CallbackTransport();
+        using var services = new IBDataServices(transport, "ignored-because-transport-supplies-identity");
+        var requestId = services.RequestScanner(new IBScannerRequest("STK", "STK.US.MAJOR", "TOP_PERC_GAIN"));
+        var sourceTime = DateTimeOffset.Parse("2026-07-22T12:00:00+00:00");
+
+        transport.RaiseScannerResult(requestId, new ProviderScannerResult(0, "AAPL", "NASDAQ", "265598", null, null, null, null, ProviderDataProvenance.Unattributed(sourceTime)));
+        transport.RaiseMarketDataType(requestId, 1);
+
+        var provenance = services.GetRequests().Single().ScannerResults!.Single().Provenance;
+        provenance.ProviderConnectionId.Should().Be("ib-gateway:live:7");
+        provenance.SourceTimestamp.Should().Be(sourceTime);
+        provenance.ReceiptTimestamp.Should().NotBe(sourceTime);
+        provenance.Entitlement.Should().Be("reported");
+        provenance.MarketDataAvailability.Should().Be("Live");
     }
 
     [Fact]
@@ -206,5 +226,33 @@ public sealed class IBDataServicesTests
         public void RequestMarketRule(int requestId, int marketRuleId) => Calls.Add($"market-rule:{requestId}:{marketRuleId}");
         public void RequestDepthExchanges(int requestId) => Calls.Add($"depth-exchanges:{requestId}");
         public void CancelDataRequest(int requestId, string capability) => Calls.Add($"cancel:{requestId}:{capability}");
+    }
+
+    private sealed class CallbackTransport : IIBDataServiceTransport, IIBDataLineageSource, IIBDataCallbackSource, IIBProviderConnectionIdentity
+    {
+        public string ProviderConnectionId => "ib-gateway:live:7";
+        public event EventHandler<IBMarketDataTypeUpdate>? MarketDataTypeReceived;
+        public event EventHandler<(int RequestId, ProviderOptionContract Contract)>? OptionContractReceived;
+        public event EventHandler<(int RequestId, ProviderScannerResult Result)>? ScannerResultReceived;
+        public event EventHandler<(int RequestId, ProviderRealTimeBar Bar)>? RealTimeBarReceived;
+        public event EventHandler<(int RequestId, ProviderHistoricalTick Tick, bool Completed)>? HistoricalTickReceived;
+        public event EventHandler<(int RequestId, ProviderAccountPnl Pnl)>? PnlReceived;
+        public event EventHandler<(int RequestId, IReadOnlyList<ProviderMarketRuleIncrement> Increments)>? MarketRuleReceived;
+        public event EventHandler<int>? RequestCompleted;
+        public event EventHandler<(int RequestId, string Code, string Message)>? RequestRejected;
+
+        public void RequestScanner(int requestId, IBScannerRequest request) { }
+        public void RequestContractDetails(int requestId, SymbolConfig contract) { }
+        public void RequestOptionChain(int requestId, SymbolConfig underlying) { }
+        public void RequestHistoricalNews(int requestId, int conId, string providerCodes, DateTimeOffset start, DateTimeOffset end, int maximumResults) { }
+        public void RequestNewsArticle(int requestId, string providerCode, string articleId) { }
+        public void RequestFundamentals(int requestId, SymbolConfig contract, string reportType) { }
+        public void RequestDividendEarnings(int requestId, SymbolConfig contract) { }
+        public void RequestTickByTick(int requestId, SymbolConfig contract, string tickType, int numberOfTicks, bool ignoreSize) { }
+        public void RequestPnl(int requestId, string account, string? modelCode) { }
+        public void RequestMarketRule(int requestId, int marketRuleId) { }
+        public void RequestDepthExchanges(int requestId) { }
+        public void RaiseScannerResult(int requestId, ProviderScannerResult result) => ScannerResultReceived?.Invoke(this, (requestId, result));
+        public void RaiseMarketDataType(int requestId, int marketDataType) => MarketDataTypeReceived?.Invoke(this, new IBMarketDataTypeUpdate(requestId, marketDataType));
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure every provider-returned record and event carries a complete, shared provenance record including provider id, `ProviderConnectionId`, source and receipt timestamps, entitlement/feed/availability, request/subscription descriptor, provider-native id, correlation id, and a stable de-duplication key.  
- Allow Infrastructure adapters (Interactive Brokers) to construct provenance at request time and to enrich previously-received observations when entitlement/market-data-type callbacks arrive while preserving original source timestamps and recording receipt time.  
- Preserve compatibility for existing presentation types by providing convenience constructors that attach unattributed provenance when caller context is not yet available.  

### Description
- Added provenance fields to provider-facing typed records and responses by extending `ProviderNewsItem`, `ProviderCalendarEvent`, `ProviderInstrumentDiscoveryResult`, `ProviderDataAvailability`, `ProviderNewsArticle`, `ProviderInstrument`, `ProviderPnlUpdate`, and `ProviderMarketRule` to include `ProviderDataProvenance` and provided compatibility constructors where appropriate (files under `src/Meridian.ProviderSdk/`).  
- Updated the IB adapter `IBDataServices` to refresh stored observation provenance when entitlement/market-data-type callbacks arrive by introducing `RefreshProvenance` and a `CreateProvenance` overload that preserves `SourceTimestamp` while recording a `ReceiptTimestamp`, ensures a non-empty `ProviderNativeId` fallback, and derives a deterministic stable deduplication key from provider-native id plus the request/correlation context.  
- Changed read-model publishing to re-materialize provenance on lineage updates (`RecordMarketDataType` -> use `RefreshProvenance`) and ensured all observation creation paths call `CreateObservationProvenance` so every returned record carries the required provenance.  
- Added test coverage in `tests/Meridian.Tests/Infrastructure/Providers/IBDataServicesTests.cs` to assert provenance completeness on returned records, separation of source vs receipt timestamps, stable de-duplication across repeated callbacks, and bridge-enrichment behavior using a `CallbackTransport` that supplies a concrete `ProviderConnectionId`.  

### Testing
- Ran `git diff --check` locally and it completed with no whitespace or diff-check errors.  
- Attempted to run the repository CI script with `bash scripts/ci.sh` but the run stopped during the SDK verification step because `dotnet` is not available in this environment, so full automated validation could not complete.  
- Attempted to run targeted unit tests with `dotnet test --filter "FullyQualifiedName~IBDataServicesTests"` but it could not be executed here for the same `dotnet` availability reason; the new tests are present at `tests/Meridian.Tests/Infrastructure/Providers/IBDataServicesTests.cs` for CI to run in a proper .NET-enabled environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6124c896008320a86d6bef3c13856a)