### PR TITLE
Ignore null report format rules to prevent NullReferenceException during rendering

### DIFF
--- a/src/Meridian.Reporting/ReportWriterGridEngine.cs
+++ b/src/Meridian.Reporting/ReportWriterGridEngine.cs
@@ -177,6 +177,7 @@ public static class ReportWriterGridEngine
 
     private static ReportWriterFormatRuleDto[] NormalizeFormatRules(IReadOnlyList<ReportWriterFormatRuleDto>? rules) =>
         rules?
+            .OfType<ReportWriterFormatRuleDto>()
             .Where(static rule => !string.IsNullOrWhiteSpace(rule.Column))
             .Select(static rule => rule with
             {

--- a/tests/Meridian.Tests/Reporting/ReportWriterGridEngineTests.cs
+++ b/tests/Meridian.Tests/Reporting/ReportWriterGridEngineTests.cs
@@ -400,6 +400,36 @@ public sealed class ReportWriterGridEngineTests
     }
 
     [Fact]
+    public void RenderGrids_IgnoresNullConditionalFormattingRules()
+    {
+        IReadOnlyList<ReportWriterFormatRuleDto> formatRules =
+        [
+            null!,
+            new ReportWriterFormatRuleDto("pnl", ReportWriterFilterOperatorDto.LessThan, ReportWriterCellStyleDto.Danger, "0")
+        ];
+        var grids = new[]
+        {
+            new ReportWriterGridDefinitionDto(
+                "pnl-detail",
+                "PnL Detail",
+                ReportWriterGridKindDto.Detail,
+                RowFields: ["security"],
+                Metrics: [new ReportWriterMetricDefinitionDto("pnl", "pnl")],
+                FormatRules: formatRules)
+        };
+
+        var rendered = ReportWriterGridEngine.RenderGrids(
+            grids,
+            [Row(("security", "TLT"), ("pnl", "-3"))]).Single();
+
+        rendered.Rows.Should().ContainSingle();
+        rendered.Rows[0].StyleHints.Should().NotBeNull();
+        rendered.Rows[0].StyleHints!.Should().ContainSingle()
+            .Which.Key.Should().Be("pnl");
+        rendered.Rows[0].StyleHints!["pnl"].Should().Be(ReportWriterCellStyleDto.Danger);
+    }
+
+    [Fact]
     public void RenderGrids_BuildsInlineChartFromRenderedRows()
     {
         var rows = new[]


### PR DESCRIPTION
### Motivation
- Prevent a `NullReferenceException` when a deserialized `formatRules` collection contains `null` elements, which causes the report render endpoint to return a 500. 
- Harden the report-writer rendering path so malformed or attacker-controlled payloads like `"formatRules": [null]` are ignored safely instead of crashing the engine.

### Description
- Filter null collection elements before normalization by using `OfType<ReportWriterFormatRuleDto>()` in `NormalizeFormatRules` in `src/Meridian.Reporting/ReportWriterGridEngine.cs` so only non-null rules are processed. 
- Add a regression unit test `RenderGrids_IgnoresNullConditionalFormattingRules` in `tests/Meridian.Tests/Reporting/ReportWriterGridEngineTests.cs` that includes a `null` rule alongside a valid rule and verifies the valid rule still applies style hints. 
- The change preserves existing behavior when `FormatRules` is absent or empty and only skips `null` elements.

### Testing
- Ran `git diff --check` and static validation checks which passed (`git diff --check` succeeded). 
- Ran repository validation status via `python3 build/python/cli/buildctl.py validation-status --summary` which reported no active blockers. 
- Could not run the local `dotnet` unit test invocation (`dotnet test ...`) because the environment does not have the .NET SDK installed; the added test is present and expected to run under CI. 
- `bash scripts/ci.sh` could not complete locally for the same reason; GitHub Actions remains the authoritative integration test runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f3a62648320ba95cfdd4386f8bf)