### PR TITLE
fix(ui): prevent stale historical chart indicator crashes

### DIFF
--- a/src/Meridian.Ui/dashboard/src/components/meridian/historical-chart.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/historical-chart.view-model.ts
@@ -695,12 +695,16 @@ export function useHistoricalChartViewModel(symbol: string): HistoricalChartView
   // pipeline runs off the main thread (with a synchronous fallback) so toggling
   // indicators or typing a compare symbol no longer recomputes it on the UI thread.
   const chronologicalCloses = useMemo(() => toChronologicalCloses(state.bars), [state.bars]);
-  const { value: candlestickIndicators } = useOffThreadCompute<number[], CandlestickIndicatorSet>({
+  const currentIndicatorKey = candlestickIndicatorKey(chronologicalCloses);
+  const { value: candlestickIndicators, valueKey: candlestickIndicatorsKey } = useOffThreadCompute<number[], CandlestickIndicatorSet>({
     input: chronologicalCloses,
-    keyOf: candlestickIndicatorKey,
+    keyOf: () => currentIndicatorKey,
     computeSync: computeCandlestickIndicators,
     createWorker: createIndicatorsWorker
   });
+  const currentCandlestickIndicators = candlestickIndicatorsKey === currentIndicatorKey
+    ? candlestickIndicators
+    : undefined;
 
   const sparklineChart = useMemo(
     () => buildHistoricalChartSparklineViewModel({ bars: state.bars, stats, symbol, timeframe: activeTimeframe.label }),
@@ -714,9 +718,9 @@ export function useHistoricalChartViewModel(symbol: string): HistoricalChartView
         symbol,
         timeframe: activeTimeframe.label,
         indicators,
-        precomputedIndicators: candlestickIndicators
+        precomputedIndicators: currentCandlestickIndicators
       }),
-    [state.bars, stats, symbol, activeTimeframe.label, indicators, candlestickIndicators]
+    [state.bars, stats, symbol, activeTimeframe.label, indicators, currentCandlestickIndicators]
   );
 
   return {
@@ -821,9 +825,14 @@ export function buildCandlestickChartViewModel({
   const bodyWidth = Math.max(1.5, slotWidth * 0.65);
 
   const closes = chartBars.map(({ bar }) => bar.close);
+  // Ignore malformed or stale worker output. It must be indexed one-for-one with
+  // the current bars; otherwise calculate indicators for this render synchronously.
+  const compatiblePrecomputedIndicators = hasIndicatorSeriesLength(precomputedIndicators, closes.length)
+    ? precomputedIndicators
+    : undefined;
 
   const bollingerBands = visibility.bollinger
-    ? precomputedIndicators?.bollinger ?? computeBollingerBands(closes, CANDLESTICK_BOLLINGER_PERIOD, CANDLESTICK_BOLLINGER_MULTIPLIER)
+    ? compatiblePrecomputedIndicators?.bollinger ?? computeBollingerBands(closes, CANDLESTICK_BOLLINGER_PERIOD, CANDLESTICK_BOLLINGER_MULTIPLIER)
     : null;
 
   const bollingerExtremes = bollingerBands
@@ -914,7 +923,7 @@ export function buildCandlestickChartViewModel({
   const midXs = candleBars.map((b) => b.midX);
 
   const smaOverlays = visibility.sma
-    ? buildSmaOverlays({ closes, midXs, yForPrice, precomputed: precomputedIndicators })
+    ? buildSmaOverlays({ closes, midXs, yForPrice, precomputed: compatiblePrecomputedIndicators })
     : [];
 
   const bollingerOverlay = visibility.bollinger
@@ -929,7 +938,7 @@ export function buildCandlestickChartViewModel({
         areaHeight: rsiAreaHeight,
         padX,
         width,
-        precomputedRsi: precomputedIndicators?.rsi
+        precomputedRsi: compatiblePrecomputedIndicators?.rsi
       })
     : null;
 
@@ -965,6 +974,16 @@ export function buildCandlestickChartViewModel({
     bollingerOverlay,
     rsiPanel
   };
+}
+
+function hasIndicatorSeriesLength(
+  indicators: CandlestickIndicatorSet | undefined,
+  expectedLength: number
+): indicators is CandlestickIndicatorSet {
+  return indicators !== undefined
+    && indicators.sma.every(({ values }) => values.length === expectedLength)
+    && indicators.bollinger.length === expectedLength
+    && indicators.rsi.length === expectedLength;
 }
 
 interface BuildSmaOverlaysInput {

--- a/src/Meridian.Ui/dashboard/src/lib/historical-chart/indicators.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/historical-chart/indicators.test.ts
@@ -73,4 +73,30 @@ describe("precomputed indicators are behaviorally identical to inline computatio
     expect(offThread?.bollingerOverlay).not.toBeNull();
     expect(offThread?.rsiPanel).not.toBeNull();
   });
+
+  it("ignores stale precomputed series when the current bar set is shorter", () => {
+    const priorBars = syntheticBars(80);
+    const currentBars = syntheticBars(5);
+    const stats = computeChartStats(currentBars);
+    const indicators = { sma: true, bollinger: true, rsi: true };
+    const staleIndicators = computeCandlestickIndicators(toChronologicalCloses(priorBars));
+
+    const inline = buildCandlestickChartViewModel({
+      bars: currentBars,
+      stats,
+      symbol: "AAPL",
+      timeframe: "1m",
+      indicators
+    });
+    const withStaleIndicators = buildCandlestickChartViewModel({
+      bars: currentBars,
+      stats,
+      symbol: "AAPL",
+      timeframe: "1m",
+      indicators,
+      precomputedIndicators: staleIndicators
+    });
+
+    expect(withStaleIndicators).toEqual(inline);
+  });
 });

--- a/src/Meridian.Ui/dashboard/src/lib/perf/off-thread-compute.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/lib/perf/off-thread-compute.test.tsx
@@ -21,8 +21,10 @@ describe("useOffThreadCompute", () => {
     );
 
     expect(result.current.value).toBe(4);
+    expect(result.current.valueKey).toBe("2");
     rerender({ n: 5 });
     await waitFor(() => expect(result.current.value).toBe(10));
+    expect(result.current.valueKey).toBe("5");
   });
 
   it("offloads recomputes to the worker while showing the previous value", async () => {

--- a/src/Meridian.Ui/dashboard/src/lib/perf/off-thread-compute.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/perf/off-thread-compute.ts
@@ -96,6 +96,8 @@ export interface UseOffThreadComputeOptions<I, O> {
 
 export interface OffThreadComputeResult<O> {
   value: O;
+  /** Key for the input that produced `value`; it can lag the current input while a worker runs. */
+  valueKey: string;
   /** True while a worker recompute is in flight (previous value still shown). */
   computing: boolean;
 }
@@ -167,5 +169,5 @@ export function useOffThreadCompute<I, O>({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [key]);
 
-  return { value: state.value, computing };
+  return { value: state.value, valueKey: state.key, computing };
 }


### PR DESCRIPTION
### Motivation
- Off-thread indicator computation could return previously computed indicator arrays that no longer match the current bar series length, causing dereferences like `midXs[i]!.toFixed(2)` to throw during render and crash the chart.
- Ensure the candlestick builder only consumes precomputed indicator arrays that are valid for the current bars, preserving the off-thread performance win while preventing availability failures.

### Description
- Added a `valueKey` to `useOffThreadCompute` (`src/Meridian.Ui/dashboard/src/lib/perf/off-thread-compute.ts`) so consumers can tell which input produced the returned async result and avoid applying stale values.
- Bound off-thread results to the current input in the historical chart view model (`src/Meridian.Ui/dashboard/src/components/meridian/historical-chart.view-model.ts`) and only pass precomputed indicators into `buildCandlestickChartViewModel` when the returned `valueKey` matches the chart’s current indicator key.
- Added a defensive length check `hasIndicatorSeriesLength` in the chart builder to reject malformed or stale `precomputedIndicators` and fall back to synchronous computation for SMA/Bollinger/RSI when series lengths do not match the current bars.
- Updated tests to cover the new behavior by asserting `valueKey` in `useOffThreadCompute` tests and adding a regression test that verifies stale, longer precomputed indicator sets are ignored when the current bars are shorter (`src/Meridian.Ui/dashboard/src/lib/perf/off-thread-compute.test.tsx`, `src/Meridian.Ui/dashboard/src/lib/historical-chart/indicators.test.ts`).

### Testing
- Ran unit tests with `npm --prefix src/Meridian.Ui/dashboard run test:vitest -- src/lib/perf/off-thread-compute.test.tsx src/lib/historical-chart/indicators.test.ts` and they passed (2 files, 9 tests).
- Ran the dashboard build with `npm --prefix src/Meridian.Ui/dashboard run build` (which runs `tsc --noEmit && vite build`) and it completed successfully.
- Ran `npm --prefix src/Meridian.Ui/dashboard ci` to restore dashboard deps successfully (no vulnerabilities found).
- `bash scripts/ci.sh` could not complete in this environment because the .NET SDK is not installed here (`dotnet: command not found`), so final repository-level CI remains to be validated by GitHub Actions as the authoritative check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a612389df8883209f89090d9ddf1f33)