### PR TITLE
fix(ledger): reject negative depreciation inputs

### DIFF
--- a/src/Meridian.Ledger/FixedAssetDepreciationDraftBuilder.cs
+++ b/src/Meridian.Ledger/FixedAssetDepreciationDraftBuilder.cs
@@ -12,7 +12,8 @@ public static class FixedAssetDepreciationDraftBuilder
 {
     /// <summary>
     /// Builds one balanced depreciation draft covering every asset in <paramref name="assets"/> whose
-    /// charge is positive. Returns null when no asset has a charge to post.
+    /// charge is positive. Zero charges are skipped; negative charges are rejected. Returns null when
+    /// no asset has a charge to post.
     /// </summary>
     /// <param name="periodEnd">The accounting period the depreciation run belongs to.</param>
     /// <param name="asOf">Timestamp used for the journal event and retained evidence.</param>
@@ -27,6 +28,9 @@ public static class FixedAssetDepreciationDraftBuilder
         string? description = null)
     {
         ArgumentNullException.ThrowIfNull(assets);
+
+        if (assets.Any(static asset => asset is not null && asset.DepreciationAmount < 0m))
+            throw new ArgumentOutOfRangeException(nameof(assets), "Depreciation amount cannot be negative.");
 
         var projected = assets
             .Where(static asset => asset is not null && asset.DepreciationAmount > 0m)

--- a/tests/Meridian.Tests/Ledger/FixedAssetDepreciationDraftBuilderTests.cs
+++ b/tests/Meridian.Tests/Ledger/FixedAssetDepreciationDraftBuilderTests.cs
@@ -48,7 +48,7 @@ public sealed class FixedAssetDepreciationDraftBuilderTests
     }
 
     [Fact]
-    public void BuildDraft_SkipsZeroAndNegativeCharges()
+    public void BuildDraft_SkipsZeroCharges()
     {
         var draft = FixedAssetDepreciationDraftBuilder.BuildDraft(
             PeriodEnd,
@@ -58,6 +58,18 @@ public sealed class FixedAssetDepreciationDraftBuilderTests
         draft.Should().NotBeNull();
         draft!.Lines.Should().HaveCount(2); // only AssetB projected
         draft.TotalDebits.Should().Be(150m);
+    }
+
+    [Fact]
+    public void BuildDraft_NegativeCharge_ThrowsInsteadOfSilentlyOmittingAsset()
+    {
+        var build = () => FixedAssetDepreciationDraftBuilder.BuildDraft(
+            PeriodEnd,
+            AsOf,
+            [Input(AssetA, -100m), Input(AssetB, 150m)]);
+
+        build.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("assets");
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation

- Prevent malformed negative depreciation amounts from being silently omitted during batching so governed drafts cannot understate depreciation expense without an audit signal. 
- Preserve the intended behavior that zero charges are no-ops and may be skipped. 

### Description

- Add a fail-closed validation to `FixedAssetDepreciationDraftBuilder.BuildDraft` that throws `ArgumentOutOfRangeException` when any `DepreciationInput.DepreciationAmount` is negative. 
- Clarify the XML doc comment to state that zero charges are skipped and negative charges are rejected. 
- Add a regression unit test `BuildDraft_NegativeCharge_ThrowsInsteadOfSilentlyOmittingAsset` and rename the existing mixed-case test to `BuildDraft_SkipsZeroCharges` to reflect the tightened contract. 

### Testing

- Ran `git diff --check` (repository lint) which passed without whitespace issues. 
- Attempted to run the repository CI script `bash scripts/ci.sh` but it could not complete in this environment because the `.NET SDK` is not available (`dotnet: command not found`). 
- Added unit test coverage for the rejected-negative-input behavior; these tests were added but could not be executed here due to the missing `.NET SDK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f3b04588320b76ca8adb5a72ebe)