### PR TITLE
fix(security-master): tolerate malformed date terms

### DIFF
--- a/src/Meridian.Application/SecurityMaster/SecurityMasterDataQualityService.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityMasterDataQualityService.cs
@@ -354,7 +354,7 @@ public sealed class SecurityMasterDataQualityService : ISecurityMasterDataQualit
     {
         if (element.ValueKind == JsonValueKind.Object
             && element.TryGetProperty(fieldName, out var prop)
-            && prop.ValueKind != JsonValueKind.Null
+            && prop.ValueKind == JsonValueKind.String
             && prop.TryGetDateTimeOffset(out var result))
             return result;
 

--- a/tests/Meridian.Tests/SecurityMaster/SecurityMasterDataQualityServiceTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/SecurityMasterDataQualityServiceTests.cs
@@ -54,6 +54,25 @@ public sealed class SecurityMasterDataQualityServiceTests
     }
 
     [Fact]
+    public async Task RunQualityChecksAsync_ReportsMissingMaturity_WhenBondMaturityIsNotAString()
+    {
+        var (sut, store) = BuildSut();
+        var security = MakeSecurity(
+            Guid.NewGuid(),
+            "Bond",
+            currency: "USD",
+            assetSpecificTerms: new { maturity = 123 });
+        store.LoadActiveAsync(Arg.Any<CancellationToken>()).Returns(new[] { security });
+
+        var report = await sut.RunQualityChecksAsync();
+
+        report.Violations.Should().Contain(v =>
+            v.RuleId == "MA001"
+            && v.Category == DataQualityRuleCategory.MinimumAttribute
+            && v.SecurityId == security.SecurityId);
+    }
+
+    [Fact]
     public async Task RunQualityChecksAsync_DoesNotFlagMaturity_ForEquity()
     {
         var (sut, store) = BuildSut();


### PR DESCRIPTION
### Motivation

- Prevent the Security Master quality-scan from throwing when attacker- or import-controlled JSON stores non-string date tokens (e.g. `"maturity": 123`) which previously caused `JsonElement.TryGetDateTimeOffset` to raise `InvalidOperationException` and abort the scan.

### Description

- Require the maturity/expiry JSON token be a string before calling `JsonElement.TryGetDateTimeOffset` in `TryReadDateField`, so non-string tokens safely resolve to `null` instead of throwing.
- Add a regression unit test that persists a bond with a numeric `maturity` value and asserts the existing `MA001` missing-maturity violation is produced rather than crashing; files changed: `src/Meridian.Application/SecurityMaster/SecurityMasterDataQualityService.cs` and `tests/Meridian.Tests/SecurityMaster/SecurityMasterDataQualityServiceTests.cs`.

### Testing

- Ran `git diff --check` which reported no formatting errors and `python build/python/cli/buildctl.py validation-status --summary` which returned a non-blocking validation summary (`blocked=false`).
- Attempted to run the relevant unit test filter via `dotnet test` but the container lacks the `dotnet` SDK so the test run could not be executed.
- Attempted to run the full local CI with `bash scripts/ci.sh` but it could not complete for the same missing `dotnet` runtime; the change includes a focused regression test that should pass when executed in an environment with the .NET SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a612389ea7c832094f6ffcc0731f95d)