### PR TITLE
Fix backfill provider audit secret disclosure

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/BackfillEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/BackfillEndpoints.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using Meridian.Contracts.Api;
 using Meridian.Contracts.Backfill;
+using Meridian.Identity.Auth;
 using Meridian.Infrastructure.Adapters.Core;
 using Meridian.Ui.Shared.Services;
 using Microsoft.AspNetCore.Builder;
@@ -187,11 +188,18 @@ public static class BackfillEndpoints
         {
             var auditReader = services.GetService<IBackfillProviderConfigAuditReader>();
             var entries = auditReader?.GetAuditLog() ?? Array.Empty<Meridian.Contracts.Configuration.ProviderConfigAuditEntryDto>();
-            return Results.Json(entries, jsonOptions);
+            return Results.Json(entries.Select(static entry => new Meridian.Contracts.Configuration.ProviderConfigAuditEntryDto
+            {
+                Timestamp = entry.Timestamp,
+                ProviderId = entry.ProviderId,
+                Action = entry.Action,
+                Source = entry.Source
+            }), jsonOptions);
         })
         .WithName("GetBackfillProviderConfigAudit")
-        .WithDescription("Returns the audit trail of provider configuration changes.")
-        .Produces<Meridian.Contracts.Configuration.ProviderConfigAuditEntryDto[]>(200);
+        .WithDescription("Returns the sanitized audit trail of provider configuration changes.")
+        .Produces<Meridian.Contracts.Configuration.ProviderConfigAuditEntryDto[]>(200)
+        .RequirePermission(UserPermission.ManageProviders);
     }
 
     private static Meridian.Contracts.Configuration.BackfillProviderMetadataDto[] GetKnownProviderMetadata()

--- a/tests/Meridian.Tests/Ui/BackfillAuditEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/BackfillAuditEndpointsTests.cs
@@ -1,0 +1,97 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Meridian.Application.Backfill;
+using Meridian.Contracts.Api;
+using Meridian.Contracts.Configuration;
+using Meridian.Core.Config;
+using Meridian.Identity;
+using Meridian.Identity.Auth;
+using Meridian.Ui.Shared.Endpoints;
+using Meridian.Ui.Shared.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Meridian.Tests.Ui;
+
+public sealed class BackfillAuditEndpointsTests
+{
+    [Fact]
+    public async Task GetProviderConfigAudit_WithoutManageProviders_ReturnsForbidden()
+    {
+        await using var app = await CreateAppAsync(UserPermission.ViewConfig);
+
+        var response = await app.GetTestClient().GetAsync(UiApiRoutes.BackfillProviderConfigAudit);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task GetProviderConfigAudit_WithManageProviders_RedactsConfigurationValues()
+    {
+        const string secret = "backfill-audit-secret";
+        await using var app = await CreateAppAsync(UserPermission.ManageProviders, new StubAuditReader(
+        [
+            new ProviderConfigAuditEntryDto
+            {
+                ProviderId = "alpaca",
+                Action = "updated",
+                PreviousValue = $"{{\"apiKey\":\"{secret}\"}}",
+                NewValue = $"{{\"token\":\"{secret}\"}}"
+            }
+        ]));
+
+        var response = await app.GetTestClient().GetAsync(UiApiRoutes.BackfillProviderConfigAudit);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().NotContain(secret);
+
+        var entries = await response.Content.ReadFromJsonAsync<ProviderConfigAuditEntryDto[]>();
+        entries.Should().ContainSingle();
+        entries![0].ProviderId.Should().Be("alpaca");
+        entries[0].Action.Should().Be("updated");
+        entries[0].PreviousValue.Should().BeNull();
+        entries[0].NewValue.Should().BeNull();
+    }
+
+    private static async Task<WebApplication> CreateAppAsync(
+        UserPermission permissions,
+        IBackfillProviderConfigAuditReader? auditReader = null)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "meridian-tests", "backfill-audit-endpoints", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        var configPath = Path.Combine(root, "appsettings.json");
+        await File.WriteAllTextAsync(configPath, "{}");
+
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Development });
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton(new ConfigStore(configPath));
+        builder.Services.AddSingleton<BackfillCoordinator>();
+        if (auditReader is not null)
+        {
+            builder.Services.AddSingleton(auditReader);
+        }
+
+        var app = builder.Build();
+        app.Use(async (context, next) =>
+        {
+            context.Items[LoginSessionMiddleware.CurrentUserPermissionsKey] = permissions;
+            await next();
+        });
+        app.MapBackfillEndpoints(new JsonSerializerOptions(JsonSerializerDefaults.Web), new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        await app.StartAsync();
+        return app;
+    }
+
+    private sealed class StubAuditReader(IReadOnlyList<ProviderConfigAuditEntryDto> entries) : IBackfillProviderConfigAuditReader
+    {
+        public IReadOnlyList<ProviderConfigAuditEntryDto> GetAuditLog(int maxEntries = 100) => entries.Take(maxEntries).ToArray();
+    }
+}


### PR DESCRIPTION
### Motivation

- The backfill provider configuration audit route returned raw `PreviousValue`/`NewValue` JSON and lacked an authorization guard, allowing low-privilege workstation users to read provider-specific extension bags that may contain secrets. 

### Description

- Restrict the backfill provider-audit GET route by requiring the `UserPermission.ManageProviders` permission via `RequirePermission`. 
- Sanitize the endpoint response in `MapBackfillEndpoints` so it returns only audit metadata (`Timestamp`, `ProviderId`, `Action`, `Source`) and omits `PreviousValue`/`NewValue`. 
- Add focused endpoint tests in `tests/Meridian.Tests/Ui/BackfillAuditEndpointsTests.cs` that assert a caller without `ManageProviders` receives `403 Forbidden` and an authorized caller receives redacted entries with `PreviousValue`/`NewValue` null. 

### Testing

- `git diff --check` passed with no whitespace or diff-check errors. 
- `python build/python/cli/buildctl.py validation-status --summary` reported no active locks and `blocked=false`. 
- Attempted `dotnet test` for the new test and full `bash scripts/ci.sh` could not run locally because `dotnet` is not installed in the execution environment, so the .NET test run is pending on CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a611f3a72a483209d096c72f8732b4c)