### PR TITLE
fix(ledger): retain P&L in mixed retained earnings entries

### DIFF
--- a/src/Meridian.Ledger/LedgerFinancialStatementBuilder.cs
+++ b/src/Meridian.Ledger/LedgerFinancialStatementBuilder.cs
@@ -373,8 +373,8 @@ public static class LedgerFinancialStatementBuilder
     /// Sums current-period net income from revenue/expense journal activity in
     /// (<paramref name="periodStart"/>, <paramref name="asOf"/>], excluding closing entries that move
     /// accumulated P&amp;L into Retained Earnings. For both revenue and expense accounts the net-income
-    /// contribution of a leg is (credit − debit), so a single term covers both. Closing transfers are a
-    /// reclassification within equity, not a current-period result, so they are not allocated here.
+    /// contribution of a leg is (credit − debit), so a single term covers both. Pure closing transfers
+    /// are a reclassification within equity, not a current-period result, so they are not allocated here.
     /// </summary>
     private static decimal PeriodNetIncomeFromActivity(
         IReadOnlyLedger ledger,
@@ -386,11 +386,7 @@ public static class LedgerFinancialStatementBuilder
         var total = 0m;
         foreach (var entry in PeriodEntries(ledger, periodStart, asOf))
         {
-            var closesToRetainedEarnings = entry.Lines.Any(line =>
-                MatchesScope(line, financialAccountId, lineDimensions)
-                && line.Account.AccountType == LedgerAccountType.Equity
-                && line.Account.Name.Equals("Retained Earnings", StringComparison.Ordinal));
-            if (closesToRetainedEarnings)
+            if (IsPureRetainedEarningsClosingEntry(entry, financialAccountId, lineDimensions))
                 continue;
 
             foreach (var line in entry.Lines)
@@ -407,7 +403,7 @@ public static class LedgerFinancialStatementBuilder
     }
 
     /// <summary>
-    /// Decomposes current-period net income (excluding Retained-Earnings closing transfers, matching
+    /// Decomposes current-period net income (excluding pure Retained-Earnings closing transfers, matching
     /// <see cref="PeriodNetIncomeFromActivity"/>) into its income/gain, (non-fee) expense, and fund-fee
     /// drivers. Revenue legs contribute (credit − debit) to income; expense legs contribute
     /// (debit − credit) to either the fee or the expense bucket. By construction
@@ -425,11 +421,7 @@ public static class LedgerFinancialStatementBuilder
         var fee = 0m;
         foreach (var entry in PeriodEntries(ledger, periodStart, asOf))
         {
-            var closesToRetainedEarnings = entry.Lines.Any(line =>
-                MatchesScope(line, financialAccountId, lineDimensions)
-                && line.Account.AccountType == LedgerAccountType.Equity
-                && line.Account.Name.Equals("Retained Earnings", StringComparison.Ordinal));
-            if (closesToRetainedEarnings)
+            if (IsPureRetainedEarningsClosingEntry(entry, financialAccountId, lineDimensions))
                 continue;
 
             foreach (var line in entry.Lines)
@@ -453,6 +445,33 @@ public static class LedgerFinancialStatementBuilder
         }
 
         return (income, expense, fee);
+    }
+
+    private static bool IsPureRetainedEarningsClosingEntry(
+        JournalEntry entry,
+        string? financialAccountId,
+        LedgerLineDimensionSet? lineDimensions)
+    {
+        var hasRetainedEarnings = false;
+        foreach (var line in entry.Lines)
+        {
+            if (!MatchesScope(line, financialAccountId, lineDimensions))
+                continue;
+
+            if (line.Account.AccountType is LedgerAccountType.Revenue or LedgerAccountType.Expense)
+                continue;
+
+            if (line.Account.AccountType == LedgerAccountType.Equity
+                && line.Account.Name.Equals("Retained Earnings", StringComparison.Ordinal))
+            {
+                hasRetainedEarnings = true;
+                continue;
+            }
+
+            return false;
+        }
+
+        return hasRetainedEarnings;
     }
 
     /// <summary>

--- a/tests/Meridian.Tests/Ledger/LedgerPeriodStatementsTests.cs
+++ b/tests/Meridian.Tests/Ledger/LedgerPeriodStatementsTests.cs
@@ -156,6 +156,38 @@ public sealed class LedgerPeriodStatementsTests
     }
 
     [Fact]
+    public void PartnersCapital_SameEntryRetainedEarningsAndFeeExpensesIncludesPeriodFees()
+    {
+        var ledger = new Meridian.Ledger.Ledger();
+        var projection = PartnershipInvestorAccountingProjector.Project(new PartnershipInvestorAllocationInput(
+            "fund-a",
+            "2026-05",
+            new DateTimeOffset(2026, 5, 31, 0, 0, 0, TimeSpan.Zero),
+            BeginningNav: 1_000m,
+            EndingNavBeforeFees: 1_200m,
+            HighWaterMark: 1_050m,
+            ManagementFeeRate: 0.02m,
+            PerformanceFeeRate: 0.20m,
+            [
+                new PartnershipInvestor("lp-1", "Limited Partner", 1m),
+            ]));
+
+        ledger.PostLines(projection.Input.AsOf, projection.Description, projection.Lines);
+
+        var statements = LedgerFinancialStatementBuilder.BuildForPeriod(
+            ledger,
+            new DateTimeOffset(2025, 12, 31, 0, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 12, 31, 0, 0, 0, TimeSpan.Zero));
+        var partnersCapital = statements.PartnersCapital!;
+        var undistributed = partnersCapital.Accounts.Single(account => account.AccountName == "Undistributed Net Income");
+
+        undistributed.AllocatedResult.Should().Be(-46m);
+        undistributed.FeeAllocations.Should().Be(46m);
+        partnersCapital.AllocatedResult.Should().Be(108m);
+        partnersCapital.IsReconciled.Should().BeTrue();
+    }
+
+    [Fact]
     public void PeriodStatements_ScopeBalancesToLineDimensions()
     {
         var ledger = new Meridian.Ledger.Ledger();


### PR DESCRIPTION
### Motivation
- A prior change treated any journal entry that touched a scoped `Retained Earnings` equity line as a closing entry and skipped the entire entry, which omitted same-entry P&L legs (e.g. management/performance fee expenses) and caused partners-capital results to misstate allocated period P&L. 
- The intent is to exclude only pure close reclassifications (temporary P&L → retained earnings) while preserving genuine current-period revenue/expense activity that happens to be batched in the same journal. 

### Description
- Replace the broad per-entry skip with a targeted predicate `IsPureRetainedEarningsClosingEntry(...)` and use it in `PeriodNetIncomeFromActivity` and `PeriodPnlComponentsFromActivity` so only pure scoped P&L-to-Retained-Earnings reclassifications are excluded (`src/Meridian.Ledger/LedgerFinancialStatementBuilder.cs`).
- Preserve revenue/expense (including fee) legs when they are present in mixed entries that also include retained-earnings legs so period-fee/activity is counted correctly. 
- Add a focused regression test `PartnersCapital_SameEntryRetainedEarningsAndFeeExpensesIncludesPeriodFees` that posts `PartnershipInvestorAccountingProjector` output and verifies the partners-capital roll-forward and fee decomposition (`tests/Meridian.Tests/Ledger/LedgerPeriodStatementsTests.cs`).

### Testing
- Ran `git diff --check` and code diff review; no whitespace/format issues were reported. (passed)
- Attempted the focused unit run with `dotnet test --filter 'FullyQualifiedName~PartnersCapital_SameEntryRetainedEarningsAndFeeExpensesIncludesPeriodFees'` but `dotnet` is not available in this environment so the test could not be executed here. (not run)
- Ran `python3 build/python/cli/buildctl.py validation-status --summary` which reported `blocked=false` and no active build locks. (passed)
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary` which reported pre-existing repository-wide documentation hash drift (37 errors including `SRC-LEDGER`); this is unrelated to the code fix but surfaced during validation. (warning)
- `bash scripts/ci.sh` could not complete in this environment because the local `.NET` SDK verification failed (`dotnet: command not found`); CI should be run on the repository CI (GitHub Actions) where `dotnet` is available to prove the change. (blocked until CI runs)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f3af99883209db2e538fa8910ab)