### PR TITLE
Validate externally supplied CapitalCallPlan before issuing drafts

### DIFF
--- a/docs/source/generated/source-hash-manifest.json
+++ b/docs/source/generated/source-hash-manifest.json
@@ -205,8 +205,8 @@
       "id": "SRC-LEDGER",
       "path": "src/Meridian.Ledger",
       "readme": "src/Meridian.Ledger/README.md",
-      "readme_hash": "efd3784503f32b1f6f3b8d41a74b0e1b8b33ca53804aa9ad40d9a1d86304e5aa",
-      "source_hash": "2920f6ca63ab79a9d2e2b406d9a4ee88a97fc0b1e4cca6efce34ba0e2c671dde"
+      "readme_hash": "697d14f409bd75ccea1b987ebb8e5bb5f76325a28367d2094cdc8b4a1ecc84fc",
+      "source_hash": "285a08cff81c8c250f0a51ee0aa76a827355c6e721a281cf62127ce46e47c198"
     },
     {
       "id": "SRC-LIFECYCLE-SUPERVISOR",

--- a/src/Meridian.Ledger/CapitalCallPlanBuilder.cs
+++ b/src/Meridian.Ledger/CapitalCallPlanBuilder.cs
@@ -123,8 +123,13 @@ public sealed record CapitalCallPlan(
     IReadOnlyList<AccountingConfigurationValidationIssueDto> ValidationIssues)
 {
     public bool IsExecutable =>
-        AllocatedAmount == Request.AmountToCall
-        && Lines.Count > 0
+        Request is not null
+        && Lines is { Count: > 0 }
+        && ValidationIssues is not null
+        && Lines.All(static line => line is not null)
+        && ValidationIssues.All(static issue => issue is not null)
+        && Lines.Sum(static line => line.CallAmount) == AllocatedAmount
+        && AllocatedAmount == Request.AmountToCall
         && !ValidationIssues.Any(static issue =>
             issue.Severity == AccountingConfigurationValidationSeverityDto.Critical);
 }

--- a/src/Meridian.Ledger/CapitalCallScheduleDraftBuilder.cs
+++ b/src/Meridian.Ledger/CapitalCallScheduleDraftBuilder.cs
@@ -44,13 +44,7 @@ public static class CapitalCallScheduleDraftBuilder
         IReadOnlyDictionary<string, IReadOnlyList<JournalEvidenceReference>>? evidenceByCommitmentId = null)
     {
         ArgumentNullException.ThrowIfNull(plan);
-        if (!plan.IsExecutable)
-        {
-            var criticalCount = plan.ValidationIssues.Count(static issue =>
-                issue.Severity == AccountingConfigurationValidationSeverityDto.Critical);
-            throw new InvalidOperationException(FormattableString.Invariant(
-                $"Capital call '{plan.Request.CallId}' is not executable: allocated {plan.AllocatedAmount} of requested {plan.Request.AmountToCall} across {plan.Lines.Count} line(s) with {criticalCount} critical validation issue(s)."));
-        }
+        var commitmentsById = ValidateExecutablePlan(plan);
 
         var drafts = new List<AutomatedJournalDraft>(plan.Lines.Count);
         foreach (var line in plan.Lines
@@ -63,7 +57,7 @@ public static class CapitalCallScheduleDraftBuilder
                     : null;
 
             drafts.Add(CapitalCallDraftFactory.BuildCapitalCallDraft(
-                line.Commitment,
+                commitmentsById[line.Commitment.CommitmentId],
                 line.InstallmentId,
                 line.CallAmount,
                 effectiveDate: plan.Request.NoticeDate,
@@ -72,5 +66,47 @@ public static class CapitalCallScheduleDraftBuilder
         }
 
         return drafts;
+    }
+
+    private static IReadOnlyDictionary<string, InvestorCommitment> ValidateExecutablePlan(CapitalCallPlan plan)
+    {
+        if (!plan.IsExecutable)
+        {
+            var criticalCount = plan.ValidationIssues?.Count(static issue =>
+                issue.Severity == AccountingConfigurationValidationSeverityDto.Critical) ?? 0;
+            throw new InvalidOperationException(FormattableString.Invariant(
+                $"Capital call '{plan.Request?.CallId}' is not executable: allocated {plan.AllocatedAmount} across {plan.Lines?.Count ?? 0} line(s) with {criticalCount} critical validation issue(s)."));
+        }
+
+        var rollForwardsByCommitmentId = plan.Request.RollForwards.ToDictionary(
+            static rollForward => rollForward.CommitmentId,
+            static rollForward => rollForward,
+            StringComparer.OrdinalIgnoreCase);
+        var seenCommitments = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var seenInstallments = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var line in plan.Lines)
+        {
+            if (string.IsNullOrWhiteSpace(line.InstallmentId)
+                || line.Commitment is null
+                || line.CallAmount <= 0m
+                || !seenCommitments.Add(line.Commitment.CommitmentId)
+                || !seenInstallments.Add(line.InstallmentId.Trim())
+                || !rollForwardsByCommitmentId.TryGetValue(line.Commitment.CommitmentId, out var rollForward)
+                || !Equals(line.Commitment, rollForward.Commitment)
+                || !rollForward.InvariantHolds
+                || !rollForward.Commitment.IsCallable
+                || line.CallAmount > rollForward.Uncalled
+                || !string.Equals(line.Commitment.FundProfileId, plan.Request.FundProfileId, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(FormattableString.Invariant(
+                    $"Capital call '{plan.Request.CallId}' contains an invalid plan line and cannot issue drafts."));
+            }
+        }
+
+        return rollForwardsByCommitmentId.ToDictionary(
+            static pair => pair.Key,
+            static pair => pair.Value.Commitment,
+            StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/tests/Meridian.Tests/Ledger/CapitalCallScheduleDraftBuilderTests.cs
+++ b/tests/Meridian.Tests/Ledger/CapitalCallScheduleDraftBuilderTests.cs
@@ -126,4 +126,81 @@ public sealed class CapitalCallScheduleDraftBuilderTests
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("*not executable*");
     }
+
+    [Fact]
+    public void ThrowsWhenSuppliedPlanLinesDoNotTieToTheApprovedRequest()
+    {
+        var approved = FreshRollForward(Commitment("cmt-approved", "lp-approved", 1_000_000m));
+        var unauthorized = Commitment("cmt-unauthorized", "lp-unauthorized", 5_000_000m);
+        var request = CallRequest(1_000_000m, approved);
+        var forgedPlan = new CapitalCallPlan(
+            request,
+            [new CapitalCallPlanLine("call-1:cmt-unauthorized", unauthorized, 5_000_000m, 1m, 5_000_000m, 0m)],
+            AllocatedAmount: 1_000_000m,
+            ValidationIssues: []);
+
+        var act = () => CapitalCallScheduleDraftBuilder.BuildIssuanceDrafts(forgedPlan, OccurredAt);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*not executable*");
+    }
+
+    [Fact]
+    public void ThrowsWhenSuppliedPlanLineExceedsItsUncalledCapacity()
+    {
+        var commitment = Commitment("cmt-1", "lp-1", 1_000_000m);
+        var request = CallRequest(1_000_001m, FreshRollForward(commitment));
+        var plan = new CapitalCallPlan(
+            request,
+            [new CapitalCallPlanLine("call-1:cmt-1", commitment, 1_000_001m, 1m, 1_000_000m, -1m)],
+            AllocatedAmount: 1_000_001m,
+            ValidationIssues: []);
+
+        var act = () => CapitalCallScheduleDraftBuilder.BuildIssuanceDrafts(plan, OccurredAt);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*invalid plan line*");
+    }
+
+    [Fact]
+    public void ThrowsWhenSuppliedPlanDuplicatesACommitment()
+    {
+        var first = Commitment("cmt-1", "lp-1", 1_000_000m);
+        var second = Commitment("cmt-2", "lp-2", 1_000_000m);
+        var request = CallRequest(2_000_000m, FreshRollForward(first), FreshRollForward(second));
+        var plan = new CapitalCallPlan(
+            request,
+            [
+                new CapitalCallPlanLine("call-1:cmt-1:1", first, 1_000_000m, 0.5m, 1_000_000m, 0m),
+                new CapitalCallPlanLine("call-1:cmt-1:2", first, 1_000_000m, 0.5m, 1_000_000m, 0m),
+            ],
+            AllocatedAmount: 2_000_000m,
+            ValidationIssues: []);
+
+        var act = () => CapitalCallScheduleDraftBuilder.BuildIssuanceDrafts(plan, OccurredAt);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*invalid plan line*");
+    }
+
+    [Fact]
+    public void ThrowsWhenSuppliedPlanDuplicatesAnInstallment()
+    {
+        var first = Commitment("cmt-1", "lp-1", 1_000_000m);
+        var second = Commitment("cmt-2", "lp-2", 1_000_000m);
+        var request = CallRequest(2_000_000m, FreshRollForward(first), FreshRollForward(second));
+        var plan = new CapitalCallPlan(
+            request,
+            [
+                new CapitalCallPlanLine("call-1:duplicate", first, 1_000_000m, 0.5m, 1_000_000m, 0m),
+                new CapitalCallPlanLine("call-1:duplicate", second, 1_000_000m, 0.5m, 1_000_000m, 0m),
+            ],
+            AllocatedAmount: 2_000_000m,
+            ValidationIssues: []);
+
+        var act = () => CapitalCallScheduleDraftBuilder.BuildIssuanceDrafts(plan, OccurredAt);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*invalid plan line*");
+    }
 }


### PR DESCRIPTION
### Motivation

- Close a trust-boundary vulnerability where a public `BuildIssuanceDrafts(CapitalCallPlan, ...)` overload could accept a forged `CapitalCallPlan` whose stored `AllocatedAmount` matched the request but whose `Lines` did not sum to that total, allowing unauthorized or oversized drafts to be created. 
- Ensure governed capital-call drafts are only produced from request-authorized commitment data and that per-line invariants (capacity, fund membership, callability) are enforced. 
- Add regression coverage to prevent future regressions that reintroduce line-sum or plan-line tampering.

### Description

- Harden `CapitalCallPlan.IsExecutable` to require `Lines.Sum(line => line.CallAmount) == AllocatedAmount` and non-null/collection invariants so the plan cannot be declared executable from a stale stored total alone. 
- Add `ValidateExecutablePlan` to `CapitalCallScheduleDraftBuilder` that recomputes and validates every plan line, checking that each line references a request-authorized roll-forward commitment, that the commitment matches the request fund, that `InvariantHolds` and `IsCallable` are true, that `line.CallAmount` is positive and does not exceed the roll-forward `Uncalled` capacity, and that commitment and installment identifiers are unique; the builder now uses the request-authorized `InvestorCommitment` instances when calling `CapitalCallDraftFactory`. 
- Add focused tests in `tests/Meridian.Tests/Ledger/CapitalCallScheduleDraftBuilderTests.cs` that assert rejection of forged plans, capacity overflows, duplicate commitments, and duplicate installment identifiers. 
- Refresh the `SRC-LEDGER` entry in `docs/source/generated/source-hash-manifest.json` to reflect the source changes.

### Testing

- Ran `git diff --check` which completed with no whitespace or index errors. 
- Ran `python3 build/scripts/docs/validate-source-readmes.py --summary` which passed. 
- Refreshed the ledger doc-hash manifest with `python3 build/scripts/docs/validate-doc-hashes.py --write-module SRC-LEDGER --summary` to keep generated docs aligned with source changes. 
- Attempted to run the unit tests via `dotnet test ...` and execute `bash scripts/ci.sh`, but the environment lacks the `dotnet` SDK so the .NET unit test run and CI script could not execute here; the new xUnit tests were added to the test project and should be validated by CI/GitHub Actions where `dotnet` is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f3a365c8320975ff812919eb2a9)