### PR TITLE
Fix Alpaca execution-stream health gating to not block REST cancels/modifies

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaBrokerageGateway.cs
+++ b/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaBrokerageGateway.cs
@@ -207,7 +207,6 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway, IBrokerageAccoun
         ArgumentException.ThrowIfNullOrWhiteSpace(orderId);
         ObjectDisposedException.ThrowIf(_disposed, this);
         EnsureConnected();
-        EnsureExecutionStreamHealthy();
 
         using var client = CreateHttpClient();
 
@@ -257,7 +256,6 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway, IBrokerageAccoun
         ArgumentNullException.ThrowIfNull(modification);
         ObjectDisposedException.ThrowIf(_disposed, this);
         EnsureConnected();
-        EnsureExecutionStreamHealthy();
 
         var payload = new AlpacaOrderModifyPayload
         {

--- a/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaTradeUpdatesClient.cs
+++ b/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaTradeUpdatesClient.cs
@@ -19,13 +19,11 @@ public sealed class AlpacaTradeUpdatesClient : IAsyncDisposable
     private readonly Queue<string> _seenOrder = new();
     private Func<CancellationToken, Task<IReadOnlyList<ExecutionReport>>> _reconcile;
     private readonly TimeProvider _clock;
-    private readonly TimeSpan _staleAfter;
     private readonly IAlpacaTradeUpdateCursorStore _cursorStore;
     private ClientWebSocket? _socket;
     private CancellationTokenSource? _runCts;
     private Task? _runTask;
     private DateTimeOffset? _watermark;
-    private DateTimeOffset? _lastUpdateAt;
     private string? _failure;
 
     public AlpacaTradeUpdatesClient(AlpacaOptions options, ILogger<AlpacaTradeUpdatesClient> logger,
@@ -36,13 +34,15 @@ public sealed class AlpacaTradeUpdatesClient : IAsyncDisposable
         _logger = logger;
         _reconcile = reconcile ?? (_ => Task.FromResult<IReadOnlyList<ExecutionReport>>([]));
         _clock = clock ?? TimeProvider.System;
-        _staleAfter = staleAfter ?? TimeSpan.FromSeconds(30);
+        _ = staleAfter; // Kept for source compatibility; event silence is not a stream-health signal.
         _cursorStore = cursorStore ?? new FileAlpacaTradeUpdateCursorStore();
     }
 
-    public bool IsHealthy => _socket?.State == WebSocketState.Open && _lastUpdateAt is { } at && _clock.GetUtcNow() - at <= _staleAfter && _failure is null;
+    // Trade updates are event-driven, so an idle but open authenticated socket is healthy.
+    // The receive loop records socket closures and transport failures in _failure.
+    public bool IsHealthy => _socket?.State == WebSocketState.Open && _failure is null;
     public DateTimeOffset? Watermark => _watermark;
-    public string? UnhealthyReason => IsHealthy ? null : _failure ?? "Trade-update stream is delayed, disconnected, or has not produced an update.";
+    public string? UnhealthyReason => IsHealthy ? null : _failure ?? "Trade-update stream is disconnected or has not connected.";
     public IAsyncEnumerable<ExecutionReport> Reports => _reports.Reader.ReadAllAsync();
 
     public Task StartAsync(CancellationToken ct = default)
@@ -73,7 +73,6 @@ public sealed class AlpacaTradeUpdatesClient : IAsyncDisposable
         var timestamp = ReadTime(data, "timestamp") ?? ReadTime(order, "updated_at") ?? _clock.GetUtcNow();
         _watermark = _watermark is null || timestamp > _watermark ? timestamp : _watermark;
         _cursorStore.Save(_watermark.Value, _seenOrder);
-        _lastUpdateAt = _clock.GetUtcNow();
         _failure = null;
         var status = order.TryGetProperty("status", out var statusElement) ? statusElement.GetString() : null;
         var mapped = Map(status);

--- a/tests/Meridian.Tests/Infrastructure/Providers/AlpacaBrokerageGatewayTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/AlpacaBrokerageGatewayTests.cs
@@ -20,13 +20,17 @@ public sealed class AlpacaBrokerageGatewayTests
 
     // ── Helpers ──────────────────────────────────────────────────────────
 
-    private static AlpacaBrokerageGateway CreateSut(HttpMessageHandler handler, bool useSandbox = true)
+    private static AlpacaBrokerageGateway CreateSut(
+        HttpMessageHandler handler,
+        bool useSandbox = true,
+        AlpacaTradeUpdatesClient? tradeUpdates = null)
     {
         var options = new AlpacaOptions(KeyId: "test-key", SecretKey: "test-secret", UseSandbox: useSandbox);
         return new AlpacaBrokerageGateway(
             new StubHttpClientFactory(handler),
             options,
-            NullLogger<AlpacaBrokerageGateway>.Instance);
+            NullLogger<AlpacaBrokerageGateway>.Instance,
+            tradeUpdates: tradeUpdates);
     }
 
     private static StringContent BuildAccountResponse(string status = "active") =>
@@ -62,6 +66,11 @@ public sealed class AlpacaBrokerageGatewayTests
 
     private static StringContent BuildJson(object obj) =>
         new StringContent(JsonSerializer.Serialize(obj), Encoding.UTF8, "application/json");
+
+    private static void MarkConnected(AlpacaBrokerageGateway gateway) =>
+        typeof(AlpacaBrokerageGateway)
+            .GetField("_connected", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(gateway, true);
 
     // ── Capabilities ─────────────────────────────────────────────────────
 
@@ -274,6 +283,47 @@ public sealed class AlpacaBrokerageGatewayTests
 
         report.ReportType.Should().Be(ExecutionReportType.Rejected);
         report.OrderStatus.Should().Be(OrderStatus.Rejected);
+        await sut.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task CancelOrderAsync_UnhealthyExecutionStream_UsesRestCancellation()
+    {
+        var stream = new AlpacaTradeUpdatesClient(
+            new AlpacaOptions(KeyId: "test-key", SecretKey: "test-secret"),
+            NullLogger<AlpacaTradeUpdatesClient>.Instance);
+        var responses = new Queue<HttpResponseMessage>(new[]
+        {
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = BuildOrderResponse("ord-1") },
+            new HttpResponseMessage(HttpStatusCode.NoContent),
+        });
+        var sut = CreateSut(new SequentialStubHandler(responses), tradeUpdates: stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        MarkConnected(sut);
+
+        var report = await sut.CancelOrderAsync("ord-1", cts.Token);
+
+        report.ReportType.Should().Be(ExecutionReportType.Cancelled);
+        await sut.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task ModifyOrderAsync_UnhealthyExecutionStream_UsesRestModification()
+    {
+        var stream = new AlpacaTradeUpdatesClient(
+            new AlpacaOptions(KeyId: "test-key", SecretKey: "test-secret"),
+            NullLogger<AlpacaTradeUpdatesClient>.Instance);
+        var responses = new Queue<HttpResponseMessage>(new[]
+        {
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = BuildOrderResponse("ord-1") },
+        });
+        var sut = CreateSut(new SequentialStubHandler(responses), tradeUpdates: stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        MarkConnected(sut);
+
+        var report = await sut.ModifyOrderAsync("ord-1", new OrderModification { NewQuantity = 2m }, cts.Token);
+
+        report.ReportType.Should().Be(ExecutionReportType.Modified);
         await sut.DisposeAsync();
     }
 


### PR DESCRIPTION
### Motivation
- The Alpaca trade-update stream health logic treated a connected but idle socket as unhealthy because it required a recent event timestamp, which caused `EnsureExecutionStreamHealthy` to block not only submissions but also cancellation and modification operations.
- This introduced an availability/risk regression where REST-capable cancellations and modifications were prevented during normal idle periods or selective stream disruptions.

### Description
- Relaxed `AlpacaTradeUpdatesClient.IsHealthy` to consider an open socket with no transport failure as healthy, and preserved the `staleAfter` constructor parameter for source compatibility without using it as a health signal.
- Removed event-timestamp based state (`_lastUpdateAt`) and the idle-time check so normal event silence does not mark the stream unhealthy.
- Allowed REST-based order cancellation and modification to proceed even when the trade-update stream is unhealthy by removing the `EnsureExecutionStreamHealthy()` gate from `CancelOrderAsync` and `ModifyOrderAsync`, while keeping the gate for new submissions (`SubmitOrderAsync`).
- Added unit tests `CancelOrderAsync_UnhealthyExecutionStream_UsesRestCancellation` and `ModifyOrderAsync_UnhealthyExecutionStream_UsesRestModification` and a `CreateSut` test helper variant to inject the `AlpacaTradeUpdatesClient` and mark a gateway connected for the tests.

### Testing
- Ran `git diff --check` and static checks which passed without warnings.
- Ran repository validation with `python build/python/cli/buildctl.py validation-status --summary`, which reported no active build locks and returned success.
- Attempted to run the targeted unit tests via `dotnet test` and the repository `scripts/ci.sh`, but `dotnet` was not available in this environment so the .NET tests were not executed here (these tests are present in `tests/Meridian.Tests` and should pass in CI).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6289ea2c4c832097f7917cc0b5c826)