### PR TITLE
Handle statement source read errors and add missing-file validation test

### DIFF
--- a/docs/source/generated/source-hash-manifest.json
+++ b/docs/source/generated/source-hash-manifest.json
@@ -9,8 +9,8 @@
       "id": "SRC-APP",
       "path": "src/Meridian.Application",
       "readme": "src/Meridian.Application/README.md",
-      "readme_hash": "63c278af7d534f95e4344527d4ac07d27c8d31e19f3744e5438eebaf17a37e7d",
-      "source_hash": "4d80eb05faea49a126a2d992f0ed25d3431098802cbfd63c201a0afbbc448250"
+      "readme_hash": "8b5732e1a3284b4eab015bfeb3fb5c749b3dfdce28a79a930a1cc44c2c8b2faa",
+      "source_hash": "4055ecb4c0fe9b855b633a6e892cbd9271a869f223e290e5a5022dee125ddfd3"
     },
     {
       "id": "SRC-BACKTESTING",

--- a/src/Meridian.Application/Commands/StatementImportCommands.cs
+++ b/src/Meridian.Application/Commands/StatementImportCommands.cs
@@ -34,22 +34,42 @@ public sealed class StatementImportCommands(
             return CliResult.Fail(ErrorCode.ValidationFailed);
         }
 
-        // Bound the file before buffering it into memory: the connectors are invoked only after the
-        // whole file is read, and a very large camt.053/BAI2 file could otherwise exhaust the CLI
-        // process. Apply the same 20 MiB limit the workstation upload route enforces.
-        var fileInfo = new FileInfo(path);
-        if (fileInfo.Exists && fileInfo.Length > StatementConnectorLimits.MaxFileBytes)
+        byte[] content;
+        try
         {
-            Console.Error.WriteLine(
-                $"Statement file exceeds the {StatementConnectorLimits.MaxFileBytes / (1024 * 1024)} MiB import limit.");
-            return CliResult.Fail(ErrorCode.ValidationFailed);
+            // Bound the file before buffering it into memory: the connectors are invoked only after the
+            // whole file is read, and a very large camt.053/BAI2 file could otherwise exhaust the CLI
+            // process. Apply the same 20 MiB limit the workstation upload route enforces.
+            var fileInfo = new FileInfo(path);
+            if (fileInfo.Exists && fileInfo.Length > StatementConnectorLimits.MaxFileBytes)
+            {
+                Console.Error.WriteLine(
+                    $"Statement file exceeds the {StatementConnectorLimits.MaxFileBytes / (1024 * 1024)} MiB import limit.");
+                return CliResult.Fail(ErrorCode.ValidationFailed);
+            }
+
+            // Read the raw source once and route both validate and import through the connector pipeline
+            // (CSV, OFX, IB Flex, Alpaca, camt.053, BAI2) rather than the CSV/IB-Flex-only broker router,
+            // so the bank formats registered for the workstation are equally usable from the CLI. The
+            // connector resolves from file content unless an explicit connector id is supplied.
+            content = await File.ReadAllBytesAsync(path, ct).ConfigureAwait(false);
+        }
+        catch (FileNotFoundException ex)
+        {
+            Console.Error.WriteLine(ex.Message);
+            return CliResult.Fail(ErrorCode.FileNotFound);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Console.Error.WriteLine(ex.Message);
+            return CliResult.Fail(ErrorCode.FileAccessDenied);
+        }
+        catch (IOException ex)
+        {
+            Console.Error.WriteLine(ex.Message);
+            return CliResult.Fail(ErrorCode.ReadFailed);
         }
 
-        // Read the raw source once and route both validate and import through the connector pipeline
-        // (CSV, OFX, IB Flex, Alpaca, camt.053, BAI2) rather than the CSV/IB-Flex-only broker router,
-        // so the bank formats registered for the workstation are equally usable from the CLI. The
-        // connector resolves from file content unless an explicit connector id is supplied.
-        var content = await File.ReadAllBytesAsync(path, ct).ConfigureAwait(false);
         var document = new StatementSourceDocument(
             Path.GetFileName(path),
             content,

--- a/src/Meridian.Application/README.md
+++ b/src/Meridian.Application/README.md
@@ -207,7 +207,9 @@ and UI presentation concerns in their owning layers.
   invoke `Meridian.FinancialOperations.Reconciliation` services for statement intake, validation,
   matching, decision journals, and statement-run persistence. Reconciliation workflow state, match
   rules, break classification, repository implementations, and durable case materialization are
-  owned by the Financial Operations design module rather than the application layer. The
+  owned by the Financial Operations design module rather than the application layer. Statement
+  validation and import commands report missing, inaccessible, or unreadable local source files as
+  structured CLI failures before connector parsing. The
   Security Master-enriched portfolio-vs-ledger reconciliation engine also lives in Financial
   Operations and consumes the contracts-owned Security Master query interface.
 - `Backfill/` - historical backfill request orchestration and execution coordination. Shared run

--- a/tests/Meridian.Tests/Application/Commands/StatementImportCommandsTests.cs
+++ b/tests/Meridian.Tests/Application/Commands/StatementImportCommandsTests.cs
@@ -60,6 +60,28 @@ public sealed class StatementImportCommandsTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_StatementValidate_MissingSource_ReturnsFileNotFound()
+    {
+        // An operator can validate a path before a statement arrives; that failure must remain a
+        // structured CLI result rather than escaping from the connector-pipeline source read.
+        var commitService = new StubStatementImportCommitService();
+        var command = new StatementImportCommands(commitService, Logger.None);
+        var missingPath = Path.Combine(Path.GetTempPath(), $"meridian-missing-statement-{Guid.NewGuid():N}.csv");
+
+        var result = await CommandTestConsole.CaptureErrorAsync(
+            () => command.ExecuteAsync(
+                [
+                    "--statement-validate",
+                    "--statement-broker", "samplebroker",
+                    "--statement-source-path", missingPath,
+                    "--statement-date", "2026-01-31"
+                ]));
+
+        result.Error.Should().Be(ErrorCode.FileNotFound);
+        commitService.ValidatedDocuments.Should().BeEmpty("a missing source cannot be validated by a connector");
+    }
+
+    [Fact]
     public async Task Dispatcher_PrefersBrokerImportOnlyForBrokerSpecificStatementArgs()
     {
         var root = Path.Combine(Path.GetTempPath(), $"meridian-statement-cli-{Guid.NewGuid():N}");


### PR DESCRIPTION
### Motivation
- The CLI previously buffered the statement file before entering the validate path, causing file I/O exceptions (e.g. `FileNotFoundException`, `UnauthorizedAccessException`, `IOException`) to propagate as crashes instead of returning structured CLI failures.
- Make `--statement-validate` behave like `--statement-import` in that connector parsing remains used but local I/O problems are reported as `CliResult.Fail` with the appropriate `ErrorCode` to improve robustness and operator UX.

### Description
- Wrap the file inspection and `File.ReadAllBytesAsync` call in `StatementImportCommands.ExecuteAsync` with a `try/catch` and map exceptions to structured CLI failures (`ErrorCode.FileNotFound`, `ErrorCode.FileAccessDenied`, `ErrorCode.ReadFailed`) so I/O errors return `CliResult.Fail` rather than escaping the dispatcher; changes are in `src/Meridian.Application/Commands/StatementImportCommands.cs`.
- Add a regression unit test `ExecuteAsync_StatementValidate_MissingSource_ReturnsFileNotFound` to `tests/Meridian.Tests/Application/Commands/StatementImportCommandsTests.cs` that asserts a missing source path returns `ErrorCode.FileNotFound` and does not call the connector validator.
- Document the CLI behavior change in `src/Meridian.Application/README.md` and refresh the generated source-hash manifest entry for the Application module (`docs/source/generated/source-hash-manifest.json`).

### Testing
- `git diff --check` was run and passed locally.
- Documentation hash refresh via `python3 build/scripts/docs/validate-doc-hashes.py --write-module SRC-APP --summary` succeeded and updated the `SRC-APP` manifest entry.
- Attempted `dotnet test` for the `StatementImportCommandsTests` filter, but the environment lacks the `dotnet` SDK so unit tests were not executed here (`dotnet` not found).
- `bash scripts/ci.sh` could not complete in this environment because the `dotnet` SDK is not installed (CI blocked at Verify .NET SDK); `python3 build/python/cli/buildctl.py validation-status --summary` completed and reported no active build locks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f39af408320b6f5b24839f20995)