### PR TITLE
Fix worker-plan dimensional scope authority

### DIFF
--- a/src/Meridian.Ui.Shared/Services/AccountingMigrationRunExecutionService.cs
+++ b/src/Meridian.Ui.Shared/Services/AccountingMigrationRunExecutionService.cs
@@ -149,7 +149,7 @@ public sealed class AccountingMigrationRunExecutionService
         {
             FundProfileId = NormalizeOptional(request.FundProfileId) ?? workerPlan.FundProfileId,
             LedgerBookId = request.LedgerBookId ?? workerPlan.LedgerBookId,
-            Dimensions = request.Dimensions ?? workerPlan.Dimensions,
+            Dimensions = workerPlan.Dimensions,
             EvidenceLinks = evidenceLinks,
             TenantId = NormalizeOptional(request.TenantId) ?? workerPlan.TenantId,
             CompanyId = NormalizeOptional(request.CompanyId) ?? workerPlan.CompanyId,

--- a/tests/Meridian.Tests/Ui/AccountingMigrationRunExecutionServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/AccountingMigrationRunExecutionServiceTests.cs
@@ -279,7 +279,7 @@ public sealed class AccountingMigrationRunExecutionServiceTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_UsesWorkerPlanDimensionsForDimensionalBackfill()
+    public async Task ExecuteAsync_PreservesWorkerPlanDimensionsWhenRequestSuppliesDifferentDimensions()
     {
         var artifactStore = new InMemoryAccountingMigrationRunArtifactStore();
         var workerPlans = new InMemoryAccountingMigrationRunWorkerPlanStore();
@@ -327,6 +327,11 @@ public sealed class AccountingMigrationRunExecutionServiceTests
             LedgerBookId: LedgerBookId,
             RunId: "migration-run-dimensional-worker-plan",
             CertifyOnSuccess: true,
+            Dimensions: new LedgerDimensionSetDto(
+                FundId: "default-fund",
+                BookId: LedgerBookId.ToString("D"),
+                EntityId: "untrusted-entity",
+                InvestorId: "untrusted-investor"),
             TenantId: "company-alpha",
             CompanyId: "company-alpha",
             ActionOrigin: OperationsActionOriginDto.HumanOperator,
@@ -337,6 +342,7 @@ public sealed class AccountingMigrationRunExecutionServiceTests
         result.Artifact.Dimensions!.FundId.Should().Be("default-fund");
         result.Artifact.Dimensions.BookId.Should().Be(LedgerBookId.ToString("D"));
         result.Artifact.Dimensions.EntityId.Should().Be("fund-entity-main");
+        result.Artifact.Dimensions.InvestorId.Should().Be("investor-lp-001");
         result.Artifact.Dimensions.ExternalGlDimensions.Should().ContainKey("external-company");
         result.Artifact.SourceRecordCount.Should().Be(812);
         result.Artifact.MigratedRecordCount.Should().Be(812);


### PR DESCRIPTION
### Motivation
- Prevent a security/regression where an authenticated caller could supply alternate `Dimensions` in a migration-run request and have those override the retained worker plan's canonical dimensional scope, undermining certification evidence integrity.  

### Description
- Make retained worker-plan dimensions authoritative by changing `ApplyWorkerPlan` to set `Dimensions = workerPlan.Dimensions` instead of preferring `request.Dimensions`.  
- Add a regression test `ExecuteAsync_PreservesWorkerPlanDimensionsWhenRequestSuppliesDifferentDimensions` that submits conflicting request-supplied dimensions and asserts the persisted artifact contains the worker-plan's canonical `EntityId`/`InvestorId`.  
- Change is limited to `src/Meridian.Ui.Shared/Services/AccountingMigrationRunExecutionService.cs` and `tests/Meridian.Tests/Ui/AccountingMigrationRunExecutionServiceTests.cs` and preserves existing behavior for other worker-plan fields.  

### Testing
- Ran `git diff --check` which reported no issues.  
- Ran `python build/python/cli/buildctl.py validation-status --summary` which completed successfully in this environment.  
- Attempted `dotnet test` and `bash scripts/ci.sh` but they could not be executed here because `dotnet` is not installed (so unit tests and CI were not run locally); GitHub Actions remains the authoritative runner for full validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f399ca48320a34068c7cfb0ff8f)