### PR TITLE
Route reconnect gap recovery through AutoGapRemediationService to enforce guardrails

### DIFF
--- a/src/Meridian.Application/Backfill/AutoGapRemediationService.cs
+++ b/src/Meridian.Application/Backfill/AutoGapRemediationService.cs
@@ -5,6 +5,7 @@ using Meridian.Core.Logging;
 using Meridian.DataIntegration.Monitoring.DataQuality;
 using Meridian.Application.Scheduling;
 using Meridian.Infrastructure.Adapters.Core;
+using Meridian.Infrastructure.Resilience;
 using Serilog;
 using QualityDataGap = Meridian.DataIntegration.Monitoring.DataQuality.DataGap;
 using StorageGapAnalysisResult = Meridian.Infrastructure.Adapters.Core.GapAnalysisResult;
@@ -24,7 +25,8 @@ public enum AutoRemediationTriggerSource
 {
     DataQualityGap,
     GapAnalyzerScan,
-    QualityAlert
+    QualityAlert,
+    ReconnectionGap
 }
 
 /// <summary>
@@ -427,6 +429,40 @@ public sealed class AutoGapRemediationService : IDataQualityGapRemediationServic
     }
 
     /// <summary>
+    /// Routes a streaming-provider reconnection through the same policy, cooldown, idempotency,
+    /// and concurrency controls used by all other automatic remediations.
+    /// </summary>
+    public Task HandleReconnectionGapAsync(
+        ReconnectionGap gap,
+        IReadOnlyList<string> symbols,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(symbols);
+
+        if (gap.Duration < _policy.MinimumGapDuration)
+        {
+            _log.Debug(
+                "Skipping reconnection remediation for {Provider}: gap {Duration} below minimum {Minimum}",
+                gap.ProviderName,
+                gap.Duration,
+                _policy.MinimumGapDuration);
+            return Task.CompletedTask;
+        }
+
+        return EnqueueRemediationAsync(
+            symbols,
+            DateOnly.FromDateTime(gap.DisconnectedAt.UtcDateTime),
+            DateOnly.FromDateTime(gap.ReconnectedAt.UtcDateTime),
+            provider: "composite",
+            AutoRemediationTriggerSource.ReconnectionGap,
+            $"reconnection:{gap.ProviderName}",
+            gapSize: Math.Max(symbols.Count, 1),
+            severity: null,
+            downstreamWorkflow: null,
+            ct);
+    }
+
+    /// <summary>
     /// Executes the same guarded quality-gap path used by event-driven remediation and reports the
     /// observed outcome to an interactive caller. Existing fire-and-forget integrations continue
     /// to use <see cref="HandleDataQualityGapAsync"/> unchanged.
@@ -541,6 +577,9 @@ public sealed class AutoGapRemediationService : IDataQualityGapRemediationServic
         int maxExecutions = 100,
         TimeSpan? dueSoonWindow = null)
         => _slaEvaluator.Evaluate(nowUtc, maxExecutions, dueSoonWindow);
+
+    /// <summary>Configured minimum duration for all automatic gap remediation signals.</summary>
+    public TimeSpan MinimumGapDuration => _policy.MinimumGapDuration;
 
     private void OnQualityGapDetected(QualityDataGap gap)
     {

--- a/src/Meridian.Application/Backfill/GapBackfillService.cs
+++ b/src/Meridian.Application/Backfill/GapBackfillService.cs
@@ -20,6 +20,7 @@ public sealed class GapBackfillService
     private readonly bool _enabled;
     private readonly TimeSpan _minimumGap;
     private readonly DataGranularity _recoveryGranularity;
+    private readonly AutoGapRemediationService? _guardedRemediation;
     private int _gapBackfillsTriggered;
     private int _gapBackfillsSucceeded;
 
@@ -36,18 +37,22 @@ public sealed class GapBackfillService
     /// gaps are intraday windows, so this defaults to 1-minute bars; the backfill service rejects the
     /// request loudly when no configured historical provider supports it, rather than silently
     /// remediating an intraday gap with daily bars.</param>
+    /// <param name="guardedRemediation">When supplied, reconnection gaps are routed through the
+    /// shared auto-remediation policy instead of executing directly.</param>
     public GapBackfillService(
         Func<BackfillRequest, CancellationToken, Task<BackfillResult>> backfillExecutor,
         Func<IReadOnlyCollection<string>>? subscribedSymbols = null,
         bool enabled = true,
         TimeSpan? minimumGap = null,
-        DataGranularity recoveryGranularity = DataGranularity.Minute1)
+        DataGranularity recoveryGranularity = DataGranularity.Minute1,
+        AutoGapRemediationService? guardedRemediation = null)
     {
         _backfillExecutor = backfillExecutor;
         _subscribedSymbols = subscribedSymbols ?? (static () => Array.Empty<string>());
         _enabled = enabled;
         _minimumGap = minimumGap ?? TimeSpan.FromSeconds(10);
         _recoveryGranularity = recoveryGranularity;
+        _guardedRemediation = guardedRemediation;
     }
 
     /// <summary>
@@ -120,8 +125,24 @@ public sealed class GapBackfillService
             gap.ProviderName, symbols.Length,
             gap.DisconnectedAt, gap.ReconnectedAt, gap.Duration.TotalSeconds);
 
-        // Fire and forget - backfill runs in the background
-        _ = EnqueueGapBackfillAsync(gap, symbols);
+        // Fire and forget - all production reconnection recovery is routed through the shared
+        // remediation service, which enforces configured threshold, cooldown, idempotency, and
+        // concurrency limits. The direct executor remains available for focused standalone use.
+        _ = _guardedRemediation is null
+            ? EnqueueGapBackfillAsync(gap, symbols)
+            : EnqueueGuardedRemediationAsync(gap, symbols);
+    }
+
+    private async Task EnqueueGuardedRemediationAsync(ReconnectionGap gap, string[] symbols)
+    {
+        try
+        {
+            await _guardedRemediation!.HandleReconnectionGapAsync(gap, symbols).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Guarded gap remediation error for {Provider} after reconnection", gap.ProviderName);
+        }
     }
 
     private async Task EnqueueGapBackfillAsync(ReconnectionGap gap, string[] symbols, CancellationToken ct = default)

--- a/src/Meridian.Application/Composition/Startup/ModeRunners/CollectorModeRunner.cs
+++ b/src/Meridian.Application/Composition/Startup/ModeRunners/CollectorModeRunner.cs
@@ -181,12 +181,14 @@ public sealed class CollectorModeRunner
         // disconnection, backfill the missed window for the currently subscribed symbols.
         GapBackfillService? gapBackfill = null;
         string[] gapBackfillSymbols = Array.Empty<string>();
-        var backfillGateway = hostStartup.GetService<IBackfillExecutionGateway>();
-        if (backfillGateway is not null && gapSources.Count > 0)
+        var autoGapRemediation = hostStartup.GetService<AutoGapRemediationService>();
+        if (autoGapRemediation is not null && gapSources.Count > 0)
         {
             gapBackfill = new GapBackfillService(
-                backfillGateway.RunAsync,
-                () => gapBackfillSymbols);
+                backfillExecutor: (_, _) => throw new InvalidOperationException("Direct gap backfill execution is not used in collector mode."),
+                subscribedSymbols: () => gapBackfillSymbols,
+                minimumGap: autoGapRemediation.MinimumGapDuration,
+                guardedRemediation: autoGapRemediation);
             foreach (var gapSource in gapSources)
                 gapBackfill.Subscribe(gapSource);
 

--- a/tests/Meridian.Tests/Application/Backfill/AutoGapRemediationServiceTests.cs
+++ b/tests/Meridian.Tests/Application/Backfill/AutoGapRemediationServiceTests.cs
@@ -75,6 +75,39 @@ public sealed class AutoGapRemediationServiceTests
     }
 
     [Fact]
+    public async Task ReconnectionGap_UsesConfiguredThresholdAndProviderCooldown()
+    {
+        var gateway = new FakeGateway();
+        var history = new BackfillExecutionHistory();
+        var service = new AutoGapRemediationService(
+            gateway,
+            history,
+            policy: new AutoGapRemediationPolicy(
+                MinimumGapDuration: TimeSpan.FromMinutes(2),
+                MinimumGapSize: 1,
+                SymbolCooldown: TimeSpan.Zero,
+                ProviderCooldown: TimeSpan.FromMinutes(5),
+                MaxConcurrentRemediations: 2,
+                DefaultProvider: "stooq"));
+
+        var reconnectedAt = DateTimeOffset.UtcNow;
+        await service.HandleReconnectionGapAsync(
+            new ReconnectionGap("live-provider", reconnectedAt.AddSeconds(-30), reconnectedAt, 1),
+            ["AAPL", "MSFT"]);
+
+        gateway.Calls.Should().Be(0, "a sub-threshold reconnection must not start a backfill");
+
+        var qualifyingGap = new ReconnectionGap("live-provider", reconnectedAt.AddMinutes(-3), reconnectedAt, 1);
+        await service.HandleReconnectionGapAsync(qualifyingGap, ["AAPL", "MSFT"]);
+        await service.HandleReconnectionGapAsync(qualifyingGap, ["AAPL", "MSFT"]);
+
+        gateway.Calls.Should().Be(1, "the shared provider cooldown suppresses repeated reconnects");
+        gateway.Requests.Should().ContainSingle().Which.Provider.Should().Be("composite");
+        history.GetRecentExecutions(10).Should().ContainSingle()
+            .Which.AutoRemediationSla!.TriggerSource.Should().Be(AutoRemediationTriggerSource.ReconnectionGap);
+    }
+
+    [Fact]
     public async Task ProviderCooldown_NormalizesProviderNameAcrossSymbolsAndRetainedEvidence()
     {
         var gateway = new FakeGateway();


### PR DESCRIPTION
### Motivation
- Prevent reconnect-triggered all-symbol backfills from bypassing the existing auto-remediation policy and its cooldown/concurrency guardrails, which created an availability/resource-exhaustion vector. 
- Ensure reconnection gap recovery honors configured minimum-gap thresholds, provider/symbol cooldowns, idempotency, and max-concurrency rules already implemented in `AutoGapRemediationService`.

### Description
- Add `HandleReconnectionGapAsync` to `AutoGapRemediationService` so streaming-provider reconnection signals are enqueued through the guarded remediation path instead of invoking an unthrottled direct backfill. 
- Extend `GapBackfillService` to accept an optional `guardedRemediation` and route production reconnection recovery through that service while retaining the direct executor for standalone use. 
- Wire the collector runner (`CollectorModeRunner`) to resolve `AutoGapRemediationService` from DI and construct `GapBackfillService` with `guardedRemediation`, and set the service minimum gap from the configured policy. 
- Add a unit test `ReconnectionGap_UsesConfiguredThresholdAndProviderCooldown` to `AutoGapRemediationServiceTests` verifying sub-threshold reconnects are skipped and repeated qualifying reconnects are suppressed by provider cooldown.

### Testing
- `git diff --check` — passed. 
- `python3 build/python/cli/buildctl.py validation-status --summary` — passed (`blocked=false`, no active processes). 
- `bash scripts/ci.sh` — could not complete in this environment because the .NET SDK is not available (`dotnet: command not found`), so local `dotnet test` runs were not executed here; CI (GitHub Actions) should run the full test suite on the branch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a612388f90083208465c2c16b34b638)