### PR TITLE
fix(ui): clear API session cookies on endpoint changes

### DIFF
--- a/src/Meridian.Ui.Services/Services/ApiClientService.cs
+++ b/src/Meridian.Ui.Services/Services/ApiClientService.cs
@@ -101,6 +101,10 @@ public sealed class ApiClientService : IDisposable
 
             if (urlChanged)
             {
+                // Cookie domains do not include ports. Remove the prior endpoint's session
+                // before using the replacement URL so a localhost port change cannot reuse it.
+                ApiClientSession.Clear(oldUrl);
+
                 ServiceUrlChanged?.Invoke(this, new ServiceUrlChangedEventArgs
                 {
                     OldUrl = oldUrl,

--- a/tests/Meridian.Tests/UiServices/ApiClientSessionTests.cs
+++ b/tests/Meridian.Tests/UiServices/ApiClientSessionTests.cs
@@ -13,8 +13,14 @@ namespace Meridian.Tests.UiServices;
 public sealed class ApiClientSessionTests : IDisposable
 {
     private const string BaseUrl = "http://localhost:8080";
+    private const string AlternateBaseUrl = "http://localhost:9090";
 
-    public void Dispose() => ApiClientSession.Clear(BaseUrl);
+    public void Dispose()
+    {
+        ApiClientSession.Clear(BaseUrl);
+        ApiClientSession.Clear(AlternateBaseUrl);
+        ApiClientService.Instance.Configure(BaseUrl);
+    }
 
     [Fact]
     public void GetCsrfToken_ReturnsServerIssuedCookieForBaseUrl()
@@ -37,6 +43,18 @@ public sealed class ApiClientSessionTests : IDisposable
 
         ApiClientSession.GetCsrfToken(BaseUrl).Should().BeNull(
             "desktop sign-out must expire the stored session cookies");
+    }
+
+    [Fact]
+    public void Configure_RemovesSessionCookiesFromPreviousEndpoint()
+    {
+        ApiClientService.Instance.Configure(BaseUrl);
+        ApiClientSession.Cookies.Add(new Uri(BaseUrl), new Cookie(ApiClientSession.CsrfCookieName, "csrf-token-4"));
+
+        ApiClientService.Instance.Configure(AlternateBaseUrl);
+
+        ApiClientSession.GetCsrfToken(AlternateBaseUrl).Should().BeNull(
+            "cookies are scoped to hosts rather than ports and must not survive an endpoint switch");
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- The shared process-wide `CookieContainer` allowed session and CSRF cookies to persist across same-host different-port endpoint switches, enabling potential session/CSRF reuse.
- The change prevents cookie leakage when the configured workstation API base URL changes so a prior endpoint's session material cannot be reused by a new endpoint on the same host.

### Description
- When the service URL is changed in `ApiClientService.Configure`, expire the previous endpoint's cookies by calling `ApiClientSession.Clear(oldUrl)` before notifying consumers. (updated `src/Meridian.Ui.Services/Services/ApiClientService.cs`)
- Add a regression unit test `Configure_RemovesSessionCookiesFromPreviousEndpoint` that exercises a same-host different-port switch and verify cookies do not survive the endpoint change, and extend test cleanup to clear both URLs and restore the singleton base URL. (updated `tests/Meridian.Tests/UiServices/ApiClientSessionTests.cs`)
- Small explanatory comment added alongside the new clear call; no other behavior changes introduced.

### Testing
- `python3 build/python/cli/buildctl.py validation-status --summary` ran successfully and reported no active build blockers. 
- `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~ApiClientSessionTests"` could not be executed in this environment because `dotnet` is not installed. 
- `bash scripts/ci.sh` was attempted but is blocked by the local environment's missing .NET SDK (`dotnet` not found), so CI-level verification must run on the repository's CI or a machine with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61299e5e248320a0fd80fd31bdb75c)