### PR TITLE
Fix authorization for storage cleanup idempotency replays

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.DataOperationsAssurance.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.DataOperationsAssurance.cs
@@ -142,7 +142,7 @@ public static partial class WorkstationEndpoints
                 return EndpointHelpers.Forbidden();
             if (string.IsNullOrWhiteSpace(request.IdempotencyKey))
                 return Results.BadRequest(new { error = "Idempotency key is required." });
-            var action = service.GetPreviewAction(request.PreviewId);
+            var action = service.GetExecuteAction(request.PreviewId, request.IdempotencyKey);
             if (action.HasValue && !CanExecuteStorageAction(context, action.Value))
                 return EndpointHelpers.Forbidden();
             try

--- a/src/Meridian.Ui.Shared/Services/StorageAssuranceService.cs
+++ b/src/Meridian.Ui.Shared/Services/StorageAssuranceService.cs
@@ -159,8 +159,14 @@ public sealed class StorageAssuranceService
         return result;
     }
 
-    public StorageMaintenanceActionDto? GetPreviewAction(string previewId) =>
-        _previews.TryGetValue(previewId, out var preview) ? preview.Action : null;
+    public StorageMaintenanceActionDto? GetExecuteAction(string previewId, string idempotencyKey)
+    {
+        if (_previews.TryGetValue(previewId, out var preview))
+            return preview.Action;
+
+        var key = $"{previewId}:{idempotencyKey.Trim()}";
+        return _idempotency.TryGetValue(key, out var result) ? result.Action : null;
+    }
 
     private IReadOnlyList<StorageMaintenanceCandidateDto> BuildCleanupCandidates()
     {

--- a/tests/Meridian.Tests/Ui/DataOperationsAssuranceServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/DataOperationsAssuranceServiceTests.cs
@@ -68,6 +68,7 @@ public sealed class DataOperationsAssuranceServiceTests : IDisposable
         File.Exists(retained).Should().BeTrue();
         result.Status.Should().Be("Completed");
         result.EvidenceVaultId.Should().NotBeNullOrWhiteSpace();
+        service.GetExecuteAction(preview.PreviewId, "cleanup-1").Should().Be(StorageMaintenanceActionDto.Cleanup);
     }
 
     public void Dispose()


### PR DESCRIPTION
### Motivation

- Close a permission gap where cached idempotent results returned after a preview is removed could expose prior `Cleanup` results to callers who only have `ManageStorage` but not `AdminMaintenance`.

### Description

- Resolve the maintenance action used for endpoint authorization from either the live preview or the matching cached idempotent result by replacing the preview-only lookup with `GetExecuteAction(previewId, idempotencyKey)` at the execute endpoint.
- Add `GetExecuteAction` to `StorageAssuranceService` so it first checks `_previews` and then consults `_idempotency` for the stored result action when no live preview exists.
- Add a regression assertion in `DataOperationsAssuranceServiceTests` confirming a completed `Cleanup` execution still reports `Cleanup` via `GetExecuteAction` so the `AdminMaintenance` requirement can be enforced.
- Files changed: `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.DataOperationsAssurance.cs`, `src/Meridian.Ui.Shared/Services/StorageAssuranceService.cs`, and `tests/Meridian.Tests/Ui/DataOperationsAssuranceServiceTests.cs`.

### Testing

- Ran `git diff --check` which passed with no whitespace/errors reported.
- Ran `python3 build/python/cli/buildctl.py validation-status --summary` which returned `blocked=false` and no active build processes.
- Attempted `bash scripts/ci.sh` but it could not run in this environment because the .NET SDK is not available (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f399e7883208cbc9f2feb00f08f)