### PR TITLE
Fix leading evidence token boundary

### DIFF
--- a/src/Meridian.FinancialOperations/AccountingSystem/AccountingSystemIntegrationService.cs
+++ b/src/Meridian.FinancialOperations/AccountingSystem/AccountingSystemIntegrationService.cs
@@ -2126,7 +2126,8 @@ public sealed class AccountingSystemIntegrationService
     }
 
     private static bool IsEvidenceTokenBoundary(string reference, int index)
-        => index >= reference.Length ||
+        => index < 0 ||
+           index >= reference.Length ||
            reference[index] is '/' or ':' or '?' or '&' or '#' or ';' or ',' or ')' or ']' or '}' or ' ' or '\t' or '\r' or '\n';
 
 

--- a/tests/Meridian.Tests/Ui/AccountingSystemIntegrationServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/AccountingSystemIntegrationServiceTests.cs
@@ -3420,6 +3420,24 @@ public sealed class AccountingSystemIntegrationServiceTests
     }
 
     [Fact]
+    public async Task MappingProfiles_CertifiesProfileWithLeadingProfileEvidenceToken()
+    {
+        var service = CreateService(CreateMatchedQuickBooksFixtureLedgerStore());
+        var profile = CertifiedQuickBooksMappingProfile() with
+        {
+            ProfileId = "qbo-default-fund-leading-profile-evidence-certified"
+        };
+
+        var upserted = await service.UpsertMappingProfileAsync(new AccountingSystemMappingProfileUpsertRequestDto(
+            profile,
+            "accounting-ops",
+            FundProfileId: "default-fund",
+            EvidenceLinks: [$"{profile.ProfileId}:mapping-approval"]));
+
+        upserted.CertificationState.Should().Be(AccountingCertificationStateDto.Certified);
+    }
+
+    [Fact]
     public async Task MappingProfiles_DowngradesCertifiedProfileWithExtendedProfileEvidenceToken()
     {
         var service = CreateService(CreateMatchedQuickBooksFixtureLedgerStore());


### PR DESCRIPTION
### Motivation
- Prevent an IndexOutOfRangeException when an evidence token appears at the start of an evidence link so certified mapping-profile upserts do not crash the endpoint. 

### Description
- Treat the start-of-string (index < 0) as a valid evidence-token boundary by updating `IsEvidenceTokenBoundary` to check `index < 0` in addition to the existing end-of-string guard. 
- Add a regression test `MappingProfiles_CertifiesProfileWithLeadingProfileEvidenceToken` that verifies a certified mapping profile remains certified when the evidence link begins with the profile identifier. 
- Modified files: `src/Meridian.FinancialOperations/AccountingSystem/AccountingSystemIntegrationService.cs` and `tests/Meridian.Tests/Ui/AccountingSystemIntegrationServiceTests.cs`.

### Testing
- Verified the source-level regression guard via a local Python check script and updated tests insertion, which passed. 
- Ran `git diff --check` which reported no whitespace/formatting issues. 
- Ran `python3 build/python/cli/buildctl.py validation-status --summary` which returned `blocked=false` and no active build processes. 
- Attempted to run the focused `dotnet test` and `bash scripts/ci.sh` but both could not run in this environment because `dotnet` is not installed; the regression test added is present and must be validated by the repository CI (`GitHub Actions`) where the .NET SDK is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f3b82cc83209d85e962f3e6e598)