### PR TITLE
fix(security-master): atomically guard overlay edits

### DIFF
--- a/src/Meridian.Application/SecurityMaster/NullSecurityMasterServices.cs
+++ b/src/Meridian.Application/SecurityMaster/NullSecurityMasterServices.cs
@@ -265,7 +265,8 @@ internal sealed class NullOperatorOverridesStore : IOperatorOverridesStore
         Guid securityId,
         OperatorOverridesPatchRequest request,
         string updatedBy,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        long? expectedCanonicalVersion = null)
         => Task.FromException<OperatorOverridesDto>(new InvalidOperationException(
             "Security Master is not configured. " +
             "Set the MERIDIAN_SECURITY_MASTER_CONNECTION_STRING environment variable to enable operator overrides."));

--- a/src/Meridian.Application/SecurityMaster/SecurityMasterWorkbenchCommandService.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityMasterWorkbenchCommandService.cs
@@ -12,7 +12,7 @@ namespace Meridian.Application.SecurityMaster;
 /// <list type="bullet">
 ///   <item><c>UpdateSecurityFieldAsync</c> — justification-gated operator field edits staged as
 ///     overlay annotations in <see cref="IOperatorOverridesStore"/>. The passport-displayed security
-///     version is a read-only staleness guard (a stale <c>ExpectedVersion</c> surfaces as
+///     version is an optimistic-concurrency staleness guard (a stale <c>ExpectedVersion</c> surfaces as
 ///     <see cref="SecurityMasterConcurrencyException"/> → HTTP 409). Overlay edits are deliberately
 ///     NOT appended to the economic event stream: that stream is replayed verbatim to rebuild the
 ///     passport, so a partial field-edit payload would corrupt the economic definition.</item>
@@ -87,9 +87,10 @@ public sealed class SecurityMasterWorkbenchCommandService : ISecurityMasterWorkb
                 "Operator field edits require a justification.", nameof(request));
         }
 
-        // The passport-displayed security version is a read-only staleness guard: a stale view of
-        // the canonical security (it was amended/deactivated since the operator loaded it) is
-        // rejected before any overlay write. Operator field edits are overlay annotations and must
+        // The passport-displayed security version is an optimistic-concurrency staleness guard: a
+        // stale view of the canonical security (it was amended/deactivated since the operator
+        // loaded it) is rejected before any overlay write and rechecked atomically by the store.
+        // Operator field edits are overlay annotations and must
         // NOT be appended to the economic event stream — that stream is replayed verbatim through
         // SecurityMasterMapping.FromEconomicPayload to rebuild the passport, so a partial
         // field-edit payload would clobber the economic definition on the next reload/replay.
@@ -119,7 +120,24 @@ public sealed class SecurityMasterWorkbenchCommandService : ISecurityMasterWorkb
         {
             ReasonCode = request.Justification,
         };
-        await _overrides.PatchAsync(request.SecurityId, patch, request.Actor, ct).ConfigureAwait(false);
+        try
+        {
+            await _overrides
+                .PatchAsync(
+                    request.SecurityId,
+                    patch,
+                    request.Actor,
+                    ct,
+                    expectedCanonicalVersion: currentVersion)
+                .ConfigureAwait(false);
+        }
+        catch (OperatorOverrideCanonicalVersionConflictException ex)
+        {
+            throw new SecurityMasterConcurrencyException(
+                request.SecurityId,
+                request.ExpectedVersion,
+                ex.CurrentVersion);
+        }
 
         // Open a durable Draft revision carrying the field-edit metadata so the governed lifecycle
         // (submit → approve → publish) is anchored to a real, server-issued revision id, and publish

--- a/src/Meridian.Storage/SecurityMaster/IOperatorOverridesStore.cs
+++ b/src/Meridian.Storage/SecurityMaster/IOperatorOverridesStore.cs
@@ -15,7 +15,8 @@ public interface IOperatorOverridesStore
         Guid securityId,
         OperatorOverridesPatchRequest request,
         string updatedBy,
-        CancellationToken ct = default);
+        CancellationToken ct = default,
+        long? expectedCanonicalVersion = null);
 
     /// <summary>
     /// Records a reviewer's Approved/Rejected decision on the current override overlay, stamping the
@@ -38,3 +39,22 @@ public sealed record OperatorOverrideDecision(
     SecurityOverrideApprovalStatusDto Decision,
     string Reviewer,
     string? Comment = null);
+
+/// <summary>
+/// Thrown when an overlay patch was submitted for a canonical Security Master version that no
+/// longer matches the stream version observed while the patch transaction held the stream lock.
+/// </summary>
+public sealed class OperatorOverrideCanonicalVersionConflictException : InvalidOperationException
+{
+    public OperatorOverrideCanonicalVersionConflictException(Guid securityId, long expectedVersion, long currentVersion)
+        : base($"Security stream version conflict for {securityId}. Expected {expectedVersion}, actual {currentVersion}.")
+    {
+        SecurityId = securityId;
+        ExpectedVersion = expectedVersion;
+        CurrentVersion = currentVersion;
+    }
+
+    public Guid SecurityId { get; }
+    public long ExpectedVersion { get; }
+    public long CurrentVersion { get; }
+}

--- a/src/Meridian.Storage/SecurityMaster/PostgresOperatorOverridesStore.cs
+++ b/src/Meridian.Storage/SecurityMaster/PostgresOperatorOverridesStore.cs
@@ -51,7 +51,8 @@ public sealed class PostgresOperatorOverridesStore : IOperatorOverridesStore
         Guid securityId,
         OperatorOverridesPatchRequest request,
         string updatedBy,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        long? expectedCanonicalVersion = null)
     {
         if (string.IsNullOrWhiteSpace(updatedBy))
         {
@@ -62,6 +63,19 @@ public sealed class PostgresOperatorOverridesStore : IOperatorOverridesStore
         await using var transaction = await connection
             .BeginTransactionAsync(IsolationLevel.Serializable, ct)
             .ConfigureAwait(false);
+
+        if (expectedCanonicalVersion is { } expectedVersion)
+        {
+            // Coordinate with event-stream appends before reading its head. A row lock alone cannot
+            // protect an empty stream, and a separate read followed by this patch would permit a
+            // canonical amendment to slip between the stale-view check and the overlay write.
+            await LockCanonicalStreamAsync(connection, transaction, securityId, ct).ConfigureAwait(false);
+            var currentVersion = await LoadCanonicalVersionAsync(connection, transaction, securityId, ct).ConfigureAwait(false);
+            if (currentVersion != expectedVersion)
+            {
+                throw new OperatorOverrideCanonicalVersionConflictException(securityId, expectedVersion, currentVersion);
+            }
+        }
 
         var (current, currentAudit) = await LoadForUpdateAsync(connection, transaction, securityId, ct).ConfigureAwait(false);
         var next = new Dictionary<string, string>(current, StringComparer.Ordinal);
@@ -239,6 +253,33 @@ public sealed class PostgresOperatorOverridesStore : IOperatorOverridesStore
             ReviewedAt = reviewedAt,
             AuditTrail = auditTrail
         };
+    }
+
+    private async Task LockCanonicalStreamAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        Guid securityId,
+        CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = "select pg_advisory_xact_lock(hashtext(@security_id::text));";
+        command.Parameters.AddWithValue("security_id", securityId);
+        await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    private async Task<long> LoadCanonicalVersionAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        Guid securityId,
+        CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText =
+            $"select coalesce(max(stream_version), 0) from {Qualified(\"security_events\")} where security_id = @security_id;";
+        command.Parameters.AddWithValue("security_id", securityId);
+        return (long)(await command.ExecuteScalarAsync(ct).ConfigureAwait(false) ?? 0L);
     }
 
     private async Task<(Dictionary<string, string> Values, IReadOnlyList<SecurityOverrideAuditEntryDto> AuditTrail)> LoadForUpdateAsync(

--- a/src/Meridian.Storage/SecurityMaster/PostgresSecurityMasterEventStore.cs
+++ b/src/Meridian.Storage/SecurityMaster/PostgresSecurityMasterEventStore.cs
@@ -29,6 +29,10 @@ public sealed class PostgresSecurityMasterEventStore : ISecurityMasterEventStore
         await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
         await using var transaction = await connection.BeginTransactionAsync(IsolationLevel.Serializable, ct).ConfigureAwait(false);
 
+        // Overlay edits acquire the same transaction-scoped lock before checking the stream head.
+        // This makes their expected-version guard atomic with canonical appends without placing
+        // partial operator annotations in the replayed economic event stream.
+        await LockStreamAsync(connection, transaction, securityId, ct).ConfigureAwait(false);
         var currentVersion = await LoadCurrentVersionAsync(connection, transaction, securityId, ct).ConfigureAwait(false);
         if (currentVersion != expectedVersion)
         {
@@ -161,6 +165,19 @@ public sealed class PostgresSecurityMasterEventStore : ISecurityMasterEventStore
             """;
         command.Parameters.AddWithValue("security_id", securityId);
         return (long)(await command.ExecuteScalarAsync(ct).ConfigureAwait(false) ?? 0L);
+    }
+
+    private static async Task LockStreamAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        Guid securityId,
+        CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = "select pg_advisory_xact_lock(hashtext(@security_id::text));";
+        command.Parameters.AddWithValue("security_id", securityId);
+        await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
     }
 
     private async Task<IReadOnlyList<SecurityMasterEventEnvelope>> ReadEventsAsync(NpgsqlCommand command, CancellationToken ct)

--- a/tests/Meridian.Tests/SecurityMaster/Workbench/SecurityMasterWorkbenchCommandServiceTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/Workbench/SecurityMasterWorkbenchCommandServiceTests.cs
@@ -73,7 +73,7 @@ public sealed class SecurityMasterWorkbenchCommandServiceTests
         await harness.Service.Invoking(s => s.UpdateSecurityFieldAsync(request))
             .Should().ThrowAsync<InvalidOperationException>();
         harness.Overrides.Verify(
-            o => o.PatchAsync(It.IsAny<Guid>(), It.IsAny<OperatorOverridesPatchRequest>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            o => o.PatchAsync(It.IsAny<Guid>(), It.IsAny<OperatorOverridesPatchRequest>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<long?>()),
             Times.Never);
     }
 
@@ -118,8 +118,39 @@ public sealed class SecurityMasterWorkbenchCommandServiceTests
                 SecurityId,
                 It.Is<OperatorOverridesPatchRequest>(p => p.SetValues != null && p.SetValues.ContainsKey("EconomicDefinition.Coupon")),
                 "ops.analyst",
-                It.IsAny<CancellationToken>()),
+                It.IsAny<CancellationToken>(),
+                7),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateSecurityField_CanonicalVersionAdvancesDuringOverlayPatch_ThrowsConcurrency()
+    {
+        var harness = new Harness(currentVersion: 7);
+        harness.Overrides
+            .Setup(o => o.PatchAsync(
+                SecurityId,
+                It.IsAny<OperatorOverridesPatchRequest>(),
+                "ops.analyst",
+                It.IsAny<CancellationToken>(),
+                7))
+            .ThrowsAsync(new OperatorOverrideCanonicalVersionConflictException(SecurityId, 7, 8));
+
+        var request = new UpdateSecurityFieldRequest(
+            SecurityId,
+            ExpectedVersion: 7,
+            FieldPath: "EconomicDefinition.Coupon",
+            NewValue: "4.250",
+            EffectiveFrom: DateTimeOffset.UtcNow,
+            Actor: "ops.analyst",
+            Justification: "Corrected coupon per agent term sheet.");
+
+        var exception = await harness.Service.Invoking(s => s.UpdateSecurityFieldAsync(request))
+            .Should().ThrowAsync<SecurityMasterConcurrencyException>();
+
+        exception.Which.ExpectedVersion.Should().Be(7);
+        exception.Which.CurrentVersion.Should().Be(8);
+        harness.EventStore.Appends.Should().BeEmpty("the retry-safe overlay remains outside the economic stream");
     }
 
     // ---- ResolveSourceConflict (validation guards) --------------------------------------------
@@ -662,8 +693,8 @@ public sealed class SecurityMasterWorkbenchCommandServiceTests
             EventStore = new FakeEventStore(currentVersion);
 
             Overrides
-                .Setup(o => o.PatchAsync(It.IsAny<Guid>(), It.IsAny<OperatorOverridesPatchRequest>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((Guid id, OperatorOverridesPatchRequest _, string actor, CancellationToken _) =>
+                .Setup(o => o.PatchAsync(It.IsAny<Guid>(), It.IsAny<OperatorOverridesPatchRequest>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<long?>()))
+                .ReturnsAsync((Guid id, OperatorOverridesPatchRequest _, string actor, CancellationToken _, long? _) =>
                     new OperatorOverridesDto(id, new Dictionary<string, string>(), actor, DateTimeOffset.UtcNow));
 
             QueryService

--- a/tests/Meridian.Tests/Ui/ProviderLedgerReconciliationServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/ProviderLedgerReconciliationServiceTests.cs
@@ -3390,7 +3390,8 @@ public sealed class ProviderLedgerReconciliationServiceTests
             Guid requestedSecurityId,
             OperatorOverridesPatchRequest request,
             string updatedBy,
-            CancellationToken ct = default) =>
+            CancellationToken ct = default,
+            long? expectedCanonicalVersion = null) =>
             throw new NotSupportedException();
 
         public Task<OperatorOverridesDto> RecordApprovalDecisionAsync(

--- a/tests/Meridian.Tests/Ui/SecurityMasterExceptionCaseworkServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/SecurityMasterExceptionCaseworkServiceTests.cs
@@ -705,7 +705,8 @@ public sealed class SecurityMasterExceptionCaseworkServiceTests
             Guid securityId,
             OperatorOverridesPatchRequest request,
             string updatedBy,
-            CancellationToken ct = default)
+            CancellationToken ct = default,
+            long? expectedCanonicalVersion = null)
         {
             var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             if (_overrides.TryGetValue(securityId, out var existing))

--- a/tests/Meridian.Tests/Ui/SecurityMasterOperatorOverrideDecisionEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/SecurityMasterOperatorOverrideDecisionEndpointsTests.cs
@@ -132,7 +132,8 @@ public sealed class SecurityMasterOperatorOverrideDecisionEndpointsTests
             Guid securityId,
             OperatorOverridesPatchRequest request,
             string updatedBy,
-            CancellationToken ct = default)
+            CancellationToken ct = default,
+            long? expectedCanonicalVersion = null)
             => throw new NotSupportedException();
 
         public Task<OperatorOverridesDto> RecordApprovalDecisionAsync(


### PR DESCRIPTION
### Motivation
- Close a TOCTOU race where operator overlay patches could be committed against a stale canonical Security Master stream head, bypassing the intended `ExpectedVersion` 409 guard. 
- Preserve the overlay-only model (no operator events appended to the economic replay stream) while restoring atomic optimistic-concurrency checks.

### Description
- Add an optional expected-version precondition to the overrides API by extending `IOperatorOverridesStore.PatchAsync` with `expectedCanonicalVersion` and a typed `OperatorOverrideCanonicalVersionConflictException` to signal a version mismatch. 
- Make the Postgres override store hold a transaction-scoped advisory lock and validate the canonical `security_events` head inside the same transaction before applying the overlay, and introduce helper methods `LockCanonicalStreamAsync` and `LoadCanonicalVersionAsync`. 
- Acquire the same advisory lock in the canonical event store (`PostgresSecurityMasterEventStore.AppendAsync`) so canonical appends and overlay patches coordinate on the same lock. 
- Have `SecurityMasterWorkbenchCommandService.UpdateSecurityFieldAsync` pass the observed `currentVersion` into `PatchAsync` and translate a storage `OperatorOverrideCanonicalVersionConflictException` into the existing `SecurityMasterConcurrencyException` (HTTP 409 semantics). 
- Update null/stub/mock `PatchAsync` signatures and test harnesses to accept the new parameter and add a regression test `UpdateSecurityField_CanonicalVersionAdvancesDuringOverlayPatch_ThrowsConcurrency` that asserts a concurrent canonical advance results in a concurrency failure while still emitting no economic event.

### Testing
- Ran `git diff --check` to validate whitespace/format issues and it passed. 
- Ran `python build/python/cli/buildctl.py validation-status --summary` to confirm no blocking local build locks and it passed. 
- Attempted the canonical local verification `bash scripts/ci.sh` but it was blocked because the environment lacks the .NET SDK (`dotnet: command not found`), so .NET build/tests were not executed here. 
- Added a targeted regression unit test exercising the failing interleaving; the test was added to the repository but could not be executed locally due to the missing `dotnet` tool.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f3ab4c083209d23b110ef7651ba)