### PR TITLE
Authorize close task approval roles

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/LedgerEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/LedgerEndpoints.cs
@@ -1018,7 +1018,7 @@ public static class LedgerEndpoints
             UpsertClosePeriodPlanConfigurationRequestDto request,
             HttpContext context) =>
         {
-            if (!HasLedgerMutationPermission(context))
+            if (!HasLedgerMutationPermission(context) || !CanConfigureCloseTaskApprovalRoles(context, request.TaskConfigurations))
             {
                 return EndpointHelpers.Forbidden();
             }
@@ -1165,7 +1165,7 @@ public static class LedgerEndpoints
             SignOffCloseTaskRequestDto request,
             HttpContext context) =>
         {
-            if (!HasLedgerMutationPermission(context))
+            if (!HasLedgerMutationPermission(context) || !HasCloseTaskSignOffRoleAuthority(context, request.Role))
             {
                 return EndpointHelpers.Forbidden();
             }
@@ -2076,6 +2076,38 @@ public static class LedgerEndpoints
 
     private static bool HasLedgerCertificationPermission(HttpContext context)
         => EndpointAuthorization.HasPermission(context, UserPermission.AdminMaintenance);
+
+    private static bool CanConfigureCloseTaskApprovalRoles(
+        HttpContext context,
+        IReadOnlyList<CloseTaskConfigurationDto> taskConfigurations)
+        => taskConfigurations.All(configuration =>
+            string.IsNullOrWhiteSpace(configuration.RequiredApprovalRole) ||
+            HasCloseTaskSignOffRoleAuthority(context, configuration.RequiredApprovalRole));
+
+    private static bool HasCloseTaskSignOffRoleAuthority(HttpContext context, string role)
+    {
+        if (string.IsNullOrWhiteSpace(role))
+        {
+            return false;
+        }
+
+        if (HasLedgerCertificationPermission(context))
+        {
+            return true;
+        }
+
+        var normalizedRole = role.Trim();
+        if (context.Items.TryGetValue(LoginSessionMiddleware.CurrentUserRoleKey, out var rawRole) &&
+            rawRole is UserRole currentRole &&
+            string.Equals(currentRole.ToString(), normalizedRole, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return context.Items.TryGetValue(LoginSessionMiddleware.CurrentUserRoleProfileNameKey, out var rawProfile) &&
+            rawProfile is string profileName &&
+            string.Equals(profileName.Trim(), normalizedRole, StringComparison.OrdinalIgnoreCase);
+    }
 
     private static bool HasManualJournalLifecycleActionPermission(
         HttpContext context,

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.Wave4.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.Wave4.cs
@@ -993,6 +993,59 @@ public sealed partial class WorkstationEndpointsTests
     }
 
     [Fact]
+    public async Task LedgerCloseManagementEndpoints_AccountingUserCannotConfigureOrSignOffElevatedCloseApprovalRole()
+    {
+        await using var app = await CreateAppAsync(
+            RegisterOperationsContinuityServices,
+            currentUserPermissions: UserPermission.ManageDirectLending,
+            currentUserRole: UserRole.Accounting,
+            currentUserRoleProfileName: "accounting-ops");
+        var client = app.GetTestClient();
+        var ledgerBookId = Guid.NewGuid();
+
+        using var startResponse = await client.PostAsJsonAsync(
+            UiApiRoutes.OperationsContinuity,
+            new OperationsStartWorkflowRequestDto(
+                Guid.NewGuid(),
+                "2026-08",
+                SecurityMasterSnapshotId: null,
+                BrokerSource: "custodian",
+                Actor: "local-actor",
+                LedgerBookId: ledgerBookId));
+        startResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var start = await startResponse.Content.ReadFromJsonAsync<OperationsTransitionResultDto>(ServerJsonOptions);
+        var workflowId = start!.Workflow!.WorkflowId;
+        var taskId = start.Workflow.CloseChecklist[0].TaskId;
+
+        using var configureResponse = await client.PostAsJsonAsync(
+            UiApiRoutes.LedgerCloseManagementPeriodPlanConfiguration,
+            new UpsertClosePeriodPlanConfigurationRequestDto(
+                workflowId,
+                TaskConfigurations:
+                [
+                    new CloseTaskConfigurationDto(
+                        taskId,
+                        RequiredApprovalCount: 1,
+                        RequiredApprovalRole: "CFO")
+                ],
+                Actor: "payload-actor",
+                EvidenceLinks: [$"evidence:close-plan:{workflowId:D}:2026-08:book:{ledgerBookId:D}:configuration-approval"]));
+        configureResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        using var signOffResponse = await client.PostAsJsonAsync(
+            UiApiRoutes.LedgerCloseManagementTaskSignOffs,
+            new SignOffCloseTaskRequestDto(
+                workflowId,
+                taskId,
+                "CFO",
+                ManualJournalEntryStatusDto.Approved,
+                "accounting-user",
+                "Attempted elevated CFO sign-off.",
+                EvidenceLinks: [$"evidence:close-task:{taskId}:CFO:2026-08:book:{ledgerBookId:D}:cfo-signoff"]));
+        signOffResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
     public async Task LedgerCloseManagementEndpoints_ConfigureClosePlanMaterialitySignOffsAndDependencies()
     {
         await using var app = await CreateAppAsync(


### PR DESCRIPTION
### Motivation
- A user-controlled `RequiredApprovalRole` and unconstrained sign-off path allowed any caller with ledger mutation permission to configure and sign off as elevated business roles (e.g., `CFO`), creating an integrity vulnerability in close governance.
- The intent is to bind configuration and sign-off role strings to the authenticated session or an elevated certification permission so role-scoped approvals cannot be forged by lower-privileged ledger mutators.

### Description
- Added server-side authorization helpers to `src/Meridian.Ui.Shared/Endpoints/LedgerEndpoints.cs`: `CanConfigureCloseTaskApprovalRoles` and `HasCloseTaskSignOffRoleAuthority` to validate role strings against the authenticated session or elevated permission.
- Gate the close-plan configuration endpoint (`UpsertClosePeriodPlanConfiguration`) with `CanConfigureCloseTaskApprovalRoles` and gate the task sign-off endpoint (`SignOffCloseTask`) with `HasCloseTaskSignOffRoleAuthority` so only sessions that actually hold the role/profile or have `AdminMaintenance` may configure or sign as that role.
- Role check logic permits the action when the caller has certification permission (`AdminMaintenance`) or when the caller's `UserRole` or role-profile name matches the configured/sign-off role string (case-insensitive normalized match).
- Added a regression test `LedgerCloseManagementEndpoints_AccountingUserCannotConfigureOrSignOffElevatedCloseApprovalRole` in `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.Wave4.cs` that verifies an `Accounting` user with `ManageDirectLending` cannot set or sign off as `CFO`.

### Testing
- Ran `git diff --check` and a small Python assertion script to confirm the new authorization checks are present and wired into `LedgerEndpoints.cs` (static assertions passed).
- Attempted to run the targeted `dotnet test` for the new and related endpoint tests with the filter `FullyQualifiedName~LedgerCloseManagementEndpoints_AccountingUserCannotConfigureOrSignOffElevatedCloseApprovalRole|FullyQualifiedName~LedgerCloseManagementEndpoints_ConfigureClosePlanMaterialitySignOffsAndDependencies`, but `dotnet` was not available in this environment so the test run could not be executed (`/bin/bash: line 1: dotnet: command not found`).
- The change includes the new test file entry `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.Wave4.cs` which should be run in CI or a developer environment with the .NET SDK to validate behavior end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ae50333d48320b40e7ace43f9e67f)