### PR TITLE
Reject invalid European waterfall catch-up rates

### DIFF
--- a/docs/source/generated/source-hash-manifest.json
+++ b/docs/source/generated/source-hash-manifest.json
@@ -205,8 +205,8 @@
       "id": "SRC-LEDGER",
       "path": "src/Meridian.Ledger",
       "readme": "src/Meridian.Ledger/README.md",
-      "readme_hash": "efd3784503f32b1f6f3b8d41a74b0e1b8b33ca53804aa9ad40d9a1d86304e5aa",
-      "source_hash": "2920f6ca63ab79a9d2e2b406d9a4ee88a97fc0b1e4cca6efce34ba0e2c671dde"
+      "readme_hash": "8831906f93a12e1daf0472efa838fbbebc778fcc645c8f61d9eafc9db7a967a9",
+      "source_hash": "e64b3e83344fb5cab1cc2cbda1d5f36f95cb9759b935ec0df870f1f57e1efa1d"
     },
     {
       "id": "SRC-LIFECYCLE-SUPERVISOR",

--- a/src/Meridian.Ledger/EuropeanDistributionWaterfall.cs
+++ b/src/Meridian.Ledger/EuropeanDistributionWaterfall.cs
@@ -28,8 +28,8 @@ public sealed record EuropeanWaterfallInput
             throw new ArgumentOutOfRangeException(nameof(amountToDistribute), amountToDistribute, "Amount to distribute cannot be negative.");
         if (carryRate < 0m || carryRate >= 1m)
             throw new ArgumentOutOfRangeException(nameof(carryRate), carryRate, "Carry rate must be in [0, 1).");
-        if (catchUpRate <= 0m || catchUpRate > 1m)
-            throw new ArgumentOutOfRangeException(nameof(catchUpRate), catchUpRate, "Catch-up rate must be in (0, 1].");
+        if (catchUpRate <= carryRate || catchUpRate > 1m)
+            throw new ArgumentOutOfRangeException(nameof(catchUpRate), catchUpRate, "Catch-up rate must be greater than the carry rate and no more than 1.");
         if (priorReturnOfCapital < 0m || priorPreferredPaid < 0m || priorGpCatchUp < 0m)
             throw new ArgumentOutOfRangeException(nameof(priorReturnOfCapital), "Prior cumulative amounts cannot be negative.");
         if (priorCatchUpPool < 0m)

--- a/src/Meridian.Ledger/README.md
+++ b/src/Meridian.Ledger/README.md
@@ -57,7 +57,8 @@ account symbols; the currency-aware `Ledger.PostLines` overload and
 
 Fund-ops economics are modeled as pure calculators: `PreferredReturnCalculator` (compounding or
 simple preferred return on a contribution timeline), `EuropeanDistributionWaterfall` (return of
-capital → preferred return → automatic GP catch-up → carried-interest split),
+capital → preferred return → automatic GP catch-up → carried-interest split; the catch-up rate must
+exceed the carried-interest rate),
 `CarriedInterestClawbackCalculator` (end-of-life GP giveback), and the share-class/unit register
 (`ShareClass`, `ShareClassUnitRegisterProjector`, `NavPerUnitCalculator`, `EqualizationCalculator`)
 for unitized NAV-per-unit with single-NAV equalisation. `PrivateCapitalCommitments` plus

--- a/tests/Meridian.Tests/Ledger/EuropeanDistributionWaterfallTests.cs
+++ b/tests/Meridian.Tests/Ledger/EuropeanDistributionWaterfallTests.cs
@@ -7,6 +7,22 @@ namespace Meridian.Tests.Ledger;
 public sealed class EuropeanDistributionWaterfallTests
 {
     [Fact]
+    public void Constructor_CatchUpRateDoesNotExceedCarryRate_RejectsInvalidWaterfall()
+    {
+        // A 10% catch-up cannot achieve a 20% carried-interest target. Rejecting this configuration
+        // avoids silently skipping the catch-up tier and paying the higher residual carry rate.
+        var act = () => new EuropeanWaterfallInput(
+            contributedCapital: 100m,
+            preferredReturnAccrued: 10m,
+            amountToDistribute: 120m,
+            carryRate: 0.20m,
+            catchUpRate: 0.10m);
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .Which.ParamName.Should().Be("catchUpRate");
+    }
+
+    [Fact]
     public void ReturnOfCapitalTier_PaidFirstToLp()
     {
         var result = EuropeanDistributionWaterfall.Distribute(new EuropeanWaterfallInput(


### PR DESCRIPTION
### Motivation
- Fix a fund-allocation integrity bug where a configured `CatchUpRate` less than or equal to `CarryRate` was accepted, which caused the GP catch-up tier to be skipped and remaining proceeds to be allocated using the higher residual `CarryRate`, overpaying the GP relative to the configured catch-up split.

### Description
- Require `CatchUpRate > CarryRate` (and `<= 1`) in `EuropeanWaterfallInput` by changing the constructor validation to reject invalid rate pairs, using the message `"Catch-up rate must be greater than the carry rate and no more than 1."`.
- Add a regression unit test `Constructor_CatchUpRateDoesNotExceedCarryRate_RejectsInvalidWaterfall` in `tests/Meridian.Tests/Ledger/EuropeanDistributionWaterfallTests.cs` that asserts the constructor throws `ArgumentOutOfRangeException` when `catchUpRate <= carryRate` (example: 20% carry / 10% catch-up).
- Document the invariant in `src/Meridian.Ledger/README.md` and refresh the ledger module entry in the generated docs manifest `docs/source/generated/source-hash-manifest.json`.

### Testing
- Attempted unit test run with `python3 build/python/cli/buildctl.py test --project tests/Meridian.Tests/Meridian.Tests.csproj --filter 'FullyQualifiedName~EuropeanDistributionWaterfallTests' --queue` but it could not be executed in the environment because `dotnet` is not installed (blocked).
- Ran the repository validation check `python3 build/python/cli/buildctl.py validation-status --summary` which completed successfully (passed).
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --write-module SRC-LEDGER --summary` which refreshed the Ledger manifest entry (passed) while a full `--summary` reported pre-existing unrelated doc-hash drift in other modules (unrelated failures present).
- Ran `git diff --check` which reported no whitespace or diff-check errors (passed) and `bash scripts/ci.sh` which is blocked locally due to missing `.NET SDK` (blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a612389d33483208e5588ea941e76a5)