### PR TITLE
Fix audit evidence hash coverage

### DIFF
--- a/src/Meridian.Ledger/FundAdministrationEventLog.cs
+++ b/src/Meridian.Ledger/FundAdministrationEventLog.cs
@@ -210,6 +210,13 @@ public sealed class FundAdministrationEventLog : IFundAdministrationEventSink
             AppendField(builder, reference.SubjectId ?? string.Empty);
             AppendField(builder, reference.ContentHash ?? string.Empty);
             AppendField(builder, reference.Description ?? string.Empty);
+            AppendField(builder, reference.SourceReference ?? string.Empty);
+            AppendField(builder, reference.ReviewStatus ?? string.Empty);
+            AppendField(builder, reference.ReviewedBy ?? string.Empty);
+            AppendField(builder, reference.ReviewedAtUtc?.ToUniversalTime().ToString("O") ?? string.Empty);
+            AppendField(builder, reference.EffectiveDate?.ToString("O", CultureInfo.InvariantCulture) ?? string.Empty);
+            AppendField(builder, reference.EvidenceVersion?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
+            AppendField(builder, reference.SubjectType ?? string.Empty);
         }
 
         AppendField(builder, evt.PreviousHash ?? string.Empty);

--- a/tests/Meridian.Tests/Ledger/FundAdministrationEventLogTests.cs
+++ b/tests/Meridian.Tests/Ledger/FundAdministrationEventLogTests.cs
@@ -99,17 +99,42 @@ public sealed class FundAdministrationEventLogTests
     [Fact]
     public void Append_EvidenceFieldChange_ChangesHash()
     {
-        // Altering any evidence field (here the URI) — not just its id or content hash — must change
-        // the chained hash, so tampering with the supporting record for a governed action is detectable.
-        var left = new FundAdministrationEventLog();
-        var right = new FundAdministrationEventLog();
-        var evidence = new JournalEvidenceReference("ev-1", "vault://approval/1", "Approval", "Governance", At, "approver");
-        var tampered = evidence with { Uri = "vault://approval/forged" };
+        // Every evidence property carries provenance for a privileged action and must be folded into
+        // the event hash, so changing any one of them invalidates the record.
+        var evidence = new JournalEvidenceReference(
+            "ev-1", "vault://approval/1", "Approval", "Governance", At, "approver",
+            SubjectId: "approval-1", ContentHash: "sha256:original", Description: "Controller approval",
+            SourceReference: "ticket-123", ReviewStatus: "Approved", ReviewedBy: "reviewer",
+            ReviewedAtUtc: At.AddMinutes(1), EffectiveDate: DateOnly.FromDateTime(At.DateTime),
+            EvidenceVersion: 1, SubjectType: "PeriodReopen");
 
-        var original = left.Append(FundAdministrationEventKind.PeriodReopened, "approver", "FUND:2026-Q2", "Reopened", evidence: [evidence], occurredAtUtc: At);
-        var altered = right.Append(FundAdministrationEventKind.PeriodReopened, "approver", "FUND:2026-Q2", "Reopened", evidence: [tampered], occurredAtUtc: At);
+        var original = AppendWithEvidence(evidence);
+        var tamperedEvidence = new[]
+        {
+            evidence with { Uri = "vault://approval/forged" },
+            evidence with { SourceReference = "ticket-forged" },
+            evidence with { ReviewStatus = "Rejected" },
+            evidence with { ReviewedBy = "forged-reviewer" },
+            evidence with { ReviewedAtUtc = At.AddMinutes(2) },
+            evidence with { EffectiveDate = DateOnly.FromDateTime(At.AddDays(1).DateTime) },
+            evidence with { EvidenceVersion = 2 },
+            evidence with { SubjectType = "Journal" },
+        };
 
-        altered.Hash.Should().NotBe(original.Hash);
+        foreach (var tampered in tamperedEvidence)
+            AppendWithEvidence(tampered).Hash.Should().NotBe(original.Hash);
+    }
+
+    private static FundAdministrationEvent AppendWithEvidence(JournalEvidenceReference evidence)
+    {
+        var log = new FundAdministrationEventLog();
+        return log.Append(
+            FundAdministrationEventKind.PeriodReopened,
+            "approver",
+            "FUND:2026-Q2",
+            "Reopened",
+            evidence: [evidence],
+            occurredAtUtc: At);
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- The fund-administration event hash omitted several `JournalEvidenceReference` provenance fields so changes to URI/source/review/date/version/subject-type could be made without invalidating `VerifyIntegrity()`, undermining the tamper-evident audit trail.

### Description
- Extend the canonical hash in `ComputeHash` to fold every `JournalEvidenceReference` field into the SHA-256 input, including `SourceReference`, `ReviewStatus`, `ReviewedBy`, `ReviewedAtUtc`, `EffectiveDate`, `EvidenceVersion`, and `SubjectType` in addition to the existing fields.
- Update the `FundAdministrationEventLog` canonicalization to length-prefix and include the newly covered evidence fields for unambiguous hashing in `src/Meridian.Ledger/FundAdministrationEventLog.cs`.
- Strengthen the regression test `Append_EvidenceFieldChange_ChangesHash` to exercise changes to the new provenance fields and verify that mutating any of them changes the event hash, and add a small `AppendWithEvidence` helper in `tests/Meridian.Tests/Ledger/FundAdministrationEventLogTests.cs`.

### Testing
- `git diff --check` passed with no whitespace or diff-check issues.
- A lightweight Python static check confirming all 16 `JournalEvidenceReference` fields are present in the `ComputeHash` canonicalization passed.
- Attempted `dotnet test` for `FundAdministrationEventLogTests` could not be run because the environment lacks the .NET SDK, so unit tests were not executed locally.
- `bash scripts/ci.sh` could not complete in this environment because the CI step requires `dotnet`, so full CI validation remains to be run by GitHub Actions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a612389cd648320b246ae7b223bc3d6)