### PR TITLE
Fix IBKR activity sync account scoping

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.IBApi.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.IBApi.cs
@@ -1125,7 +1125,7 @@ public sealed partial class EnhancedIBConnectionManager : EWrapper, IDisposable
             order.AuxPrice > 0 ? order.AuxPrice : null,
             orderState.Status ?? "Submitted",
             string.IsNullOrWhiteSpace(order.OrderRef) ? null : order.OrderRef,
-            null,
+            string.IsNullOrWhiteSpace(order.Account) ? null : order.Account,
             orderState.CommissionAndFees > 0 ? orderState.CommissionAndFees : null,
             string.IsNullOrWhiteSpace(orderState.RejectReason) ? null : orderState.RejectReason,
             metadata,

--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBBrokerageGateway.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBBrokerageGateway.cs
@@ -41,6 +41,7 @@ public sealed class IBBrokerageGateway :
     private readonly ConcurrentDictionary<int, SubmittedOrderContext> _submittedOrders = new();
     private readonly ConcurrentDictionary<string, int> _gatewayOrderIdsByExternalId = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<int, BrokerOrder> _openOrders = new();
+    private readonly ConcurrentDictionary<int, string> _openOrderAccounts = new();
     private readonly ConcurrentDictionary<string, IBExecutionUpdate> _executions = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<int, PendingOrderOperation> _pendingOrderOperations = new();
     private readonly ConcurrentDictionary<int, AccountSummaryCollector> _accountSummaryRequests = new();
@@ -431,7 +432,12 @@ public sealed class IBBrokerageGateway :
             ProviderId,
             externalAccountId,
             DateTimeOffset.UtcNow,
-            orders.Select(order => new BrokerageOrderSnapshotDto(
+            orders
+                .Where(order =>
+                    int.TryParse(order.OrderId, out var orderId) &&
+                    _openOrderAccounts.TryGetValue(orderId, out var accountId) &&
+                    string.Equals(accountId, externalAccountId, StringComparison.OrdinalIgnoreCase))
+                .Select(order => new BrokerageOrderSnapshotDto(
                 order.OrderId, order.ClientOrderId, order.Symbol, order.Side, order.Type, order.Status,
                 order.Quantity, order.FilledQuantity, order.LimitPrice, order.StopPrice, order.CreatedAt)).ToArray(),
             fills,
@@ -663,6 +669,11 @@ public sealed class IBBrokerageGateway :
     private void OnOpenOrderReceived(object? sender, IBOpenOrderUpdate update)
     {
         var gatewayOrderId = update.OrderId;
+        if (string.IsNullOrWhiteSpace(update.Account))
+            _openOrderAccounts.TryRemove(gatewayOrderId, out _);
+        else
+            _openOrderAccounts[gatewayOrderId] = update.Account.Trim();
+
         var context = _submittedOrders.TryGetValue(gatewayOrderId, out var tracked) ? tracked : null;
         var brokerOrder = new BrokerOrder
         {

--- a/tests/Meridian.Tests/Infrastructure/Providers/IBBrokerageGatewayTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/IBBrokerageGatewayTests.cs
@@ -364,6 +364,33 @@ public sealed class IBBrokerageGatewayTests
     }
 
     [Fact]
+    public async Task GetActivitySnapshotAsync_OnlyReturnsOpenOrdersForRequestedAccount()
+    {
+        var client = new FakeIbBrokerageClient
+        {
+            OnRequestNextValidId = c => c.RaiseNextValidId(7101),
+            OnRequestOpenOrders = c =>
+            {
+                c.RaiseOpenOrder(new IBOpenOrderUpdate(
+                    7101, "AAPL", "STK", "BUY", "LMT", 10m, 0m,
+                    200d, null, "Submitted", "account-a-order", "DU111111", null, null, null, DateTimeOffset.UtcNow));
+                c.RaiseOpenOrder(new IBOpenOrderUpdate(
+                    7102, "TSLA", "STK", "SELL", "LMT", 5m, 0m,
+                    250d, null, "Submitted", "account-b-order", "DU222222", null, null, null, DateTimeOffset.UtcNow));
+                c.RaiseOpenOrdersCompleted();
+            }
+        };
+
+        await using var sut = CreateSut(client);
+        await sut.ConnectAsync();
+
+        var activity = await ((IBrokerageActivitySync)sut).GetActivitySnapshotAsync("DU111111");
+
+        activity.Orders.Should().ContainSingle(order => order.OrderId == "7101");
+        activity.Orders.Should().NotContain(order => order.OrderId == "7102");
+    }
+
+    [Fact]
     public async Task GetAccountInfoAsync_MapsAccountSummaryCallbacks()
     {
         var client = new FakeIbBrokerageClient


### PR DESCRIPTION
### Motivation
- Prevent cross-account leakage where `GetActivitySnapshotAsync` returned open orders for all IB accounts instead of only the requested `externalAccountId`.

### Description
- Preserve the IB open-order source account by adding `_openOrderAccounts : ConcurrentDictionary<int,string>` and storing `update.Account` in `OnOpenOrderReceived` in `IBBrokerageGateway.cs`.
- Fail-closed when the callback `Account` is missing by removing any existing map entry for that order id in `OnOpenOrderReceived`.
- Scope activity snapshots by filtering open orders in `GetActivitySnapshotAsync` to only include orders whose stored account equals the requested `externalAccountId`.
- Propagate the native IB `order.Account` from `EnhancedIBConnectionManager.IBApi.openOrder` into the `IBOpenOrderUpdate` so the account field is available to the gateway mapping.
- Add a regression unit test `GetActivitySnapshotAsync_OnlyReturnsOpenOrdersForRequestedAccount` in `IBBrokerageGatewayTests.cs` that emits two open-order callbacks for different accounts and asserts only the requested account's order is returned.
- Modified files: `src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBBrokerageGateway.cs`, `src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.IBApi.cs`, and `tests/Meridian.Tests/Infrastructure/Providers/IBBrokerageGatewayTests.cs`.

### Testing
- Ran `git diff --check` and it passed.
- Ran `python build/python/cli/buildctl.py validation-status --summary` and it returned `blocked=false` (local validation summary OK).
- Attempted `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter 'FullyQualifiedName~IBBrokerageGatewayTests' --no-restore` but the environment has no `dotnet` executable so the unit tests could not be executed locally.
- Ran `bash scripts/ci.sh` which also could not complete due to the missing .NET SDK in the environment.
- Added a focused regression test that proves the leak is fixed; this test will run under CI/GitHub Actions where the .NET SDK is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f3a9c008320884b406f57a5fec5)