### PR TITLE
fix(ui): scope activity history to browser sessions

### DIFF
--- a/src/Meridian.Ui/dashboard/src/lib/activity-log/activity-log.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/lib/activity-log/activity-log.test.tsx
@@ -38,6 +38,25 @@ function entry(overrides: Partial<ActivityEntry> = {}): ActivityEntry {
 }
 
 describe("activity-log storage", () => {
+  it("uses session storage by default so history does not outlive the browser session", () => {
+    window.localStorage.removeItem(ACTIVITY_LOG_STORAGE_KEY);
+    window.sessionStorage.removeItem(ACTIVITY_LOG_STORAGE_KEY);
+
+    window.localStorage.setItem(
+      ACTIVITY_LOG_STORAGE_KEY,
+      JSON.stringify({ version: 1, entries: [entry({ id: "legacy-local" })] })
+    );
+    expect(loadActivityLog()).toEqual([]);
+
+    saveActivityLog([entry({ id: "session-only" })]);
+
+    expect(loadActivityLog()).toMatchObject([{ id: "session-only", title: "Added SPY" }]);
+    expect(window.localStorage.getItem(ACTIVITY_LOG_STORAGE_KEY)).toContain("legacy-local");
+
+    window.localStorage.removeItem(ACTIVITY_LOG_STORAGE_KEY);
+    window.sessionStorage.removeItem(ACTIVITY_LOG_STORAGE_KEY);
+  });
+
   it("round-trips entries through save/load", () => {
     const storage = memoryStorage();
     saveActivityLog([entry({ id: "a", undoStatus: "undone" })], storage);

--- a/src/Meridian.Ui/dashboard/src/lib/activity-log/storage.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/activity-log/storage.ts
@@ -1,7 +1,6 @@
-// Durable, bounded persistence for the action-history drawer, following the
-// meridian.workstation.<feature>.vN localStorage convention. Undo thunks are
-// in-memory only and never persisted; a reloaded reversible-but-idle entry is
-// downgraded to `expired` (history only) on load.
+// Bounded, session-scoped persistence for the action-history drawer. Undo
+// thunks are in-memory only and never persisted; a reloaded reversible-but-idle
+// entry is downgraded to `expired` (history only) on load.
 import type { ActivityEntry, ActivityTone, ActivityUndoStatus } from "./types";
 
 export const ACTIVITY_LOG_STORAGE_KEY = "meridian.workstation.activity.v1";
@@ -29,7 +28,7 @@ function resolveStorage(storage?: StorageLike | null): StorageLike | null {
     return null;
   }
   try {
-    return window.localStorage;
+    return window.sessionStorage;
   } catch {
     return null;
   }

--- a/src/Meridian.Ui/dashboard/src/lib/activity-log/store.tsx
+++ b/src/Meridian.Ui/dashboard/src/lib/activity-log/store.tsx
@@ -40,7 +40,7 @@ const noopActivityLog: ActivityLogApi = {
 };
 
 export interface UseActivityLogServiceOptions {
-  /** Injectable storage for tests; defaults to localStorage. */
+  /** Injectable storage for tests; defaults to sessionStorage. */
   storage?: StorageLike | null;
   /** Injectable clock for deterministic tests. */
   now?: () => number;


### PR DESCRIPTION
### Motivation

- Prevent persisted workstation activity from leaking between different operators who reuse the same browser profile by scoping the activity ledger to the browser session rather than durable storage.

### Description

- Change storage fallback to use `sessionStorage` instead of `localStorage` so the default persisted activity is session-scoped (`src/.../activity-log/storage.ts`).
- Update the service options documentation to state the storage default is session-scoped while preserving injectable `storage` for tests (`src/.../activity-log/store.tsx`).
- Add a regression test that verifies legacy `localStorage` payloads are ignored and new activity is persisted/read from `sessionStorage` (`src/.../activity-log/activity-log.test.tsx`).
- Preserve existing behavior: undo handlers remain in-memory only, entries continue to be serializable, and the service interface is unchanged.

### Testing

- Ran `npm --prefix src/Meridian.Ui/dashboard run test -- src/lib/activity-log/activity-log.test.tsx`, and the activity-log test suite passed (12 tests).
- Ran `npm --prefix src/Meridian.Ui/dashboard run build`, and the dashboard build step succeeded locally.
- Ran `git diff --check` to verify no whitespace/check issues (no problems found).
- Attempted full local CI via `bash scripts/ci.sh`, but it could not complete in this environment because the `.NET` SDK (`dotnet`) was unavailable (CI exited with code 127); the change is small and JavaScript tests/build passed locally, but the repository-level CI must run on the upstream GitHub Actions gate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f3a7e908320b48b550c88416a60)