### PR TITLE
fix: bound failed-login tracking to prevent unauthenticated memory DoS

### DIFF
--- a/src/Meridian.Identity/Application/LoginSessionService.cs
+++ b/src/Meridian.Identity/Application/LoginSessionService.cs
@@ -21,6 +21,8 @@ public sealed class LoginSessionService
     public static readonly TimeSpan SessionDuration = TimeSpan.FromHours(8);
 
     private const int MaximumFailedAttempts = 5;
+    // Keep unauthenticated login state bounded even when callers supply distinct usernames.
+    private const int MaximumTrackedFailedAttemptWindows = 1_024;
     private static readonly TimeSpan AttemptWindow = TimeSpan.FromMinutes(15);
     private static readonly TimeSpan LockoutDuration = TimeSpan.FromMinutes(15);
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web) { WriteIndented = true };
@@ -29,6 +31,7 @@ public sealed class LoginSessionService
     private readonly UserProfileRegistry profileRegistry;
     private readonly ConcurrentDictionary<string, SessionEntry> _sessions = new();
     private readonly ConcurrentDictionary<string, FailedAttemptWindow> _failedAttempts = new(StringComparer.Ordinal);
+    private readonly object _failedAttemptGate = new();
     private readonly object _persistenceGate = new();
     private readonly string? _sessionStorePath;
 
@@ -79,10 +82,7 @@ public sealed class LoginSessionService
         var profile = profileRegistry.Authenticate(username, password);
         if (profile is null)
         {
-            var failed = _failedAttempts.AddOrUpdate(
-                attemptKey,
-                _ => FailedAttemptWindow.First(now),
-                (_, existing) => existing.Register(now));
+            var failed = RegisterFailedAttempt(attemptKey, now);
             if (failed.LockedUntil > now)
             {
                 return LoginAttemptResult.Locked(failed.LockedUntil.Value - now);
@@ -211,7 +211,42 @@ public sealed class LoginSessionService
     }
 
     private static string BuildAttemptKey(string username, string clientKey)
-        => $"{username.Trim().ToUpperInvariant()}|{clientKey.Trim().ToUpperInvariant()}";
+        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(
+            $"{username.Trim().ToUpperInvariant()}|{clientKey.Trim().ToUpperInvariant()}")));
+
+    private FailedAttemptWindow RegisterFailedAttempt(string attemptKey, DateTimeOffset now)
+    {
+        lock (_failedAttemptGate)
+        {
+            PruneExpiredFailedAttempts(now);
+            if (_failedAttempts.TryGetValue(attemptKey, out var existing))
+            {
+                var updated = existing.Register(now);
+                _failedAttempts[attemptKey] = updated;
+                return updated;
+            }
+
+            if (_failedAttempts.Count >= MaximumTrackedFailedAttemptWindows)
+            {
+                return FailedAttemptWindow.Untracked;
+            }
+
+            var first = FailedAttemptWindow.First(now);
+            _failedAttempts[attemptKey] = first;
+            return first;
+        }
+    }
+
+    private void PruneExpiredFailedAttempts(DateTimeOffset now)
+    {
+        foreach (var (attemptKey, window) in _failedAttempts)
+        {
+            if (window.ExpiresAt <= now)
+            {
+                _failedAttempts.TryRemove(attemptKey, out _);
+            }
+        }
+    }
 
     private static string HashToken(string token)
         => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(token.Trim())));
@@ -281,7 +316,11 @@ public sealed class LoginSessionService
 
     private sealed record FailedAttemptWindow(int Count, DateTimeOffset WindowStartedAt, DateTimeOffset? LockedUntil)
     {
+        public static readonly FailedAttemptWindow Untracked = new(0, DateTimeOffset.MinValue, null);
+
         public static FailedAttemptWindow First(DateTimeOffset now) => new(1, now, null);
+
+        public DateTimeOffset ExpiresAt => LockedUntil ?? WindowStartedAt + AttemptWindow;
 
         public FailedAttemptWindow Register(DateTimeOffset now)
         {

--- a/tests/Meridian.Tests/Identity/LoginSessionServiceTests.cs
+++ b/tests/Meridian.Tests/Identity/LoginSessionServiceTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Meridian.Identity;
 using Meridian.Identity.Auth;
+using System.Reflection;
 using Xunit;
 
 namespace Meridian.Tests.Identity;
@@ -159,6 +160,26 @@ public sealed class LoginSessionServiceTests
     }
 
     [Fact]
+    public void TryCreateSession_DistinctInvalidUsernames_BoundsTrackedAttemptWindows()
+    {
+        using var env = new EnvironmentVariableScope()
+            .Set("MDC_USERS", null)
+            .Set("MDC_DEMO_USERS", null)
+            .Set("MDC_USERNAME", null)
+            .Set("MDC_PASSWORD_HASH", null)
+            .Set("MDC_AUTH_MODE", null);
+        var service = CreateService("Production");
+
+        for (var index = 0; index < 1_100; index++)
+        {
+            service.TryCreateSession($"unknown-{index}", "wrong", "127.0.0.1")
+                .Status.Should().Be(LoginAttemptStatus.InvalidCredentials);
+        }
+
+        GetTrackedFailedAttemptWindowCount(service).Should().BeLessOrEqualTo(1_024);
+    }
+
+    [Fact]
     public void DurableSessionStore_RestartAndRevocationPreserveAuthoritativeStateWithoutRawToken()
     {
         using var env = ConfigureUsers(("operator", "pw-operator", UserRole.Accounting));
@@ -197,6 +218,13 @@ public sealed class LoginSessionServiceTests
 
     private static LoginSessionService CreateService(string environmentName)
         => new(new FakeHostEnvironment(environmentName), new UserProfileRegistry());
+
+    private static int GetTrackedFailedAttemptWindowCount(LoginSessionService service)
+    {
+        var field = typeof(LoginSessionService).GetField("_failedAttempts", BindingFlags.Instance | BindingFlags.NonPublic);
+        field.Should().NotBeNull();
+        return (int)field!.GetValue(service)!.GetType().GetProperty("Count")!.GetValue(field.GetValue(service))!;
+    }
 
     private static EnvironmentVariableScope ConfigureUsers(params (string Username, string Password, UserRole Role)[] users)
     {


### PR DESCRIPTION
### Motivation
- Prevent an unauthenticated attacker from causing unbounded in-memory growth by submitting many unique usernames to the failed-login tracker, which could lead to availability/DoS of the UI host.

### Description
- Add a hard cap `MaximumTrackedFailedAttemptWindows = 1024` and a synchronization gate `_failedAttemptGate` to bound and serialize admission of new failed-attempt windows.
- Replace raw username/clientKey dictionary keys with a SHA-256 digest in `BuildAttemptKey` so attacker-controlled strings are not retained verbatim as dictionary keys.
- Implement `RegisterFailedAttempt` which prunes expired entries before admitting new windows and returns a sentinel `FailedAttemptWindow.Untracked` when capacity is reached, plus `PruneExpiredFailedAttempts` and an `ExpiresAt` helper on `FailedAttemptWindow`.
- Add a regression test `TryCreateSession_DistinctInvalidUsernames_BoundsTrackedAttemptWindows` that submits 1,100 distinct invalid usernames and asserts the tracked window count remains at or below the configured cap.

### Testing
- `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter FullyQualifiedName~LoginSessionServiceTests ...` was attempted but could not run here because `dotnet` is not installed in the environment (blocked).
- Ran `python3 build/python/cli/buildctl.py validation-status --summary`, which completed successfully.
- Ran `git diff --check` with no issues; `bash scripts/ci.sh` could not complete locally due to missing .NET SDK (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61299d29a0832080abf62bb5da4a76)