### PR TITLE
Add Alpaca trade update execution stream

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaBrokerageGateway.cs
+++ b/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaBrokerageGateway.cs
@@ -50,6 +50,7 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway, IBrokerageAccoun
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly AlpacaOptions _options;
     private readonly ILogger<AlpacaBrokerageGateway> _logger;
+    private readonly AlpacaTradeUpdatesClient? _tradeUpdates;
     private readonly Channel<ExecutionReport> _reportChannel;
     private volatile bool _connected;
     private bool _disposed;
@@ -57,11 +58,14 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway, IBrokerageAccoun
     public AlpacaBrokerageGateway(
         IHttpClientFactory httpClientFactory,
         AlpacaOptions options,
-        ILogger<AlpacaBrokerageGateway> logger)
+        ILogger<AlpacaBrokerageGateway> logger,
+        AlpacaTradeUpdatesClient? tradeUpdates = null)
     {
         _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _tradeUpdates = tradeUpdates;
+        _tradeUpdates?.ConfigureReconciliation(ReconcileExecutionSnapshotsAsync);
 
         if (!CurrentCredentials.HasCredentials)
         {
@@ -115,6 +119,8 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway, IBrokerageAccoun
                 "Alpaca KeyId and SecretKey are required for brokerage. Configure credentials before calling ConnectAsync.");
 
         var account = await GetAccountInfoAsync(ct).ConfigureAwait(false);
+        if (_tradeUpdates is not null)
+            await _tradeUpdates.StartAsync(ct).ConfigureAwait(false);
         _connected = true;
         _logger.LogInformation("Alpaca brokerage connected: account {AccountId}, status {Status}",
             account.AccountId, account.Status);
@@ -134,6 +140,7 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway, IBrokerageAccoun
         ArgumentNullException.ThrowIfNull(request);
         ObjectDisposedException.ThrowIf(_disposed, this);
         EnsureConnected();
+        EnsureExecutionStreamHealthy();
 
         _logger.LogInformation(
             "Alpaca submitting order: {Side} {Quantity} {Symbol} @ {Type}",
@@ -200,6 +207,7 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway, IBrokerageAccoun
         ArgumentException.ThrowIfNullOrWhiteSpace(orderId);
         ObjectDisposedException.ThrowIf(_disposed, this);
         EnsureConnected();
+        EnsureExecutionStreamHealthy();
 
         using var client = CreateHttpClient();
 
@@ -249,6 +257,7 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway, IBrokerageAccoun
         ArgumentNullException.ThrowIfNull(modification);
         ObjectDisposedException.ThrowIf(_disposed, this);
         EnsureConnected();
+        EnsureExecutionStreamHealthy();
 
         var payload = new AlpacaOrderModifyPayload
         {
@@ -285,6 +294,12 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway, IBrokerageAccoun
     public async IAsyncEnumerable<ExecutionReport> StreamExecutionReportsAsync(
         [EnumeratorCancellation] CancellationToken ct = default)
     {
+        if (_tradeUpdates is not null)
+        {
+            await foreach (var report in _tradeUpdates.Reports.WithCancellation(ct).ConfigureAwait(false))
+                yield return report;
+            yield break;
+        }
         await foreach (var report in _reportChannel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
         {
             yield return report;
@@ -376,6 +391,8 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway, IBrokerageAccoun
         {
             if (!_connected)
                 return BrokerHealthStatus.Unhealthy("Not connected");
+            if (_tradeUpdates is not null && !_tradeUpdates.IsHealthy)
+                return BrokerHealthStatus.Unhealthy(_tradeUpdates.UnhealthyReason!);
             var account = await GetAccountInfoAsync(ct).ConfigureAwait(false);
             return account.Status == "active"
                 ? BrokerHealthStatus.Healthy($"Account {account.AccountId} active")
@@ -527,7 +544,7 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway, IBrokerageAccoun
         _disposed = true;
         _connected = false;
         _reportChannel.Writer.TryComplete();
-        return ValueTask.CompletedTask;
+        return _tradeUpdates?.DisposeAsync() ?? ValueTask.CompletedTask;
     }
 
     // ── Helpers ─────────────────────────────────────────────────────────
@@ -536,6 +553,28 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway, IBrokerageAccoun
     {
         if (!_connected)
             throw new InvalidOperationException("Alpaca brokerage gateway is not connected. Call ConnectAsync first.");
+    }
+
+    private void EnsureExecutionStreamHealthy()
+    {
+        if (_tradeUpdates is not null && !_tradeUpdates.IsHealthy)
+            throw new InvalidOperationException($"Alpaca live submission is blocked because the execution stream is unhealthy: {_tradeUpdates.UnhealthyReason}");
+    }
+
+    // Reconciliation deliberately reads the broker snapshot after every socket reconnect so orders
+    // created outside Meridian and updates missed during the disconnect become immutable reports.
+    private async Task<IReadOnlyList<ExecutionReport>> ReconcileExecutionSnapshotsAsync(CancellationToken ct)
+    {
+        var orders = await GetOpenOrdersAsync(ct).ConfigureAwait(false);
+        return orders.Select(order => new ExecutionReport
+        {
+            OrderId = order.OrderId, GatewayOrderId = order.OrderId, ClientOrderId = order.ClientOrderId,
+            Symbol = order.Symbol, Side = order.Side, OrderQuantity = order.Quantity,
+            FilledQuantity = order.FilledQuantity, OrderStatus = order.Status,
+            ReportType = order.Status == OrderStatus.PartiallyFilled ? ExecutionReportType.PartialFill : ExecutionReportType.New,
+            Timestamp = order.CreatedAt,
+            Diagnostics = new ExecutionDiagnostics { Category = "alpaca-rest-reconciliation", RecommendedAction = "Reconciled after execution-stream reconnect." }
+        }).ToArray();
     }
 
     private HttpClient CreateHttpClient()

--- a/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaProviderModule.cs
+++ b/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaProviderModule.cs
@@ -127,7 +127,7 @@ public sealed class AlpacaProviderModule : ConfigurableProviderModuleBase, IProv
         // Constructor does not validate credentials eagerly; auth errors
         // surface when orders are submitted.
         // ----------------------------------------------------------------
-        services.AddSingleton<AlpacaBrokerageGateway>(sp =>
+            services.AddSingleton<AlpacaBrokerageGateway>(sp =>
         {
             var httpFactory = sp.GetRequiredService<IHttpClientFactory>();
             // Prefer context-resolved credentials; fall back to a registered AlpacaOptions or empty
@@ -135,7 +135,9 @@ public sealed class AlpacaProviderModule : ConfigurableProviderModuleBase, IProv
                 ? new AlpacaOptions(KeyId: keyId, SecretKey: secretKey, Feed: feed, UseSandbox: useSandbox, SubscribeQuotes: subscribeQuotes)
                 : sp.GetService<AlpacaOptions>() ?? new AlpacaOptions();
             var logger = sp.GetRequiredService<ILogger<AlpacaBrokerageGateway>>();
-            return new AlpacaBrokerageGateway(httpFactory, brokerageOptions, logger);
+            var streamLogger = sp.GetRequiredService<ILogger<AlpacaTradeUpdatesClient>>();
+            var stream = new AlpacaTradeUpdatesClient(brokerageOptions, streamLogger);
+            return new AlpacaBrokerageGateway(httpFactory, brokerageOptions, logger, stream);
         });
         services.AddSingleton<IBrokerageAccountCatalog>(sp =>
             sp.GetRequiredService<AlpacaBrokerageGateway>());

--- a/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaTradeUpdatesClient.cs
+++ b/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaTradeUpdatesClient.cs
@@ -1,0 +1,160 @@
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Channels;
+using Meridian.Core.Config;
+using Meridian.Execution.Sdk;
+using Microsoft.Extensions.Logging;
+
+namespace Meridian.Infrastructure.Adapters.Alpaca;
+
+/// <summary>Authenticated Alpaca <c>trade_updates</c> stream with durable event-id deduplication.</summary>
+/// <remarks>The trading stream is an execution source of record only after REST reconciliation succeeds.</remarks>
+public sealed class AlpacaTradeUpdatesClient : IAsyncDisposable
+{
+    private readonly AlpacaOptions _options;
+    private readonly ILogger<AlpacaTradeUpdatesClient> _logger;
+    private readonly Channel<ExecutionReport> _reports = Channel.CreateUnbounded<ExecutionReport>();
+    private readonly HashSet<string> _seenEventIds = new(StringComparer.Ordinal);
+    private readonly Queue<string> _seenOrder = new();
+    private Func<CancellationToken, Task<IReadOnlyList<ExecutionReport>>> _reconcile;
+    private readonly TimeProvider _clock;
+    private readonly TimeSpan _staleAfter;
+    private readonly IAlpacaTradeUpdateCursorStore _cursorStore;
+    private ClientWebSocket? _socket;
+    private CancellationTokenSource? _runCts;
+    private Task? _runTask;
+    private DateTimeOffset? _watermark;
+    private DateTimeOffset? _lastUpdateAt;
+    private string? _failure;
+
+    public AlpacaTradeUpdatesClient(AlpacaOptions options, ILogger<AlpacaTradeUpdatesClient> logger,
+        Func<CancellationToken, Task<IReadOnlyList<ExecutionReport>>>? reconcile = null,
+        TimeProvider? clock = null, TimeSpan? staleAfter = null, IAlpacaTradeUpdateCursorStore? cursorStore = null)
+    {
+        _options = options;
+        _logger = logger;
+        _reconcile = reconcile ?? (_ => Task.FromResult<IReadOnlyList<ExecutionReport>>([]));
+        _clock = clock ?? TimeProvider.System;
+        _staleAfter = staleAfter ?? TimeSpan.FromSeconds(30);
+        _cursorStore = cursorStore ?? new FileAlpacaTradeUpdateCursorStore();
+    }
+
+    public bool IsHealthy => _socket?.State == WebSocketState.Open && _lastUpdateAt is { } at && _clock.GetUtcNow() - at <= _staleAfter && _failure is null;
+    public DateTimeOffset? Watermark => _watermark;
+    public string? UnhealthyReason => IsHealthy ? null : _failure ?? "Trade-update stream is delayed, disconnected, or has not produced an update.";
+    public IAsyncEnumerable<ExecutionReport> Reports => _reports.Reader.ReadAllAsync();
+
+    public Task StartAsync(CancellationToken ct = default)
+    {
+        if (_runTask is not null) return Task.CompletedTask;
+        _watermark = _cursorStore.Load();
+        foreach (var eventId in _cursorStore.LoadRecentEventIds()) Remember(eventId);
+        _runCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        _runTask = Task.Run(() => RunAsync(_runCts.Token), CancellationToken.None);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Sets the REST snapshot reconciliation invoked after every authenticated reconnect.</summary>
+    public void ConfigureReconciliation(Func<CancellationToken, Task<IReadOnlyList<ExecutionReport>>> reconcile) =>
+        _reconcile = reconcile ?? throw new ArgumentNullException(nameof(reconcile));
+
+    internal async Task ProcessMessageAsync(string message, CancellationToken ct = default)
+    {
+        using var doc = JsonDocument.Parse(message);
+        var root = doc.RootElement;
+        if (root.TryGetProperty("stream", out var stream) && stream.GetString() != "trade_updates") return;
+        if (!root.TryGetProperty("data", out var data)) return;
+        var eventId = data.TryGetProperty("event_id", out var id) ? id.GetString() : null;
+        if (string.IsNullOrWhiteSpace(eventId)) eventId = data.TryGetProperty("id", out id) ? id.GetString() : null;
+        if (string.IsNullOrWhiteSpace(eventId) || !Remember(eventId)) return;
+
+        var order = data.GetProperty("order");
+        var timestamp = ReadTime(data, "timestamp") ?? ReadTime(order, "updated_at") ?? _clock.GetUtcNow();
+        _watermark = _watermark is null || timestamp > _watermark ? timestamp : _watermark;
+        _cursorStore.Save(_watermark.Value, _seenOrder);
+        _lastUpdateAt = _clock.GetUtcNow();
+        _failure = null;
+        var status = order.TryGetProperty("status", out var statusElement) ? statusElement.GetString() : null;
+        var mapped = Map(status);
+        var report = new ExecutionReport {
+            OrderId = ReadString(order, "id") ?? throw new JsonException("Alpaca trade update lacks order.id."),
+            GatewayOrderId = ReadString(order, "id"), ClientOrderId = ReadString(order, "client_order_id"),
+            Symbol = ReadString(order, "symbol") ?? string.Empty,
+            Side = string.Equals(ReadString(order, "side"), "sell", StringComparison.OrdinalIgnoreCase) ? OrderSide.Sell : OrderSide.Buy,
+            OrderStatus = mapped.status, ReportType = mapped.type,
+            OrderQuantity = ReadDecimal(order, "qty"), FilledQuantity = ReadDecimal(order, "filled_qty"),
+            FillPrice = ReadNullableDecimal(data, "price") ?? ReadNullableDecimal(order, "filled_avg_price"),
+            Timestamp = timestamp,
+            RejectReason = ReadString(data, "reason"),
+            Diagnostics = new ExecutionDiagnostics { BrokerStatus = status, Category = "alpaca-trade-update" }
+        };
+        await _reports.Writer.WriteAsync(report, ct).ConfigureAwait(false);
+    }
+
+    private async Task RunAsync(CancellationToken ct)
+    {
+        var delay = TimeSpan.FromSeconds(1);
+        while (!ct.IsCancellationRequested)
+        {
+            try {
+                _socket = new ClientWebSocket();
+                await _socket.ConnectAsync(new Uri(_options.UseSandbox ? "wss://paper-api.alpaca.markets/stream" : "wss://api.alpaca.markets/stream"), ct).ConfigureAwait(false);
+                await SendAsync(new { action = "auth", key = _options.KeyId, secret = _options.SecretKey }, ct).ConfigureAwait(false);
+                await SendAsync(new { action = "listen", data = new { streams = new[] { "trade_updates" } } }, ct).ConfigureAwait(false);
+                foreach (var report in await _reconcile(ct).ConfigureAwait(false)) await _reports.Writer.WriteAsync(report, ct).ConfigureAwait(false);
+                delay = TimeSpan.FromSeconds(1);
+                var buffer = new byte[64 * 1024];
+                while (_socket.State == WebSocketState.Open && !ct.IsCancellationRequested) {
+                    var result = await _socket.ReceiveAsync(buffer, ct).ConfigureAwait(false);
+                    if (result.MessageType == WebSocketMessageType.Close) break;
+                    await ProcessMessageAsync(Encoding.UTF8.GetString(buffer, 0, result.Count), ct).ConfigureAwait(false);
+                }
+                _failure = "Alpaca trade-update socket closed.";
+            } catch (OperationCanceledException) when (ct.IsCancellationRequested) { break; }
+            catch (Exception ex) { _failure = ex.Message; _logger.LogWarning(ex, "Alpaca trade-update stream failed; reconnecting"); }
+            finally { _socket?.Dispose(); _socket = null; }
+            await Task.Delay(delay, ct).ConfigureAwait(false);
+            delay = TimeSpan.FromSeconds(Math.Min(30, delay.TotalSeconds * 2));
+        }
+    }
+
+    private async Task SendAsync<T>(T value, CancellationToken ct) => await _socket!.SendAsync(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(value)), WebSocketMessageType.Text, true, ct).ConfigureAwait(false);
+    private bool Remember(string id) { if (!_seenEventIds.Add(id)) return false; _seenOrder.Enqueue(id); if (_seenOrder.Count > 8192) _seenEventIds.Remove(_seenOrder.Dequeue()); return true; }
+    private static string? ReadString(JsonElement e, string name) => e.TryGetProperty(name, out var v) ? v.GetString() : null;
+    private static decimal ReadDecimal(JsonElement e, string name) => ReadNullableDecimal(e, name) ?? 0m;
+    private static decimal? ReadNullableDecimal(JsonElement e, string name) => e.TryGetProperty(name, out var v) && decimal.TryParse(v.GetString(), System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out var d) ? d : null;
+    private static DateTimeOffset? ReadTime(JsonElement e, string name) => e.TryGetProperty(name, out var v) && DateTimeOffset.TryParse(v.GetString(), out var t) ? t : null;
+    private static (OrderStatus status, ExecutionReportType type) Map(string? s) => s?.ToLowerInvariant() switch { "filled" => (OrderStatus.Filled, ExecutionReportType.Fill), "partially_filled" => (OrderStatus.PartiallyFilled, ExecutionReportType.PartialFill), "canceled" => (OrderStatus.Cancelled, ExecutionReportType.Cancelled), "rejected" => (OrderStatus.Rejected, ExecutionReportType.Rejected), "expired" => (OrderStatus.Expired, ExecutionReportType.Expired), _ => (OrderStatus.Accepted, ExecutionReportType.New) };
+    public async ValueTask DisposeAsync() { if (_runCts is not null) { await _runCts.CancelAsync().ConfigureAwait(false); if (_runTask is not null) await _runTask.ConfigureAwait(false); _runCts.Dispose(); } _reports.Writer.TryComplete(); }
+}
+
+/// <summary>Durable execution watermark seam; implementations must not persist credentials or payloads.</summary>
+public interface IAlpacaTradeUpdateCursorStore
+{
+    DateTimeOffset? Load();
+    IReadOnlyList<string> LoadRecentEventIds() => [];
+    void Save(DateTimeOffset watermark, IReadOnlyCollection<string> recentEventIds);
+}
+
+/// <summary>Atomic, local cursor store used by the default execution stream client.</summary>
+public sealed class FileAlpacaTradeUpdateCursorStore : IAlpacaTradeUpdateCursorStore
+{
+    private readonly string _path;
+    public FileAlpacaTradeUpdateCursorStore(string? path = null) => _path = path ?? Path.Combine(AppContext.BaseDirectory, "state", "alpaca-trade-updates.cursor");
+    public DateTimeOffset? Load() => Read().watermark;
+    public IReadOnlyList<string> LoadRecentEventIds() => Read().ids;
+    public void Save(DateTimeOffset watermark, IReadOnlyCollection<string> recentEventIds)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
+        var temporary = _path + ".tmp";
+        File.WriteAllText(temporary, JsonSerializer.Serialize(new PersistedState(watermark, recentEventIds.TakeLast(8192).ToArray())));
+        File.Move(temporary, _path, overwrite: true);
+    }
+    private (DateTimeOffset? watermark, IReadOnlyList<string> ids) Read()
+    {
+        try { var state = File.Exists(_path) ? JsonSerializer.Deserialize<PersistedState>(File.ReadAllText(_path)) : null; return (state?.Watermark, state?.EventIds ?? []); }
+        catch (JsonException) { return (null, []); }
+    }
+    private sealed record PersistedState(DateTimeOffset Watermark, IReadOnlyList<string> EventIds);
+}


### PR DESCRIPTION
### Motivation

- Provide a first Alpaca-expansion execution source by ingesting the broker-authenticated `trade_updates` WebSocket so broker-side order events become a source of record. 
- Prevent double-processing and missed state by persisting a watermark/cursor and deduplicating broker event IDs across reconnects. 
- Ensure correctness by translating every broker update into an immutable `ExecutionReport` and reconciling against REST open-order snapshots after reconnect, and by surfacing stream-health so live submissions are blocked while execution-state is unhealthy.

### Description

- Added `AlpacaTradeUpdatesClient` (`src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaTradeUpdatesClient.cs`) which authenticates, subscribes to `trade_updates`, reconnects with backoff, emits normalized `ExecutionReport` objects, and runs a bounded event-id deduplication window. 
- Added a durable cursor store (`IAlpacaTradeUpdateCursorStore` / `FileAlpacaTradeUpdateCursorStore`) that atomically persists the latest watermark and recent event IDs so reconnects resume without reprocessing old events. 
- Wired the trade-update stream into `AlpacaBrokerageGateway` so: the gateway starts the stream on `ConnectAsync`, the gateway includes stream health in `CheckHealthAsync`, and `SubmitOrderAsync`/`CancelOrderAsync`/`ModifyOrderAsync` fail-closed when the execution stream is unhealthy. 
- Implemented reconnect-time REST reconciliation (`ReconcileExecutionSnapshotsAsync`) that reads open orders via REST and emits reconciled immutable `ExecutionReport`s after authenticated reconnects. 
- Registered the new stream client in the Alpaca provider module so it is created alongside the brokerage gateway (`AlpacaProviderModule`).

### Testing

- Ran `git diff --check` which reported no whitespace or diff-check issues. 
- Attempted local build with `dotnet build src/Meridian.Infrastructure/Meridian.Infrastructure.csproj --no-restore /p:EnableWindowsTargeting=true` but the environment does not have `dotnet` installed (`/bin/bash: dotnet: command not found`).
- No automated unit/integration test suite was executed in this environment; GitHub Actions remains the authoritative integration gate and should run the full `bash scripts/ci.sh` and repository test matrix as part of PR validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a612b3de4c48320950bae6a73debb72)