### PR TITLE
Secure provider data-projection endpoint with tenant-scope and ViewTrades permission

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/ProviderDataProjectionEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/ProviderDataProjectionEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Meridian.Contracts.Api;
+using Meridian.Identity.Auth;
 using Meridian.Ui.Shared.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -16,7 +17,9 @@ public static class ProviderDataProjectionEndpoints
             Results.Json(CreateProjection(service), jsonOptions))
             .WithName("GetProviderDataProjection")
             .WithTags("Providers")
-            .Produces<ProviderDataProjectionSnapshot>(StatusCodes.Status200OK);
+            .Produces<ProviderDataProjectionSnapshot>(StatusCodes.Status200OK)
+            .RequireWorkstationTenantScope()
+            .RequirePermission(UserPermission.ViewTrades);
     }
 
     public static ProviderDataProjectionSnapshot CreateProjection(ProviderDataReadModelService service) =>

--- a/tests/Meridian.Tests/Integration/EndpointTests/ProviderDataProjectionAuthorizationTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/ProviderDataProjectionAuthorizationTests.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using FluentAssertions;
+using Meridian.Identity.Auth;
+using Meridian.Ui.Shared.Endpoints;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Meridian.Tests.Integration.EndpointTests;
+
+[Trait("Category", "Integration")]
+[Collection("Endpoint")]
+public sealed class ProviderDataProjectionAuthorizationTests : IDisposable
+{
+    private const string Route = "/api/providers/data-projection";
+    private readonly EndpointTestFixture _fixture;
+    private readonly HttpClient _unauthenticatedClient;
+
+    public ProviderDataProjectionAuthorizationTests(EndpointTestFixture fixture)
+    {
+        _fixture = fixture;
+        _unauthenticatedClient = fixture.CreateNoRedirectClient();
+    }
+
+    public void Dispose() => _unauthenticatedClient.Dispose();
+
+    [Fact]
+    public async Task ProviderDataProjection_WithoutViewTradesPermission_IsRejected()
+    {
+        var response = await _unauthenticatedClient.GetAsync(Route);
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public void ProviderDataProjection_RequiresTenantScopeAndViewTradesPermission()
+    {
+        var endpoint = _fixture.Services
+            .GetRequiredService<EndpointDataSource>()
+            .Endpoints
+            .OfType<RouteEndpoint>()
+            .Single(candidate =>
+                NormalizeRoute(candidate.RoutePattern.RawText) == Route &&
+                candidate.Metadata.GetMetadata<HttpMethodMetadata>()!.HttpMethods.Contains("GET"));
+
+        endpoint.Metadata.GetMetadata<WorkstationTenantScopeMetadata>().Should().NotBeNull();
+        var authorization = endpoint.Metadata.GetMetadata<EndpointAuthorizationMetadata>();
+        authorization.Should().NotBeNull();
+        authorization!.Permissions.Should().ContainSingle().Which.Should().Be(UserPermission.ViewTrades);
+    }
+
+    private static string NormalizeRoute(string? rawRoute) =>
+        string.IsNullOrEmpty(rawRoute) || rawRoute.StartsWith('/') ? rawRoute ?? string.Empty : "/" + rawRoute;
+}


### PR DESCRIPTION
### Motivation
- Close an authorization gap that exposed provider account identifiers, P&L, and entitlement/connection details to any authenticated workstation user.
- Align the new provider projection endpoint with existing provider-related routes that require explicit tenant scoping and permission gates.

### Description
- Require a workstation tenant scope by calling `.RequireWorkstationTenantScope()` and require `UserPermission.ViewTrades` via `.RequirePermission(UserPermission.ViewTrades)` on the `/api/providers/data-projection` `MapGet` handler.
- Import `Meridian.Identity.Auth` for the `UserPermission` enum and leave the projection payload and assembly logic unchanged to preserve existing behavior.
- Add an integration test `ProviderDataProjectionAuthorizationTests` that asserts unauthorized GETs are rejected and that the mapped endpoint exposes both `WorkstationTenantScopeMetadata` and `EndpointAuthorizationMetadata` requiring `ViewTrades`.

### Testing
- Ran `git diff --check` which passed with no style/whitespace issues detected.
- Attempted to run the repository validation via `bash scripts/ci.sh`, but the local container lacks the `dotnet` SDK so the check halted at SDK verification and could not run the test suite.
- Added integration-level coverage that will run in CI; GitHub Actions remains the authoritative test run and should be used to validate the new test and endpoint metadata in a full .NET environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6289eaf17883208b1fe27e26ec2c94)