### PR TITLE
fix(storage): preserve trailing-root tier migrations

### DIFF
--- a/src/Meridian.Storage/Services/TierMigrationService.cs
+++ b/src/Meridian.Storage/Services/TierMigrationService.cs
@@ -73,8 +73,11 @@ public sealed class TierMigrationService : ITierMigrationService
         // storage root before any filesystem access: an unconstrained source path would let a
         // request read — and with DeleteSource, delete — arbitrary files the process can touch.
         var storageRoot = Path.GetFullPath(_options.RootPath);
+        var storageRootPrefix = Path.EndsInDirectorySeparator(storageRoot)
+            ? storageRoot
+            : storageRoot + Path.DirectorySeparatorChar;
         var resolvedSourcePath = Path.GetFullPath(sourcePath);
-        if (!resolvedSourcePath.StartsWith(storageRoot + Path.DirectorySeparatorChar, StringComparison.Ordinal)
+        if (!resolvedSourcePath.StartsWith(storageRootPrefix, StringComparison.Ordinal)
             && !string.Equals(resolvedSourcePath, storageRoot, StringComparison.Ordinal))
         {
             return new MigrationResult(
@@ -293,7 +296,11 @@ public sealed class TierMigrationService : ITierMigrationService
         // MigrateAsync already refused out-of-root sources, so files can only be inside the
         // storage root here; this local guard makes that invariant self-evident.
         sourcePath = Path.GetFullPath(sourcePath);
-        if (!sourcePath.StartsWith(Path.GetFullPath(_options.RootPath) + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+        var storageRoot = Path.GetFullPath(_options.RootPath);
+        var storageRootPrefix = Path.EndsInDirectorySeparator(storageRoot)
+            ? storageRoot
+            : storageRoot + Path.DirectorySeparatorChar;
+        if (!sourcePath.StartsWith(storageRootPrefix, StringComparison.Ordinal))
         {
             throw new InvalidOperationException(
                 $"Refusing to migrate '{sourcePath}': the file escapes the storage root.");

--- a/tests/Meridian.Tests/Storage/TierMigrationServiceTests.cs
+++ b/tests/Meridian.Tests/Storage/TierMigrationServiceTests.cs
@@ -120,6 +120,40 @@ public sealed class TierMigrationServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task Scenario_StorageRootRollover_WithTrailingSeparatorMigratesContainedFiles()
+    {
+        var storageRootWithTrailingSeparator = _root + Path.DirectorySeparatorChar;
+        var service = new TierMigrationService(new StorageOptions
+        {
+            RootPath = storageRootWithTrailingSeparator,
+            Tiering = new TieringOptions
+            {
+                Enabled = true,
+                Tiers =
+                [
+                    new TierConfig { Name = "Hot", Path = _hot, MaxAgeDays = 7, Format = "jsonl", Compression = CompressionCodec.None },
+                    new TierConfig { Name = "Warm", Path = _warm, MaxAgeDays = 90, Format = "jsonl", Compression = CompressionCodec.Gzip }
+                ]
+            }
+        });
+        var sourceFile = Path.Combine(_hot, "alpaca", "AAPL", "Trade", "session.jsonl");
+        Directory.CreateDirectory(Path.GetDirectoryName(sourceFile)!);
+        await File.WriteAllTextAsync(sourceFile, "{\"symbol\":\"AAPL\",\"price\":213.45}");
+
+        var result = await service.MigrateAsync(
+            storageRootWithTrailingSeparator,
+            StorageTier.Warm,
+            new MigrationOptions(DeleteSource: false, VerifyChecksum: true, ParallelFiles: 1));
+
+        result.Success.Should().BeTrue("a configured storage root with a trailing separator must accept its enumerated child files");
+        result.FilesProcessed.Should().Be(1);
+        result.FilesFailed.Should().Be(0);
+        var targetFile = Path.Combine(_warm, "hot", "alpaca", "AAPL", "Trade", "session.jsonl.gz");
+        File.Exists(targetFile).Should().BeTrue();
+        (await ReadGzipTextAsync(targetFile)).Should().Be("{\"symbol\":\"AAPL\",\"price\":213.45}");
+    }
+
+    [Fact]
     public async Task Scenario_ParquetTierRequest_FailsClosedInsteadOfRelabelingJsonlBytes()
     {
         // The old behaviour renamed the target to .parquet without converting the payload, then


### PR DESCRIPTION
### Motivation
- A defensive per-file chokepoint added path containment checks used `Path.GetFullPath(_options.RootPath) + Path.DirectorySeparatorChar`, which produces a doubled separator when `RootPath` already ends with a separator and causes valid child files to be rejected for root-wide migrations.
- The change restores correct operator-facing behavior for the common case where the HTTP endpoint defaults `SourcePath` to the configured storage `RootPath` (including trailing-separator values) while keeping defense-in-depth validation.

### Description
- Compute a normalized containment prefix once as `storageRootPrefix` using `Path.EndsInDirectorySeparator(storageRoot)` and avoid appending a duplicate `Path.DirectorySeparatorChar` when the root already ends with a separator.
- Use the normalized `storageRootPrefix` in the entry guard (the initial `MigrateAsync` source check) and in the per-file chokepoint inside `MigrateFileAsync` so child files enumerated from the root are accepted.
- Preserve the existing equality check that allows migrating the storage root itself while preventing out-of-root traversal.
- Add a regression test `Scenario_StorageRootRollover_WithTrailingSeparatorMigratesContainedFiles` in `tests/Meridian.Tests/Storage/TierMigrationServiceTests.cs` that verifies a configured `RootPath` with a trailing separator successfully migrates its contained JSONL file into the warm tier (gzip payload verified).

### Testing
- Ran `git diff --check` which reported no whitespace or patch errors and `python3 build/python/cli/buildctl.py validation-status --summary` which returned a clean local validation status.
- The new regression test was added to `tests/Meridian.Tests/Storage/TierMigrationServiceTests.cs` and committed with the change, but `dotnet test` could not be executed in this environment because the `dotnet` SDK is not available (`/bin/bash: dotnet: command not found`).
- CI-level validation (`bash scripts/ci.sh`) was not run here for the same reason; GitHub Actions remains the authoritative test run for merge readiness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a612389c71c8320895db7053de32db1)