### PR TITLE
fix(ui): preserve maintenance warning failures

### DIFF
--- a/src/Meridian.Ui.Services/Services/ScheduledMaintenanceService.cs
+++ b/src/Meridian.Ui.Services/Services/ScheduledMaintenanceService.cs
@@ -589,14 +589,10 @@ public sealed class ScheduledMaintenanceService
 
         var execution = response.Data;
         var status = ResolveExecutionStatus(execution.Status);
-        var completed =
-            string.Equals(status, "Completed", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(status, "CompletedWithWarnings", StringComparison.OrdinalIgnoreCase);
-
-        result.Success = completed;
+        result.Success = IsSuccessfulArchiveMaintenanceExecution(status, execution.Result?.Success ?? false);
         result.Message = !string.IsNullOrWhiteSpace(execution.Result?.Summary)
             ? execution.Result!.Summary!
-            : completed
+            : result.Success
                 ? $"Archive maintenance ({serverTaskType}) completed."
                 : $"Archive maintenance ({serverTaskType}) ended with status {status ?? "unknown"}.";
         result.Error = execution.ErrorMessage;
@@ -605,10 +601,10 @@ public sealed class ScheduledMaintenanceService
         result.FilesSuccessful = Math.Max(0, execution.FilesProcessed - result.FilesFailed);
         result.BytesSaved = execution.BytesSaved;
 
-        if (!completed)
+        if (!result.Success)
         {
             Log.Warning(
-                "Maintenance task {TaskId} ({ServerTaskType}) ended with status {Status}: {Error}",
+                "Maintenance task {TaskId} ({ServerTaskType}) did not complete successfully with status {Status}: {Error}",
                 task.Id,
                 serverTaskType,
                 status,
@@ -617,6 +613,9 @@ public sealed class ScheduledMaintenanceService
 
         return result;
     }
+
+    internal static bool IsSuccessfulArchiveMaintenanceExecution(string? status, bool maintenanceSucceeded) =>
+        maintenanceSucceeded && string.Equals(status, "Completed", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Normalizes the execution status, which the host may serialize as either an enum name or

--- a/tests/Meridian.Ui.Tests/Services/ScheduledMaintenanceServiceTests.cs
+++ b/tests/Meridian.Ui.Tests/Services/ScheduledMaintenanceServiceTests.cs
@@ -309,6 +309,23 @@ public sealed class ScheduledMaintenanceServiceTests
         Enum.GetValues<MaintenanceTaskType>().Should().HaveCount(6);
     }
 
+    [Fact]
+    public void IsSuccessfulArchiveMaintenanceExecution_CompletedWithWarningsAndFailedMaintenance_ReturnsFalse()
+    {
+        ScheduledMaintenanceService.IsSuccessfulArchiveMaintenanceExecution(
+            "CompletedWithWarnings",
+            maintenanceSucceeded: false).Should().BeFalse(
+            "maintenance warnings can represent archive integrity failures");
+    }
+
+    [Fact]
+    public void IsSuccessfulArchiveMaintenanceExecution_CompletedAndSuccessfulMaintenance_ReturnsTrue()
+    {
+        ScheduledMaintenanceService.IsSuccessfulArchiveMaintenanceExecution(
+            "Completed",
+            maintenanceSucceeded: true).Should().BeTrue();
+    }
+
     // ── ScheduleType enum ───────────────────────────────────────────
 
     [Theory]


### PR DESCRIPTION
### Motivation
- Prevent scheduled-maintenance from treating server `CompletedWithWarnings` executions as successful when the underlying maintenance run reported `Success=false`, so integrity/checksum failures are not hidden behind a fabricated UI success flag.

### Description
- Replace the previous status-only translation with `IsSuccessfulArchiveMaintenanceExecution(status, maintenanceSucceeded)` so a run is successful only when the execution status is `Completed` and the server-side `Result.Success` is true.
- Adjust the completion message and warning log to rely on the corrected `result.Success` value so notifications and persisted `LastRunSuccess` reflect real maintenance success or failure.
- Add two unit tests in `tests/Meridian.Ui.Tests/Services/ScheduledMaintenanceServiceTests.cs` to cover the `CompletedWithWarnings`+failed maintenance and `Completed`+successful maintenance cases.
- Changes made in `src/Meridian.Ui.Services/Services/ScheduledMaintenanceService.cs` and corresponding tests were committed (commit `5e9cebe1`).

### Testing
- Ran `git diff --check` which passed locally. 
- Executed a static regression guard script (Python) that validated the important translations and it passed. 
- Ran `python build/python/cli/buildctl.py validation-status --summary` which returned without active build locks and is considered passed in this environment. 
- `dotnet`/unit test execution and `bash scripts/ci.sh` could not be completed here because the .NET SDK is not installed (`dotnet: command not found`), so CI test runs remain required on the repository CI (GitHub Actions) to validate the new unit tests and integration checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f3a24188320a861659b1bb1a53c)