### PR TITLE
Fix API-key header session bypass on non-API routes

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/ApiKeyMiddleware.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/ApiKeyMiddleware.cs
@@ -91,13 +91,14 @@ public sealed class ApiKeyMiddleware
     }
 
     /// <summary>
-    /// True when API-key authentication is configured and the request presents an
+    /// True when API-key authentication is configured and an API request presents an
     /// <c>X-Api-Key</c> header. <see cref="LoginSessionMiddleware"/> uses this to defer
     /// judgment on such requests to this middleware instead of rejecting them for
-    /// lacking a session.
+    /// lacking a session. Non-API routes remain protected by session authentication.
     /// </summary>
     internal static bool IsApiKeyCandidate(HttpContext context) =>
         !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(ApiKeyEnvVar)) &&
+        context.Request.Path.StartsWithSegments("/api", StringComparison.OrdinalIgnoreCase) &&
         context.Request.Headers.ContainsKey(ApiKeyHeaderName);
 
     /// <summary>

--- a/tests/Meridian.Tests/Integration/EndpointTests/AuthEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/AuthEndpointTests.cs
@@ -379,6 +379,30 @@ public sealed class AuthEndpointTests : EndpointIntegrationTestBase
         }
     }
 
+    [Theory]
+    [InlineData("/api/status", true)]
+    [InlineData("/apiary/status", false)]
+    [InlineData("/workstation/evidence/vault/example", false)]
+    public void ApiKeyMiddleware_IsApiKeyCandidate_DefersOnlyApiRequests(
+        string path,
+        bool expectedCandidate)
+    {
+        var originalApiKey = Environment.GetEnvironmentVariable("MDC_API_KEY");
+        Environment.SetEnvironmentVariable("MDC_API_KEY", "integration-test-key");
+        try
+        {
+            var context = new DefaultHttpContext();
+            context.Request.Path = path;
+            context.Request.Headers["X-Api-Key"] = "attacker-controlled-value";
+
+            ApiKeyMiddleware.IsApiKeyCandidate(context).Should().Be(expectedCandidate);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MDC_API_KEY", originalApiKey);
+        }
+    }
+
     [Fact]
     public async Task ApiKeyMiddleware_SessionAuthenticatedRequest_PassesWithoutApiKey()
     {


### PR DESCRIPTION
### Motivation

- Prevent unauthenticated non-/api routes from being allowed through when a caller supplies any `X-Api-Key` header while `MDC_API_KEY` is set, which could expose protected file/evidence endpoints.

### Description

- Restrict `ApiKeyMiddleware.IsApiKeyCandidate` to only consider requests whose path begins with the `/api` segment so non-API routes remain governed by session authentication. (Change in `src/Meridian.Ui.Shared/Endpoints/ApiKeyMiddleware.cs`.)
- Clarify the `IsApiKeyCandidate` documentation to note that candidates must be API requests and that non-API routes remain protected by session auth. (Comment update in `ApiKeyMiddleware.cs`.)
- Add a regression test that asserts `IsApiKeyCandidate` only returns true for API paths and not for non-API evidence/workstation routes, and that similarly prefixed but non-API paths do not count as API candidates. (New test in `tests/Meridian.Tests/Integration/EndpointTests/AuthEndpointTests.cs`.)

### Testing

- Added a regression test `ApiKeyMiddleware_IsApiKeyCandidate_DefersOnlyApiRequests` in `AuthEndpointTests` to cover API and non-API path behavior; the test was added but could not be executed in this environment because `dotnet` is not installed.
- Ran repository static checks: `git diff --check` passed and `python3 build/python/cli/buildctl.py validation-status --summary` completed successfully.
- Attempted to run `dotnet test` and `bash scripts/ci.sh` but both are blocked in this environment due to missing .NET SDK (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61238c36788320a340396373873dc7)