### PR TITLE
Scope accounting close audit trails by dimensions

### DIFF
--- a/src/Meridian.FinancialOperations/AccountingClose/AccountingCloseModels.cs
+++ b/src/Meridian.FinancialOperations/AccountingClose/AccountingCloseModels.cs
@@ -114,7 +114,8 @@ public sealed record ClosePeriod(
     CloseEvidence Evidence,
     ImmutableArray<string> Blockers,
     DateTimeOffset? LockedAt = null,
-    string? ClosedBy = null)
+    string? ClosedBy = null,
+    LedgerDimensionSetDto? Dimensions = null)
 {
     public bool IsLocked => State == ClosePeriodState.Closed || LockedAt is not null;
 }

--- a/src/Meridian.FinancialOperations/AccountingClose/AccountingCloseServices.cs
+++ b/src/Meridian.FinancialOperations/AccountingClose/AccountingCloseServices.cs
@@ -86,7 +86,15 @@ public sealed class AccountingPostingService
     public ImmutableArray<JournalEntry> Replay(string ledgerId)
         => _journals.TryGetValue(ledgerId, out var entries) ? entries : ImmutableArray<JournalEntry>.Empty;
 
-    public ImmutableArray<SourceLinkedAuditLine> Audit(string ledgerId) => BuildAudit(Replay(ledgerId));
+    public ImmutableArray<SourceLinkedAuditLine> Audit(
+        string ledgerId,
+        LedgerDimensionSetDto? dimensions = null)
+        => BuildAudit(Replay(ledgerId).Where(entry => EntryMatchesDimensions(entry, dimensions)));
+
+    private static bool EntryMatchesDimensions(JournalEntry entry, LedgerDimensionSetDto? dimensions)
+        => dimensions is null ||
+           (!entry.Lines.IsDefaultOrEmpty &&
+            entry.Lines.All(line => TrialBalanceProjectionService.MatchesDimensions(dimensions, line.Dimensions)));
 
     private static JournalEntry NormalizeEntry(string ledgerId, JournalEntry entry)
         => entry with
@@ -552,7 +560,7 @@ public sealed class TrialBalanceProjectionService
         => string.Equals(leftAccountCode, rightAccountCode, StringComparison.OrdinalIgnoreCase) &&
            string.Equals(BuildDimensionSignature(leftDimensions), BuildDimensionSignature(rightDimensions), StringComparison.OrdinalIgnoreCase);
 
-    private static bool MatchesDimensions(LedgerDimensionSetDto? expected, LedgerDimensionSetDto? actual)
+    internal static bool MatchesDimensions(LedgerDimensionSetDto? expected, LedgerDimensionSetDto? actual)
     {
         if (expected is null)
         {

--- a/src/Meridian.Ui.Services/Services/Accounting/AccountingProjectionQueryService.cs
+++ b/src/Meridian.Ui.Services/Services/Accounting/AccountingProjectionQueryService.cs
@@ -8,7 +8,7 @@ public interface IAccountingProjectionQueryService
 {
     ImmutableArray<TrialBalanceLine> GetTrialBalance(string ledgerId, LedgerDimensionSetDto? dimensions = null);
     ImmutableArray<RollForwardLine> GetRollForward(string ledgerId, LedgerDimensionSetDto? dimensions = null);
-    ImmutableArray<SourceLinkedAuditLine> GetAuditLines(string ledgerId);
+    ImmutableArray<SourceLinkedAuditLine> GetAuditLines(string ledgerId, LedgerDimensionSetDto? dimensions = null);
     SourceLinkedAuditLine? GetAuditLine(string ledgerId, Guid journalEntryId);
     AccountingCloseProjection GetCloseProjection(
         string ledgerId,
@@ -45,8 +45,8 @@ public sealed class AccountingProjectionQueryService : IAccountingProjectionQuer
         return _projectionService.BuildRollForward([], trial, []);
     }
 
-    public ImmutableArray<SourceLinkedAuditLine> GetAuditLines(string ledgerId)
-        => _postingService.Audit(ledgerId);
+    public ImmutableArray<SourceLinkedAuditLine> GetAuditLines(string ledgerId, LedgerDimensionSetDto? dimensions = null)
+        => _postingService.Audit(ledgerId, dimensions);
 
     public SourceLinkedAuditLine? GetAuditLine(string ledgerId, Guid journalEntryId)
         => GetAuditLines(ledgerId).FirstOrDefault(line => line.JournalEntryId == journalEntryId);
@@ -59,9 +59,9 @@ public sealed class AccountingProjectionQueryService : IAccountingProjectionQuer
     {
         var trialBalance = GetTrialBalance(ledgerId, dimensions);
         var rollForward = GetRollForward(ledgerId, dimensions);
-        var audit = GetAuditLines(ledgerId);
+        var audit = GetAuditLines(ledgerId, dimensions);
         var balanced = _projectionService.IsBalanced(trialBalance);
-        var closePeriod = new ClosePeriod(ledgerId, period, ClosePeriodState.Validating, evidence, []);
+        var closePeriod = new ClosePeriod(ledgerId, period, ClosePeriodState.Validating, evidence, [], Dimensions: dimensions);
         var state = _closeStateMachine.Transition(closePeriod, evidence, balanced);
         var evidencePackage = _evidencePackageService.Build(state, balanced, audit);
         return new AccountingCloseProjection(

--- a/tests/Meridian.Tests/Ui/AccountingProjectionQueryServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/AccountingProjectionQueryServiceTests.cs
@@ -52,7 +52,7 @@ public sealed class AccountingProjectionQueryServiceTests
     }
 
     [Fact]
-    public void GetCloseProjection_WithDimensionScope_UsesScopedTrialBalanceAndRollForward()
+    public void GetCloseProjection_WithDimensionScope_UsesOnlyScopedCloseData()
     {
         var service = CreateServiceWithDimensionedLedger();
 
@@ -67,6 +67,9 @@ public sealed class AccountingProjectionQueryServiceTests
         projection.RollForward.Should().HaveCount(2);
         projection.TrialBalance.Select(static line => line.Dimensions?.EntityId).Should().OnlyContain(entityId => entityId == "entity-alpha");
         projection.RollForward.Select(static line => line.Dimensions?.EntityId).Should().OnlyContain(entityId => entityId == "entity-alpha");
+        projection.AuditTrail.Select(static line => line.SourceEventId).Should().BeEquivalentTo(["evt-alpha"]);
+        projection.EvidencePackage.SourceEventIds.Should().BeEquivalentTo(["evt-alpha"]);
+        projection.ClosePeriod.Dimensions.Should().BeEquivalentTo(new LedgerDimensionSetDto(FundId: "fund-alpha", EntityId: "entity-alpha"));
         projection.ClosePeriod.State.Should().Be(ClosePeriodState.Closed);
     }
 


### PR DESCRIPTION
### Motivation
- `GetCloseProjection` began accepting an optional `LedgerDimensionSetDto` but only applied it to trial-balance and roll-forward paths, which allowed ledger-wide audit rows and evidence lineage to leak across dimension scopes. 
- The `ClosePeriod` identity remained ledger-only, which could misrepresent a dimension-scoped validation as a ledger-wide close state. 
- The change aims to make close projections consistently dimension-scoped so audit, evidence, and the derived close-period identity match the requested dimensions.

### Description
- Add an optional `dimensions` parameter to `AccountingPostingService.Audit` and filter `Replay(ledgerId)` entries via a new `EntryMatchesDimensions` predicate so audit rows are limited to entries matching the requested dimensions. 
- Propagate the `dimensions` parameter through `IAccountingProjectionQueryService.GetAuditLines` and `AccountingProjectionQueryService.GetCloseProjection`, and pass the scoped audit into the evidence package builder. 
- Record the requested `LedgerDimensionSetDto` on `ClosePeriod` (new `Dimensions` property) so the derived close-state carries the same scope as the projection. 
- Make `TrialBalanceProjectionService.MatchesDimensions` `internal` for reuse in the audit filter and add a regression assertion in `AccountingProjectionQueryServiceTests` that the projection's `AuditTrail`, `EvidencePackage.SourceEventIds`, and `ClosePeriod.Dimensions` contain only the scoped events.

### Testing
- `git diff --check` passed with no whitespace or diff checks reported. 
- Attempted `dotnet test` for `AccountingProjectionQueryServiceTests` but it could not be executed in this environment because `dotnet` is not installed (blocked). 
- `python build/python/cli/buildctl.py validation-status --summary` completed successfully in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a612389bc508320bee27a1c8df1f114)