### PR TITLE
Fix PnL provider routing safeguards

### DIFF
--- a/src/Meridian.Application/ProviderRouting/ProviderRoutingEngine.cs
+++ b/src/Meridian.Application/ProviderRouting/ProviderRoutingEngine.cs
@@ -318,7 +318,8 @@ public sealed class ProviderRoutingService : ICapabilityRouter
             ProviderCapabilityKind.AccountBalances or
             ProviderCapabilityKind.AccountPositions or
             ProviderCapabilityKind.CashTransactions or
-            ProviderCapabilityKind.BankStatements;
+            ProviderCapabilityKind.BankStatements or
+            ProviderCapabilityKind.PnLStream;
 
         if (policy.RequireExplicitBinding && strictAccountCapability && context.AccountId is not null && binding.Target?.AccountId is null)
             return $"Capability '{policy.Capability}' requires an account-scoped binding.";

--- a/src/Meridian.ProviderSdk/ProviderRoutingModels.cs
+++ b/src/Meridian.ProviderSdk/ProviderRoutingModels.cs
@@ -228,7 +228,8 @@ public sealed record ProviderSafetyPolicy(
             ProviderCapabilityKind.AccountBalances or
             ProviderCapabilityKind.AccountPositions or
             ProviderCapabilityKind.CashTransactions or
-            ProviderCapabilityKind.BankStatements
+            ProviderCapabilityKind.BankStatements or
+            ProviderCapabilityKind.PnLStream
                 => new ProviderSafetyPolicy(
                     capability,
                     ProviderSafetyMode.NoAutomaticFailover,

--- a/tests/Meridian.Tests/Application/ProviderRouting/ProviderRoutingServiceTests.cs
+++ b/tests/Meridian.Tests/Application/ProviderRouting/ProviderRoutingServiceTests.cs
@@ -151,6 +151,59 @@ public sealed class ProviderRoutingServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task RouteAsync_BlocksPnLStreamWithoutAccountScopedBinding()
+    {
+        await SaveConfigAsync(new AppConfig(
+            ProviderConnections: new ProviderConnectionsConfig(
+                Connections:
+                [
+                    new ProviderConnectionConfig("broker-1", "broker", "Broker", ConnectionType: ProviderConnectionType.Brokerage)
+                ],
+                Bindings:
+                [
+                    new ProviderBindingConfig("pnl-binding", ProviderCapabilityKind.PnLStream, "broker-1", Target: new ProviderBindingTarget())
+                ])));
+
+        var service = CreateService();
+        var result = await service.RouteAsync(new ProviderRouteContext(
+            Capability: ProviderCapabilityKind.PnLStream,
+            AccountId: Guid.NewGuid()));
+
+        result.IsSuccess.Should().BeFalse();
+        result.SelectedDecision.Should().BeNull();
+        result.PolicyGate.Should().Contain("account-scoped");
+    }
+
+    [Fact]
+    public async Task RouteAsync_PnLStreamDoesNotSelectHealthyBackup()
+    {
+        var accountId = Guid.NewGuid();
+        await SaveConfigAsync(new AppConfig(
+            ProviderConnections: new ProviderConnectionsConfig(
+                Connections:
+                [
+                    new ProviderConnectionConfig("primary", "alpha", "Primary", ConnectionType: ProviderConnectionType.Brokerage),
+                    new ProviderConnectionConfig("backup", "beta", "Backup", ConnectionType: ProviderConnectionType.Brokerage)
+                ],
+                Bindings:
+                [
+                    new ProviderBindingConfig(
+                        "pnl-binding",
+                        ProviderCapabilityKind.PnLStream,
+                        "primary",
+                        Target: new ProviderBindingTarget(AccountId: accountId),
+                        FailoverConnectionIds: ["backup"])
+                ])));
+
+        var service = CreateService(new FakeHealthSource(("primary", false), ("backup", true)));
+        var result = await service.RouteAsync(new ProviderRouteContext(ProviderCapabilityKind.PnLStream, AccountId: accountId));
+
+        result.IsSuccess.Should().BeFalse();
+        result.SelectedDecision.Should().BeNull();
+        result.PolicyGate.Should().Contain("automatic failover is blocked");
+    }
+
+    [Fact]
     public async Task RouteAsync_RequestRequiresProductionReady_BlocksDraftConnection()
     {
         await SaveConfigAsync(new AppConfig(
@@ -461,11 +514,12 @@ public sealed class ProviderRoutingServiceTests : IDisposable
         public IReadOnlyList<ProviderCapabilityDescriptor> CapabilityDescriptors =>
         [
             new(ProviderCapabilityKind.HistoricalBars, "bars"),
-            new(ProviderCapabilityKind.OrderExecution, "execution", RequiresAccountBinding: true, SupportsFailover: false)
+            new(ProviderCapabilityKind.OrderExecution, "execution", RequiresAccountBinding: true, SupportsFailover: false),
+            new(ProviderCapabilityKind.PnLStream, "P&L stream", RequiresAccountBinding: true, SupportsFailover: false)
         ];
 
         public bool SupportsCapability(ProviderCapabilityKind capability)
-            => capability is ProviderCapabilityKind.HistoricalBars or ProviderCapabilityKind.OrderExecution;
+            => capability is ProviderCapabilityKind.HistoricalBars or ProviderCapabilityKind.OrderExecution or ProviderCapabilityKind.PnLStream;
 
         public Task InitializeConnectionAsync(string connectionId, ProviderConnectionScope scope, CancellationToken ct = default)
             => Task.CompletedTask;


### PR DESCRIPTION
### Motivation
- Prevent account-scoped P&L data from being satisfied by unscoped/global bindings or by automatic failover when a provider explicitly marks the capability as account-bound and non-failover.
- Close a routing-policy gap where `PnLStream` was registered with `requiresAccountBinding=true` and `supportsFailover=false` but the default safety policy and routing checks did not enforce those constraints.

### Description
- Classify `ProviderCapabilityKind.PnLStream` as account-sensitive in `ProviderSafetyPolicy.DefaultFor` so it defaults to `NoAutomaticFailover` and `RequireExplicitBinding` (`src/Meridian.ProviderSdk/ProviderRoutingModels.cs`).
- Extend the routing policy gate in `DeterminePolicyGate` to treat `PnLStream` like other strict account-scoped capabilities, blocking unscoped/global bindings when `AccountId` is present (`src/Meridian.Application/ProviderRouting/ProviderRoutingEngine.cs`).
- Ensure routing does not implicitly allow Health-Aware failover for account P&L by relying on the safety policy defaults above (affects fallback resolution and selection paths) (`src/Meridian.Application/ProviderRouting/ProviderRoutingEngine.cs`).
- Add regression tests that assert unscoped PnL bindings are blocked and that PnL streams do not select healthy backups when the primary is unhealthy, and update the test fake adapter to advertise `PnLStream` capability (`tests/Meridian.Tests/Application/ProviderRouting/ProviderRoutingServiceTests.cs`).

### Testing
- Ran `git diff --check`, which passed with no whitespace or diff-check errors.
- Ran `python build/python/cli/buildctl.py validation-status --summary`, which returned a clean local validation summary (no active build locks).
- Attempted to run the focused test filter with `dotnet test --filter FullyQualifiedName~ProviderRoutingServiceTests`, but it could not be executed in this environment because the `.NET SDK` is not installed (`dotnet: command not found`).
- Ran `bash scripts/ci.sh` which stopped at the SDK verification step for the same missing `dotnet` reason, so full CI/test verification must be completed in CI or a .NET-enabled environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6289ea86808320ae20bdc6acc31233)