### PR TITLE
fix(web): keep explorer state out of URLs

### DIFF
--- a/src/Meridian.Ui/dashboard/src/components/meridian/financial-record-explorer.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/financial-record-explorer.test.tsx
@@ -279,28 +279,25 @@ describe("FinancialRecordExplorerShell", () => {
     }));
   });
 
-  it("persists the current explorer evidence state into the browser URL", async () => {
+  it("keeps explorer evidence state out of the browser URL until it is explicitly shared", async () => {
     const user = userEvent.setup();
     window.history.replaceState(null, "", "/accounting?period=2026-06");
     renderExplorer();
 
-    await waitFor(() => {
-      expect(window.location.href).toContain("period=2026-06");
-      expect(window.location.href).toContain("frexExplorer=ledger");
-      expect(window.location.href).toContain("frexView=system-ledger-default");
-      expect(window.location.href).toContain("frexRecord=ledger%3Arun-1%3Acash");
-    });
+    expect(window.location.pathname).toBe("/accounting");
+    expect(window.location.search).toBe("?period=2026-06");
 
     await user.click(screen.getByRole("row", { name: /revenue income aapl/i }));
     await user.click(screen.getByRole("button", { name: "Close drawer" }));
     expect(screen.queryByRole("dialog", { name: "Revenue proof detail" })).not.toBeInTheDocument();
     await user.type(screen.getByRole("textbox", { name: "Search Ledger Explorer" }), "aapl");
 
-    await waitFor(() => {
-      expect(window.location.href).toContain("period=2026-06");
-      expect(window.location.href).toContain("frexSearch=aapl");
-      expect(window.location.href).toContain("frexRecord=ledger%3Arun-1%3Arevenue");
-    });
+    expect(window.location.pathname).toBe("/accounting");
+    expect(window.location.search).toBe("?period=2026-06");
+    expect(screen.getByRole("link", { name: /share ledger explorer evidence state/i })).toHaveAttribute(
+      "href",
+      "/accounting?period=2026-06&frexExplorer=ledger&frexView=system-ledger-default&frexSearch=aapl&frexRecord=ledger%3Arun-1%3Arevenue"
+    );
   });
 
   it("renders Security & Instrument Explorer DTO fields used by WPF parity proof", async () => {

--- a/src/Meridian.Ui/dashboard/src/components/meridian/financial-record-explorer.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/financial-record-explorer.tsx
@@ -201,17 +201,6 @@ export function FinancialRecordExplorerShell({
     currentHref: getCurrentExplorerHref()
   });
 
-  useEffect(() => {
-    if (!dtoMode || typeof window === "undefined" || shareHref === "#") {
-      return;
-    }
-
-    const currentHref = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-    if (currentHref !== shareHref) {
-      window.history.replaceState(window.history.state, "", shareHref);
-    }
-  }, [dtoMode, shareHref]);
-
   async function handleSaveView() {
     if (!dtoMode || !onSaveView || !canSaveView) {
       return;


### PR DESCRIPTION
### Motivation
- Prevent passive leakage of investigator-controlled explorer state (search text, filters, selected record/view) into the browser URL, history, bookmarks, and logs.  
- The existing behavior called `window.history.replaceState` on render and interaction, which materialized sensitive context without explicit user intent.  
- Keep sharing functionality intact but require an explicit share action to surface state in a URL.

### Description
- Remove the passive effect that invoked `window.history.replaceState(...)` when `shareHref` changed so explorer interactions no longer mutate the address bar.  
- Preserve the existing `buildShareableExplorerHref(...)` and the Share action/link so users can still produce a shareable URL explicitly.  
- Update the component test to assert that normal interactions keep the current browser URL unchanged and that the explicit share link contains the generated explorer state.

### Testing
- Ran `npm --prefix src/Meridian.Ui/dashboard ci` and package installation completed successfully.  
- Ran the targeted unit test command `npm --prefix src/Meridian.Ui/dashboard run test:vitest -- src/components/meridian/financial-record-explorer.test.tsx` and the file's 15 tests passed.  
- Ran `npm --prefix src/Meridian.Ui/dashboard run build` which completed successfully and `git diff --check` had no issues.  
- `bash scripts/ci.sh` could not complete the full CI validation in this environment because `dotnet` is not available, so repository-level GitHub Actions should be relied on for final validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f39ce0c8320ad4b1005cdbe224f)