### PR TITLE
Normalize case-variant ExternalGlDimensions to avoid 500 on ledger posting

### DIFF
--- a/src/Meridian.FinancialOperations/Ledger/LedgerJournalConstruction.cs
+++ b/src/Meridian.FinancialOperations/Ledger/LedgerJournalConstruction.cs
@@ -83,10 +83,21 @@ internal static class LedgerJournalConstruction
         IReadOnlyDictionary<string, string>? dimensions)
         => dimensions is null || dimensions.Count == 0
             ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            : dimensions
-                .Where(static pair => !string.IsNullOrWhiteSpace(pair.Key) && !string.IsNullOrWhiteSpace(pair.Value))
-                .OrderBy(static pair => pair.Key, StringComparer.OrdinalIgnoreCase)
-                .ToDictionary(static pair => pair.Key.Trim(), static pair => pair.Value.Trim(), StringComparer.OrdinalIgnoreCase);
+            : NormalizeExternalGlDimensionsCore(dimensions);
+
+    private static IReadOnlyDictionary<string, string> NormalizeExternalGlDimensionsCore(
+        IReadOnlyDictionary<string, string> dimensions)
+    {
+        var normalized = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var pair in dimensions
+                     .Where(static pair => !string.IsNullOrWhiteSpace(pair.Key) && !string.IsNullOrWhiteSpace(pair.Value))
+                     .OrderBy(static pair => pair.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            normalized[pair.Key.Trim()] = pair.Value.Trim();
+        }
+
+        return normalized;
+    }
 
     private static string? NormalizeOptional(string? value)
         => string.IsNullOrWhiteSpace(value) ? null : value.Trim();

--- a/tests/Meridian.Tests/Application/OperationsContinuityWorkflowServiceTests.cs
+++ b/tests/Meridian.Tests/Application/OperationsContinuityWorkflowServiceTests.cs
@@ -1473,6 +1473,40 @@ public sealed class OperationsContinuityWorkflowServiceTests
     }
 
     [Fact]
+    public async Task PostLedgerEntriesAsync_ShouldNormalizeCaseVariantExternalGlDimensionKeys()
+    {
+        var journalStore = new RecordingLedgerJournalStore();
+        var service = CreateService(out _, out _, journalStore);
+        var workflow = await CreateLedgerValidatedWorkflowAsync(service);
+        var candidate = CreateJournalCandidate(workflow.FundAccountId);
+        var cashLine = candidate.Lines[0] with
+        {
+            Dimensions = candidate.Lines[0].Dimensions! with
+            {
+                ExternalGlDimensions = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["Department"] = "Treasury",
+                    ["department"] = "Corporate Treasury"
+                }
+            }
+        };
+        candidate = candidate with { Lines = [cashLine, candidate.Lines[1]] };
+
+        var result = await service.PostLedgerEntriesAsync(workflow.WorkflowId, new OperationsLedgerPostRequestDto(
+            workflow.Version,
+            "ops-user",
+            LedgerBatchId: "ledger-batch-1",
+            PostingKind: "period-close",
+            PeriodOpen: true,
+            JournalCandidate: candidate));
+
+        result.Success.Should().BeTrue();
+        var postedCashLine = journalStore.Appended.Single().Entry.Lines.Single(static line => line.Account.Name == "Cash");
+        postedCashLine.Dimensions!.ExternalGlDimensions.Should().ContainSingle();
+        postedCashLine.Dimensions.ExternalGlDimensions["Department"].Should().Be("Corporate Treasury");
+    }
+
+    [Fact]
     public async Task ReviewedAutomationMaterialCommands_ShouldRejectAssistantOriginBeforeMutation()
     {
         var service = CreateService(out _, out var auditStore);


### PR DESCRIPTION
### Motivation
- The shared ledger dimension normalizer used `ToDictionary(..., StringComparer.OrdinalIgnoreCase)` which throws `ArgumentException` when client-supplied `ExternalGlDimensions` contains keys that differ only by case, causing an unhandled 500 from the operations ledger posting path.
- The intent is to preserve prior tolerant behavior where case-variant keys overwrite deterministically rather than crashing the request flow.

### Description
- Replace the LINQ `ToDictionary(...)` construction with a `NormalizeExternalGlDimensionsCore` helper that assigns into a `Dictionary<string,string>(StringComparer.OrdinalIgnoreCase)` and therefore merges/overwrites case-variant keys after trimming and filtering keys/values. (changed `src/Meridian.FinancialOperations/Ledger/LedgerJournalConstruction.cs`)
- Add a regression unit test `PostLedgerEntriesAsync_ShouldNormalizeCaseVariantExternalGlDimensionKeys` to `OperationsContinuityWorkflowServiceTests` that posts a candidate containing both `Department` and `department` and asserts the request succeeds and the normalized dictionary contains the expected final value. (changed `tests/Meridian.Tests/Application/OperationsContinuityWorkflowServiceTests.cs`)
- The change preserves existing trimming, filtering, and case-insensitive lookup semantics while preventing an `ArgumentException` for colliding case-variant keys.

### Testing
- Ran `git diff --check` which reported no issues and committed the changes.  
- Ran `python build/python/cli/buildctl.py validation-status --summary` which returned a clean validation-state (no active build locks).  
- Added the unit test `PostLedgerEntriesAsync_ShouldNormalizeCaseVariantExternalGlDimensionKeys` but could not run `dotnet test` locally because the .NET SDK is not installed in this environment (`dotnet: command not found`), and `bash scripts/ci.sh` is blocked for the same reason; the new test will run in CI where the SDK is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f3951708320aaa31eff4bd24df5)