### PR TITLE
Security: restrict durable IB results access

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.IBResults.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.IBResults.cs
@@ -1,4 +1,5 @@
 using Meridian.Contracts.Api;
+using Meridian.Identity.Auth;
 using Meridian.Ui.Shared.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -26,6 +27,10 @@ public static partial class WorkstationEndpoints
                     requestErrors = new { x.Request.ErrorCode, x.Request.ErrorMessage }
                 });
             return Results.Json(new { provider = "interactive-brokers", results = items }, jsonOptions);
-        }).WithName("GetWorkstationIBResults").Produces(200).Produces(403);
+        })
+        .WithName("GetWorkstationIBResults")
+        .Produces(200)
+        .Produces(403)
+        .RequirePermission(UserPermission.ViewTrades);
     }
 }

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.IBResults.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.IBResults.cs
@@ -1,0 +1,22 @@
+using System.Net;
+using FluentAssertions;
+using Meridian.Contracts.Api;
+using Meridian.Identity.Auth;
+using Microsoft.AspNetCore.TestHost;
+
+namespace Meridian.Tests.Ui;
+
+public sealed partial class WorkstationEndpointsTests
+{
+    [Fact]
+    public async Task MapWorkstationEndpoints_IBResults_ShouldRequireViewTradesPermission()
+    {
+        await using var app = await CreateAppAsync(
+            currentUserPermissions: UserPermission.ViewMarketData | UserPermission.ViewAnalytics);
+        var client = app.GetTestClient();
+
+        var response = await client.GetAsync(UiApiRoutes.IBResults + "?family=pnl");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+}


### PR DESCRIPTION
### Motivation

- The workstation `GET /api/workstation/ib/results` endpoint returned durable Interactive Brokers request results that can include account identifiers, P&L, market-data payloads, and error details without enforcing a role/permission gate.  
- Exposing that read surface to any tenant-scoped authenticated user (including analytics-only or readonly profiles) is a confidentiality risk, so the route must require an appropriate trading/market-data permission.

### Description

- Require the `ViewTrades` permission on the IB results endpoint by calling `.RequirePermission(UserPermission.ViewTrades)` on the mapped route in `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.IBResults.cs`.  
- Add a regression test `MapWorkstationEndpoints_IBResults_ShouldRequireViewTradesPermission` under `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.IBResults.cs` that asserts a tenant-scoped user with only `ViewMarketData | ViewAnalytics` receives `403 Forbidden` for `?family=pnl`.  
- Keep the change minimal and behavior-preserving for authorized callers by attaching the existing `EndpointAuthorization` permission filter rather than changing payloads or tenant materialization logic.

### Testing

- Ran `git diff --check`, which passed for the introduced changes.  
- Attempted a focused test run with `dotnet test --filter 'FullyQualifiedName~WorkstationEndpointsTests.IBResults'`, but the build/test run could not complete due to pre-existing compilation issues in `Meridian.ProviderSdk` that are unrelated to this change.  
- Executed the repository CI entrypoint `bash scripts/ci.sh` locally; restore succeeded but the CI lane reported formatting/whitespace failures originating from unrelated files, so the full CI validation is blocked until those pre-existing issues are resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6289eab4f08320b22ccca5fcec3973)