### PR TITLE
Reject conflicting active true-break escalations

### DIFF
--- a/src/Meridian.FinancialOperations/MiddleOffice/MiddleOfficeOperationsService.cs
+++ b/src/Meridian.FinancialOperations/MiddleOffice/MiddleOfficeOperationsService.cs
@@ -131,9 +131,10 @@ public sealed class MiddleOfficeOperationsService
     /// <summary>
     /// Raises an escalation for a reconciliation break. Only genuine
     /// (<see cref="BreakClassification.TrueBreak"/>) or potential breaks may be escalated; matched
-    /// rows are not exceptions and are rejected. Raising a break that already has an active escalation
-    /// is idempotent — the existing open case is returned rather than opening a duplicate case and a
-    /// second SLA timer — while a break whose prior escalation was resolved may be raised afresh.
+    /// rows are not exceptions and are rejected. An exact retry for a break that already has an active
+    /// escalation is idempotent — the existing open case is returned rather than opening a duplicate
+    /// case and a second SLA timer. A conflicting raise is rejected so its governance-relevant details
+    /// are not silently discarded, while a break whose prior escalation was resolved may be raised afresh.
     /// </summary>
     public TrueBreakEscalation RaiseTrueBreak(TrueBreakEscalationRequest request)
     {
@@ -175,14 +176,20 @@ public sealed class MiddleOfficeOperationsService
 
         lock (_gate)
         {
-            // A break can carry at most one active operator case. If an upstream retry re-raises a break
-            // that is still open, return the existing escalation idempotently rather than opening a
-            // duplicate case (with a second SLA timer and breach lane). A break whose prior escalation
-            // was resolved is free to escalate again.
+            // A break can carry at most one active operator case. Only an exact upstream retry may
+            // return that case idempotently; a conflicting raise must be explicit rather than silently
+            // hiding its severity, SLA, assignee, subject, classification, or reason.
             var active = _escalations.Values.FirstOrDefault(existing =>
                 existing.IsOpen && string.Equals(existing.BreakId, breakId, StringComparison.OrdinalIgnoreCase));
             if (active is not null)
-                return active;
+            {
+                if (IsSameEscalation(active, escalation))
+                    return active;
+
+                throw new InvalidOperationException(
+                    $"Break '{breakId}' already has an active escalation with different details; " +
+                    "resolve it before raising a new escalation.");
+            }
 
             // Record the immutable escalation event before exposing the open case. If a durable sink
             // throws, no orphaned open case is left behind — otherwise a retry would find that case and
@@ -207,6 +214,23 @@ public sealed class MiddleOfficeOperationsService
 
         return escalation;
     }
+
+    private static bool IsSameEscalation(TrueBreakEscalation existing, TrueBreakEscalation candidate)
+        => string.Equals(existing.BreakId, candidate.BreakId, StringComparison.OrdinalIgnoreCase)
+           && string.Equals(existing.SubjectId, candidate.SubjectId, StringComparison.OrdinalIgnoreCase)
+           && existing.Classification == candidate.Classification
+           && existing.Severity == candidate.Severity
+           && string.Equals(existing.AssignedTo, candidate.AssignedTo, StringComparison.OrdinalIgnoreCase)
+           && string.Equals(existing.Reason, candidate.Reason, StringComparison.Ordinal)
+           && IsSamePolicy(existing.Timer?.Policy, candidate.Timer?.Policy);
+
+    private static bool IsSamePolicy(WorkflowSlaPolicy? existing, WorkflowSlaPolicy? candidate)
+        => existing is null
+            ? candidate is null
+            : candidate is not null
+              && string.Equals(existing.PolicyId, candidate.PolicyId, StringComparison.OrdinalIgnoreCase)
+              && existing.Duration == candidate.Duration
+              && existing.WarningFraction.Equals(candidate.WarningFraction);
 
     /// <summary>
     /// Advances every open escalation whose SLA timer has breached as of <paramref name="asOfUtc"/> to

--- a/tests/Meridian.Tests/FinancialOperations/MiddleOfficeOperationsServiceTests.cs
+++ b/tests/Meridian.Tests/FinancialOperations/MiddleOfficeOperationsServiceTests.cs
@@ -276,6 +276,22 @@ public sealed class MiddleOfficeOperationsServiceTests
     }
 
     [Fact]
+    public void RaiseTrueBreak_ConflictingActiveBreak_IsRejectedWithoutSuppressingItsDetails()
+    {
+        var service = NewService(out var log);
+        var first = service.RaiseTrueBreak(new TrueBreakEscalationRequest(
+            "brk-1", BreakClassification.PotentialBreak, ReconciliationBreakSeverity.Low, "Initial review", "ops", RaisedAtUtc: At));
+
+        var act = () => service.RaiseTrueBreak(new TrueBreakEscalationRequest(
+            "brk-1", BreakClassification.TrueBreak, ReconciliationBreakSeverity.Critical, "Cash out of balance", "supervisor", RaisedAtUtc: At.AddMinutes(1)));
+
+        act.Should().Throw<InvalidOperationException>("a conflicting escalation requires an explicit resolution before re-raising");
+        service.OpenEscalations.Should().ContainSingle().Which.EscalationId.Should().Be(first.EscalationId);
+        log.EventsOfKind(FundAdministrationEventKind.ReconciliationBreakEscalated)
+            .Should().ContainSingle("the rejected request must not create a partial governance event");
+    }
+
+    [Fact]
     public void RaiseTrueBreak_ResolvedBreak_CanBeRaisedAgain()
     {
         var service = NewService(out _);


### PR DESCRIPTION
### Motivation

- A recent idempotency change returned any open escalation by `BreakId` alone, which could suppress later conflicting critical escalations by discarding their severity/SLA/assignee/subject/reason details.  
- The intent of this change is to preserve governance/audit integrity by only treating exact retries as idempotent and rejecting conflicting re-raises so they cannot be silently hidden.

### Description

- Restrict deduplication in `RaiseTrueBreak` so an active escalation is returned only when the incoming request is semantically identical; otherwise the call now throws `InvalidOperationException`.  
- Added `IsSameEscalation` and `IsSamePolicy` helper checks that compare subject, classification, severity, assignee, reason, and SLA policy before returning an existing case.  
- Updated the `RaiseTrueBreak` XML/doc comment to clarify exact-retry vs conflicting-raise behavior.  
- Added a regression test `RaiseTrueBreak_ConflictingActiveBreak_IsRejectedWithoutSuppressingItsDetails` to `tests/Meridian.Tests/FinancialOperations/MiddleOfficeOperationsServiceTests.cs` to cover a low/potential case followed by a conflicting true/critical raise; modified `src/Meridian.FinancialOperations/MiddleOffice/MiddleOfficeOperationsService.cs` accordingly.

### Testing

- Ran `git diff --check` to validate the working tree formatting and found no issues.  
- Ran `python3 build/python/cli/buildctl.py validation-status --summary` which reported no active locks or blocking validation errors in this environment.  
- Attempted the CI preflight with `bash scripts/ci.sh` but execution was blocked because the environment lacks the required `dotnet` SDK so full `.NET` tests could not be executed here; GitHub Actions remains the authoritative integration test runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a612389d8508320aab1b4a98efb6d17)