### PR TITLE
docs: regenerate program state summaries

### DIFF
--- a/docs/status/program-state-summary.json
+++ b/docs/status/program-state-summary.json
@@ -2,7 +2,7 @@
   "schemaVersion": "program-state-summary/v2",
   "programSource": "docs/roadmap/data/program-state.yml",
   "roadmapSource": "docs/roadmap/data/roadmap-items.yml",
-  "snapshotDate": "2026-07-11",
+  "snapshotDate": "2026-07-21",
   "program": {
     "id": "meridian-program",
     "title": "Meridian Evidence-Backed Investment Operations",
@@ -19,7 +19,8 @@
       "Financial Operations control center for reconciliation, exceptions, close support, workflow control, and audit evidence",
       "Shared Financial Record Explorers for accounting, portfolio, security/instrument, and report-line provenance records",
       "Evidence Vault productization and statement reconciliation onboarding over governed connector evidence",
-      "Paper-first live-readiness governance for paper-to-live promotion evidence, overrides, controls, and audit retention"
+      "Paper-first live-readiness governance for paper-to-live promotion evidence, overrides, controls, and audit retention",
+      "Ranked W9 first-order improvement slate - truthful simulation posture, seeded demo evaluation, paper-trading realism, live fill streaming, client-grade reporting, fund economics, execution safety, governance hardening, and institutional statement ingestion"
     ],
     "activeUiLane": "browser_workstation_and_wpf_desktop",
     "retainedSupportLane": "",
@@ -140,8 +141,8 @@
       "Priority": "high",
       "Owner Lane": "Accounting and Ledger",
       "Evidence Posture": "complete",
-      "Evidence": "src/Meridian.FinancialOperations/Reconciliation/Connectors/StatementImportService.cs; src/Meridian.FinancialOperations/Reconciliation/Connectors/StatementMappingProfileCatalog.cs; src/Meridian.FinancialOperations/Reconciliation/Connectors/IbFlex/IbFlexStatementConnector.cs; src/Meridian.FinancialOperations/Reconciliation/Connectors/Ofx/OfxStatementConnector.cs; src/Meridian.FinancialOperations/Reconciliation/Connectors/Alpaca/AlpacaActivityStatementConnector.cs; src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.StatementConnectors.cs; docs/adr/018-declarative-statement-mapping-profiles.md; tests/Meridian.Tests/Reconciliation/Connectors/StatementImportServiceTests.cs; tests/Meridian.Tests/Reconciliation/Connectors/IbFlexStatementConnectorTests.cs; tests/Meridian.Tests/Reconciliation/Connectors/OfxStatementConnectorTests.cs; tests/Meridian.Tests/Reconciliation/Connectors/AlpacaActivityStatementConnectorTests.cs",
-      "Last Reviewed": "2026-07-02"
+      "Evidence": "src/Meridian.FinancialOperations/Reconciliation/Connectors/StatementImportService.cs; src/Meridian.FinancialOperations/Reconciliation/Connectors/StatementMappingProfileCatalog.cs; src/Meridian.FinancialOperations/Reconciliation/Connectors/IbFlex/IbFlexStatementConnector.cs; src/Meridian.FinancialOperations/Reconciliation/Connectors/Ofx/OfxStatementConnector.cs; src/Meridian.FinancialOperations/Reconciliation/Connectors/Alpaca/AlpacaActivityStatementConnector.cs; src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.StatementConnectors.cs; docs/adr/018-declarative-statement-mapping-profiles.md; tests/Meridian.Tests/Reconciliation/Connectors/StatementImportServiceTests.cs; tests/Meridian.Tests/Reconciliation/Connectors/IbFlexStatementConnectorTests.cs; tests/Meridian.Tests/Reconciliation/Connectors/OfxStatementConnectorTests.cs; tests/Meridian.Tests/Reconciliation/Connectors/AlpacaActivityStatementConnectorTests.cs; src/Meridian.Ui/dashboard/src/screens/statement-fetch-panel.tsx; src/Meridian.Ui/dashboard/src/screens/statement-fetch-panel.test.tsx",
+      "Last Reviewed": "2026-07-18"
     },
     {
       "ID": "W5X-EVIDENCE-001",
@@ -222,6 +223,19 @@
       "Last Reviewed": "2026-07-05"
     },
     {
+      "ID": "W8-UX-CONSOL-001",
+      "Wave": "W8",
+      "Title": "Browser workstation screen consolidation",
+      "Workspaces": "Accounting; Reporting; Strategy; Data",
+      "Status": "in_progress",
+      "Health": "on_track",
+      "Priority": "medium",
+      "Owner Lane": "Workstation Shell and UX",
+      "Evidence Posture": "in_progress",
+      "Evidence": "docs/development/web-ui-structural-improvement-proposal.md; docs/development/wpf-web-ui-alignment-plan.md",
+      "Last Reviewed": "2026-07-19"
+    },
+    {
       "ID": "W8-WPF-PARITY-001",
       "Wave": "W8",
       "Title": "WPF desktop workstation reactivation and web-UI parity",
@@ -233,6 +247,136 @@
       "Evidence Posture": "in_progress",
       "Evidence": "docs/development/wpf-web-ui-alignment-plan.md; docs/development/wpf-implementation-notes.md",
       "Last Reviewed": "2026-07-06"
+    },
+    {
+      "ID": "W9-ALPACA-004",
+      "Wave": "W9",
+      "Title": "Alpaca fill streaming into order and ledger state",
+      "Workspaces": "Trading",
+      "Status": "planned",
+      "Health": "green",
+      "Priority": "high",
+      "Owner Lane": "Execution and Fund Accounts",
+      "Evidence Posture": "planned_evidence",
+      "Evidence": "",
+      "Last Reviewed": "2026-07-21"
+    },
+    {
+      "ID": "W9-ASSET-010",
+      "Wave": "W9",
+      "Title": "Asset Accounting Event Spine and atomic lot posting",
+      "Workspaces": "Accounting; Portfolio; Reporting",
+      "Status": "in_progress",
+      "Health": "on_track",
+      "Priority": "critical",
+      "Owner Lane": "Accounting and Ledger",
+      "Evidence Posture": "in_progress",
+      "Evidence": "docs/architecture/event-accounting-architecture.md; src/Meridian.FinancialOperations/Ledger/AssetAccountingEventSpineService.cs; src/Meridian.Storage/Ledger/PostgresLedgerJournalStore.AtomicTaxLots.cs; tests/Meridian.Tests/Storage/AtomicTaxLotJournalStoreTests.cs; tests/Meridian.Tests/Storage/AssetAccountingPostingEvidenceValidatorTests.cs",
+      "Last Reviewed": "2026-07-21"
+    },
+    {
+      "ID": "W9-DEMO-002",
+      "Wave": "W9",
+      "Title": "One-command seeded demo with durable storage",
+      "Workspaces": "Data; Settings",
+      "Status": "planned",
+      "Health": "green",
+      "Priority": "critical",
+      "Owner Lane": "Workstation Shell and UX",
+      "Evidence Posture": "planned_evidence",
+      "Evidence": "",
+      "Last Reviewed": "2026-07-21"
+    },
+    {
+      "ID": "W9-GOV-008",
+      "Wave": "W9",
+      "Title": "Route-level authorization, fail-closed tenancy, and hash-chained accounting audit",
+      "Workspaces": "Settings; Accounting",
+      "Status": "planned",
+      "Health": "green",
+      "Priority": "high",
+      "Owner Lane": "Platform Security and Governance",
+      "Evidence Posture": "planned_evidence",
+      "Evidence": "",
+      "Last Reviewed": "2026-07-21"
+    },
+    {
+      "ID": "W9-INGEST-009",
+      "Wave": "W9",
+      "Title": "Institutional file ingestion (camt.053/BAI2) and sided reconciliation matcher",
+      "Workspaces": "Accounting; Data",
+      "Status": "planned",
+      "Health": "green",
+      "Priority": "high",
+      "Owner Lane": "Accounting and Ledger",
+      "Evidence Posture": "planned_evidence",
+      "Evidence": "",
+      "Last Reviewed": "2026-07-21"
+    },
+    {
+      "ID": "W9-NAV-006",
+      "Wave": "W9",
+      "Title": "Unitized NAV and real fee, waterfall, and capital-call economics",
+      "Workspaces": "Accounting; Portfolio",
+      "Status": "planned",
+      "Health": "green",
+      "Priority": "high",
+      "Owner Lane": "Accounting and Ledger",
+      "Evidence Posture": "planned_evidence",
+      "Evidence": "",
+      "Last Reviewed": "2026-07-21"
+    },
+    {
+      "ID": "W9-PAPER-003",
+      "Wave": "W9",
+      "Title": "Paper-trading realism with limit/stop matching and costs",
+      "Workspaces": "Trading; Strategy",
+      "Status": "planned",
+      "Health": "green",
+      "Priority": "critical",
+      "Owner Lane": "Execution and Fund Accounts",
+      "Evidence Posture": "planned_evidence",
+      "Evidence": "",
+      "Last Reviewed": "2026-07-21"
+    },
+    {
+      "ID": "W9-REPORT-005",
+      "Wave": "W9",
+      "Title": "Client-grade PDF/XLSX exports and partners-capital statement",
+      "Workspaces": "Reporting; Accounting",
+      "Status": "planned",
+      "Health": "green",
+      "Priority": "high",
+      "Owner Lane": "Accounting and Ledger",
+      "Evidence Posture": "planned_evidence",
+      "Evidence": "",
+      "Last Reviewed": "2026-07-21"
+    },
+    {
+      "ID": "W9-SAFETY-007",
+      "Wave": "W9",
+      "Title": "Kill-switch cancel-all and fat-finger, notional, and collar rules",
+      "Workspaces": "Trading; Settings",
+      "Status": "planned",
+      "Health": "green",
+      "Priority": "high",
+      "Owner Lane": "Execution and Fund Accounts",
+      "Evidence Posture": "planned_evidence",
+      "Evidence": "",
+      "Last Reviewed": "2026-07-21"
+    },
+    {
+      "ID": "W9-TRUTH-001",
+      "Wave": "W9",
+      "Title": "Loud fail-closed handling of simulated data and in-memory persistence",
+      "Workspaces": "Trading; Portfolio; Accounting; Reporting; Data",
+      "Status": "planned",
+      "Health": "green",
+      "Priority": "critical",
+      "Owner Lane": "Data Confidence and Validation",
+      "Evidence Posture": "planned_evidence",
+      "Evidence": "",
+      "Last Reviewed": "2026-07-21"
     }
   ]
 }

--- a/docs/status/program-state-summary.md
+++ b/docs/status/program-state-summary.md
@@ -2,7 +2,7 @@
 
 This file is generated from `docs/roadmap/data/program-state.yml` and `docs/roadmap/data/roadmap-items.yml`.
 
-Snapshot date: 2026-07-11
+Snapshot date: 2026-07-21
 
 | ID | Wave | Title | Workspaces | Status | Health | Priority | Owner Lane | Evidence Posture | Last Reviewed |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -14,14 +14,25 @@ Snapshot date: 2026-07-11
 | W4-RPT-001 | W4 | Governed report pack readiness | Reporting; Accounting | done | green | high | Accounting and Ledger | complete | 2026-05-29 |
 | W5-ACCT-001 | W5 | Accounting records and operational evidence | Accounting; Reporting; Portfolio; Data | done | green | high | Accounting and Ledger | complete | 2026-06-04 |
 | W5-MASSET-001 | W5 | Multi-asset operational coverage proof lane | Portfolio; Accounting; Data; Settings | done | green | high | Accounting and Ledger | complete | 2026-07-02 |
-| W5X-CONNECT-001 | W5X | Custodian and broker statement connector library | Accounting; Data | done | green | high | Accounting and Ledger | complete | 2026-07-02 |
+| W5X-CONNECT-001 | W5X | Custodian and broker statement connector library | Accounting; Data | done | green | high | Accounting and Ledger | complete | 2026-07-18 |
 | W5X-EVIDENCE-001 | W5X | Evidence Vault productization | Accounting; Reporting; Data | in_progress | green | high | Accounting and Ledger | in_progress | 2026-07-02 |
 | W5X-FINOPS-001 | W5X | Financial operations control center | Accounting; Reporting; Portfolio; Data | done | green | high | Accounting and Ledger | complete | 2026-06-24 |
 | W5X-FREX-001 | W5X | Shared financial record explorers | Accounting; Portfolio; Data; Reporting | done | green | high | Workstation Shell and UX | complete | 2026-06-22 |
 | W5X-STMT-ONBOARD-001 | W5X | Statement reconciliation onboarding wedge | Accounting | in_progress | green | high | Accounting and Ledger | in_progress | 2026-07-02 |
 | W6-BTSTUDIO-001 | W6 | Backtesting studio evidence loop | Strategy | planned | green | medium | Strategy Analytics | planned_evidence | 2026-06-04 |
 | W7-LIVE-001 | W7 | Live-readiness governance | Trading; Settings | done | green | medium | Accounting and Ledger | complete | 2026-07-05 |
+| W8-UX-CONSOL-001 | W8 | Browser workstation screen consolidation | Accounting; Reporting; Strategy; Data | in_progress | on_track | medium | Workstation Shell and UX | in_progress | 2026-07-19 |
 | W8-WPF-PARITY-001 | W8 | WPF desktop workstation reactivation and web-UI parity | Trading; Portfolio; Accounting; Reporting; Strategy; Data; Settings | in_progress | on_track | high | Desktop Workstation | in_progress | 2026-07-06 |
+| W9-ALPACA-004 | W9 | Alpaca fill streaming into order and ledger state | Trading | planned | green | high | Execution and Fund Accounts | planned_evidence | 2026-07-21 |
+| W9-ASSET-010 | W9 | Asset Accounting Event Spine and atomic lot posting | Accounting; Portfolio; Reporting | in_progress | on_track | critical | Accounting and Ledger | in_progress | 2026-07-21 |
+| W9-DEMO-002 | W9 | One-command seeded demo with durable storage | Data; Settings | planned | green | critical | Workstation Shell and UX | planned_evidence | 2026-07-21 |
+| W9-GOV-008 | W9 | Route-level authorization, fail-closed tenancy, and hash-chained accounting audit | Settings; Accounting | planned | green | high | Platform Security and Governance | planned_evidence | 2026-07-21 |
+| W9-INGEST-009 | W9 | Institutional file ingestion (camt.053/BAI2) and sided reconciliation matcher | Accounting; Data | planned | green | high | Accounting and Ledger | planned_evidence | 2026-07-21 |
+| W9-NAV-006 | W9 | Unitized NAV and real fee, waterfall, and capital-call economics | Accounting; Portfolio | planned | green | high | Accounting and Ledger | planned_evidence | 2026-07-21 |
+| W9-PAPER-003 | W9 | Paper-trading realism with limit/stop matching and costs | Trading; Strategy | planned | green | critical | Execution and Fund Accounts | planned_evidence | 2026-07-21 |
+| W9-REPORT-005 | W9 | Client-grade PDF/XLSX exports and partners-capital statement | Reporting; Accounting | planned | green | high | Accounting and Ledger | planned_evidence | 2026-07-21 |
+| W9-SAFETY-007 | W9 | Kill-switch cancel-all and fat-finger, notional, and collar rules | Trading; Settings | planned | green | high | Execution and Fund Accounts | planned_evidence | 2026-07-21 |
+| W9-TRUTH-001 | W9 | Loud fail-closed handling of simulated data and in-memory persistence | Trading; Portfolio; Accounting; Reporting; Data | planned | green | critical | Data Confidence and Validation | planned_evidence | 2026-07-21 |
 
 ## Source Contract
 


### PR DESCRIPTION
### Motivation
- The program-state source `docs/roadmap/data/program-state.yml` was updated (new `snapshot_date`) but the generated compatibility summaries under `docs/status/` were not regenerated, breaking the repository consistency check.

### Description
- Regenerated the machine-readable and Markdown program-state summaries by running the repository generator and wrote updated `docs/status/program-state-summary.json` and `docs/status/program-state-summary.md` to match the current roadmap registry.
- The changes primarily update the `snapshotDate`/`Snapshot date` and add the current W8/W9 roadmap rows and minor evidence/last-reviewed updates.
- The updates were committed on branch `codex/regenerate-program-state-summary` as `bab26a1c` with commit message `docs: regenerate program state summaries`.

### Testing
- `python3 scripts/generate_program_state_summary.py --check` passed and reported the outputs were up to date after regeneration.
- `python3 scripts/check_program_state_consistency.py` passed and no staleness errors were reported after the update.
- `git diff --check` passed with no whitespace errors reported for the modified files.
- `bash scripts/ci.sh` could not complete in this environment because `dotnet` is not installed, so the full CI run is blocked here and must be validated by GitHub Actions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61238a58e08320af29bf14328aa035)