### PR TITLE
Preserve pending replay order after cancellation

### DIFF
--- a/docs/source/generated/source-hash-manifest.json
+++ b/docs/source/generated/source-hash-manifest.json
@@ -290,7 +290,7 @@
       "path": "src/Meridian.Wpf",
       "readme": "src/Meridian.Wpf/README.md",
       "readme_hash": "4045a2e96c42733a95893eec226a74ff0c660b151330d56e6060b87162f317d2",
-      "source_hash": "4b3a5bcd9fca755dfc241dd22b85412f4666ae4f8881600b60adb0fc371b732f"
+      "source_hash": "1ea725a22afcc2e9f36a36cf956b4a7d580f3dfa0068f02cc35869a3ea0dd859"
     }
   ],
   "schema": {

--- a/src/Meridian.Wpf/Services/PendingOperationsQueueService.cs
+++ b/src/Meridian.Wpf/Services/PendingOperationsQueueService.cs
@@ -88,6 +88,7 @@ public sealed class PendingOperationsQueueService
         new(() => new PendingOperationsQueueService());
 
     private readonly ConcurrentQueue<PendingOperation> _queue = new();
+    private readonly ConcurrentQueue<PendingOperation> _replayFront = new();
     private readonly ConcurrentDictionary<string, Func<object?, Task>> _handlers = new();
     private readonly SemaphoreSlim _persistGate = new(1, 1);
     private bool _initialized;
@@ -106,7 +107,7 @@ public sealed class PendingOperationsQueueService
     /// <summary>
     /// Gets the number of pending operations in the queue.
     /// </summary>
-    public int PendingCount => _queue.Count;
+    public int PendingCount => _replayFront.Count + _queue.Count;
 
     internal PendingOperationsQueueService()
     {
@@ -170,6 +171,7 @@ public sealed class PendingOperationsQueueService
         }
 
         _initialized = false;
+        _replayFront.Clear();
         _queue.Clear();
     }
 
@@ -226,7 +228,7 @@ public sealed class PendingOperationsQueueService
     /// <returns>The next operation, or null if the queue is empty.</returns>
     public PendingOperation? Dequeue()
     {
-        return _queue.TryDequeue(out var op) ? op : null;
+        return TryDequeueNext(out var op) ? op : null;
     }
 
     /// <summary>
@@ -235,7 +237,12 @@ public sealed class PendingOperationsQueueService
     /// <returns>The next operation, or null if the queue is empty.</returns>
     public PendingOperation? Peek()
     {
-        return _queue.TryPeek(out var op) ? op : null;
+        if (_replayFront.TryPeek(out var op))
+        {
+            return op;
+        }
+
+        return _queue.TryPeek(out op) ? op : null;
     }
 
     /// <summary>
@@ -243,7 +250,7 @@ public sealed class PendingOperationsQueueService
     /// </summary>
     public IReadOnlyList<PendingOperation> GetAll()
     {
-        return _queue.ToArray();
+        return _replayFront.Concat(_queue).ToArray();
     }
 
     /// <summary>
@@ -258,7 +265,7 @@ public sealed class PendingOperationsQueueService
         var count = _queue.Count;
         for (var i = 0; i < count; i++)
         {
-            if (!_queue.TryDequeue(out var op))
+            if (!TryDequeueNext(out var op))
                 break;
 
             if (!_handlers.TryGetValue(op.OperationType, out var handler))
@@ -274,9 +281,9 @@ public sealed class PendingOperationsQueueService
             catch (OperationCanceledException)
             {
                 // Cancellation (for example shutdown mid-replay) is not a failure of the
-                // operation: put it back untouched and persist so the next reconnect or
-                // session replays it, then let the cancellation propagate.
-                _queue.Enqueue(op);
+                // operation: put it back at the front and persist so the next reconnect or
+                // session replays it before dependent operations, then let cancellation propagate.
+                _replayFront.Enqueue(op);
                 await PersistAsync(CancellationToken.None).ConfigureAwait(false);
                 throw;
             }
@@ -315,6 +322,16 @@ public sealed class PendingOperationsQueueService
         }
     }
 
+    private bool TryDequeueNext(out PendingOperation operation)
+    {
+        if (_replayFront.TryDequeue(out operation))
+        {
+            return true;
+        }
+
+        return _queue.TryDequeue(out operation);
+    }
+
     private async Task WriteSnapshotLockedAsync(CancellationToken ct)
     {
         try
@@ -322,7 +339,8 @@ public sealed class PendingOperationsQueueService
             var envelope = new PendingOperationsEnvelope
             {
                 SavedAt = DateTimeOffset.UtcNow,
-                Operations = _queue
+                Operations = _replayFront
+                    .Concat(_queue)
                     .Select(static op => new PersistedPendingOperation
                     {
                         Id = op.Id,

--- a/tests/Meridian.Wpf.Tests/Services/PendingOperationsQueuePersistenceTests.cs
+++ b/tests/Meridian.Wpf.Tests/Services/PendingOperationsQueuePersistenceTests.cs
@@ -159,6 +159,30 @@ public sealed class PendingOperationsQueuePersistenceTests : IDisposable
     }
 
     [Fact]
+    public async Task ProcessAllAsync_CancelledHandler_PreservesOrderOfDependentOperationsAcrossSessions()
+    {
+        var service = new PendingOperationsQueueService();
+        service.RegisterHandler("test.review", _ => throw new OperationCanceledException());
+        service.RegisterHandler("test.resolve", _ => Task.CompletedTask);
+        service.Enqueue("test.review", null);
+        service.Enqueue("test.resolve", null);
+
+        var act = () => service.ProcessAllAsync();
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        service.GetAll().Select(operation => operation.OperationType)
+            .Should().Equal("test.review", "test.resolve");
+        service.Peek()!.RetryCount.Should().Be(0);
+
+        var reader = new PendingOperationsQueueService();
+        await reader.InitializeAsync();
+
+        reader.GetAll().Select(operation => operation.OperationType)
+            .Should().Equal("test.review", "test.resolve",
+                "the durable rescue snapshot must retain the original replay order");
+    }
+
+    [Fact]
     public async Task PersistAsync_AfterShutdown_DoesNotOverwriteFinalSnapshot()
     {
         // An enqueue-scheduled background persist that loses the race with shutdown must not


### PR DESCRIPTION
### Motivation
- Fix a replay-order corruption where a cancelled replayed operation was re-enqueued at the tail, changing durable ordering and allowing dependent operations to be processed out of sequence and silently dropped.

### Description
- Add a dedicated front replay queue `_replayFront` and `TryDequeueNext` so rescued/cancelled operations are replayed before remaining queued work and the in-memory/durable order is preserved.
- Adjust `PendingCount`, `Peek`, `Dequeue`, `GetAll`, `ShutdownAsync`, `ProcessAllAsync`, and snapshot `WriteSnapshotLockedAsync` to include the replay-front ordering and to persist the combined ordering.
- On `OperationCanceledException` the operation is enqueued to the replay-front instead of the tail so retry budget and original FIFO ordering are preserved across restarts.
- Add a regression test `ProcessAllAsync_CancelledHandler_PreservesOrderOfDependentOperationsAcrossSessions` in `tests/Meridian.Wpf.Tests/Services/PendingOperationsQueuePersistenceTests.cs` and refresh the generated WPF source-hash manifest in `docs/source/generated/source-hash-manifest.json`.

### Testing
- Attempted to run the focused unit tests with `dotnet test --filter 'FullyQualifiedName~PendingOperationsQueuePersistenceTests'`, but the environment lacks `dotnet` so the test run could not be executed locally.
- Ran `python3 build/python/cli/buildctl.py validation-status --summary` which completed and reported no active build locks or processes.
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary` which refreshed the WPF module hash and reported unrelated existing documentation-hash drifts elsewhere in the repo.
- Ran `bash scripts/ci.sh` which stopped during the SDK verification because `dotnet` is not installed in this container.
- Ran `git diff --check` before committing and it passed; the new regression test was added but not executed locally due to the missing `dotnet` runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61238a5ffc8320857fdaf83ad8bc9d)