### PR TITLE
fix(execution): authorize amended order quantities locally

### DIFF
--- a/src/Meridian.Execution/OrderManagementSystem.cs
+++ b/src/Meridian.Execution/OrderManagementSystem.cs
@@ -644,10 +644,13 @@ public sealed class OrderManagementSystem : IOrderManager, IDisposable, IAsyncDi
             };
         }
 
+        // The gateway report stream is not an authorization channel. Only this locally
+        // initiated modification may change the quantity cap, and it may do so only to
+        // the quantity the caller requested; never to a gateway-supplied quantity.
         var updated = _orders.AddOrUpdate(
             orderId,
-            _ => ApplyReport(state, report),
-            (_, existing) => ApplyReport(existing, report));
+            _ => ApplyReport(state, report, modification.NewQuantity),
+            (_, existing) => ApplyReport(existing, report, modification.NewQuantity));
         await RecordSessionOrderUpdateAsync(ResolveSessionId(orderId), updated, ct).ConfigureAwait(false);
         await RecordOrderLifecycleAuditAsync(
             action: "OrderModified",
@@ -850,7 +853,10 @@ public sealed class OrderManagementSystem : IOrderManager, IDisposable, IAsyncDi
         return $"MDN-{DateTimeOffset.UtcNow:yyyyMMdd}-{seq:D6}";
     }
 
-    private static OrderState ApplyReport(OrderState current, ExecutionReport report)
+    private static OrderState ApplyReport(
+        OrderState current,
+        ExecutionReport report,
+        decimal? locallyAuthorizedModifiedQuantity = null)
     {
         // Once the OMS has reached a terminal state, late or malicious stream reports
         // must not reopen, resize, or otherwise mutate the completed local order.
@@ -859,13 +865,13 @@ public sealed class OrderManagementSystem : IOrderManager, IDisposable, IAsyncDi
             return current;
         }
 
-        // A broker-accepted modification establishes the new authorized order
-        // quantity. Preserve the current quantity for report types that do not
-        // carry a reliable order quantity (for example, fills from some brokers).
+        // Gateway-streamed modifications are not trusted to authorize a quantity change.
+        // A quantity may change only while applying the response to a locally initiated
+        // modification, and is capped to the local request rather than report data.
         var authorizedQuantity = report.ReportType is ExecutionReportType.Modified
             && report.OrderStatus is OrderStatus.Accepted
-            && report.OrderQuantity > 0m
-            ? Math.Max(report.OrderQuantity, current.FilledQuantity)
+            && locallyAuthorizedModifiedQuantity is > 0m
+            ? Math.Max(locallyAuthorizedModifiedQuantity.Value, current.FilledQuantity)
             : current.Quantity;
 
         return current with

--- a/tests/Meridian.Tests/Execution/OrderManagementSystemReportStreamTests.cs
+++ b/tests/Meridian.Tests/Execution/OrderManagementSystemReportStreamTests.cs
@@ -241,6 +241,48 @@ public sealed class OrderManagementSystemReportStreamTests
     }
 
     [Fact]
+    public async Task UnsolicitedAcceptedModification_CannotIncreaseAuthorizedQuantity()
+    {
+        var portfolio = new PaperTradingPortfolio(100_000m);
+        var gateway = new StreamingGateway
+        {
+            SubmitAck = BuildReport("pending", OrderStatus.Accepted, ExecutionReportType.New, filledQty: 0m, fillPrice: null)
+        };
+        using var oms = new OrderManagementSystem(
+            gateway,
+            NullLogger<OrderManagementSystem>.Instance,
+            portfolioState: portfolio);
+
+        var result = await oms.PlaceOrderAsync(new OrderRequest
+        {
+            Symbol = "AAPL",
+            Side = OrderSide.Buy,
+            Type = OrderType.Limit,
+            Quantity = 10m,
+            LimitPrice = 150m
+        });
+        result.Success.Should().BeTrue();
+
+        await gateway.PublishAsync(
+            BuildReport(result.OrderId, OrderStatus.Accepted, ExecutionReportType.Modified, filledQty: 0m, fillPrice: null, orderQuantity: 1_000m));
+        await WaitUntilAsync(() => oms.GetOrder(result.OrderId)!.Status == OrderStatus.Accepted,
+            "the unsolicited report still reaches the tracked order");
+
+        oms.GetOrder(result.OrderId)!.Quantity.Should().Be(10m,
+            because: "a gateway report without a local modification must not authorize a larger order");
+
+        await gateway.PublishAsync(
+            BuildReport(result.OrderId, OrderStatus.Filled, ExecutionReportType.Fill, filledQty: 1_000m, fillPrice: 150m));
+        await WaitUntilAsync(() => oms.GetOrder(result.OrderId)!.Status == OrderStatus.Filled,
+            "the oversized completion report reaches the tracked order");
+
+        oms.GetOrder(result.OrderId)!.FilledQuantity.Should().Be(10m);
+        portfolio.Positions["AAPL"].Quantity.Should().Be(10m,
+            because: "the portfolio must only receive the originally authorized fill quantity");
+        portfolio.Cash.Should().Be(100_000m - 1_500m);
+    }
+
+    [Fact]
     public async Task LateFillAfterTerminalOrder_DoesNotMutatePortfolioOrOrderState()
     {
         var portfolio = new PaperTradingPortfolio(100_000m);


### PR DESCRIPTION
### Motivation
- The OMS previously trusted gateway-streamed `Modified/Accepted` reports to set the local authorized `OrderState.Quantity`, which allowed a malicious or corrupted gateway report to inflate an order and permit oversized fills.  
- The intent is to ensure only a locally initiated and approved modification can change the authorized quantity, and only up to the locally requested amount.

### Description
- Change `ApplyReport` to accept an optional `locallyAuthorizedModifiedQuantity` and treat gateway-streamed `Modified/Accepted` reports as status updates only unless the change is applied as part of a local `ModifyOrderAsync` response.  
- In `ModifyOrderAsync` pass the local `modification.NewQuantity` into `ApplyReport` so an accepted modification is capped to the locally requested amount rather than the gateway-supplied `OrderQuantity`.  
- Add regression test `UnsolicitedAcceptedModification_CannotIncreaseAuthorizedQuantity` to `OrderManagementSystemReportStreamTests.cs` that publishes an unsolicited `Modified/Accepted` with an inflated `orderQuantity` followed by a huge fill and verifies the tracked order and `PaperTradingPortfolio` remain capped to the original local authorization.  
- Files changed: `src/Meridian.Execution/OrderManagementSystem.cs` and `tests/Meridian.Tests/Execution/OrderManagementSystemReportStreamTests.cs`.

### Testing
- Ran static checks: `git diff --check HEAD^ HEAD` passed with no whitespace errors.  
- Added a targeted unit test covering unsolicited modification behavior (`UnsolicitedAcceptedModification_CannotIncreaseAuthorizedQuantity`) but could not run `dotnet test` in this environment because the `.NET SDK` is not installed (attempts returned `dotnet: command not found`).  
- Running `bash scripts/ci.sh` in this environment is blocked by the same missing `.NET SDK`; CI must run on an environment with the SDK to validate the new test and full suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611ecfb35883209f8202cbcc8ca671)