### PR TITLE
Contain schema-control configured output paths

### DIFF
--- a/tests/scripts/test_schema_control_cli.py
+++ b/tests/scripts/test_schema_control_cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 from tools.schema_control.cli import (
+    _configured_output_paths,
     _deleted_migration_findings,
     _prepare_candidate_root,
     _promote,
@@ -17,6 +18,43 @@ from tools.schema_control.cli import (
 
 
 class SchemaControlCliTests(unittest.TestCase):
+    def test_configured_output_paths_reject_absolute_and_escaping_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "repository"
+            root.mkdir()
+
+            for output_path in ("/tmp/schema-control-secret", "../outside-repository"):
+                with self.subTest(output_path=output_path):
+                    with self.assertRaisesRegex(ValueError, "inside the repository"):
+                        _configured_output_paths(
+                            root,
+                            {
+                                "outputs": {
+                                    "manifest": output_path,
+                                    "docs": "docs/generated/database",
+                                }
+                            },
+                        )
+
+    def test_configured_output_paths_reject_symlink_escaping_repository(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "repository"
+            root.mkdir()
+            outside = Path(directory) / "outside"
+            outside.mkdir()
+            (root / "linked-output").symlink_to(outside, target_is_directory=True)
+
+            with self.assertRaisesRegex(ValueError, "inside the repository"):
+                _configured_output_paths(
+                    root,
+                    {
+                        "outputs": {
+                            "manifest": "linked-output",
+                            "docs": "docs/generated/database",
+                        }
+                    },
+                )
+
     def test_promote_validates_all_sources_before_replacing_outputs(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory) / "repository"
@@ -48,7 +86,7 @@ class SchemaControlCliTests(unittest.TestCase):
             sentinel = root / "sentinel.txt"
             sentinel.write_text("keep", encoding="utf-8")
 
-            with self.assertRaisesRegex(ValueError, "outside the repository"):
+            with self.assertRaisesRegex(ValueError, "inside the repository"):
                 _promote(
                     root,
                     {"outputs": {"manifest": ".", "docs": "docs/generated/database"}},

--- a/tools/schema_control/README.md
+++ b/tools/schema_control/README.md
@@ -69,6 +69,8 @@ database.
 
 The candidate workspace is `build/schema-control/candidate/`. Only `promote` writes to the tracked
 manifest and documentation roots, and it must be followed by `verify` in GitHub Actions.
+Configured output roots must resolve to a non-root path within the repository; schema control
+rejects absolute paths, repository escapes, and symlinks that resolve outside the checkout.
 
 ## Policy behavior
 

--- a/tools/schema_control/cli.py
+++ b/tools/schema_control/cli.py
@@ -54,6 +54,32 @@ def _resolve(root: Path, value: str | Path) -> Path:
     return path.resolve() if path.is_absolute() else (root / path).resolve()
 
 
+def _resolve_output_path(root: Path, value: str | Path) -> Path:
+    """Resolve a configured artifact output without leaving the repository."""
+
+    resolved_root = root.resolve()
+    path = _resolve(resolved_root, value)
+    if path == resolved_root or not path.is_relative_to(resolved_root):
+        raise ValueError(
+            f"Schema-control output path must be inside the repository: {value}"
+        )
+    return path
+
+
+def _configured_output_paths(root: Path, config: Mapping[str, Any]) -> tuple[Path, Path]:
+    outputs = config.get("outputs", {})
+    if not isinstance(outputs, Mapping):
+        raise ValueError("schema-control outputs must be a JSON object.")
+    return (
+        _resolve_output_path(
+            root, str(outputs.get("manifest") or "database/manifest")
+        ),
+        _resolve_output_path(
+            root, str(outputs.get("docs") or "docs/generated/database")
+        ),
+    )
+
+
 def _finding_sort_key(item: Mapping[str, Any]) -> tuple[str, str, str, str]:
     return (
         str(item.get("severity") or ""),
@@ -564,17 +590,15 @@ def _merge_drift(
 
 
 def _promote(root: Path, config: Mapping[str, Any], candidate_root: Path) -> None:
-    outputs = config.get("outputs", {})
-    if not isinstance(outputs, Mapping):
-        raise ValueError("schema-control outputs must be a JSON object.")
+    manifest_destination, docs_destination = _configured_output_paths(root, config)
     pairs = [
         (
             (candidate_root / "manifest").resolve(),
-            _resolve(root, str(outputs.get("manifest") or "database/manifest")),
+            manifest_destination,
         ),
         (
             (candidate_root / "docs").resolve(),
-            _resolve(root, str(outputs.get("docs") or "docs/generated/database")),
+            docs_destination,
         ),
     ]
     resolved_root = root.resolve()
@@ -735,13 +759,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"Schema-control candidate written to {candidate_root}.")
             return 1 if failed else 0
 
-        outputs = config.get("outputs", {})
-        expected_manifest = _resolve(
-            root, str(outputs.get("manifest") or "database/manifest")
-        )
-        expected_docs = _resolve(
-            root, str(outputs.get("docs") or "docs/generated/database")
-        )
+        expected_manifest, expected_docs = _configured_output_paths(root, config)
         manifest_drift = compare_artifact_trees(
             expected_manifest, candidate_root / "manifest"
         )


### PR DESCRIPTION
### Motivation
- The schema-control verifier previously accepted repository-controlled `outputs.manifest`/`outputs.docs` values that could resolve to absolute paths, repository escapes, or symlink targets outside the checkout, enabling recursive reads and potential leakage of local JSON files into CI artifacts. 
- The change prevents attacker-controlled configuration from causing filesystem traversal or exfiltration by failing closed when configured outputs resolve outside the repository.

### Description
- Add a safe resolver ` _resolve_output_path(root, value)` that ensures a configured output resolves to a non-root path inside the repository and raises `ValueError` if it does not. 
- Add `_configured_output_paths(root, config)` to centralize output-path validation and use it in both `verify` and `promote` flows instead of resolving outputs with the permissive `_resolve`. 
- Update `promote` and the `verify`/reporting code paths to use the new resolver so both promotion and verification enforce containment before walking or reading the expected output trees. 
- Add regression tests in `tests/scripts/test_schema_control_cli.py` covering absolute paths, `..` traversal, and symlink-escaping output roots, and document the output-root constraint in `tools/schema_control/README.md`.

### Testing
- Ran `python -m unittest tests.scripts.test_schema_control_cli tests.scripts.test_schema_control_diffing tests.scripts.test_schema_control_workflow`, which passed (21 tests executed) and exercised the new assertions. 
- Ran `git diff --check` and local checks for diff formatting, which passed. 
- Attempted `bash scripts/ci.sh` but the run was blocked in this environment during the `.NET SDK` verification step because `dotnet` is not installed, so full CI was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6123899cac832097c8bb83680bad4f)