### PR TITLE
Require opt-in for live gap remediation

### DIFF
--- a/config/appsettings.schema.json
+++ b/config/appsettings.schema.json
@@ -434,6 +434,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "Enabled": {
+          "type": "boolean",
+          "default": false
+        },
         "DefaultProvider": {
           "type": "string"
         },

--- a/src/Meridian.Application/Backfill/AutoGapRemediationService.cs
+++ b/src/Meridian.Application/Backfill/AutoGapRemediationService.cs
@@ -73,13 +73,18 @@ public sealed record AutoGapRemediationRequestResult(
 /// and providers. Enforced by a semaphore, independent of the cooldown windows.
 /// </param>
 /// <param name="DefaultProvider">Provider used when a signal does not specify one.</param>
+/// <param name="Enabled">
+/// Enables remediation initiated by live data-quality gap events. This is disabled by default so
+/// provider-controlled ingress remains passive monitoring unless an operator explicitly opts in.
+/// </param>
 public sealed record AutoGapRemediationPolicy(
     TimeSpan MinimumGapDuration,
     int MinimumGapSize,
     TimeSpan SymbolCooldown,
     TimeSpan ProviderCooldown,
     int MaxConcurrentRemediations,
-    string DefaultProvider)
+    string DefaultProvider,
+    bool Enabled = false)
 {
     public static AutoGapRemediationPolicy Default { get; } = new(
         MinimumGapDuration: TimeSpan.FromMinutes(2),
@@ -87,7 +92,8 @@ public sealed record AutoGapRemediationPolicy(
         SymbolCooldown: TimeSpan.FromMinutes(5),
         ProviderCooldown: TimeSpan.FromMinutes(1),
         MaxConcurrentRemediations: 2,
-        DefaultProvider: "stooq");
+        DefaultProvider: "stooq",
+        Enabled: false);
 
     /// <summary>
     /// Policy builder: constructs a policy from optional overrides, falling back to
@@ -100,14 +106,16 @@ public sealed record AutoGapRemediationPolicy(
         TimeSpan? symbolCooldown = null,
         TimeSpan? providerCooldown = null,
         int? maxConcurrentRemediations = null,
-        string? defaultProvider = null)
+        string? defaultProvider = null,
+        bool? enabled = null)
         => new(
             minimumGapDuration ?? Default.MinimumGapDuration,
             minimumGapSize ?? Default.MinimumGapSize,
             symbolCooldown ?? Default.SymbolCooldown,
             providerCooldown ?? Default.ProviderCooldown,
             maxConcurrentRemediations ?? Default.MaxConcurrentRemediations,
-            defaultProvider ?? Default.DefaultProvider);
+            defaultProvider ?? Default.DefaultProvider,
+            enabled ?? Default.Enabled);
 }
 
 public enum BackfillRemediationSlaTier
@@ -336,7 +344,7 @@ public sealed class AutoGapRemediationService : IDataQualityGapRemediationServic
         _slaEvaluator = new BackfillRemediationSlaEvaluator(_history);
         _concurrencyGate = new SemaphoreSlim(Math.Max(1, _policy.MaxConcurrentRemediations));
 
-        if (_qualityMonitoringService is not null)
+        if (_policy.Enabled && _qualityMonitoringService is not null)
         {
             _qualityMonitoringService.OnGapDetected += OnQualityGapDetected;
         }
@@ -355,7 +363,7 @@ public sealed class AutoGapRemediationService : IDataQualityGapRemediationServic
             _disposed = true;
         }
 
-        if (_qualityMonitoringService is not null)
+        if (_policy.Enabled && _qualityMonitoringService is not null)
         {
             _qualityMonitoringService.OnGapDetected -= OnQualityGapDetected;
         }

--- a/src/Meridian.Application/Composition/Features/BackfillFeatureRegistration.cs
+++ b/src/Meridian.Application/Composition/Features/BackfillFeatureRegistration.cs
@@ -115,6 +115,7 @@ internal sealed class BackfillFeatureRegistration : IServiceFeatureRegistration
             maxConcurrentRemediations: Math.Max(1, config.MaxConcurrentRemediations),
             defaultProvider: string.IsNullOrWhiteSpace(config.DefaultProvider)
                 ? AutoGapRemediationPolicy.Default.DefaultProvider
-                : config.DefaultProvider.Trim());
+                : config.DefaultProvider.Trim(),
+            enabled: config.Enabled);
     }
 }

--- a/src/Meridian.Core/Config/BackfillConfig.cs
+++ b/src/Meridian.Core/Config/BackfillConfig.cs
@@ -53,7 +53,8 @@ public sealed record AutoGapRemediationConfig(
     int SymbolCooldownSeconds = 300,
     int ProviderCooldownSeconds = 60,
     int MaxConcurrentRemediations = 2,
-    string DefaultProvider = "stooq");
+    string DefaultProvider = "stooq",
+    bool Enabled = false);
 
 /// <summary>
 /// Configuration for backfill job management.

--- a/tests/Meridian.Tests/Application/Backfill/AutoGapRemediationServiceTests.cs
+++ b/tests/Meridian.Tests/Application/Backfill/AutoGapRemediationServiceTests.cs
@@ -19,6 +19,38 @@ namespace Meridian.Tests.Application.Backfill;
 public sealed class AutoGapRemediationServiceTests
 {
     [Fact]
+    public async Task LiveQualityGap_DefaultPolicy_DoesNotStartBackfill()
+    {
+        var gateway = new FakeGateway();
+        var history = new BackfillExecutionHistory();
+        await using var quality = CreateQualityServiceWithShortGapThreshold();
+        using var service = new AutoGapRemediationService(gateway, history, quality);
+
+        PublishLiveGap(quality);
+
+        gateway.Calls.Should().Be(0);
+        history.GetRecentExecutions(10).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task LiveQualityGap_ExplicitlyEnabledPolicy_StartsBackfill()
+    {
+        var gateway = new FakeGateway();
+        var history = new BackfillExecutionHistory();
+        await using var quality = CreateQualityServiceWithShortGapThreshold();
+        using var service = new AutoGapRemediationService(
+            gateway,
+            history,
+            quality,
+            AutoGapRemediationPolicy.Default with { Enabled = true });
+
+        PublishLiveGap(quality);
+
+        gateway.Calls.Should().Be(1);
+        history.GetRecentExecutions(10).Should().ContainSingle();
+    }
+
+    [Fact]
     public void BackfillRemediationSlaPolicy_CriticalWorkflow_RequiresSameBusinessDayOwnerAssignment()
     {
         var observedAt = new DateTimeOffset(2026, 06, 30, 14, 00, 00, TimeSpan.Zero);
@@ -483,6 +515,19 @@ public sealed class AutoGapRemediationServiceTests
                 StartedUtc: DateTimeOffset.UtcNow.AddSeconds(-2),
                 CompletedUtc: DateTimeOffset.UtcNow));
         }
+    }
+
+    private static DataQualityMonitoringService CreateQualityServiceWithShortGapThreshold() =>
+        new(new DataQualityMonitoringConfig
+        {
+            GapAnalyzerConfig = new GapAnalyzerConfig { GapThresholdSeconds = 1 }
+        });
+
+    private static void PublishLiveGap(DataQualityMonitoringService quality)
+    {
+        var timestamp = new DateTimeOffset(2026, 07, 10, 14, 00, 00, TimeSpan.Zero);
+        quality.ProcessTrade("AAPL", timestamp, 150m, 100m, sequence: 1, provider: "stooq");
+        quality.ProcessTrade("AAPL", timestamp.AddMinutes(5), 150m, 100m, sequence: 2, provider: "stooq");
     }
 
     private static SymbolGapInfo BuildGap(string symbol, params DateOnly[] gapDates)

--- a/tests/Meridian.Tests/Application/Composition/BackfillFeatureRegistrationTests.cs
+++ b/tests/Meridian.Tests/Application/Composition/BackfillFeatureRegistrationTests.cs
@@ -71,7 +71,8 @@ public sealed class BackfillFeatureRegistrationTests
             SymbolCooldownSeconds: 90,
             ProviderCooldownSeconds: 15,
             MaxConcurrentRemediations: 3,
-            DefaultProvider: " polygon ");
+            DefaultProvider: " polygon ",
+            Enabled: true);
 
         var policy = BackfillFeatureRegistration.CreateAutoGapRemediationPolicy(config);
 
@@ -81,6 +82,7 @@ public sealed class BackfillFeatureRegistrationTests
         policy.ProviderCooldown.Should().Be(TimeSpan.FromSeconds(15));
         policy.MaxConcurrentRemediations.Should().Be(3);
         policy.DefaultProvider.Should().Be("polygon");
+        policy.Enabled.Should().BeTrue();
     }
 
     [Fact]
@@ -102,6 +104,7 @@ public sealed class BackfillFeatureRegistrationTests
         policy.ProviderCooldown.Should().Be(TimeSpan.Zero);
         policy.MaxConcurrentRemediations.Should().Be(1);
         policy.DefaultProvider.Should().Be(AutoGapRemediationPolicy.Default.DefaultProvider);
+        policy.Enabled.Should().BeFalse();
     }
 
     private sealed class RecordingSymbolResolver(string provider, string providerSymbol) : ISymbolResolver


### PR DESCRIPTION
### Motivation
- Prevent provider-controlled live trade/quote ingress from automatically triggering backfill work by making live-gap driven remediation opt-in. 
- Keep data-quality monitoring passive by default while preserving existing guarded remediation APIs and workflows.

### Description
- Add an `Enabled` flag to `AutoGapRemediationConfig` and the configuration schema so hosts can opt in to live-gap remediation via `AutoRemediation.Enabled` (default `false`).
- Extend `AutoGapRemediationPolicy` with an `Enabled` field and map the new config flag into the policy via `CreateAutoGapRemediationPolicy`.
- Gate the `AutoGapRemediationService` subscription to `DataQualityMonitoringService.OnGapDetected` on the policy `Enabled` flag so live feed observations do not start remediation unless explicitly enabled.
- Update the JSON schema `config/appsettings.schema.json` to expose the new `Enabled` boolean and default it to `false`.
- Add unit tests that assert live quality gaps do not start backfills under the default (disabled) policy and do start backfills when the opt-in is enabled: `LiveQualityGap_DefaultPolicy_DoesNotStartBackfill` and `LiveQualityGap_ExplicitlyEnabledPolicy_StartsBackfill`.

### Testing
- Added unit tests under `tests/Meridian.Tests/Application/Backfill/AutoGapRemediationServiceTests.cs` that cover disabled and enabled live-gap behavior (new tests present but not executed in this environment).
- Verified repository checks: `git diff --check` passed and `python3 -m json.tool config/appsettings.schema.json` validated the updated schema.
- Ran repository validation `python3 build/python/cli/buildctl.py validation-status --summary` which reported no active block; `bash scripts/ci.sh` could not be completed here because the environment lacks the .NET SDK (`dotnet: command not found`) so full `dotnet test`/CI runs remain to be executed in CI or a developer environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a612388f71483209d8e005fc2da1f61)