### PR TITLE
Accept BAI2 and camt.053 file extensions for statement uploads

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.StatementConnectors.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.StatementConnectors.cs
@@ -17,7 +17,7 @@ public static partial class WorkstationEndpoints
     private const long StatementConnectorMaxFileBytes = StatementConnectorLimits.MaxFileBytes;
 
     private static readonly string[] StatementConnectorAcceptedExtensions =
-        [".csv", ".txt", ".ofx", ".qfx", ".xml", ".json"];
+        [".csv", ".txt", ".ofx", ".qfx", ".xml", ".json", ".bai", ".bai2", ".camt", ".053"];
 
     private static void MapStatementConnectorEndpoints(RouteGroupBuilder group, JsonSerializerOptions jsonOptions)
     {

--- a/tests/Meridian.Tests/Ui/WorkstationStatementReconciliationEndpointTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationStatementReconciliationEndpointTests.cs
@@ -57,6 +57,35 @@ public sealed partial class WorkstationEndpointsTests
         }
     }
 
+    [Theory]
+    [InlineData("statement.bai")]
+    [InlineData("statement.bai2")]
+    [InlineData("statement.camt")]
+    [InlineData("statement.053")]
+    public async Task MapWorkstationEndpoints_StatementToReport_ShouldAcceptRegisteredConnectorExtensions(string fileName)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "meridian-statement-connector-extension", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var workflow = new StatementToReportWorkflowService(
+                new EndpointStatementImportService(),
+                new EndpointStatementEvidenceRetainer(),
+                new EndpointStatementRunWorkflowService(),
+                root);
+            await using var app = await CreateAppAsync(services => services.AddSingleton(workflow));
+            using var content = BuildStatementToReportContent(fileName);
+
+            var response = await app.GetTestClient().PostAsync(UiApiRoutes.ReconciliationStatementToReport, content);
+
+            response.StatusCode.Should().Be(HttpStatusCode.Created);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
     [Fact]
     public async Task MapWorkstationEndpoints_StatementRunRoutes_ShouldReturnListDetailExceptionsAndNotFound()
     {
@@ -221,14 +250,14 @@ public sealed partial class WorkstationEndpointsTests
         return accounts;
     }
 
-    private static MultipartFormDataContent BuildStatementToReportContent()
+    private static MultipartFormDataContent BuildStatementToReportContent(string fileName = "statement.csv")
     {
         var content = new MultipartFormDataContent();
         content.Add(
             new ByteArrayContent(Encoding.UTF8.GetBytes(
                 "account,symbol,quantity,price,cashAmount,activityType,tradeDate\nA,AAPL,1,100,0,position,2026-06-30")),
             "file",
-            "statement.csv");
+            fileName);
         content.Add(new StringContent("csv"), "connectorId");
         content.Add(new StringContent("broker"), "sourceKind");
         content.Add(new StringContent("Broker Alpha"), "sourceInstitution");


### PR DESCRIPTION
### Motivation

- Statement connectors for BAI2 and camt.053 advertise standard extensions (`.bai`, `.bai2`, `.camt`, `.053`) but the shared upload endpoint used a restrictive allow-list that rejected those files before connector sniffing could run.
- This mismatch caused valid connector fixtures to be rejected at upload time and prevented operator uploads of standard BAI2/camt files.

### Description

- Extend the shared statement-import allow-list in `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.StatementConnectors.cs` to include `.bai`, `.bai2`, `.camt`, and `.053` so uploads reach connector content-sniffing.
- Add an endpoint-level test (`Theory`) in `tests/Meridian.Tests/Ui/WorkstationStatementReconciliationEndpointTests.cs` that posts multipart uploads with the registered connector extensions to verify they are accepted by the `ReconciliationStatementToReport` endpoint.
- Update the multipart helper `BuildStatementToReportContent` to accept an optional `fileName` parameter so tests can supply different upload filenames while preserving the existing CSV default.

### Testing

- Ran `git diff --check`; no problems found.
- Ran repository validation via `python build/python/cli/buildctl.py validation-status --summary`; it reported no active locks and returned normally.
- Attempted to run the focused `dotnet test` for the new endpoint test, but `dotnet` is not available in the execution environment so the unit tests could not be executed locally (`/bin/bash: dotnet: command not found`).
- `bash scripts/ci.sh` could not complete locally because the environment lacks the .NET SDK; full CI (GitHub Actions) is required to run the project tests and will be the authoritative verification of the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a612389fba48320aa7275afc59a4364)