### PR TITLE
fix(reconciliation): snapshot canonical statement intake

### DIFF
--- a/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs
@@ -366,19 +366,18 @@ public sealed class StatementReconciliationService
             return new ExternalStatementCaseIntakeResult(importId, normalizedSourceKind, sourcePath, 0, 0, []);
         }
 
-        var rows = ReadCanonicalStatementRows(normalizedSourceKind, sourcePath, mappingProfileId);
-        var (matches, cases) = MatchRows(rows);
-        // Compute the import id from the resolved profile and file content, identical to the import
-        // path (and to ReadCanonicalStatementRows for non-empty files), so import and reconcile/intake
-        // refer to the same run even for a valid but empty (header-only) statement.
-        var profile = _mappingProfiles.ResolveForSourceKind(normalizedSourceKind, mappingProfileId);
         var canonicalContent = File.ReadAllText(sourcePath);
-        var canonicalImportId = DeterministicFingerprint.Compute($"{normalizedSourceKind}|{profile.ProfileId}|{sourcePath}|{canonicalContent}");
-        return new ExternalStatementCaseIntakeResult(
-            canonicalImportId,
+        var canonicalStatement = ReadCanonicalStatementRows(
             normalizedSourceKind,
             sourcePath,
-            rows.Count,
+            mappingProfileId,
+            canonicalContent);
+        var (matches, cases) = MatchRows(canonicalStatement.Rows);
+        return new ExternalStatementCaseIntakeResult(
+            canonicalStatement.ImportId,
+            normalizedSourceKind,
+            sourcePath,
+            canonicalStatement.Rows.Count,
             matches.Count,
             cases);
     }
@@ -550,17 +549,22 @@ public sealed class StatementReconciliationService
         }
     }
 
-    private IReadOnlyList<NormalizedStatementRow> ReadCanonicalStatementRows(string normalizedSourceKind, string sourcePath, string? mappingProfileId = null)
+    private CanonicalStatementReadResult ReadCanonicalStatementRows(
+        string normalizedSourceKind,
+        string sourcePath,
+        string? mappingProfileId,
+        string content)
     {
-        var profile = ValidateStatementHeader(normalizedSourceKind, sourcePath, mappingProfileId);
+        using var reader = new StringReader(content);
+        var headerLine = reader.ReadLine();
+        var profile = ValidateStatementHeader(normalizedSourceKind, mappingProfileId, headerLine);
 
-        var content = File.ReadAllText(sourcePath);
         var importId = DeterministicFingerprint.Compute($"{normalizedSourceKind}|{profile.ProfileId}|{sourcePath}|{content}");
         var rows = new List<NormalizedStatementRow>();
-        var header = File.ReadLines(sourcePath).First().Split(',', StringSplitOptions.TrimEntries);
-        var lines = File.ReadLines(sourcePath).Skip(1);
+        var header = headerLine!.Split(',', StringSplitOptions.TrimEntries);
         var rowNumber = 1;
-        foreach (var line in lines)
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
         {
             rowNumber++;
             if (string.IsNullOrWhiteSpace(line))
@@ -632,14 +636,19 @@ public sealed class StatementReconciliationService
                 rawSnapshot));
         }
 
-        return rows;
+        return new CanonicalStatementReadResult(importId, rows);
     }
 
 
     private StatementMappingProfile ValidateStatementHeader(string normalizedSourceKind, string sourcePath, string? mappingProfileId = null)
     {
-        var profile = _mappingProfiles.ResolveForSourceKind(normalizedSourceKind, mappingProfileId);
         var header = File.ReadLines(sourcePath).FirstOrDefault();
+        return ValidateStatementHeader(normalizedSourceKind, mappingProfileId, header);
+    }
+
+    private StatementMappingProfile ValidateStatementHeader(string normalizedSourceKind, string? mappingProfileId, string? header)
+    {
+        var profile = _mappingProfiles.ResolveForSourceKind(normalizedSourceKind, mappingProfileId);
         if (string.IsNullOrWhiteSpace(header))
         {
             throw new InvalidDataException("Statement source file is empty.");
@@ -665,6 +674,8 @@ public sealed class StatementReconciliationService
 
         return profile;
     }
+
+    private sealed record CanonicalStatementReadResult(string ImportId, IReadOnlyList<NormalizedStatementRow> Rows);
 
     private static void EnsureUniqueStatementHeaderColumns(string[] header, string profileId)
     {

--- a/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
+++ b/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
@@ -320,6 +320,7 @@ public sealed class StatementReconciliationServiceTests
 
             Assert.Equal(1, intake.RowCount);
             Assert.Single(intake.Cases);
+            Assert.Equal(intake.ImportId, intake.Cases[0].ImportId);
         }
         finally
         {


### PR DESCRIPTION
### Motivation
- Prevent a TOCTOU integrity mismatch where canonical rows/cases were parsed from one file snapshot but the top-level intake `ImportId` was recomputed from a second file read.  This could desynchronize evidence and case IDs if the source file changed between reads.

### Description
- Snapshot the canonical statement content once (`File.ReadAllText`) and pass the immutable content into a new `ReadCanonicalStatementRows` flow that returns a `CanonicalStatementReadResult` containing the `ImportId` and parsed rows.
- Derive the intake `ImportId`, row IDs, and case IDs from that same snapshot so rows/cases and the top-level intake all share the same `ImportId` and avoid TOCTOU races.  (`StatementReconciliationService.cs` changes).
- Add a targeted regression assertion ensuring a case-producing canonical statement has `case.ImportId == intake.ImportId` (test updated in `tests/Meridian.Tests/StatementReconciliationServiceTests.cs`).

### Testing
- Ran `git diff --check` which passed. 
- Ran `python3 build/python/cli/buildctl.py validation-status --summary` which passed (no active build locks reported). 
- Ran `bash scripts/ci.sh` in this environment but it is blocked because the container lacks the .NET SDK (`dotnet` not found), so full CI could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f3a9f088320b094d310dd0e3e14)