### PR TITLE
Fix Security Master profile term validation scope

### DIFF
--- a/src/Meridian.Application/SecurityMaster/Validation/AssetClassValidatorRegistry.cs
+++ b/src/Meridian.Application/SecurityMaster/Validation/AssetClassValidatorRegistry.cs
@@ -663,7 +663,7 @@ internal sealed record FieldRule(
     public SecurityValidationIssueDto? Validate(SecurityValidationContext context)
     {
         var field = $"assetSpecificTerms.{FieldPath}";
-        if (!JsonValidationReader.TryGetAssetTermProperty(context.Record.AssetSpecificTerms, FieldPath, out var property))
+        if (!JsonValidationReader.TryGetAssetTermProperty(context.Record.AssetSpecificTerms, FieldPath, context.Record.AssetClass, out var property))
         {
             return RequiresPresence(RuleKind)
                 ? Issue(field)
@@ -720,8 +720,8 @@ internal sealed record DateOrderRule(
 
     public SecurityValidationIssueDto? Validate(SecurityValidationContext context)
     {
-        var hasStart = JsonValidationReader.TryGetAssetTermDate(context.Record.AssetSpecificTerms, StartFieldPath, out var start);
-        var hasEnd = JsonValidationReader.TryGetAssetTermDate(context.Record.AssetSpecificTerms, EndFieldPath, out var end);
+        var hasStart = JsonValidationReader.TryGetAssetTermDate(context.Record.AssetSpecificTerms, StartFieldPath, context.Record.AssetClass, out var start);
+        var hasEnd = JsonValidationReader.TryGetAssetTermDate(context.Record.AssetSpecificTerms, EndFieldPath, context.Record.AssetClass, out var end);
         if (!hasStart || !hasEnd)
         {
             return RequiresBothFields
@@ -754,8 +754,8 @@ internal sealed record DistinctStringRule(
 
     public SecurityValidationIssueDto? Validate(SecurityValidationContext context)
     {
-        if (!JsonValidationReader.TryGetAssetTermString(context.Record.AssetSpecificTerms, LeftFieldPath, out var left)
-            || !JsonValidationReader.TryGetAssetTermString(context.Record.AssetSpecificTerms, RightFieldPath, out var right))
+        if (!JsonValidationReader.TryGetAssetTermString(context.Record.AssetSpecificTerms, LeftFieldPath, context.Record.AssetClass, out var left)
+            || !JsonValidationReader.TryGetAssetTermString(context.Record.AssetSpecificTerms, RightFieldPath, context.Record.AssetClass, out var right))
         {
             return null;
         }
@@ -807,14 +807,15 @@ internal static class JsonValidationReader
         return true;
     }
 
-    public static bool TryGetAssetTermProperty(JsonElement root, string path, out JsonElement property)
+    public static bool TryGetAssetTermProperty(JsonElement root, string path, string assetClass, out JsonElement property)
     {
         if (TryGetProperty(root, path, out property))
         {
             return true;
         }
 
-        if (TryGetProperty(root, "profileFields", out var profileFields)
+        if (SupportsProfileBackedTerms(assetClass)
+            && TryGetProperty(root, "profileFields", out var profileFields)
             && TryGetProperty(profileFields, path, out property))
         {
             return true;
@@ -823,6 +824,15 @@ internal static class JsonValidationReader
         property = default;
         return false;
     }
+
+    private static bool SupportsProfileBackedTerms(string assetClass)
+        => string.Equals(assetClass, "CustomAsset", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(assetClass, "OtherSecurity", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(assetClass, "StructuredCredit", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(assetClass, "PrivateFundInterest", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(assetClass, "PrivateCompanyEquity", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(assetClass, "RealEstateHolding", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(assetClass, "CommitmentGuarantee", StringComparison.OrdinalIgnoreCase);
 
     public static bool HasNonBlankString(JsonElement property)
         => property.ValueKind == JsonValueKind.String
@@ -859,10 +869,10 @@ internal static class JsonValidationReader
         return true;
     }
 
-    public static bool TryGetAssetTermString(JsonElement root, string path, out string value)
+    public static bool TryGetAssetTermString(JsonElement root, string path, string assetClass, out string value)
     {
         value = string.Empty;
-        if (!TryGetAssetTermProperty(root, path, out var property) || property.ValueKind != JsonValueKind.String)
+        if (!TryGetAssetTermProperty(root, path, assetClass, out var property) || property.ValueKind != JsonValueKind.String)
         {
             return false;
         }
@@ -905,10 +915,10 @@ internal static class JsonValidationReader
         return DateOnly.TryParse(property.GetString(), CultureInfo.InvariantCulture, DateTimeStyles.None, out value);
     }
 
-    public static bool TryGetAssetTermDate(JsonElement root, string path, out DateOnly value)
+    public static bool TryGetAssetTermDate(JsonElement root, string path, string assetClass, out DateOnly value)
     {
         value = default;
-        if (!TryGetAssetTermProperty(root, path, out var property) || property.ValueKind != JsonValueKind.String)
+        if (!TryGetAssetTermProperty(root, path, assetClass, out var property) || property.ValueKind != JsonValueKind.String)
         {
             return false;
         }

--- a/tests/Meridian.Tests/SecurityMaster/SecurityValidationServiceTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/SecurityValidationServiceTests.cs
@@ -179,6 +179,41 @@ public sealed class SecurityValidationServiceTests
     }
 
     [Fact]
+    public void Scenario_OptionTermsHiddenInProfileFields_BlockValidationReadiness()
+    {
+        var record = CreateProjection(
+            Guid.NewGuid(),
+            "Option",
+            [CreateIdentifier(SecurityIdentifierKind.ProviderSymbol, "AAPL260620C00100000", isPrimary: true, provider: "OPRA")],
+            assetSpecificTerms: JsonSerializer.SerializeToElement(new
+            {
+                profileFields = new
+                {
+                    underlyingId = Guid.NewGuid(),
+                    putCall = "Call",
+                    strike = 100m,
+                    expiry = "2026-06-20",
+                    multiplier = 100m
+                },
+                valuationProfile = new { pricingSource = "OPRA" },
+                accountingClassification = "DerivativeAsset"
+            }));
+        var service = new SecurityValidationService(
+            Substitute.For<ISecurityMasterStore>(),
+            AssetClassValidatorRegistry.CreateDefault());
+
+        var report = service.ValidateRecord(record, [record], Now);
+
+        report.HasBlockingIssues.Should().BeTrue();
+        report.Issues.Select(static issue => issue.Code).Should().Contain(
+            "SM_OPTION_UNDERLYING_REQUIRED",
+            "SM_OPTION_PUT_CALL_INVALID",
+            "SM_OPTION_STRIKE_INVALID",
+            "SM_OPTION_EXPIRY_REQUIRED",
+            "SM_OPTION_MULTIPLIER_INVALID");
+    }
+
+    [Fact]
     public void Scenario_UnsupportedAssetClass_ProducesActionableRegistryIssue()
     {
         var record = CreateProjection(


### PR DESCRIPTION
### Motivation
- A global fallback caused validators to accept `assetSpecificTerms.profileFields` for all asset classes, allowing non-profile-backed instruments (e.g. Option, Future, Bond, FxSpot) to bypass required top-level term checks and creating a mismatch with downstream mapping.

### Description
- Scope profile-backed lookup by adding an `assetClass` parameter to `JsonValidationReader.TryGetAssetTermProperty` and only falling back to `profileFields` when the asset class supports profile-backed terms via `SupportsProfileBackedTerms`.
- Propagate `context.Record.AssetClass` into `FieldRule`, `DateOrderRule`, and `DistinctStringRule` validations so property/date/string lookups use the scoped lookup signature.
- Added `TryGetAssetTermString` and `TryGetAssetTermDate` overloads that accept `assetClass` and updated call sites accordingly.
- Added a regression test `Scenario_OptionTermsHiddenInProfileFields_BlockValidationReadiness` to ensure an `Option` with required terms only under `profileFields` remains blocked by validation.

### Testing
- Ran `git diff --check` locally; no diff-check issues were reported.
- Attempted `bash scripts/ci.sh`, which initially failed locally because `dotnet` was not present in the environment; this is an environment constraint not related to the change.
- Installed .NET SDK 10.0.100 and invoked a targeted run `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj -c Release --filter 'FullyQualifiedName~SecurityValidationServiceTests'`; restore/build started and the filtered test run was launched, but the constrained environment did not produce a final test-suite summary here; GitHub Actions remains the authoritative CI and will run the full test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f3a62688320b282a31d81094cdc)