### PR TITLE
Deduplicate undeclared provider capabilities in setup validation

### DIFF
--- a/src/Meridian.Application/Integrations/ProviderIntegrationSetupValidation.cs
+++ b/src/Meridian.Application/Integrations/ProviderIntegrationSetupValidation.cs
@@ -177,9 +177,10 @@ public static class ProviderIntegrationSetupValidator
         var declaredCapabilities = (manifest.Capabilities ?? [])
             .Select(capability => capability.Capability)
             .ToHashSet();
+        var undeclaredCapabilities = new HashSet<ProviderCapabilityKindDto>();
         foreach (var capability in connection.EnabledCapabilities ?? [])
         {
-            if (!declaredCapabilities.Contains(capability))
+            if (!declaredCapabilities.Contains(capability) && undeclaredCapabilities.Add(capability))
             {
                 issues.Add(new ProviderIntegrationSetupValidationIssue(
                     "connection.enabledCapabilities",

--- a/src/Meridian.Ui/dashboard/src/lib/provider-integration-setup-validation.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/provider-integration-setup-validation.test.ts
@@ -124,6 +124,17 @@ describe("validateProviderIntegrationSetupDraft", () => {
     });
   });
 
+  it("reports each undeclared capability once", () => {
+    const connection = createConnection({
+      enabledCapabilities: ["Positions", "Transactions", "Transactions", "Transactions"]
+    });
+
+    const issues = validateProviderIntegrationSetupDraft(createManifest(), connection);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.message).toContain("Transactions");
+  });
+
   it("reports missing capability collections from hand-edited JSON instead of crashing", () => {
     const manifest = {
       ...createManifest(),

--- a/src/Meridian.Ui/dashboard/src/lib/provider-integration-setup-validation.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/provider-integration-setup-validation.ts
@@ -96,8 +96,10 @@ export function validateProviderIntegrationSetupDraft(
       .map((capability) => capability?.capability)
       .filter((capability): capability is NonNullable<typeof capability> => Boolean(capability))
   );
+  const undeclaredCapabilities = new Set<string>();
   for (const capability of Array.isArray(connection.enabledCapabilities) ? connection.enabledCapabilities : []) {
-    if (!declaredCapabilities.has(capability)) {
+    if (!declaredCapabilities.has(capability) && !undeclaredCapabilities.has(capability)) {
+      undeclaredCapabilities.add(capability);
       issues.push({
         field: "connection.enabledCapabilities",
         label: "Connection enabled capabilities",

--- a/tests/Meridian.Tests/Application/Integrations/ProviderIntegrationSetupServiceTests.cs
+++ b/tests/Meridian.Tests/Application/Integrations/ProviderIntegrationSetupServiceTests.cs
@@ -97,6 +97,32 @@ public sealed class ProviderIntegrationSetupServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task SaveDraftAsync_ReportsEachUndeclaredCapabilityOnce()
+    {
+        var service = new ProviderIntegrationSetupService(new FileProviderIntegrationManifestStore(testRoot));
+        var request = CreateRequest();
+        request = request with
+        {
+            Connection = request.Connection with
+            {
+                EnabledCapabilities =
+                [
+                    ProviderCapabilityKindDto.Transactions,
+                    ProviderCapabilityKindDto.Transactions,
+                    ProviderCapabilityKindDto.Transactions
+                ]
+            }
+        };
+
+        var act = () => service.SaveDraftAsync(request);
+
+        var assertion = await act.Should().ThrowAsync<ProviderIntegrationSetupValidationException>();
+        assertion.Which.Issues.Should().ContainSingle(issue =>
+            issue.Code == "provider-setup.connection-capability-not-declared" &&
+            issue.Message.Contains("Transactions", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task SaveDraftAsync_ReportsNullCapabilityCollectionsAsValidationIssues()
     {
         var store = new FileProviderIntegrationManifestStore(testRoot);


### PR DESCRIPTION
### Motivation

- Aardvark flagged an unbounded amplification issue where repeated undeclared `connection.enabledCapabilities` entries could produce very large validation issue lists, exception messages, logs, and RFC 7807 responses.  
- The change bounds the validation output by deduplicating capability issues so a malicious or accidental repeated list cannot cause large-memory or large-response amplification while preserving the aggregated validation contract.

### Description

- Server: deduplicate undeclared capabilities before adding issues in `ProviderIntegrationSetupValidator` by tracking seen undeclared capability kinds with a `HashSet<ProviderCapabilityKindDto>` so each undeclared capability yields at most one issue (`src/Meridian.Application/Integrations/ProviderIntegrationSetupValidation.cs`).
- Client: keep the browser mirror aligned by deduplicating undeclared capabilities in the workstation draft validator (`src/Meridian.Ui/dashboard/src/lib/provider-integration-setup-validation.ts`).
- Tests: add regression coverage that repeated undeclared capabilities produce a single server-side issue and a single client-side draft issue (`tests/Meridian.Tests/Application/Integrations/ProviderIntegrationSetupServiceTests.cs` and `src/Meridian.Ui/dashboard/src/lib/provider-integration-setup-validation.test.ts`).

### Testing

- Ran `npm --prefix src/Meridian.Ui/dashboard ci --include=optional` successfully to install dashboard deps.  
- Ran `npm --prefix src/Meridian.Ui/dashboard run test:vitest -- src/lib/provider-integration-setup-validation.test.ts` and the dashboard tests passed.  
- Ran `npm --prefix src/Meridian.Ui/dashboard run typecheck:strict` and TypeScript strict typecheck passed.  
- Attempted full CI with `bash scripts/ci.sh` but the environment lacks the .NET SDK (`dotnet: command not found`), so server-side .NET tests could not be executed locally; the new C# regression test was added and will run in the repository GitHub Actions CI where the .NET SDK is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f3a68748320be7ae4395f9f8135)