### PR TITLE
fix(pipeline): preserve WAL batches after sink faults

### DIFF
--- a/src/Meridian.Application/Pipeline/EventPipeline.cs
+++ b/src/Meridian.Application/Pipeline/EventPipeline.cs
@@ -707,8 +707,9 @@ public sealed class EventPipeline : IMarketEventPublisher, IEtlEventPipeline, IB
         try
         {
             var batchBuffer = new List<TracedMarketEvent>(_maxAdaptiveBatchSize);
+            var retryPendingBatch = false;
 
-            while (await _channel.Reader.WaitToReadAsync(_cts.Token).ConfigureAwait(false))
+            while (retryPendingBatch || await _channel.Reader.WaitToReadAsync(_cts.Token).ConfigureAwait(false))
             {
                 Interlocked.Increment(ref _activeConsumers);
                 var startTs = Stopwatch.GetTimestamp();
@@ -717,11 +718,16 @@ public sealed class EventPipeline : IMarketEventPublisher, IEtlEventPipeline, IB
                 {
                     var targetBatchSize = GetAdaptiveBatchSize();
 
-                    // Drain up to _batchSize events from the channel
-                    batchBuffer.Clear();
-                    while (batchBuffer.Count < targetBatchSize && _channel.Reader.TryRead(out var evt))
+                    // Drain up to _batchSize events from the channel. A WAL-backed batch that
+                    // failed after its records were appended is retried before reading later
+                    // events, because WAL commits are cumulative through a sequence number.
+                    if (!retryPendingBatch)
                     {
-                        batchBuffer.Add(evt);
+                        batchBuffer.Clear();
+                        while (batchBuffer.Count < targetBatchSize && _channel.Reader.TryRead(out var evt))
+                        {
+                            batchBuffer.Add(evt);
+                        }
                     }
 
                     // [3.1] E2E trace propagation: start a per-batch activity so each consume
@@ -777,6 +783,8 @@ public sealed class EventPipeline : IMarketEventPublisher, IEtlEventPipeline, IB
                         else if (_wal != null)
                         {
                             var walRecord = await _wal.AppendAsync(evt, GetEventTypeName(evt.Type), _cts.Token).ConfigureAwait(false);
+                            tracedEvent = tracedEvent with { WalSequence = walRecord.Sequence };
+                            batchBuffer[i] = tracedEvent;
                             maxWalSequence = Math.Max(maxWalSequence, walRecord.Sequence);
                         }
 
@@ -817,22 +825,27 @@ public sealed class EventPipeline : IMarketEventPublisher, IEtlEventPipeline, IB
                     }
 
                     Interlocked.Add(ref _consumedCount, batchBuffer.Count);
+                    retryPendingBatch = false;
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     // A persistence failure must not kill the consumer: before this catch existed,
                     // any sink/WAL/dedup exception silently faulted the consumer task (observed
                     // only at disposal) while producers kept publishing into a channel nobody
-                    // drained. The failed batch's WAL records remain uncommitted —
-                    // _lastCommittedWalSequence only advances on the success path — so they
-                    // replay on restart; the dead-letter record covers the no-WAL configuration.
+                    // drained. A WAL-backed batch that has appended records must be retried
+                    // before later batches: committing a later WAL sequence would otherwise
+                    // cumulatively acknowledge the failed records.
                     Interlocked.Increment(ref _consumerIterationFailures);
                     Interlocked.Exchange(ref _lastConsumerFaultTicks, DateTimeOffset.UtcNow.UtcTicks);
+                    retryPendingBatch = _wal != null && batchBuffer.Any(static traced => traced.WalSequence > 0);
                     _logger.LogError(ex,
-                        "Pipeline consumer iteration failed while persisting a batch of {BatchCount} events; WAL commit withheld and consumer continuing",
-                        batchBuffer.Count);
+                        "Pipeline consumer iteration failed while persisting a batch of {BatchCount} events; {RecoveryAction}",
+                        batchBuffer.Count,
+                        retryPendingBatch
+                            ? "the WAL-backed batch will retry before later batches are committed"
+                            : "WAL commit withheld and consumer continuing");
 
-                    if (_deadLetterSink != null)
+                    if (_deadLetterSink != null && !retryPendingBatch)
                     {
                         foreach (var traced in batchBuffer)
                         {

--- a/src/Meridian.Application/Pipeline/EventPipeline.cs
+++ b/src/Meridian.Application/Pipeline/EventPipeline.cs
@@ -708,6 +708,7 @@ public sealed class EventPipeline : IMarketEventPublisher, IEtlEventPipeline, IB
         {
             var batchBuffer = new List<TracedMarketEvent>(_maxAdaptiveBatchSize);
             var retryPendingBatch = false;
+            var nextPendingEventIndex = 0;
 
             while (retryPendingBatch || await _channel.Reader.WaitToReadAsync(_cts.Token).ConfigureAwait(false))
             {
@@ -724,6 +725,7 @@ public sealed class EventPipeline : IMarketEventPublisher, IEtlEventPipeline, IB
                     if (!retryPendingBatch)
                     {
                         batchBuffer.Clear();
+                        nextPendingEventIndex = 0;
                         while (batchBuffer.Count < targetBatchSize && _channel.Reader.TryRead(out var evt))
                         {
                             batchBuffer.Add(evt);
@@ -737,7 +739,7 @@ public sealed class EventPipeline : IMarketEventPublisher, IEtlEventPipeline, IB
                     long maxWalSequence = _lastCommittedWalSequence;
 
                     // Write each event: dedup → validate → WAL (if enabled) → sink
-                    for (var i = 0; i < batchBuffer.Count; i++)
+                    for (var i = nextPendingEventIndex; i < batchBuffer.Count; i++)
                     {
                         var tracedEvent = batchBuffer[i];
                         var evt = tracedEvent.Event;
@@ -757,6 +759,7 @@ public sealed class EventPipeline : IMarketEventPublisher, IEtlEventPipeline, IB
                             if (await _dedupLedger.IsDuplicateAsync(evt, _cts.Token).ConfigureAwait(false))
                             {
                                 Interlocked.Increment(ref _deduplicatedCount);
+                                nextPendingEventIndex = i + 1;
                                 continue; // Skip duplicate events
                             }
                         }
@@ -772,6 +775,7 @@ public sealed class EventPipeline : IMarketEventPublisher, IEtlEventPipeline, IB
                                 {
                                     await _deadLetterSink.RecordAsync(evt, validationResult.Errors, _cts.Token).ConfigureAwait(false);
                                 }
+                                nextPendingEventIndex = i + 1;
                                 continue; // Skip persisting invalid events
                             }
                         }
@@ -796,6 +800,10 @@ public sealed class EventPipeline : IMarketEventPublisher, IEtlEventPipeline, IB
                         storageActivity?.SetTag("event.source", evt.Source);
 
                         await _sink.AppendAsync(evt, _cts.Token).ConfigureAwait(false);
+                        // AppendAsync returning successfully is the sink acknowledgement boundary.
+                        // If a later append or the batch flush fails, retry only the suffix that has
+                        // not crossed that boundary; arbitrary sinks are not necessarily idempotent.
+                        nextPendingEventIndex = i + 1;
                     }
 
                     // [1.2] WAL-sink transaction: flush the sink first, then update local sequence
@@ -826,6 +834,7 @@ public sealed class EventPipeline : IMarketEventPublisher, IEtlEventPipeline, IB
 
                     Interlocked.Add(ref _consumedCount, batchBuffer.Count);
                     retryPendingBatch = false;
+                    nextPendingEventIndex = 0;
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {

--- a/tests/Meridian.Tests/Application/Pipeline/WalEventPipelineTests.cs
+++ b/tests/Meridian.Tests/Application/Pipeline/WalEventPipelineTests.cs
@@ -132,6 +132,29 @@ public sealed class WalEventPipelineTests : IAsyncDisposable
             .Which.Symbol.Should().Be("AAPL");
     }
 
+    [Fact]
+    public async Task Consumer_WhenWalBackedSinkThrows_RetriesFailedBatchBeforeCommittingLaterEvents()
+    {
+        var wal = new WriteAheadLog(_walDir, new WalOptions { SyncMode = WalSyncMode.EveryWrite });
+        await wal.InitializeAsync();
+
+        await using var sink = new MockWalSink { FailuresRemaining = 1 };
+        await using var pipeline = new EventPipeline(
+            sink,
+            capacity: 100,
+            batchSize: 1,
+            enablePeriodicFlush: false,
+            wal: wal);
+
+        pipeline.TryPublish(CreateTradeEvent("LOST"));
+        pipeline.TryPublish(CreateTradeEvent("OK"));
+
+        await WaitForConsumption(sink, expectedCount: 2);
+
+        sink.ReceivedEvents.Select(evt => evt.Symbol).Should().Contain(new[] { "LOST", "OK" });
+        pipeline.GetStatistics().ConsumerIterationFailures.Should().BeGreaterThanOrEqualTo(1);
+    }
+
     #endregion
 
     #region Crash Recovery Tests
@@ -512,6 +535,7 @@ internal sealed class MockWalSink : IStorageSink
 {
     private readonly List<MarketEvent> _receivedEvents = new();
     private readonly object _lock = new();
+    private int _failuresRemaining;
 
     public IReadOnlyList<MarketEvent> ReceivedEvents
     {
@@ -526,8 +550,20 @@ internal sealed class MockWalSink : IStorageSink
 
     public int FlushCount { get; private set; }
 
+    public int FailuresRemaining
+    {
+        get => Volatile.Read(ref _failuresRemaining);
+        set => Volatile.Write(ref _failuresRemaining, value);
+    }
+
     public ValueTask AppendAsync(MarketEvent evt, CancellationToken ct = default)
     {
+        if (Volatile.Read(ref _failuresRemaining) > 0)
+        {
+            Interlocked.Decrement(ref _failuresRemaining);
+            throw new InvalidOperationException("Simulated sink failure");
+        }
+
         lock (_lock)
         {
             _receivedEvents.Add(evt);

--- a/tests/Meridian.Tests/Application/Pipeline/WalEventPipelineTests.cs
+++ b/tests/Meridian.Tests/Application/Pipeline/WalEventPipelineTests.cs
@@ -155,6 +155,38 @@ public sealed class WalEventPipelineTests : IAsyncDisposable
         pipeline.GetStatistics().ConsumerIterationFailures.Should().BeGreaterThanOrEqualTo(1);
     }
 
+    [Fact]
+    public async Task Consumer_WhenWalBackedBatchFlushThrows_DoesNotReappendPersistedEvents()
+    {
+        var wal = new WriteAheadLog(_walDir, new WalOptions { SyncMode = WalSyncMode.EveryWrite });
+        await wal.InitializeAsync();
+
+        await using var sink = new MockWalSink { FlushFailuresRemaining = 1 };
+        await using var pipeline = new EventPipeline(
+            sink,
+            capacity: 100,
+            batchSize: 3,
+            enablePeriodicFlush: false,
+            wal: wal);
+
+        pipeline.TryPublish(CreateTradeEvent("FIRST"));
+        pipeline.TryPublish(CreateTradeEvent("SECOND"));
+        pipeline.TryPublish(CreateTradeEvent("THIRD"));
+
+        await WaitForConsumption(sink, expectedCount: 3);
+        var timeout = DateTime.UtcNow.AddSeconds(5);
+        while (pipeline.GetStatistics().ConsumerIterationFailures == 0 && DateTime.UtcNow < timeout)
+        {
+            await Task.Delay(1);
+        }
+        await pipeline.FlushAsync();
+
+        sink.ReceivedEvents.Select(evt => evt.Symbol)
+            .Should().BeEquivalentTo(new[] { "FIRST", "SECOND", "THIRD" });
+        sink.ReceivedEvents.Should().HaveCount(3);
+        pipeline.GetStatistics().ConsumerIterationFailures.Should().BeGreaterThanOrEqualTo(1);
+    }
+
     #endregion
 
     #region Crash Recovery Tests
@@ -536,6 +568,7 @@ internal sealed class MockWalSink : IStorageSink
     private readonly List<MarketEvent> _receivedEvents = new();
     private readonly object _lock = new();
     private int _failuresRemaining;
+    private int _flushFailuresRemaining;
 
     public IReadOnlyList<MarketEvent> ReceivedEvents
     {
@@ -556,6 +589,12 @@ internal sealed class MockWalSink : IStorageSink
         set => Volatile.Write(ref _failuresRemaining, value);
     }
 
+    public int FlushFailuresRemaining
+    {
+        get => Volatile.Read(ref _flushFailuresRemaining);
+        set => Volatile.Write(ref _flushFailuresRemaining, value);
+    }
+
     public ValueTask AppendAsync(MarketEvent evt, CancellationToken ct = default)
     {
         if (Volatile.Read(ref _failuresRemaining) > 0)
@@ -574,6 +613,12 @@ internal sealed class MockWalSink : IStorageSink
     public Task FlushAsync(CancellationToken ct = default)
     {
         FlushCount++;
+        if (Volatile.Read(ref _flushFailuresRemaining) > 0)
+        {
+            Interlocked.Decrement(ref _flushFailuresRemaining);
+            throw new InvalidOperationException("Simulated sink flush failure");
+        }
+
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
### Motivation
- Prevent a WAL durability regression where a sink exception after a consumer-appended WAL record could be silently skipped by a later cumulative WAL commit, losing events that never reached primary storage.
- Ensure the pipeline continues to be resilient to sink faults while preserving write-ahead log integrity and replayability.

### Description
- Changed the consumer loop in `src/Meridian.Application/Pipeline/EventPipeline.cs` to track and retry a pending WAL-backed batch before reading newer events, via a `retryPendingBatch` flag that prevents later commits from cumulatively acknowledging failed WAL records.
- Persisted the consumer-assigned `WalSequence` back into the buffered `TracedMarketEvent` so retries reuse the original WAL sequence instead of appending duplicate WAL records.
- Suppressed dead-letter routing for a batch that will be retried, and updated the consumer logging to reflect whether the failed batch will be retried before later commits.
- Added a regression test `Consumer_WhenWalBackedSinkThrows_RetriesFailedBatchBeforeCommittingLaterEvents` and enhanced `MockWalSink` in `tests/Meridian.Tests/Application/Pipeline/WalEventPipelineTests.cs` to simulate transient sink failures and verify the failed event is retried and preserved.

### Testing
- Ran `git diff --check` to validate the working tree and found no check failures.
- Ran `python3 build/python/cli/buildctl.py validation-status --summary` which returned `blocked=false` and no active build locks, indicating the environment is ready for CI work.
- Attempted to run `bash scripts/ci.sh` locally but it could not complete because the environment lacks the `dotnet` SDK (`dotnet: command not found`), so full local `dotnet` unit test execution was not possible here; the new unit test is intended to run under the repository CI.
- Added one targeted unit test that exercises the regression scenario and should pass under normal CI (`tests/Meridian.Tests/Application/Pipeline/WalEventPipelineTests.cs::Consumer_WhenWalBackedSinkThrows_RetriesFailedBatchBeforeCommittingLaterEvents`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a612388ac948320ae017dcb4e47ed75)