### PR TITLE
fix(health): preserve diagnostic bundle cancellation

### DIFF
--- a/src/Meridian.Ui.Services/Services/SystemHealthService.cs
+++ b/src/Meridian.Ui.Services/Services/SystemHealthService.cs
@@ -96,6 +96,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<DiagnosticBundle?> GenerateDiagnosticBundleAsync(CancellationToken ct = default)
     {
+        ct.ThrowIfCancellationRequested();
         return (await _apiClient.PostWithResponseAsync<DiagnosticBundle>(UiApiRoutes.HealthDiagnosticsBundle, null, ct).ConfigureAwait(false)).DataOrLoggedNull("Generate diagnostic bundle");
     }
 

--- a/tests/Meridian.Ui.Tests/Services/SystemHealthServiceTests.cs
+++ b/tests/Meridian.Ui.Tests/Services/SystemHealthServiceTests.cs
@@ -178,6 +178,19 @@ public sealed class SystemHealthServiceTests
     }
 
     [Fact]
+    public async Task GenerateDiagnosticBundleAsync_CancelledTokenAndNullLegacyClient_ThrowsOperationCanceledException()
+    {
+        // A compatibility client can return null without honoring cancellation.
+        var service = new SystemHealthService(new NullSystemHealthApiClient());
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Func<Task> act = () => service.GenerateDiagnosticBundleAsync(cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
     public async Task Instance_ThreadSafety_MultipleThreadsGetSameInstance()
     {
         // Arrange
@@ -352,13 +365,11 @@ public sealed class SystemHealthServiceTests
     {
         public Task<T?> GetAsync<T>(string endpoint, CancellationToken ct = default) where T : class
         {
-            ct.ThrowIfCancellationRequested();
             return Task.FromResult<T?>(null);
         }
 
         public Task<T?> PostAsync<T>(string endpoint, object? body = null, CancellationToken ct = default) where T : class
         {
-            ct.ThrowIfCancellationRequested();
             return Task.FromResult<T?>(null);
         }
     }


### PR DESCRIPTION
### Motivation
- Restore fail-fast cancellation behavior for diagnostic bundle generation to avoid silently converting a cancelled operation into a null/404-style compatibility result through the ApiResponse seam.

### Description
- Add an explicit `ct.ThrowIfCancellationRequested();` at the start of `GenerateDiagnosticBundleAsync` to preserve cancellation propagation. (modified `src/Meridian.Ui.Services/Services/SystemHealthService.cs`).
- Add a regression test that uses a legacy/null-returning client to assert that a cancelled token produces an `OperationCanceledException`. (added `GenerateDiagnosticBundleAsync_CancelledTokenAndNullLegacyClient_ThrowsOperationCanceledException` in `tests/Meridian.Ui.Tests/Services/SystemHealthServiceTests.cs`).
- Adjust the test-local `NullSystemHealthApiClient` to model a legacy client that returns `null` without throwing on cancellation so the regression is exercised. (test-only change in `tests/.../SystemHealthServiceTests.cs`).

### Testing
- `git diff --check` passed locally. 
- `python3 build/python/cli/buildctl.py validation-status --summary` ran and reported `blocked=false` (no active processes) in this environment. 
- Targeted `dotnet` test: attempted `dotnet test tests/Meridian.Ui.Tests/Meridian.Ui.Tests.csproj --filter 'FullyQualifiedName~GenerateDiagnosticBundleAsync_CancelledTokenAndNullLegacyClient_ThrowsOperationCanceledException'` could not be executed here because `dotnet` is not available in the environment. 
- Full CI gate: attempted `bash scripts/ci.sh` could not be executed here for the same `dotnet` absence; GitHub Actions remains the authoritative integration check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a612388bb708320bda9ec2ac78b7220)