### PR TITLE
Reject seeded/sample/demo evidence at ledger append boundary

### DIFF
--- a/src/Meridian.Storage/Ledger/AccountingPostingCommandValidator.cs
+++ b/src/Meridian.Storage/Ledger/AccountingPostingCommandValidator.cs
@@ -179,7 +179,11 @@ public static class AccountingPostingCommandValidator
     // command Provenance mark is the primary gate; this is a narrow safety net for a source that is
     // labeled simulated while the posting forgot to carry the mark.
     private static readonly string[] SimulatedOriginTokens =
-        ["simulated", "simulation", "synthetic", "backtest"];
+    [
+        "simulated", "simulation", "synthetic", "backtest",
+        "seeded", "seed", "demo", "fixture",
+        "sample", "placeholder"
+    ];
 
     private static bool DeclaresSimulatedOrigin(AccountingPostingCommandDto command)
     {

--- a/tests/Meridian.Tests/Storage/LedgerJournalStoreTests.cs
+++ b/tests/Meridian.Tests/Storage/LedgerJournalStoreTests.cs
@@ -995,10 +995,17 @@ public sealed class LedgerJournalStoreTests
     }
 
 
-    [Fact]
-    public void PostingCommand_UnmarkedSimulatedEvidence_IsRejectedAtAppendBoundary()
+    [Theory]
+    [InlineData("Simulated")]
+    [InlineData("seeded")]
+    [InlineData("seed")]
+    [InlineData("demo")]
+    [InlineData("fixture")]
+    [InlineData("sample")]
+    [InlineData("placeholder")]
+    public void PostingCommand_UnmarkedNonRealEvidence_IsRejectedAtAppendBoundary(string evidenceSource)
     {
-        var write = BuildSimulatedOriginPostingWrite(DataProvenance.Real);
+        var write = BuildSimulatedOriginPostingWrite(DataProvenance.Real, evidenceSource);
 
         var act = () => AccountingPostingCommandValidator.NormalizeAndValidate(write);
 
@@ -1017,7 +1024,9 @@ public sealed class LedgerJournalStoreTests
         normalized.Entry.Metadata.Tags["dataProvenance"].Should().Be("SIMULATED");
     }
 
-    private static LedgerJournalEntryWrite BuildSimulatedOriginPostingWrite(DataProvenance provenance)
+    private static LedgerJournalEntryWrite BuildSimulatedOriginPostingWrite(
+        DataProvenance provenance,
+        string evidenceSource = "Simulated")
     {
         var periodId = Guid.NewGuid();
         var aggregateId = Guid.NewGuid();
@@ -1041,7 +1050,7 @@ public sealed class LedgerJournalStoreTests
                         "evidence-sim-1",
                         "evidence://sim/shadow-book-1",
                         AccountingPostingEvidenceKindDto.Source,
-                        "Simulated",
+                        evidenceSource,
                         DateTimeOffset.Parse("2026-01-31T20:00:00Z"),
                         "fund-controller")
                 ],


### PR DESCRIPTION
### Motivation
- Close a fail-closed bypass where non-real evidence tokens like `seeded`, `sample`, `demo`, and `fixture` could be persisted as real because the append-boundary validator only matched a small subset of non-real tokens. 
- Ensure the ledger append gate and retained journal metadata faithfully label non-real origins so simulated/demo data can never be mistaken for real in authoritative journal entries.

### Description
- Expanded the append-boundary allowlist in `src/Meridian.Storage/Ledger/AccountingPostingCommandValidator.cs` to include `seeded`, `seed`, `demo`, `fixture`, `sample`, and `placeholder` alongside the existing simulated tokens. 
- Added regression coverage in `tests/Meridian.Tests/Storage/LedgerJournalStoreTests.cs` converting the single simulated-token test into a theory that verifies each recognized non-real marker is rejected when the command remains marked `Real`. 
- Updated the test helper `BuildSimulatedOriginPostingWrite` to accept a custom evidence `Source` so the test exercises each token variant.

### Testing
- `git diff --check` passed locally. 
- `bash scripts/ci.sh` could not complete because the environment lacks the .NET SDK (`dotnet` not found), so the full .NET test/CI validation was not executed. 
- A new theory-based unit test was added to cover the previously-missed tokens but .NET test execution (e.g. `dotnet test` or `bash scripts/ci.sh`) must be run in an environment with the SDK to confirm passing test results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61238a688483208712734788d57071)