### PR TITLE
Allow durable walk-forward evidence updates for completed runs

### DIFF
--- a/docs/source/generated/source-hash-manifest.json
+++ b/docs/source/generated/source-hash-manifest.json
@@ -254,8 +254,8 @@
       "id": "SRC-STRATEGIES",
       "path": "src/Meridian.Strategies",
       "readme": "src/Meridian.Strategies/README.md",
-      "readme_hash": "016be97fb7033a2fc2f7cf119ca9feed92c5627cb559d8b065a711e0d1a4253e",
-      "source_hash": "9aa7f70c011e65011bb6f4ff79b079fdc0ab74edee586b1aa66f77a18e882e87"
+      "readme_hash": "fbe60ebc6857c1c6ed917e6a02808c9e3093ebbb335270fb125c1f113e62123c",
+      "source_hash": "7df10dc18f9bed83159dabf5124d8618ae1fc447f8ace9bb376054f50b2a53c8"
     },
     {
       "id": "SRC-UI",

--- a/src/Meridian.Strategies/README.md
+++ b/src/Meridian.Strategies/README.md
@@ -50,6 +50,9 @@ data-root-backed durable history store.
 retained evidence links, accounting-record references, approval references, paper-validation
 lineage, and governed-report references are stored with the run so downstream review surfaces do
 not need to infer backtest acceptance from dashboard-only state.
+Completed runs may receive a subsequent append-only walk-forward evidence snapshot when the
+snapshot changes only that evidence; durable replay preserves the completed lifecycle state while
+allowing paper-to-live promotion to evaluate the newly retained out-of-sample evidence.
 `LedgerReadService` projects strategy-run trial balance and journal rows with canonical
 `LedgerDimensionSetDto` scope for fund, strategy, portfolio, book, account, entity, sleeve,
 organization, customer, vendor, project, and `externalGl.*` run-parameter filters so workstation

--- a/src/Meridian.Strategies/Storage/StrategyRunStore.cs
+++ b/src/Meridian.Strategies/Storage/StrategyRunStore.cs
@@ -890,7 +890,8 @@ public sealed class StrategyRunStore : IStrategyRepository
             return "the lifecycle event timestamp moved backwards";
         }
 
-        if (!IsAllowedTransition(previous.LastLifecycleEvent, current.LastLifecycleEvent))
+        if (!IsWalkForwardEvidenceOnlyCompletedRunUpdate(previous, current) &&
+            !IsAllowedTransition(previous.LastLifecycleEvent, current.LastLifecycleEvent))
         {
             return $"transition '{previous.LastLifecycleEvent}' to '{current.LastLifecycleEvent}' is not allowed";
         }
@@ -912,6 +913,26 @@ public sealed class StrategyRunStore : IStrategyRepository
         }
 
         return null;
+    }
+
+    private static bool IsWalkForwardEvidenceOnlyCompletedRunUpdate(
+        StrategyRunEntry previous,
+        StrategyRunEntry current)
+    {
+        if (previous.LastLifecycleEvent != StrategyRunLifecycleEventType.Completed ||
+            current.LastLifecycleEvent != StrategyRunLifecycleEventType.Completed ||
+            previous.WalkForwardEvidence == current.WalkForwardEvidence)
+        {
+            return false;
+        }
+
+        var previousWithoutEvidence = JsonSerializer.Serialize(
+            previous with { WalkForwardEvidence = null },
+            StrategyRunPersistenceJson.Options);
+        var currentWithoutEvidence = JsonSerializer.Serialize(
+            current with { WalkForwardEvidence = null },
+            StrategyRunPersistenceJson.Options);
+        return string.Equals(previousWithoutEvidence, currentWithoutEvidence, StringComparison.Ordinal);
     }
 
     private static string ComputeCanonicalInputHash(StrategyRunEntry entry) =>

--- a/tests/Meridian.Tests/Strategies/PromotionWalkForwardGateTests.cs
+++ b/tests/Meridian.Tests/Strategies/PromotionWalkForwardGateTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Meridian.Backtesting.Sdk;
 using Meridian.Execution.Sdk;
+using Meridian.Storage.Operations;
 using Meridian.Strategies.Models;
 using Meridian.Strategies.Promotions;
 using Meridian.Strategies.Services;
@@ -191,6 +192,44 @@ public sealed class PromotionWalkForwardGateTests
     }
 
     [Fact]
+    public async Task RecordWalkForwardEvidenceAsync_CompletedPaperRunInDurableStore_PersistsAndRemovesWalkForwardBlocker()
+    {
+        var dataRoot = Path.Combine(Path.GetTempPath(), $"meridian-walk-forward-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataRoot);
+        try
+        {
+            var store = new StrategyRunStore(new FileOperationalCaseHistoryStore(dataRoot));
+            var service = BuildService(store, dataRoot);
+            var run = StrategyRunEntry.Start("s-wf-durable", "Strategy WF Durable", RunType.Paper)
+                .Complete(BuildPassingResult());
+            await store.RecordRunAsync(run);
+
+            var evidence = new StrategyRunWalkForwardEvidence(
+                OutOfSampleSharpeRatio: 1.0,
+                OutOfSampleMaxDrawdownPercent: 0.09m,
+                DegradationRatio: 0.8,
+                WindowCount: 8,
+                RecordedAt: DateTimeOffset.UtcNow,
+                SourceReference: "reports/wf-durable-run.json");
+
+            var updated = await service.RecordWalkForwardEvidenceAsync(run.RunId, evidence);
+
+            updated.Should().NotBeNull();
+            var restarted = new StrategyRunStore(new FileOperationalCaseHistoryStore(dataRoot));
+            var replayed = await restarted.GetRunByIdAsync(run.RunId);
+            replayed!.WalkForwardEvidence.Should().Be(evidence);
+
+            var after = await service.EvaluateAsync(run.RunId);
+            after.BlockingReasons?.Should().NotContain(reason =>
+                reason.Contains("walk-forward", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            Directory.Delete(dataRoot, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task EvaluateAsync_WithEvidenceRequirementDisabledInCriteria_SkipsWalkForwardGate()
     {
         var service = BuildService(out var store);
@@ -257,8 +296,13 @@ public sealed class PromotionWalkForwardGateTests
     private static PromotionService BuildService(out StrategyRunStore store)
     {
         store = new StrategyRunStore();
+        return BuildService(store, Path.Combine(Path.GetTempPath(), $"mdc-wf-gate-{Guid.NewGuid():N}"));
+    }
+
+    private static PromotionService BuildService(StrategyRunStore store, string dataRoot)
+    {
         var promotionStore = new JsonlPromotionRecordStore(
-            Path.Combine(Path.Combine(Path.GetTempPath(), $"mdc-wf-gate-{Guid.NewGuid():N}"), "promotion-history"),
+            Path.Combine(dataRoot, "promotion-history"),
             NullLogger<JsonlPromotionRecordStore>.Instance);
         return new PromotionService(
             store,


### PR DESCRIPTION
### Motivation
- Walk-forward evidence recorded after a run completed could not be persisted in the durable `StrategyRunStore` because terminal `Completed -> Completed` updates are rejected by lifecycle-progression validation.
- This made the new walk-forward evidence API unusable with the production durable history store while tests using the parameterless in-memory store passed.

### Description
- Permit an append-only `Completed -> Completed` update when the only change to the snapshot is `WalkForwardEvidence` by adding `IsWalkForwardEvidenceOnlyCompletedRunUpdate` and short-circuiting lifecycle rejection in `StrategyRunStore.RecordRunAsync`'s validation path.
- Add an end-to-end durable regression `RecordWalkForwardEvidenceAsync_CompletedPaperRunInDurableStore_PersistsAndRemovesWalkForwardBlocker` to `PromotionWalkForwardGateTests` that records evidence via `PromotionService`, restarts a `StrategyRunStore` backed by `FileOperationalCaseHistoryStore`, and asserts the evidence is replayed and the walk-forward blocker is cleared.
- Document the behavior in `src/Meridian.Strategies/README.md` to note that completed runs may receive append-only evidence snapshots that only change `WalkForwardEvidence`.
- Refresh the scoped strategies source-hash manifest (`docs/source/generated/source-hash-manifest.json`) to reflect the updated README.

### Testing
- Ran `git diff --check` and static diff hygiene; no issues found.
- Updated the strategies docs hash with `python3 build/scripts/docs/validate-doc-hashes.py --write-module SRC-STRATEGIES`; the module manifest was refreshed successfully.
- Ran `python3 build/python/cli/buildctl.py validation-status --summary`; no local build-server locks were detected.
- Attempted to run the focused unit tests with `dotnet test --filter

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61238934dc832089aa2b51a5dad1cd)