### PR TITLE
Enforce desktop RBAC and real-actor attribution for WPF close-plan configuration

### DIFF
--- a/src/Meridian.Wpf/ViewModels/Accounting/AccountingCloseViewModel.Drafts.cs
+++ b/src/Meridian.Wpf/ViewModels/Accounting/AccountingCloseViewModel.Drafts.cs
@@ -178,7 +178,8 @@ public sealed partial class AccountingCloseViewModel
 
     private UpsertClosePeriodPlanConfigurationRequestDto BuildClosePlanConfigurationRequest(
         Guid workflowId,
-        ClosePeriodPlanDto closePlan)
+        ClosePeriodPlanDto closePlan,
+        string actor)
     {
         var materialityPolicy = new MaterialityPolicyDto(
             closePlan.MaterialityPolicy.PolicyId,
@@ -275,7 +276,7 @@ public sealed partial class AccountingCloseViewModel
             workflowId,
             materialityPolicy,
             taskConfigurations,
-            Actor: "wpf-accounting-controller",
+            Actor: actor,
             EvidenceLinks: BuildClosePlanConfigurationEvidence(workflowId, closePlan),
             CorrelationId: $"wpf-close-plan-configuration-{workflowId:D}",
             ActionOrigin: OperationsActionOriginDto.HumanOperator,

--- a/src/Meridian.Wpf/ViewModels/Accounting/AccountingCloseViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/Accounting/AccountingCloseViewModel.cs
@@ -2,7 +2,9 @@ using System.Collections.ObjectModel;
 using Meridian.Contracts.Ledger;
 using Meridian.Contracts.Workstation;
 using Meridian.FinancialOperations.AccountingClose;
+using Meridian.Identity.Auth;
 using Meridian.Ui.Services.Services.Accounting;
+using Meridian.Wpf.Services;
 using System.Globalization;
 
 namespace Meridian.Wpf.ViewModels.Accounting;
@@ -11,6 +13,7 @@ public sealed partial class AccountingCloseViewModel : Meridian.Wpf.ViewModels.B
 {
     private readonly IAccountingProjectionQueryService _queryService;
     private readonly IAccountingCloseManagementService? _closeManagementService;
+    private readonly DesktopAuthenticationSession? _authenticationSession;
     private ClosePeriodPlanDto? _closePlan;
     private ClosePostingGateDto? _closingEntriesGate;
     private Guid _closeWorkflowId;
@@ -61,10 +64,12 @@ public sealed partial class AccountingCloseViewModel : Meridian.Wpf.ViewModels.B
 
     public AccountingCloseViewModel(
         IAccountingProjectionQueryService queryService,
-        IAccountingCloseManagementService? closeManagementService = null)
+        IAccountingCloseManagementService? closeManagementService = null,
+        DesktopAuthenticationSession? authenticationSession = null)
     {
         _queryService = queryService ?? throw new ArgumentNullException(nameof(queryService));
         _closeManagementService = closeManagementService;
+        _authenticationSession = authenticationSession;
         LoadClosePlanCommand = new AsyncRelayCommand(LoadClosePlanAsync, CanLoadClosePlan);
         ConfigureClosePlanCommand = new AsyncRelayCommand(ConfigureClosePlanAsync, CanConfigureClosePlan);
         SignOffCloseTaskCommand = new AsyncRelayCommand(SignOffCloseTaskAsync, CanSignOffCloseTask);
@@ -1050,7 +1055,12 @@ public sealed partial class AccountingCloseViewModel : Meridian.Wpf.ViewModels.B
         => _closeManagementService is not null &&
            _closeWorkflowId != Guid.Empty &&
            _closePlan is { IsPeriodLocked: false } closePlan &&
+           HasLedgerMutationPermission() &&
            ValidateCloseSetupDraft(closePlan) is null;
+
+    private bool HasLedgerMutationPermission()
+        => _authenticationSession?.HasPermission(UserPermission.AdminMaintenance) == true ||
+           _authenticationSession?.HasPermission(UserPermission.ManageDirectLending) == true;
 
     private bool CanLoadClosePlan()
         => _closeManagementService is not null &&
@@ -1164,11 +1174,18 @@ public sealed partial class AccountingCloseViewModel : Meridian.Wpf.ViewModels.B
             return;
         }
 
+        if (!HasLedgerMutationPermission())
+        {
+            ClosePlanSetupStatusText = "Your desktop session does not have permission to retain close-plan setup.";
+            return;
+        }
+
         try
         {
-            var request = BuildClosePlanConfigurationRequest(_closeWorkflowId, _closePlan);
+            var actor = _authenticationSession!.CurrentActor;
+            var request = BuildClosePlanConfigurationRequest(_closeWorkflowId, _closePlan, actor);
             var updated = await _closeManagementService
-                .ConfigurePeriodPlanAsync(request, "wpf-accounting-controller")
+                .ConfigurePeriodPlanAsync(request, actor)
                 .ConfigureAwait(true);
 
             if (updated is null)

--- a/tests/Meridian.Wpf.Tests/ViewModels/AccountingCloseViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/AccountingCloseViewModelTests.cs
@@ -3,15 +3,24 @@ using Meridian.Contracts.Ledger;
 using Meridian.Contracts.Workstation;
 using Meridian.FinancialOperations.AccountingClose;
 using Meridian.Ui.Services.Services.Accounting;
+using Meridian.Wpf.Tests.Services;
 using Meridian.Wpf.ViewModels.Accounting;
 
 namespace Meridian.Wpf.Tests.ViewModels;
 
+[Collection("DesktopAuthenticationEnvironment")]
 public sealed class AccountingCloseViewModelTests
 {
     [Fact]
     public async Task ConfigureClosePlanCommand_RetainsLoadedPlanThroughSharedCloseManagementService()
     {
+        using var env = new DesktopAuthenticationSessionTests.EnvironmentVariableScope()
+            .Set("MDC_USERS", DesktopAuthenticationSessionTests.HashedDesktopAdminUsersJson())
+            .Set("MDC_USERNAME", null)
+            .Set("MDC_PASSWORD_HASH", null)
+            .Set("MDC_AUTH_MODE", null);
+        var session = DesktopAuthenticationSessionTests.CreateSession("Production");
+        session.SignIn("desktop-admin", "pw").Succeeded.Should().BeTrue();
         var workflowId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
         var ledgerBookId = Guid.Parse("11111111-2222-3333-4444-555555555555");
         var configuredAtUtc = DateTimeOffset.Parse("2026-06-02T02:30:00Z");
@@ -25,7 +34,7 @@ public sealed class AccountingCloseViewModelTests
                 EvidenceLinks: ["evidence/close-plan-configuration"])
         };
         var service = new CapturingCloseManagementService(closePlan);
-        var viewModel = new AccountingCloseViewModel(Substitute.For<IAccountingProjectionQueryService>(), service);
+        var viewModel = new AccountingCloseViewModel(Substitute.For<IAccountingProjectionQueryService>(), service, session);
 
         viewModel.ApplyClosePlan(workflowId, closePlan);
 
@@ -33,10 +42,10 @@ public sealed class AccountingCloseViewModelTests
 
         await viewModel.ConfigureClosePlanCommand.ExecuteAsync(null);
 
-        service.Actor.Should().Be("wpf-accounting-controller");
+        service.Actor.Should().Be("desktop-admin");
         service.Request.Should().NotBeNull();
         service.Request!.WorkflowId.Should().Be(workflowId);
-        service.Request.Actor.Should().Be("wpf-accounting-controller");
+        service.Request.Actor.Should().Be("desktop-admin");
         service.Request.CorrelationId.Should().Be($"wpf-close-plan-configuration-{workflowId:D}");
         service.Request.ActionOrigin.Should().Be(OperationsActionOriginDto.HumanOperator);
         service.Request.ExpectedConfiguredAtUtc.Should().Be(configuredAtUtc);
@@ -60,13 +69,44 @@ public sealed class AccountingCloseViewModelTests
     }
 
     [Fact]
+    public async Task ConfigureClosePlanCommand_WhenDesktopUserLacksLedgerMutationPermission_DoesNotCallService()
+    {
+        using var env = new DesktopAuthenticationSessionTests.EnvironmentVariableScope()
+            .Set("MDC_USERS", DesktopAuthenticationSessionTests.HashedDesktopReadOnlyUsersJson())
+            .Set("MDC_USERNAME", null)
+            .Set("MDC_PASSWORD_HASH", null)
+            .Set("MDC_AUTH_MODE", null);
+        var session = DesktopAuthenticationSessionTests.CreateSession("Production");
+        session.SignIn("desktop-viewer", "pw").Succeeded.Should().BeTrue();
+        var workflowId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        var closePlan = BuildClosePlan(Guid.Parse("11111111-2222-3333-4444-555555555555"));
+        var service = new CapturingCloseManagementService(closePlan);
+        var viewModel = new AccountingCloseViewModel(Substitute.For<IAccountingProjectionQueryService>(), service, session);
+
+        viewModel.ApplyClosePlan(workflowId, closePlan);
+
+        viewModel.ConfigureClosePlanCommand.CanExecute(null).Should().BeFalse();
+        await viewModel.ConfigureClosePlanCommand.ExecuteAsync(null);
+
+        service.Request.Should().BeNull();
+        viewModel.ClosePlanSetupStatusText.Should().Be("Your desktop session does not have permission to retain close-plan setup.");
+    }
+
+    [Fact]
     public async Task LoadClosePlanCommand_LoadsSharedClosePlanByWorkflowId()
     {
+        using var env = new DesktopAuthenticationSessionTests.EnvironmentVariableScope()
+            .Set("MDC_USERS", DesktopAuthenticationSessionTests.HashedDesktopAdminUsersJson())
+            .Set("MDC_USERNAME", null)
+            .Set("MDC_PASSWORD_HASH", null)
+            .Set("MDC_AUTH_MODE", null);
+        var session = DesktopAuthenticationSessionTests.CreateSession("Production");
+        session.SignIn("desktop-admin", "pw").Succeeded.Should().BeTrue();
         var workflowId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
         var ledgerBookId = Guid.Parse("11111111-2222-3333-4444-555555555555");
         var closePlan = BuildClosePlan(ledgerBookId);
         var service = new CapturingCloseManagementService(closePlan);
-        var viewModel = new AccountingCloseViewModel(Substitute.For<IAccountingProjectionQueryService>(), service)
+        var viewModel = new AccountingCloseViewModel(Substitute.For<IAccountingProjectionQueryService>(), service, session)
         {
             CloseWorkflowIdText = workflowId.ToString("D")
         };
@@ -324,11 +364,18 @@ public sealed class AccountingCloseViewModelTests
     [Fact]
     public async Task ConfigureClosePlanCommand_UsesDesktopEditedCloseSetupDraft()
     {
+        using var env = new DesktopAuthenticationSessionTests.EnvironmentVariableScope()
+            .Set("MDC_USERS", DesktopAuthenticationSessionTests.HashedDesktopAdminUsersJson())
+            .Set("MDC_USERNAME", null)
+            .Set("MDC_PASSWORD_HASH", null)
+            .Set("MDC_AUTH_MODE", null);
+        var session = DesktopAuthenticationSessionTests.CreateSession("Production");
+        session.SignIn("desktop-admin", "pw").Succeeded.Should().BeTrue();
         var workflowId = Guid.Parse("abababab-bbbb-cccc-dddd-eeeeeeeeeeee");
         var ledgerBookId = Guid.Parse("11111111-2222-3333-4444-555555555555");
         var closePlan = BuildClosePlan(ledgerBookId);
         var service = new CapturingCloseManagementService(closePlan);
-        var viewModel = new AccountingCloseViewModel(Substitute.For<IAccountingProjectionQueryService>(), service);
+        var viewModel = new AccountingCloseViewModel(Substitute.For<IAccountingProjectionQueryService>(), service, session);
 
         viewModel.ApplyClosePlan(workflowId, closePlan);
         viewModel.CloseSetupAmountThreshold = 5_000m;
@@ -392,11 +439,18 @@ public sealed class AccountingCloseViewModelTests
     [Fact]
     public async Task ConfigureClosePlanCommand_SelectsRetainedTaskBeforeDesktopSetupEdits()
     {
+        using var env = new DesktopAuthenticationSessionTests.EnvironmentVariableScope()
+            .Set("MDC_USERS", DesktopAuthenticationSessionTests.HashedDesktopAdminUsersJson())
+            .Set("MDC_USERNAME", null)
+            .Set("MDC_PASSWORD_HASH", null)
+            .Set("MDC_AUTH_MODE", null);
+        var session = DesktopAuthenticationSessionTests.CreateSession("Production");
+        session.SignIn("desktop-admin", "pw").Succeeded.Should().BeTrue();
         var workflowId = Guid.Parse("abababab-bbbb-cccc-dddd-eeeeeeeeeeee");
         var ledgerBookId = Guid.Parse("11111111-2222-3333-4444-555555555555");
         var closePlan = BuildClosePlanWithReportTask(ledgerBookId);
         var service = new CapturingCloseManagementService(closePlan);
-        var viewModel = new AccountingCloseViewModel(Substitute.For<IAccountingProjectionQueryService>(), service);
+        var viewModel = new AccountingCloseViewModel(Substitute.For<IAccountingProjectionQueryService>(), service, session);
 
         viewModel.ApplyClosePlan(workflowId, closePlan);
 


### PR DESCRIPTION
### Motivation
- Prevent a low-privilege desktop operator from weakening governed close-plan controls by retaining WPF edits without server-side RBAC or real-user attribution.
- Align WPF behavior with the HTTP endpoint which requires ledger-mutation permission and resolves the real actor before calling the close-management service.

### Description
- Require ledger-mutation permissions in the WPF view model by consulting the injected `DesktopAuthenticationSession` before allowing `ConfigureClosePlan` to run, using `HasPermission(UserPermission.AdminMaintenance)` or `UserPermission.ManageDirectLending` as the gate.
- Propagate the authenticated desktop operator into the retained configuration request and service call instead of the hard-coded actor `"wpf-accounting-controller"` by adding an `actor` parameter to `BuildClosePlanConfigurationRequest` and passing that actor into `ConfigurePeriodPlanAsync`.
- Inject `DesktopAuthenticationSession` into `AccountingCloseViewModel` and wire it into existing command readiness checks (`CanConfigureClosePlan`) and the command execution path to fail closed when permission is missing.
- Update unit tests in `tests/Meridian.Wpf.Tests/ViewModels/AccountingCloseViewModelTests.cs` to sign in a desktop admin and assert the real actor is used, and add a test that a read-only desktop user cannot execute the configure command.

### Testing
- Ran `git diff --check` successfully to verify no whitespace/format issues. (pass)
- Attempted `dotnet test` for the affected test slice with `--filter FullyQualifiedName~AccountingCloseViewModelTests` but could not run in this environment because `dotnet` is not available; tests were updated to cover positive and negative authorization paths. (not run here)
- Ran repository CI script `bash scripts/ci.sh` which stopped at the .NET SDK verification (`dotnet` not found) so full CI was not executed in this environment. (not run here)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a612388f5008320a1542ace394efe2e)