### PR TITLE
Enforce brokerage routing gate for cancel endpoints

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs
@@ -193,6 +193,11 @@ public static class ExecutionEndpoints
             if (oms is null)
                 return Results.Problem("Order management system is not active.", statusCode: StatusCodes.Status503ServiceUnavailable);
 
+            if (TryRejectBrokerOrderRouting(context.RequestServices, jsonOptions) is { } blockedRouting)
+            {
+                return blockedRouting;
+            }
+
             var logger = GetLogger(context.RequestServices);
             var actionId = GenerateActionId();
             var result = await oms.CancelOrderAsync(orderId, context.RequestAborted).ConfigureAwait(false);
@@ -231,6 +236,11 @@ public static class ExecutionEndpoints
             var oms = context.RequestServices.GetService<IOrderManager>();
             if (oms is null)
                 return Results.Problem("Order management system is not active.", statusCode: StatusCodes.Status503ServiceUnavailable);
+
+            if (TryRejectBrokerOrderRouting(context.RequestServices, jsonOptions) is { } blockedRouting)
+            {
+                return blockedRouting;
+            }
 
             var logger = GetLogger(context.RequestServices);
             var actionId = GenerateActionId();
@@ -1283,6 +1293,23 @@ public static class ExecutionEndpoints
     }
 
     private static string GenerateActionId() => $"act-{Guid.NewGuid():N}";
+
+    private static IResult? TryRejectBrokerOrderRouting(IServiceProvider services, JsonSerializerOptions jsonOptions)
+    {
+        var gateDecision = BrokerageOrderPlacementGate.Evaluate(
+            services.GetService<BrokerageConfiguration>());
+        if (gateDecision.IsAllowed)
+        {
+            return null;
+        }
+
+        var blocked = new TradingActionResult(
+            ActionId: GenerateActionId(),
+            Status: "Rejected",
+            Message: gateDecision.RejectReason ?? "Broker order routing is disabled by validation gates.",
+            OccurredAt: DateTimeOffset.UtcNow);
+        return Results.Json(blocked, jsonOptions, statusCode: StatusCodes.Status403Forbidden);
+    }
 
     private static IResult? TryRejectOrderRoutingForPhaseGate(IServiceProvider services)
     {

--- a/tests/Meridian.Tests/Ui/ExecutionWriteEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/ExecutionWriteEndpointsTests.cs
@@ -119,6 +119,37 @@ public sealed class ExecutionWriteEndpointsTests
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 
+    [Fact]
+    public async Task CancelOrder_WhenLiveProductionRoutingDisabled_Returns403AndDoesNotCancel()
+    {
+        var orderManager = new RecordingOrderManager(CreateOrderState("ord-live-001", "AAPL", 1m));
+        await using var app = await CreateAppAsync(services =>
+        {
+            services.AddSingleton<IOrderManager>(orderManager);
+            services.AddSingleton(new BrokerageConfiguration
+            {
+                Gateway = "robinhood",
+                LiveExecutionEnabled = true,
+                ReadOnlyPhaseEnabled = true,
+                PaperTradingPhaseEnabled = true,
+                ProductionRoutingPhaseEnabled = false,
+                BrokerFlows = new Dictionary<string, BrokerFlowFlags>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["robinhood"] = new() { ProductionOrderRoutingEnabled = true }
+                }
+            });
+        });
+
+        var client = app.GetTestClient();
+        var response = await client.PostAsync("/api/execution/orders/ord-live-001/cancel", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        var result = await ReadActionResultAsync(response);
+        result.Status.Should().Be("Rejected");
+        result.Message.Should().Contain("production routing is disabled");
+        orderManager.CancelledOrderIds.Should().BeEmpty();
+    }
+
     // ------------------------------------------------------------------ //
     //  POST /api/execution/orders/cancel-all                              //
     // ------------------------------------------------------------------ //
@@ -151,7 +182,7 @@ public sealed class ExecutionWriteEndpointsTests
 
 
     [Fact]
-    public async Task CancelAllOrders_WhenProductionPhaseDisabled_StillCancels()
+    public async Task CancelAllOrders_WhenProductionPhaseDisabledForPaperFlow_StillCancels()
     {
         await using var app = await CreateAppAsync(services =>
         {
@@ -168,6 +199,38 @@ public sealed class ExecutionWriteEndpointsTests
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var result = await ReadActionResultAsync(response);
         result.Status.Should().Be("Completed");
+    }
+
+    [Fact]
+    public async Task CancelAllOrders_WhenLiveProductionRoutingDisabled_Returns403AndDoesNotCancel()
+    {
+        var orderManager = new RecordingOrderManager(CreateOrderState("ord-live-001", "AAPL", 1m));
+        await using var app = await CreateAppAsync(services =>
+        {
+            services.AddSingleton<IOrderManager>(orderManager);
+            services.AddSingleton(new BrokerageConfiguration
+            {
+                Gateway = "robinhood",
+                LiveExecutionEnabled = true,
+                ReadOnlyPhaseEnabled = true,
+                PaperTradingPhaseEnabled = true,
+                ProductionRoutingPhaseEnabled = false,
+                BrokerFlows = new Dictionary<string, BrokerFlowFlags>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["robinhood"] = new() { ProductionOrderRoutingEnabled = true }
+                }
+            });
+        });
+
+        var client = app.GetTestClient();
+        var response = await client.PostAsync("/api/execution/orders/cancel-all", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        var result = await ReadActionResultAsync(response);
+        result.Status.Should().Be("Rejected");
+        result.Message.Should().Contain("production routing is disabled");
+        orderManager.CancelAllCallCount.Should().Be(0);
+        orderManager.CancelledOrderIds.Should().BeEmpty();
     }
 
     // ------------------------------------------------------------------ //
@@ -1246,6 +1309,44 @@ file sealed class StaticPortfolioState(params ExecutionPosition[] positions) : M
         position => position.Symbol,
         position => (Meridian.Execution.Sdk.IPosition)position,
         StringComparer.OrdinalIgnoreCase);
+}
+
+file sealed class RecordingOrderManager(params OrderState[] openOrders) : IOrderManager
+{
+    private readonly IReadOnlyList<OrderState> _openOrders = openOrders;
+
+    public List<string> CancelledOrderIds { get; } = new();
+    public int CancelAllCallCount { get; private set; }
+
+    public Task<OrderResult> PlaceOrderAsync(ExecutionOrderRequest request, CancellationToken ct = default) =>
+        Task.FromResult(new OrderResult { Success = true, OrderId = request.ClientOrderId ?? "recorded-order" });
+
+    public Task<OrderResult> CancelOrderAsync(string orderId, CancellationToken ct = default)
+    {
+        CancelledOrderIds.Add(orderId);
+        return Task.FromResult(new OrderResult { Success = true, OrderId = orderId });
+    }
+
+    public Task<OrderResult> ModifyOrderAsync(string orderId, OrderModification modification, CancellationToken ct = default) =>
+        Task.FromResult(new OrderResult { Success = true, OrderId = orderId });
+
+    public IReadOnlyList<OrderState> GetOpenOrders() => _openOrders;
+
+    public OrderState? GetOrder(string orderId) =>
+        _openOrders.FirstOrDefault(order => string.Equals(order.OrderId, orderId, StringComparison.OrdinalIgnoreCase));
+
+    public Task CancelAllAsync(CancellationToken ct = default)
+    {
+        CancelAllCallCount++;
+        foreach (var order in _openOrders)
+        {
+            CancelledOrderIds.Add(order.OrderId);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public IReadOnlyList<OrderState> GetCompletedOrders(int take = 20) => Array.Empty<OrderState>();
 }
 
 sealed class RecordingBrokerageGateway(params BrokerPosition[] positions) : IBrokerageGateway


### PR DESCRIPTION
### Motivation
- Prevent a safety-gate bypass that allowed authenticated ManageOrders users to send live broker cancel requests even when production-routing or validation gates were disabled. 
- Cancellation previously reached the OMS which invoked broker gateways directly without the same `BrokerageOrderPlacementGate` checks used for order placement, exposing live protective/hedge orders to unintended cancellation.

### Description
- Reintroduce a broker-routing gate helper `TryRejectBrokerOrderRouting` that evaluates `BrokerageOrderPlacementGate.Evaluate` and returns a 403 `TradingActionResult` when routing is blocked. (src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs)
- Invoke the new gate early in the `/api/execution/orders/{orderId}/cancel` handler so cancel requests are rejected before calling `IOrderManager.CancelOrderAsync`. (src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs)
- Invoke the same gate early in the `/api/execution/orders/cancel-all` handler so bulk cancellations cannot fan out to the OMS when live routing is blocked. (src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs)
- Add regression tests that assert live-routing-disabled cancel behavior is rejected without invoking downstream cancellation and that paper-flow cancel-all behavior is preserved, plus a small `RecordingOrderManager` test double used to assert no side effects. (tests/Meridian.Tests/Ui/ExecutionWriteEndpointsTests.cs)

### Testing
- Added focused xUnit tests under `ExecutionWriteEndpointsTests` verifying `CancelOrder_WhenLiveProductionRoutingDisabled_Returns403AndDoesNotCancel` and `CancelAllOrders_WhenLiveProductionRoutingDisabled_Returns403AndDoesNotCancel`; these tests were added but could not be executed locally because `dotnet` is not installed in the container.  
- Performed repository hygiene checks: `git diff --check` and `git status` succeeded and changes were committed.  
- Diff/stat summary: modified `src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs` and `tests/Meridian.Tests/Ui/ExecutionWriteEndpointsTests.cs`; commit created with message "Gate live order cancellations".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3942c918648320b6982fa4ccbf837b)