### PR TITLE
Fix close-support readiness calculation to account for off-screen blockers

### DIFF
--- a/src/Meridian.FinancialOperations/OperationsContinuity/FinancialOperationsCommandCenterReadService.cs
+++ b/src/Meridian.FinancialOperations/OperationsContinuity/FinancialOperationsCommandCenterReadService.cs
@@ -985,19 +985,25 @@ public sealed class FinancialOperationsCommandCenterReadService : IFinancialOper
             || row.SourceKind.Contains("nav-support", StringComparison.OrdinalIgnoreCase)
             || string.Equals(row.SourceKind, "close-checklist", StringComparison.OrdinalIgnoreCase));
         var decisionRows = BuildCloseSupportDecisionRows(workflow, closeCalendar, cockpit, rows).ToArray();
+        var hasBlockingDecision = rows.Any(static row => row.IsBlocked)
+            || decisionRows.Any(static row => row.IsBlocking);
+        var blockingDecisionCount = rows.Count(static row => row.IsBlocked)
+            + decisionRows.Count(decision =>
+                decision.IsBlocking
+                && !rows.Any(row => string.Equals(row.QueueId, decision.DecisionId, StringComparison.OrdinalIgnoreCase)));
         var isReady = workflow is not null
             && (workflow.CloseReadiness?.IsReadyToClose == true || workflow.Status is OperationsWorkflowStatusDto.ReadyForClose or OperationsWorkflowStatusDto.Closed)
-            && decisionRows.All(static row => !row.IsBlocking)
+            && !hasBlockingDecision
             && (cockpit?.IsReadyToClose ?? true);
         var status = isReady
             ? "Ready"
-            : decisionRows.Any(static row => row.IsBlocking)
+            : hasBlockingDecision
                 ? "Blocked"
                 : "Review";
         var summary = status switch
         {
             "Ready" => "Close support is ready: period posture, NAV/report dependencies, exceptions, approvals, and retained evidence gaps are clear.",
-            "Blocked" => $"{decisionRows.Count(static row => row.IsBlocking).ToString("N0", CultureInfo.InvariantCulture)} close-support decision(s) block completion.",
+            "Blocked" => $"{blockingDecisionCount.ToString("N0", CultureInfo.InvariantCulture)} close-support decision(s) block completion.",
             _ => "Close support requires controller review before completion."
         };
 

--- a/tests/Meridian.Tests/FinancialOperations/OperationsContinuity/FinancialOperationsCommandCenterReadServiceTests.cs
+++ b/tests/Meridian.Tests/FinancialOperations/OperationsContinuity/FinancialOperationsCommandCenterReadServiceTests.cs
@@ -50,6 +50,58 @@ public sealed class FinancialOperationsCommandCenterReadServiceTests
     }
 
     [Fact]
+    public async Task GetCommandCenterAsync_WhenBlockedQueueRowIsOutsideDecisionDisplayLimit_ShouldBlockCloseSupport()
+    {
+        var workflow = CreateWorkflow(
+            closeChecklist: Enumerable.Range(1, 12)
+                .Select(index => new OperationsCloseChecklistTaskDto(
+                    $"review-task-{index}",
+                    OperationsGateKeyDto.BrokerIngest,
+                    $"Review task {index}",
+                    "controller",
+                    "Review retained evidence.",
+                    0,
+                    null,
+                    DateOnly.Parse("2026-06-04"),
+                    "In progress",
+                    null,
+                    $"evidence:review-task-{index}",
+                    "/workstation/accounting/operations-continuity",
+                    true,
+                    null,
+                    null))
+                .ToArray(),
+            evidencePackages:
+            [
+                new OperationsEvidencePackageSummaryDto(
+                    "retained-support",
+                    "Retained support evidence",
+                    EvidenceStatusDto.Missing,
+                    false,
+                    "Retained source support is missing.",
+                    "/workstation/reporting/evidence",
+                    0,
+                    1,
+                    0,
+                    [])
+            ]);
+        var service = CreateService(workflow);
+
+        var commandCenter = await service.GetCommandCenterAsync(
+            fundAccountId: workflow.FundAccountId,
+            periodId: workflow.PeriodId);
+
+        commandCenter.QueueRows.Should().HaveCount(13);
+        commandCenter.QueueRows.Last().QueueId.Should().Be("evidence-package:retained-support");
+        commandCenter.QueueRows.Last().IsBlocked.Should().BeTrue();
+        commandCenter.CloseSupportDecision.Should().NotBeNull();
+        commandCenter.CloseSupportDecision!.Decisions.Should().HaveCount(12);
+        commandCenter.CloseSupportDecision.IsReady.Should().BeFalse();
+        commandCenter.CloseSupportDecision.Status.Should().Be("Blocked");
+        commandCenter.CloseSupportDecision.Summary.Should().Be("1 close-support decision(s) block completion.");
+    }
+
+    [Fact]
     public async Task GetCommandCenterAsync_WhenApprovalHistoryAndPeriodLockEvidenceMissing_ShouldPreserveEvidencePackageCapabilities()
     {
         var workflow = CreateWorkflow(evidencePackages:


### PR DESCRIPTION
### Motivation
- The close-support decision previously derived `IsReady` and `Status` only from a bounded (12-row) display list, which can omit blocking queue rows that occur later in the ordered queue and misreport readiness. 
- The change ensures the externally exposed close-support DTO cannot show `Ready` when any queue blocker (including those not shown in the 12-row decision display) remains unresolved.

### Description
- Update `BuildCloseSupportDecision` in `src/Meridian.FinancialOperations/OperationsContinuity/FinancialOperationsCommandCenterReadService.cs` to evaluate blockers against the full `rows` collection as well as the bounded `decisionRows`; compute `hasBlockingDecision` and `blockingDecisionCount` and use these for `isReady`, `status`, and the blocked summary.
- Maintain the existing UI-facing decision display by continuing to return the bounded `decisionRows` list while counting off-screen blockers in the blocked summary to avoid double-counting displayed rows.
- Add a regression test `GetCommandCenterAsync_WhenBlockedQueueRowIsOutsideDecisionDisplayLimit_ShouldBlockCloseSupport` to `tests/Meridian.Tests/FinancialOperations/OperationsContinuity/FinancialOperationsCommandCenterReadServiceTests.cs` that constructs 12 non-blocking checklist rows followed by a blocking evidence package to ensure the decision is `Blocked` and `IsReady == false`.

### Testing
- Ran `git diff --check` which reported no check failures (passed). 
- Executed `python build/python/cli/buildctl.py validation-status --summary` which reported no active validation blockers (passed). 
- Attempted to run the relevant unit tests with `dotnet test` but the execution environment lacks the `dotnet` SDK so the test run could not be executed (blocked). 
- Attempted `bash scripts/ci.sh` but the script run is blocked for the same reason (`dotnet` not installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f397bd08320be3829789e1ad670)