### PR TITLE
fix(data-uploads): reject duplicate XLSX relationship IDs in preview

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.DataUploadWorkbook.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.DataUploadWorkbook.cs
@@ -1036,10 +1036,10 @@ public static partial class WorkstationEndpoints
                 continue;
             }
 
-            // Tolerate malformed packages with duplicate relationship ids (first mapping wins)
-            // instead of letting ToDictionary throw ArgumentException, which the preview handler does
-            // not translate and would surface as a 500 rather than a bad-request workbook error.
-            relationshipTargets.TryAdd(relationshipId, relationship.Attribute("Target")?.Value ?? string.Empty);
+            if (!relationshipTargets.TryAdd(relationshipId, relationship.Attribute("Target")?.Value ?? string.Empty))
+            {
+                throw new InvalidDataException("Workbook contains duplicate relationship ids.");
+            }
         }
 
         var workbook = LoadWorkbookXml(workbookEntry);

--- a/tests/Meridian.Tests/Ui/WorkstationDataUploadWorkbookEndpointTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationDataUploadWorkbookEndpointTests.cs
@@ -464,6 +464,26 @@ public sealed partial class WorkstationEndpointsTests
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
+    [Fact]
+    public async Task MapWorkstationEndpoints_WorkbookPreview_DuplicateRelationshipId_ShouldRejectAmbiguousWorkbook()
+    {
+        await using var app = await CreateAppAsync();
+        var client = app.GetTestClient();
+        var workbook = XlsxWorkbookWriter.CreateWorkbook(
+        [
+            WorkbookMetaSheet(("Entities", "entity-configuration")),
+            new XlsxWorksheet(
+                "Entities",
+                ["entity_id", "entity_name", "entity_type"],
+                [["ENT-1", "Northwind Income Fund LP", "Fund"]]),
+        ]);
+
+        using var content = BuildWorkbookUploadContent(AddDuplicateWorkbookRelationshipId(workbook));
+        var response = await client.PostAsync(UiApiRoutes.WorkstationDataUploadWorkbookPreview, content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
     private static XlsxWorksheet WorkbookMetaSheet(params (string SheetName, string TemplateId)[] entries)
     {
         var rows = entries
@@ -479,6 +499,35 @@ public sealed partial class WorkstationEndpointsTests
         file.Headers.ContentType = MediaTypeHeaderValue.Parse(WorkbookTestContentType);
         content.Add(file, "file", "workbook.xlsx");
         return content;
+    }
+
+    private static byte[] AddDuplicateWorkbookRelationshipId(byte[] workbook)
+    {
+        using var stream = new MemoryStream();
+        stream.Write(workbook);
+        stream.Position = 0;
+
+        using (var archive = new ZipArchive(stream, ZipArchiveMode.Update, leaveOpen: true))
+        {
+            var entry = archive.GetEntry("xl/_rels/workbook.xml.rels");
+            entry.Should().NotBeNull();
+
+            XDocument relationships;
+            using (var entryStream = entry!.Open())
+            {
+                relationships = XDocument.Load(entryStream);
+            }
+
+            var relationship = relationships.Root!.Elements().First();
+            relationships.Root.Add(new XElement(relationship));
+
+            entry.Delete();
+            var replacement = archive.CreateEntry("xl/_rels/workbook.xml.rels");
+            using var replacementStream = replacement.Open();
+            relationships.Save(replacementStream);
+        }
+
+        return stream.ToArray();
     }
 
     private static IReadOnlyList<string> ReadWorkbookSheetNames(byte[] workbook)


### PR DESCRIPTION
### Motivation
- Prevent ambiguous/malformed .xlsx packages from being accepted by the workbook preview flow when `xl/_rels/workbook.xml.rels` contains duplicate relationship `Id` values, which could make the preview validate a different worksheet than other OOXML consumers and create evidence/integrity mismatches.

### Description
- Change workbook relationship parsing in `ResolveWorkbookSheetOrder` (`src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.DataUploadWorkbook.cs`) to throw `InvalidDataException` when a duplicate relationship `Id` is encountered instead of silently keeping the first mapping.
- Add an endpoint regression test `MapWorkstationEndpoints_WorkbookPreview_DuplicateRelationshipId_ShouldRejectAmbiguousWorkbook` in `tests/Meridian.Tests/Ui/WorkstationDataUploadWorkbookEndpointTests.cs` that mutates a valid workbook to include a duplicate relationship id and asserts the preview endpoint returns `400 Bad Request`.
- Add helper `AddDuplicateWorkbookRelationshipId` in the test to produce the malformed `workbook.xml.rels` case used by the test.

### Testing
- Ran `git diff --check` to validate the diff formatting and it passed.
- Ran `python3 build/python/cli/buildctl.py validation-status --summary` and it reported no active blockers (`blocked=false`).
- Attempted to run the targeted test with `dotnet test ... --filter 'FullyQualifiedName~MapWorkstationEndpoints_WorkbookPreview_DuplicateRelationshipId_ShouldRejectAmbiguousWorkbook' --no-restore`, but execution was blocked because the environment has no `dotnet` SDK (`dotnet: command not found`).
- Ran `bash scripts/ci.sh`, which refused to proceed at the .NET SDK verification step due to the missing `dotnet` executable in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f3974ac8320b0529b555b320a1b)