### PR TITLE
Fail closed on unknown cash-flow source freshness

### DIFF
--- a/src/Meridian.Application/SecurityMaster/CashFlow/StructuredCashFlowLedgerGate.cs
+++ b/src/Meridian.Application/SecurityMaster/CashFlow/StructuredCashFlowLedgerGate.cs
@@ -5,19 +5,26 @@ namespace Meridian.Application.SecurityMaster.CashFlow;
 /// <summary>
 /// Shared postability gate for routing a structured cash flow projection to the ledger. Both the
 /// preview bridge (<see cref="StructuredCashFlowLedgerBridge"/>) and the posting bridge
-/// (<c>SecurityMasterAmortizationLedgerBridge</c>) consult this single gate so a stale source or a
-/// rate-shocked what-if scenario can never reach the general ledger through either path.
+/// (<c>SecurityMasterAmortizationLedgerBridge</c>) consult this single gate so a source without
+/// verified freshness, a stale source, or a rate-shocked what-if scenario can never reach the
+/// general ledger through either path.
 /// </summary>
 public static class StructuredCashFlowLedgerGate
 {
     /// <summary>
     /// Returns <see langword="null"/> when the projection may post to the ledger; otherwise a
-    /// human-readable reason describing the gate that blocked it. Staleness is evaluated before the
-    /// scenario so a stale source is reported even for a what-if projection.
+    /// human-readable reason describing the gate that blocked it. Freshness is evaluated before the
+    /// scenario so a source without verified freshness or a stale source is reported even for a
+    /// what-if projection.
     /// </summary>
     public static string? EvaluateBlockReason(StructuredCashFlowProjectionDto projection)
     {
         ArgumentNullException.ThrowIfNull(projection);
+
+        if (projection.Staleness == StructuredCashFlowStaleness.Unknown)
+        {
+            return "Cash flow source freshness is unknown; refresh or confirm the source before posting accruals to the ledger.";
+        }
 
         if (projection.Staleness == StructuredCashFlowStaleness.Stale)
         {

--- a/src/Meridian.Contracts/SecurityMaster/SecurityMasterCashFlow.cs
+++ b/src/Meridian.Contracts/SecurityMaster/SecurityMasterCashFlow.cs
@@ -39,12 +39,16 @@ public enum StructuredCashFlowScenario
 
 /// <summary>
 /// Freshness classification for the cash flow source backing a projection. Consumers that post to
-/// the ledger MUST treat <see cref="Stale"/> as a hard gate rather than an advisory log line.
+/// the ledger MUST treat every state other than <see cref="Fresh"/> as a hard gate rather than an
+/// advisory log line.
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter<StructuredCashFlowStaleness>))]
 public enum StructuredCashFlowStaleness
 {
-    /// <summary>The source has no last-updated timestamp, so freshness cannot be evaluated.</summary>
+    /// <summary>
+    /// The source has no last-updated timestamp, so freshness cannot be evaluated and must not drive
+    /// ledger postings.
+    /// </summary>
     Unknown,
 
     /// <summary>The source was refreshed within the staleness threshold.</summary>

--- a/tests/Meridian.Tests/Application/StructuredCashFlowLedgerBridgeTests.cs
+++ b/tests/Meridian.Tests/Application/StructuredCashFlowLedgerBridgeTests.cs
@@ -56,6 +56,19 @@ public sealed class StructuredCashFlowLedgerBridgeTests
     }
 
     [Fact]
+    public void BuildCouponAccrualPostings_UnknownSourceFreshness_ShouldBlock()
+    {
+        var bridge = new StructuredCashFlowLedgerBridge();
+
+        var result = bridge.BuildCouponAccrualPostings(
+            BuildProjection(staleness: StructuredCashFlowStaleness.Unknown), "ABC");
+
+        result.IsPostable.Should().BeFalse();
+        result.BlockedReason.Should().Contain("freshness is unknown");
+        result.Postings.Should().BeEmpty();
+    }
+
+    [Fact]
     public void BuildCouponAccrualPostings_NonBaseScenario_ShouldBlock()
     {
         var bridge = new StructuredCashFlowLedgerBridge();


### PR DESCRIPTION
### Motivation
- The ledger posting gate previously treated `StructuredCashFlowStaleness.Unknown` as postable, allowing projections with no `LastUpdatedUtc` evidence to produce coupon-accrual postings and risking incorrect ledger writes.
- The change enforces a fail-closed policy so only sources with verified freshness (`Fresh`) may drive ledger postings, protecting accounting integrity.

### Description
- Add an explicit `Unknown` freshness block in `StructuredCashFlowLedgerGate.EvaluateBlockReason` to return a blocking reason when `projection.Staleness == StructuredCashFlowStaleness.Unknown` so such projections cannot post to the ledger.
- Clarify the contract documentation in `src/Meridian.Contracts/SecurityMaster/SecurityMasterCashFlow.cs` to state that every state other than `Fresh` is a hard gate for ledger posting and that `Unknown` must not drive postings.
- Add a regression test `BuildCouponAccrualPostings_UnknownSourceFreshness_ShouldBlock` in `tests/Meridian.Tests/Application/StructuredCashFlowLedgerBridgeTests.cs` that asserts an `Unknown`-staleness base projection is blocked and produces no postings.
- The enforcement is applied at the shared gate so both ledger-bridge callers consult the same fail-closed policy; projection rendering/display behavior is unchanged.

### Testing
- Ran static/source assertions via a small Python check that verified the new `Unknown` branch and the presence of the regression test; the assertions passed.
- Ran `git diff --check` to validate no whitespace or diff issues; it passed.
- Attempted to run the focused unit tests with `dotnet test --filter 'FullyQualifiedName~StructuredCashFlowLedgerBridgeTests'`, but `dotnet` is not available in this environment so the test run could not be executed here.
- Ran `bash scripts/ci.sh`, which also stopped early because the environment lacks the .NET SDK; recommend CI (GitHub Actions) run the full `dotnet` test suite to validate the change in the proper toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f398d6c8320a01fd70688de1992)