### PR TITLE
fix(wpf): disable insecure reconciliation replay

### DIFF
--- a/src/Meridian.Wpf/App.xaml.cs
+++ b/src/Meridian.Wpf/App.xaml.cs
@@ -547,11 +547,6 @@ public partial class App : System.Windows.Application
             // Start background task scheduler
             await InitializeBackgroundServicesAsync();
 
-            // Arm offline replay: materialize the clients that register durable-queue handlers,
-            // drain operations persisted by earlier sessions, and replay again whenever
-            // connectivity to the workstation service is restored.
-            WireOfflineOperationReplay();
-
             // Notify if running in fixture/demo mode
             if (_isFixtureMode)
             {
@@ -617,51 +612,6 @@ public partial class App : System.Windows.Application
         {
             WpfServices.LoggingService.Instance.LogWarning(
                 "Offline tracking persistence failed to initialize; continuing without crash recovery persistence");
-        }
-    }
-
-    /// <summary>
-    /// Wires durable offline-operation replay: resolves the API clients whose constructors
-    /// register pending-operation handlers, replays operations persisted by earlier sessions,
-    /// and subscribes reconnect events so queued mutations drain when the backend returns.
-    /// </summary>
-    private void WireOfflineOperationReplay()
-    {
-        try
-        {
-            // Resolving the client registers its pending-operation replay handlers.
-            _ = Services.GetService<WpfServices.IWorkstationReconciliationApiClient>();
-
-            WpfServices.ConnectionService.Instance.ReconnectSucceeded += static (_, _) =>
-                _ = ReplayPendingOperationsAsync("reconnect");
-
-            _ = ReplayPendingOperationsAsync("startup");
-        }
-        catch (Exception ex)
-        {
-            WpfServices.LoggingService.Instance.LogWarning(
-                $"Offline operation replay wiring failed: {ex.Message}");
-        }
-    }
-
-    private static async Task ReplayPendingOperationsAsync(string trigger)
-    {
-        try
-        {
-            var queue = WpfServices.PendingOperationsQueueService.Instance;
-            if (queue.PendingCount == 0)
-            {
-                return;
-            }
-
-            WpfServices.LoggingService.Instance.LogInfo(
-                $"Replaying {queue.PendingCount} pending offline operation(s) ({trigger})");
-            await queue.ProcessAllAsync();
-        }
-        catch (Exception ex)
-        {
-            WpfServices.LoggingService.Instance.LogWarning(
-                $"Pending operation replay failed: {ex.Message}");
         }
     }
 

--- a/src/Meridian.Wpf/Services/WorkstationReconciliationApiClient.cs
+++ b/src/Meridian.Wpf/Services/WorkstationReconciliationApiClient.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Meridian.Contracts.Workstation;
 using Meridian.Contracts.Operations;
 using Meridian.Ui.Services;
@@ -12,19 +11,7 @@ public sealed record WorkstationReconciliationActionResult(
     ReconciliationBreakQueueItem? Item)
 {
     public VerifiedOperationOutcome? Outcome { get; init; }
-
-    /// <summary>
-    /// True when the action failed because the workstation service was unreachable and the
-    /// operation was captured in the durable pending-operations queue for automatic replay.
-    /// </summary>
-    public bool QueuedForRetry { get; init; }
 }
-
-/// <summary>Durable payload for a queued break review.</summary>
-public sealed record PendingReviewBreakOperation(string BreakId, ReviewReconciliationBreakRequest Request);
-
-/// <summary>Durable payload for a queued break resolution.</summary>
-public sealed record PendingResolveBreakOperation(string BreakId, ResolveReconciliationBreakRequest Request);
 
 public interface IWorkstationReconciliationApiClient
 {
@@ -61,50 +48,11 @@ public interface IWorkstationReconciliationApiClient
 
 public sealed class WorkstationReconciliationApiClient : IWorkstationReconciliationApiClient
 {
-    /// <summary>Pending-operations queue type for a break review captured while offline.</summary>
-    public const string ReviewBreakOperationType = "reconciliation.review-break";
-
-    /// <summary>Pending-operations queue type for a break resolution captured while offline.</summary>
-    public const string ResolveBreakOperationType = "reconciliation.resolve-break";
-
     private readonly Meridian.Ui.Services.ApiClientService _apiClient;
-    private readonly PendingOperationsQueueService _pendingOperations;
 
     public WorkstationReconciliationApiClient(Meridian.Ui.Services.ApiClientService apiClient)
-        : this(apiClient, PendingOperationsQueueService.Instance)
-    {
-    }
-
-    internal WorkstationReconciliationApiClient(
-        Meridian.Ui.Services.ApiClientService apiClient,
-        PendingOperationsQueueService pendingOperations)
     {
         _apiClient = apiClient ?? throw new ArgumentNullException(nameof(apiClient));
-        _pendingOperations = pendingOperations ?? throw new ArgumentNullException(nameof(pendingOperations));
-
-        // Replay handlers: re-issue queued mutations against the backend. Throwing on a
-        // still-unreachable backend lets ProcessAllAsync's retry/re-enqueue semantics keep the
-        // operation durable instead of dropping it.
-        _pendingOperations.RegisterHandler(ReviewBreakOperationType, async payload =>
-        {
-            if (DeserializePayload<PendingReviewBreakOperation>(payload) is not { } operation)
-            {
-                return;
-            }
-
-            var result = await ReviewBreakCoreAsync(operation.BreakId, operation.Request).ConfigureAwait(false);
-            ThrowIfStillUnreachable(result);
-        });
-        _pendingOperations.RegisterHandler(ResolveBreakOperationType, async payload =>
-        {
-            if (DeserializePayload<PendingResolveBreakOperation>(payload) is not { } operation)
-            {
-                return;
-            }
-
-            var result = await ResolveBreakCoreAsync(operation.BreakId, operation.Request).ConfigureAwait(false);
-            ThrowIfStillUnreachable(result);
-        });
     }
 
     public Task<ReconciliationCalibrationSummaryDto?> GetCalibrationSummaryAsync(CancellationToken ct = default)
@@ -145,10 +93,7 @@ public sealed class WorkstationReconciliationApiClient : IWorkstationReconciliat
         ReviewReconciliationBreakRequest request,
         CancellationToken ct = default)
     {
-        var result = await ReviewBreakCoreAsync(breakId, request, ct).ConfigureAwait(false);
-        return result.QueuedForRetry
-            ? EnqueueForRetry(ReviewBreakOperationType, new PendingReviewBreakOperation(breakId, request), result)
-            : result;
+        return await ReviewBreakCoreAsync(breakId, request, ct).ConfigureAwait(false);
     }
 
     public async Task<WorkstationReconciliationActionResult> ResolveBreakAsync(
@@ -156,10 +101,7 @@ public sealed class WorkstationReconciliationApiClient : IWorkstationReconciliat
         ResolveReconciliationBreakRequest request,
         CancellationToken ct = default)
     {
-        var result = await ResolveBreakCoreAsync(breakId, request, ct).ConfigureAwait(false);
-        return result.QueuedForRetry
-            ? EnqueueForRetry(ResolveBreakOperationType, new PendingResolveBreakOperation(breakId, request), result)
-            : result;
+        return await ResolveBreakCoreAsync(breakId, request, ct).ConfigureAwait(false);
     }
 
     private Task<WorkstationReconciliationActionResult> ReviewBreakCoreAsync(
@@ -174,46 +116,13 @@ public sealed class WorkstationReconciliationApiClient : IWorkstationReconciliat
         CancellationToken ct = default)
         => ToActionResultAsync(_apiClient.UiApi.ResolveReconciliationBreakAsync(breakId, request, ct));
 
-    private WorkstationReconciliationActionResult EnqueueForRetry(
-        string operationType,
-        object payload,
-        WorkstationReconciliationActionResult result)
-    {
-        _pendingOperations.Enqueue(operationType, payload);
-        return result with
-        {
-            ErrorMessage =
-                "The workstation service is unreachable. The action was saved and will be " +
-                "retried automatically when the connection is restored."
-        };
-    }
-
-    private static void ThrowIfStillUnreachable(WorkstationReconciliationActionResult result)
-    {
-        if (result.QueuedForRetry)
-        {
-            throw new InvalidOperationException(
-                "The workstation service is still unreachable; the queued reconciliation action will be retried.");
-        }
-    }
-
-    private static T? DeserializePayload<T>(object? payload) where T : class => payload switch
-    {
-        T typed => typed,
-        JsonElement element => element.Deserialize<T>(Meridian.Ui.Services.DesktopJsonOptions.Api),
-        _ => null
-    };
-
     private static async Task<WorkstationReconciliationActionResult> ToActionResultAsync(
         Task<Meridian.Contracts.Api.ApiResponse<ReconciliationCaseworkOperationResult>> responseTask)
     {
         var response = await responseTask.ConfigureAwait(false);
         if (!response.Success || response.Data is null)
         {
-            return new WorkstationReconciliationActionResult(false, response.ErrorMessage, null)
-            {
-                QueuedForRetry = response.IsConnectionError
-            };
+            return new WorkstationReconciliationActionResult(false, response.ErrorMessage, null);
         }
 
         var operation = response.Data;

--- a/tests/Meridian.Wpf.Tests/Services/PendingOperationsQueuePersistenceTests.cs
+++ b/tests/Meridian.Wpf.Tests/Services/PendingOperationsQueuePersistenceTests.cs
@@ -101,6 +101,21 @@ public sealed class PendingOperationsQueuePersistenceTests : IDisposable
     }
 
     [Fact]
+    public async Task ProcessAllAsync_DoesNotReplayLegacyReconciliationMutationWithoutAHandler()
+    {
+        // Reconciliation mutations must execute only while the initiating API session is active.
+        // A snapshot written by an earlier version therefore stays inert after the replay handler
+        // is removed instead of being issued under the next signed-in user's credentials.
+        var service = new PendingOperationsQueueService();
+        service.Enqueue("reconciliation.resolve-break", new ReviewPayload("break-10", "resolve"));
+
+        await service.ProcessAllAsync();
+
+        service.PendingCount.Should().Be(1);
+        service.Peek()!.OperationType.Should().Be("reconciliation.resolve-break");
+    }
+
+    [Fact]
     public async Task ProcessAllAsync_ReplaysRestoredJsonPayloadThroughHandler()
     {
         var writer = new PendingOperationsQueueService();


### PR DESCRIPTION
### Motivation

- Fix a confused-deputy/audit vulnerability where durable offline reconciliation mutations could be persisted and later replayed under whatever API session was active at restart or reconnect, allowing attribution/permission bypass.
- Avoid executing reconciliation review/resolve mutations out-of-band until a principal-bound, integrity-protected replay design is implemented.

### Description

- Stop queueing reconciliation review/resolve mutations for durable replay by removing enqueue/retry plumbing in `WorkstationReconciliationApiClient` so those methods now return the direct API result (`ReviewBreakAsync` / `ResolveBreakAsync`).
- Remove reconciliation-specific replay handlers and the code paths that registered them against `PendingOperationsQueueService`, eliminating replay of those mutation types.
- Remove automatic startup/reconnect wiring that would drain the pending-operations queue at `App.xaml.cs`, while keeping generic offline-tracking initialization intact (`OfflineTrackingPersistenceService` still initializes).
- Add a regression test in `tests/Meridian.Wpf.Tests/Services/PendingOperationsQueuePersistenceTests.cs` asserting that a legacy `reconciliation.resolve-break` persisted operation remains inert when no handler is registered.

### Testing

- Ran `git diff --check` and repository static checks: passed.
- Static source assertions (search-based checks) verified reconciliation queue handlers and automatic replay wiring were removed: passed.
- Added a unit test `ProcessAllAsync_DoesNotReplayLegacyReconciliationMutationWithoutAHandler` to cover the regression; test added but not executed in this environment.
- Attempted to run `dotnet`-based tests and `bash scripts/ci.sh` but `dotnet` is not available in this environment so those steps are reported as blocked; `python build/python/cli/buildctl.py validation-status --summary` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61299d411883208d1960bfc998659e)