### PR TITLE
Fix live session cleanup after feed completion

### DIFF
--- a/src/Meridian.Strategies/Live/LiveStrategyRunSession.cs
+++ b/src/Meridian.Strategies/Live/LiveStrategyRunSession.cs
@@ -206,6 +206,11 @@ internal sealed class LiveStrategyRunSession
         }
         finally
         {
+            // A market feed may complete normally while no fills are pending. Complete the
+            // private inbox before awaiting its outstanding read so that teardown cannot
+            // wait indefinitely for a writer that no longer exists.
+            _fillReports.Writer.TryComplete();
+
             // The enumerator cannot be disposed while a MoveNextAsync is still pending;
             // cancellation flows into the feed subscription, so the pending advance
             // completes (or faults) promptly once the linked token fires.

--- a/tests/Meridian.Tests/Strategies/LiveTradingEngineTests.cs
+++ b/tests/Meridian.Tests/Strategies/LiveTradingEngineTests.cs
@@ -23,7 +23,8 @@ namespace Meridian.Tests.Strategies;
 /// <summary>
 /// Closed-circuit coverage for the live trading engine: promoted runs must actually execute —
 /// live events drive strategy callbacks, strategy orders reach the order manager, and fills
-/// flow back into the strategy and the run's recorded metrics.
+/// flow back into the strategy and the run's recorded metrics. It also protects the terminal
+/// cleanup path when a market-data feed completes without an operator stop request.
 /// </summary>
 public sealed class LiveTradingEngineTests
 {
@@ -92,6 +93,30 @@ public sealed class LiveTradingEngineTests
 
         var recorded = await ((IStrategyRepository)repository).GetRunByIdAsync(run.RunId);
         recorded!.EndedAt.Should().BeNull("host shutdown must leave the run open so a restarted engine resumes it");
+    }
+
+    [Fact]
+    public async Task Scenario_MarketFeedTermination_CompletesRunAndRemovesItFromEngine()
+    {
+        var repository = new InMemoryRunRepository();
+        await using var engine = CreateEngine(
+            repository,
+            new CompletedMarketEventFeed(),
+            new LiveMarketDataCache(),
+            new RecordingOrderManager(50m));
+        var run = CreatePaperRun(
+            BuyAndHoldLiveStrategy.CatalogId,
+            new Dictionary<string, string> { ["symbols"] = "MSFT" });
+        await repository.RecordRunAsync(run);
+
+        var launch = await engine.TryLaunchAsync(run);
+        var completed = await repository.CompletedRun.Task.WaitAsync(WaitBudget);
+
+        launch.Launched.Should().BeTrue(launch.Reason);
+        completed.RunId.Should().Be(run.RunId);
+        completed.EndedAt.Should().NotBeNull("a completed market feed must finalize the live run");
+        completed.LastLifecycleEvent.Should().Be(StrategyRunLifecycleEventType.Completed);
+        await WaitUntilAsync(() => !engine.ActiveRunIds.Contains(run.RunId));
     }
 
     // ---- Launch gating ----
@@ -256,7 +281,7 @@ public sealed class LiveTradingEngineTests
 
     private static LiveTradingEngine CreateEngine(
         InMemoryRunRepository repository,
-        LiveMarketEventHub hub,
+        ILiveMarketEventFeed feed,
         LiveMarketDataCache cache,
         RecordingOrderManager orderManager)
     {
@@ -267,7 +292,7 @@ public sealed class LiveTradingEngineTests
             liveFeed: cache);
         return new LiveTradingEngine(
             LiveStrategyCatalog.CreateDefault(),
-            hub,
+            feed,
             cache,
             gateway,
             orderManager,
@@ -275,6 +300,19 @@ public sealed class LiveTradingEngineTests
             repository,
             options: new LiveTradingEngineOptions(),
             loggerFactory: NullLoggerFactory.Instance);
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        // The engine removes its completed background task after session finalization, so
+        // poll the externally observable registry rather than synchronizing on internals.
+        var stopwatch = Stopwatch.StartNew();
+        while (!condition() && stopwatch.Elapsed < WaitBudget)
+        {
+            await Task.Delay(25);
+        }
+
+        condition().Should().BeTrue("the completed session must be removed from the active-run registry");
     }
 
     private static StrategyRunEntry CreatePaperRun(
@@ -316,9 +354,26 @@ public sealed class LiveTradingEngineTests
     {
         private readonly ConcurrentDictionary<string, StrategyRunEntry> _runs = new(StringComparer.Ordinal);
 
+        public TaskCompletionSource<StrategyRunEntry> CompletedRun { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
         public Task RecordRunAsync(StrategyRunEntry entry, CancellationToken ct = default)
         {
             _runs[entry.RunId] = entry;
+            return Task.CompletedTask;
+        }
+
+        public Task RecordLifecycleEventAsync(
+            StrategyRunEntry entry,
+            StrategyRunLifecycleEventType eventType,
+            CancellationToken ct = default)
+        {
+            var recorded = entry with { LastLifecycleEvent = eventType };
+            _runs[recorded.RunId] = recorded;
+            if (eventType == StrategyRunLifecycleEventType.Completed)
+            {
+                CompletedRun.TrySetResult(recorded);
+            }
+
             return Task.CompletedTask;
         }
 
@@ -396,6 +451,17 @@ public sealed class LiveTradingEngineTests
         public Task CancelAllAsync(CancellationToken ct = default) => Task.CompletedTask;
 
         public IReadOnlyList<ExecutionSdk.OrderState> GetCompletedOrders(int take = 20) => [];
+    }
+
+    private sealed class CompletedMarketEventFeed : ILiveMarketEventFeed
+    {
+        public async IAsyncEnumerable<LiveMarketEvent> SubscribeAsync(
+            IReadOnlyCollection<string> symbols,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
     }
 
     private sealed class RecordingRunLauncher : IPromotedRunLauncher


### PR DESCRIPTION
### Motivation
- Prevent the live run session from hanging during teardown if the market feed completes or faults while a pending single-reader `WaitToReadAsync` on the fill-report channel is outstanding. 
- Ensure `ExecuteAsync` can complete its terminal work (`FinishAsync` / terminal lifecycle recording) and let the `LiveTradingEngine` remove the active run when a feed ends without operator cancellation. 

### Description
- Complete the session-private fill-report channel in the `finally` block of `RunEventLoopAsync` by calling `_fillReports.Writer.TryComplete()` so any outstanding `WaitToReadAsync` unblocks. 
- Add a regression scenario in `tests/Meridian.Tests/Strategies/LiveTradingEngineTests.cs` (`Scenario_MarketFeedTermination_CompletesRunAndRemovesItFromEngine`) that uses a deterministic `CompletedMarketEventFeed` to verify the run reaches a completed lifecycle state and is removed from the engine's active-run registry. 
- Update test helpers to accept `ILiveMarketEventFeed`, add a `TaskCompletionSource` hook in the in-memory repository to observe completion, and add a small `WaitUntilAsync` polling helper used by the test. 

### Testing
- Ran `git diff --check` which passed. 
- Ran repository validation via `python build/python/cli/buildctl.py validation-status --summary` which returned no active locks or blockers. 
- Attempted to run `bash scripts/ci.sh` but it could not run in this environment because the .NET SDK is not installed (`dotnet: command not found`), so the added test could not be executed locally; the new and existing tests must be validated in an environment with the .NET 10 SDK (GitHub Actions / developer machine).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a612388fbe483208f1935712f3829b0)