### PR TITLE
Fix bounded snapshot conflict handling

### DIFF
--- a/src/Meridian.Application/Reconciliation/RetainedInternalReconciliationPopulationProvider.cs
+++ b/src/Meridian.Application/Reconciliation/RetainedInternalReconciliationPopulationProvider.cs
@@ -210,9 +210,24 @@ public sealed class RetainedInternalReconciliationPopulationProvider(
         {
             // Keep the latest snapshot effective at or before the period close; the explicit ceiling
             // check stays correct even if a store streams a record outside the requested bound.
-            if (candidate.AsOf <= ceiling && (latest is null || candidate.AsOf > latest.AsOf))
+            if (candidate.AsOf > ceiling)
+            {
+                continue;
+            }
+
+            if (latest is null || candidate.AsOf.ToUniversalTime() > latest.AsOf.ToUniversalTime())
             {
                 latest = candidate;
+                continue;
+            }
+
+            if (candidate.AsOf.ToUniversalTime() == latest.AsOf.ToUniversalTime() &&
+                !PositionSnapshotEquivalence.AreEquivalent(candidate, latest))
+            {
+                throw new PositionSnapshotConflictException(
+                    candidate.RunId,
+                    candidate.AccountId,
+                    candidate.AsOf);
             }
         }
 

--- a/tests/Meridian.Tests/Reconciliation/RetainedInternalReconciliationPopulationProviderTests.cs
+++ b/tests/Meridian.Tests/Reconciliation/RetainedInternalReconciliationPopulationProviderTests.cs
@@ -139,6 +139,27 @@ public sealed class RetainedInternalReconciliationPopulationProviderTests
     }
 
     [Fact]
+    public async Task GetPopulationsAsync_ConflictingLatestInPeriodSnapshots_FailsClosedToEmpty()
+    {
+        var accounts = Substitute.For<IAccountQueryService>();
+        accounts.GetAccountAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(Account("FUND-1", "run-1"));
+
+        var positions = Substitute.For<IPositionSnapshotStore>();
+        positions.GetSnapshotHistoryAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(_ => AsyncStream(
+                Snapshot(new DateTimeOffset(2026, 5, 31, 0, 0, 0, TimeSpan.Zero), new PositionRecord("SPY", 10m, 500m, 0m, 0m)),
+                Snapshot(new DateTimeOffset(2026, 5, 31, 0, 0, 0, TimeSpan.Zero), new PositionRecord("QQQ", 99m, 900m, 0m, 0m))));
+
+        var provider = new RetainedInternalReconciliationPopulationProvider(accounts, positions);
+
+        var result = await provider.GetPopulationsAsync(Context(AccountId.ToString("D")));
+
+        result.Should().BeSameAs(
+            InternalReconciliationPopulations.Empty,
+            "conflicting snapshots at the latest in-period timestamp must not select a file-order-dependent internal book");
+    }
+
+    [Fact]
     public async Task GetPopulationsAsync_NonGuidFundAccount_FailsClosedToEmpty()
     {
         var provider = new RetainedInternalReconciliationPopulationProvider(Substitute.For<IAccountQueryService>());


### PR DESCRIPTION
### Motivation
- Period-bounded snapshot resolution previously selected the first history record at the chosen in-period timestamp without detecting equal-time non-equivalent snapshots, enabling file-order-dependent reconciliation outcomes instead of failing closed as required by the store contract.
- Preserve the existing fail-closed semantics so conflicting equal-timestamp retained snapshots surface operator-visible breaks rather than silently choosing a winner.

### Description
- Update `ResolvePeriodSnapshotAsync` in `RetainedInternalReconciliationPopulationProvider` to skip out-of-bound records, compare candidate `AsOf` values using UTC, and throw `PositionSnapshotConflictException` when two records share the selected timestamp but are not equivalent according to `PositionSnapshotEquivalence.AreEquivalent`.
- Add a regression test `GetPopulationsAsync_ConflictingLatestInPeriodSnapshots_FailsClosedToEmpty` to `tests/Meridian.Tests/Reconciliation/RetainedInternalReconciliationPopulationProviderTests.cs` asserting that conflicting same-timestamp snapshots cause the provider to return `InternalReconciliationPopulations.Empty`.
- Files changed: `src/Meridian.Application/Reconciliation/RetainedInternalReconciliationPopulationProvider.cs` and `tests/Meridian.Tests/Reconciliation/RetainedInternalReconciliationPopulationProviderTests.cs`.

### Testing
- Passed: `git diff --check` (no whitespace or formatting errors detected).
- Passed: `python build/python/cli/buildctl.py validation-status --summary` (reported `blocked=false`, no active processes).
- Not run locally: targeted `dotnet test` for the updated tests could not be executed because `dotnet` is not installed in the environment, so the new test has not been run locally here.
- Not run locally: `bash scripts/ci.sh` could not complete because the environment lacks the .NET SDK; CI checks on GitHub Actions remain the authoritative validation and must pass before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611de3a3f483209168d846c7c46bcf)