### PR TITLE
Normalize whitespace in Postgres position overlap guard

### DIFF
--- a/src/Meridian.Storage/AssetOperations/PostgresAssetOperationsProjectionStore.InstrumentPositions.cs
+++ b/src/Meridian.Storage/AssetOperations/PostgresAssetOperationsProjectionStore.InstrumentPositions.cs
@@ -514,10 +514,10 @@ public sealed partial class PostgresAssetOperationsProjectionStore
               and security_id = @security_id
               and role_id = @role_id
               and ledger_book_id = @ledger_book_id
-              and lower(owner_scope_id) = lower(@owner_scope_id)
+              and lower(btrim(owner_scope_id)) = lower(btrim(@owner_scope_id))
               and lower(owner_scope_kind) = lower(@owner_scope_kind)
-              and lower(position_side) = lower(@position_side)
-              and lower(position_status) not in ('closed', 'inactive', 'terminated', 'matured')
+              and lower(btrim(position_side)) = lower(btrim(@position_side))
+              and lower(btrim(position_status)) not in ('closed', 'inactive', 'terminated', 'matured')
               and effective_from <= @effective_to
               and coalesce(effective_to, 'infinity'::date) >= @effective_from
             limit 1

--- a/tests/Meridian.Tests/AssetOperations/InstrumentPositionProjectionStoreTests.cs
+++ b/tests/Meridian.Tests/AssetOperations/InstrumentPositionProjectionStoreTests.cs
@@ -374,6 +374,7 @@ public sealed class PostgresInstrumentPositionProjectionStoreTests : IAsyncLifet
         {
             PositionId = Guid.Parse("a3000000-aaaa-4000-8000-000000000099"),
             Version = 1,
+            PositionSide = $"{initial.Position.PositionSide} ",
             CurrentEconomicState = null,
             OriginEvent = initial.Position.OriginEvent! with
             {


### PR DESCRIPTION
### Motivation
- The Postgres overlap check for durable book positions compared scope fields without trimming, which could be bypassed by leading/trailing whitespace even though the in-memory guard and advisory-lock normalization treat trimmed values as equivalent.
- This mismatch allows an authenticated writer to persist overlapping active positions that differ only by surrounding whitespace, risking projection integrity.

### Description
- Updated the overlap query in `src/Meridian.Storage/AssetOperations/PostgresAssetOperationsProjectionStore.InstrumentPositions.cs` to normalize text comparisons using `btrim(...)` plus `lower(...)` for `owner_scope_id`, `position_side`, and `position_status` so SQL semantics match the in-memory and advisory-lock normalization.
- Kept the existing date-range, role, security, ledger-book, and active-status semantics; only normalized whitespace/case for the string comparisons used to define overlap.
- Extended the Postgres regression scenario in `tests/Meridian.Tests/AssetOperations/InstrumentPositionProjectionStoreTests.cs` to exercise an overlapping create where `PositionSide` includes a trailing space so the durable guard is validated against whitespace variants.

### Testing
- Ran a static predicate check via `python3` to confirm the SQL now contains `btrim(...)` normalization for the three relevant predicates, and the check succeeded.
- Attempted to run the targeted Postgres overlap test (`PostgresInstrumentPositionProjectionStoreTests.DedicatedStore_ShouldQueryEffectiveBookStateAfterRestartAndRejectOverlap`) with `dotnet test`, but the container environment lacks `dotnet`, so the test could not be executed locally.
- Attempted to run `bash scripts/ci.sh` for full CI verification, but it could not complete because the environment does not provide the .NET SDK (`dotnet: command not found`).
- The updated test has been added to the repository and is expected to run and pass in the project CI (GitHub Actions) where the full .NET toolchain is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f3b146083209c62740bd9fa64b5)