### PR TITLE
Allow cancellations when order routing is disabled

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs
@@ -207,11 +207,6 @@ public static class ExecutionEndpoints
             if (oms is null)
                 return Results.Problem("Order management system is not active.", statusCode: StatusCodes.Status503ServiceUnavailable);
 
-            if (TryRejectBrokerOrderRouting(context.RequestServices, jsonOptions) is { } blockedRouting)
-            {
-                return blockedRouting;
-            }
-
             var logger = GetLogger(context.RequestServices);
             var actionId = GenerateActionId();
             var result = await oms.CancelOrderAsync(orderId, context.RequestAborted).ConfigureAwait(false);
@@ -250,11 +245,6 @@ public static class ExecutionEndpoints
             var oms = context.RequestServices.GetService<IOrderManager>();
             if (oms is null)
                 return Results.Problem("Order management system is not active.", statusCode: StatusCodes.Status503ServiceUnavailable);
-
-            if (TryRejectBrokerOrderRouting(context.RequestServices, jsonOptions) is { } blockedRouting)
-            {
-                return blockedRouting;
-            }
 
             var logger = GetLogger(context.RequestServices);
             var actionId = GenerateActionId();
@@ -1371,23 +1361,6 @@ public static class ExecutionEndpoints
     }
 
     private static string GenerateActionId() => $"act-{Guid.NewGuid():N}";
-
-    private static IResult? TryRejectBrokerOrderRouting(IServiceProvider services, JsonSerializerOptions jsonOptions)
-    {
-        var gateDecision = BrokerageOrderPlacementGate.Evaluate(
-            services.GetService<BrokerageConfiguration>());
-        if (gateDecision.IsAllowed)
-        {
-            return null;
-        }
-
-        var blocked = new TradingActionResult(
-            ActionId: GenerateActionId(),
-            Status: "Rejected",
-            Message: gateDecision.RejectReason ?? "Broker order routing is disabled by validation gates.",
-            OccurredAt: DateTimeOffset.UtcNow);
-        return Results.Json(blocked, jsonOptions, statusCode: StatusCodes.Status403Forbidden);
-    }
 
     private static IResult? TryRejectOrderRoutingForPhaseGate(IServiceProvider services)
     {

--- a/tests/Meridian.Tests/Ui/ExecutionWriteEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/ExecutionWriteEndpointsTests.cs
@@ -126,7 +126,7 @@ public sealed class ExecutionWriteEndpointsTests
     }
 
     [Fact]
-    public async Task CancelOrder_WhenLiveProductionRoutingDisabled_Returns403AndDoesNotCancel()
+    public async Task CancelOrder_WhenLiveProductionRoutingDisabled_CancelsOpenOrder()
     {
         var orderManager = new RecordingOrderManager(CreateOrderState("ord-live-001", "AAPL", 1m));
         await using var app = await CreateAppAsync(services =>
@@ -149,11 +149,11 @@ public sealed class ExecutionWriteEndpointsTests
         var client = app.GetTestClient();
         var response = await client.PostAsync("/api/execution/orders/ord-live-001/cancel", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var result = await ReadActionResultAsync(response);
-        result.Status.Should().Be("Rejected");
-        result.Message.Should().Contain("production routing is disabled");
-        orderManager.CancelledOrderIds.Should().BeEmpty();
+        result.Status.Should().Be("Completed");
+        result.Message.Should().Contain("cancelled");
+        orderManager.CancelledOrderIds.Should().ContainSingle().Which.Should().Be("ord-live-001");
     }
 
     // ------------------------------------------------------------------ //
@@ -208,7 +208,7 @@ public sealed class ExecutionWriteEndpointsTests
     }
 
     [Fact]
-    public async Task CancelAllOrders_WhenLiveProductionRoutingDisabled_Returns403AndDoesNotCancel()
+    public async Task CancelAllOrders_WhenLiveProductionRoutingDisabled_CancelsOpenOrders()
     {
         var orderManager = new RecordingOrderManager(CreateOrderState("ord-live-001", "AAPL", 1m));
         await using var app = await CreateAppAsync(services =>
@@ -231,12 +231,12 @@ public sealed class ExecutionWriteEndpointsTests
         var client = app.GetTestClient();
         var response = await client.PostAsync("/api/execution/orders/cancel-all", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var result = await ReadActionResultAsync(response);
-        result.Status.Should().Be("Rejected");
-        result.Message.Should().Contain("production routing is disabled");
-        orderManager.CancelAllCallCount.Should().Be(0);
-        orderManager.CancelledOrderIds.Should().BeEmpty();
+        result.Status.Should().Be("Completed");
+        result.Message.Should().Contain("1");
+        orderManager.CancelAllCallCount.Should().Be(1);
+        orderManager.CancelledOrderIds.Should().ContainSingle().Which.Should().Be("ord-live-001");
     }
 
     // ------------------------------------------------------------------ //


### PR DESCRIPTION
### Motivation

- A placement-readiness gate intended for new order routing was being applied to cancellation actions and could return 403 when production/live routing or validation artifacts were disabled, which could prevent operators from cancelling live broker orders in an incident.

### Description

- Remove the placement gate check from the single-order cancel and cancel-all endpoints by deleting the `TryRejectBrokerOrderRouting` early-return checks in `src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs`, allowing cancellations to reach the `IOrderManager` when routing readiness is disabled.
- Remove the local `TryRejectBrokerOrderRouting` helper implementation from `ExecutionEndpoints.cs` since it is no longer used for cancellation paths while preserving other phase/placement checks used for order submission and position actions.
- Update endpoint tests in `tests/Meridian.Tests/Ui/ExecutionWriteEndpointsTests.cs` to assert that when `ProductionRoutingPhaseEnabled == false` cancellations return success (`200 OK` and `Status: Completed`) and the `RecordingOrderManager` records the cancelled order(s). 
- Preserve existing authorization (`UserPermission.ManageOrders`) and OMS-availability checks so only authorized requests reach the order manager and the OMS presence is still validated.

### Testing

- `git diff --check` was run and reported no whitespace or diff-check issues (passed). 
- Repository validation via `python build/python/cli/buildctl.py validation-status --summary` completed with no active build locks (passed).
- `dotnet test` for the modified tests and `bash scripts/ci.sh` were not executed in this environment because the .NET SDK (`dotnet`) was not available, so the updated test assertions were not run here (blocked). 
- The change includes test updates that assert successful cancellations when production routing is disabled, but those tests must be executed in an environment with the .NET SDK and CI to confirm all checks pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6289ebdf808320a26c4a771b2628e3)