### PR TITLE
Require AdminMaintenance permission for first-run sample provisioning

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/FirstRunEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/FirstRunEndpoints.cs
@@ -1,4 +1,5 @@
 using Meridian.Contracts.Workstation;
+using Meridian.Identity.Auth;
 using Meridian.Ui.Shared.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -17,7 +18,7 @@ public static class FirstRunEndpoints
             try
             { return Results.Ok(await service.CompleteAsync(CurrentUser(context), request, ct).ConfigureAwait(false)); }
             catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
-        });
+        }).RequirePermission(UserPermission.AdminMaintenance);
         group.MapPost("/outcomes/complete", async (HttpContext context, CompleteActivationOutcomeRequestDto request, FirstRunExperienceService service, CancellationToken ct) =>
         {
             try

--- a/tests/Meridian.Tests/Ui/FirstRunEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/FirstRunEndpointsTests.cs
@@ -1,0 +1,68 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Meridian.Contracts.Workstation;
+using Meridian.Core.Config;
+using Meridian.Identity.Auth;
+using Meridian.Testing;
+using Meridian.Ui.Shared.Endpoints;
+using Meridian.Ui.Shared.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Meridian.Tests.Ui;
+
+public sealed class FirstRunEndpointsTests
+{
+    [Fact]
+    public async Task Complete_WhenUserLacksAdminMaintenancePermission_ReturnsForbidden()
+    {
+        await using var app = await CreateAppAsync(UserPermission.ViewStrategies);
+
+        var response = await app.GetTestClient().PostAsJsonAsync("/api/workstation/first-run/complete", SampleRequest);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Complete_WhenUserHasAdminMaintenancePermission_CompletesOnboarding()
+    {
+        await using var app = await CreateAppAsync(UserPermission.AdminMaintenance);
+
+        var response = await app.GetTestClient().PostAsJsonAsync("/api/workstation/first-run/complete", SampleRequest);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    private static readonly CompleteFirstRunRequestDto SampleRequest = new(
+        "monitor-investments", "personal-portfolio", "sample", true);
+
+    private static async Task<WebApplication> CreateAppAsync(UserPermission permissions)
+    {
+        var artifacts = TestArtifactDirectory.Create(nameof(FirstRunEndpointsTests));
+        var config = new ConfigStore(Path.Combine(artifacts.RootPath, "appsettings.json"));
+        await config.SaveAsync(new AppConfig(DataRoot: artifacts.RootPath));
+
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = "Development"
+        });
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton(new FirstRunExperienceService(config));
+
+        var app = builder.Build();
+        app.Lifetime.ApplicationStopped.Register(artifacts.Dispose);
+        app.Use(async (context, next) =>
+        {
+            context.Items[LoginSessionMiddleware.CurrentUserKey] = "operator";
+            context.Items[LoginSessionMiddleware.CurrentUserPermissionsKey] = permissions;
+            await next();
+        });
+        app.MapFirstRunEndpoints();
+        await app.StartAsync();
+        return app;
+    }
+}


### PR DESCRIPTION
### Motivation
- Completing first-run with sample data previously invoked the demo tenant provisioner and wrote to deployment-scoped reconciliation and strategy stores without an authorization gate, allowing low-privilege authenticated users to mutate shared read-models.

### Description
- Require `UserPermission.AdminMaintenance` on the `POST /api/workstation/first-run/complete` route by attaching `.RequirePermission(UserPermission.AdminMaintenance)` in `MapFirstRunEndpoints`.
- Add `tests/Meridian.Tests/Ui/FirstRunEndpointsTests.cs` containing TestServer-based coverage that asserts a caller without `AdminMaintenance` receives `403 Forbidden` and a caller with `AdminMaintenance` receives `200 OK` when posting to `/complete`.
- The new test host injects permission context and uses `TestArtifactDirectory` for an isolated data root with cleanup on application stop.

### Testing
- Ran a static assertion script (`python3 - <<'PY'`) that verified the endpoint is gated by `AdminMaintenance` and that the two authorization tests are present, which passed.
- Ran `git diff --check` to validate there are no diff issues, which passed.
- Executed the local validation status check (`python3 build/python/cli/buildctl.py validation-status --summary`); attempts to run the full CI script (`bash scripts/ci.sh`) could not complete locally because the environment does not have the `.NET` SDK (`dotnet: command not found`), so .NET unit tests were not executed in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a612389da148320a181b2b98f0f2f21)