### PR TITLE
Require equity account when rolling retained earnings; add regression test

### DIFF
--- a/src/Meridian.Ledger/YearEndClose.cs
+++ b/src/Meridian.Ledger/YearEndClose.cs
@@ -147,7 +147,8 @@ public static class YearEndCloseProjector
         // roll keeps its dimensional scope (a credit increases equity; a debit is a net loss).
         foreach (var line in closingEntries.JournalLines)
         {
-            if (string.Equals(line.account.Name, retainedEarningsName, StringComparison.OrdinalIgnoreCase))
+            if (line.account.AccountType == LedgerAccountType.Equity
+                && string.Equals(line.account.Name, retainedEarningsName, StringComparison.OrdinalIgnoreCase))
             {
                 AccumulateRoll(rolls, line.account.FinancialAccountId, line.dimensions, line.credit - line.debit);
             }

--- a/tests/Meridian.Tests/Ledger/YearEndCloseTests.cs
+++ b/tests/Meridian.Tests/Ledger/YearEndCloseTests.cs
@@ -68,6 +68,23 @@ public sealed class YearEndCloseTests
     }
 
     [Fact]
+    public void Project_TemporaryAccountNamedRetainedEarnings_RollsIncomeForward()
+    {
+        var sameNamedRevenue = new LedgerAccount("Retained Earnings", LedgerAccountType.Revenue);
+        var trialBalance = new List<PeriodCloseAccountBalance>
+        {
+            new(LedgerAccounts.RetainedEarnings, 5_000m),
+            new(sameNamedRevenue, 1_000m),
+        };
+
+        var projection = YearEndCloseProjector.Project(new YearEndCloseInput(
+            "FY2026", YearEnd, trialBalance, "controller"));
+
+        projection.OpeningRetainedEarnings.Should().ContainSingle().Which.OpeningBalance.Should().Be(6_000m,
+            "only the equity retained-earnings roll line carries current-year net income forward");
+    }
+
+    [Fact]
     public void Project_MissingConstituentPeriods_IsNotReady()
     {
         var input = new YearEndCloseInput(


### PR DESCRIPTION
### Motivation
- The year-end retained-earnings roll-forward matched closing journal lines by account name only, allowing a temporary revenue/expense account named "Retained Earnings" to cancel the generated equity roll and drop current-year net income from next year’s opening retained earnings.

### Description
- Tighten the closing-line filter in `YearEndCloseProjector` to require `AccountType == LedgerAccountType.Equity` in addition to matching the retained-earnings `Name` in `src/Meridian.Ledger/YearEndClose.cs`.
- Add a regression unit test `Project_TemporaryAccountNamedRetainedEarnings_RollsIncomeForward` in `tests/Meridian.Tests/Ledger/YearEndCloseTests.cs` that verifies a same-named revenue account does not remove net income from the opening retained-earnings roll.

### Testing
- Ran `git diff --check` which reported no diff/format issues.
- Attempted to run the focused unit tests with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter 'FullyQualifiedName~YearEndCloseTests'`, but `dotnet` is unavailable in this environment so tests were not executed here.
- Attempted `bash scripts/ci.sh` but it could not complete due to the missing `dotnet` SDK; GitHub Actions remains the authoritative CI run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61299e9fac832093ffa60cc1fbf640)