### PR TITLE
Fix Interactive Brokers vendor callback syntax

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.IBApiVendorStubs.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.IBApiVendorStubs.cs
@@ -64,7 +64,7 @@ public sealed partial class EnhancedIBConnectionManager
     {
         RecordMessageReceived();
         var contract = contractDetails.Contract;
-        ScannerResultReceived?.Invoke(this, (reqId, new ProviderScannerResult(rank, contract.Symbol, contract.Exchange, contract.ConId.ToString(), distance, benchmark, projection, legsStr, ProviderDataProvenance.Unattributed(DateTimeOffset.UtcNow)));
+        ScannerResultReceived?.Invoke(this, (reqId, new ProviderScannerResult(rank, contract.Symbol, contract.Exchange, contract.ConId.ToString(), distance, benchmark, projection, legsStr, ProviderDataProvenance.Unattributed(DateTimeOffset.UtcNow))));
     }
 
     public void scannerDataEnd(int reqId)
@@ -120,7 +120,7 @@ public sealed partial class EnhancedIBConnectionManager
         {
             if (!DateOnly.TryParseExact(expirationText, "yyyyMMdd", out var expiration)) continue;
             foreach (var strike in strikes)
-                OptionContractReceived?.Invoke(this, (reqId, new ProviderOptionContract(string.Empty, underlyingConId.ToString(), expiration, (decimal)strike, string.Empty, exchange, tradingClass, multiplier, null, ProviderDataProvenance.Unattributed(DateTimeOffset.UtcNow)));
+                OptionContractReceived?.Invoke(this, (reqId, new ProviderOptionContract(string.Empty, underlyingConId.ToString(), expiration, (decimal)strike, string.Empty, exchange, tradingClass, multiplier, null, ProviderDataProvenance.Unattributed(DateTimeOffset.UtcNow))));
         }
     }
 
@@ -172,13 +172,13 @@ public sealed partial class EnhancedIBConnectionManager
     public void pnl(int reqId, double dailyPnL, double unrealizedPnL, double realizedPnL)
     {
         RecordMessageReceived();
-        PnlReceived?.Invoke(this, (reqId, new ProviderAccountPnl(string.Empty, null, (decimal)dailyPnL, (decimal)unrealizedPnL, (decimal)realizedPnL, null, null, ProviderDataProvenance.Unattributed(DateTimeOffset.UtcNow)));
+        PnlReceived?.Invoke(this, (reqId, new ProviderAccountPnl(string.Empty, null, (decimal)dailyPnL, (decimal)unrealizedPnL, (decimal)realizedPnL, null, null, ProviderDataProvenance.Unattributed(DateTimeOffset.UtcNow))));
     }
 
     public void pnlSingle(int reqId, decimal pos, double dailyPnL, double unrealizedPnL, double realizedPnL, double value)
     {
         RecordMessageReceived();
-        PnlReceived?.Invoke(this, (reqId, new ProviderAccountPnl(string.Empty, null, (decimal)dailyPnL, (decimal)unrealizedPnL, (decimal)realizedPnL, pos, (decimal)value, ProviderDataProvenance.Unattributed(DateTimeOffset.UtcNow)));
+        PnlReceived?.Invoke(this, (reqId, new ProviderAccountPnl(string.Empty, null, (decimal)dailyPnL, (decimal)unrealizedPnL, (decimal)realizedPnL, pos, (decimal)value, ProviderDataProvenance.Unattributed(DateTimeOffset.UtcNow))));
     }
 
     public void historicalTicks(int reqId, HistoricalTick[] ticks, bool done)


### PR DESCRIPTION
### Motivation
- Restore compilation for the opt-in Interactive Brokers vendor build path by fixing malformed `Invoke` expressions that were left with an unmatched opening parenthesis after adding `ProviderDataProvenance` arguments.

### Description
- Add the missing closing `)` to four callback invocations in `src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.IBApiVendorStubs.cs` so the `ScannerResultReceived`, `OptionContractReceived`, and both `PnlReceived` calls are syntactically valid. 
- The change is minimal and purely syntactic and does not alter callback payloads or runtime behavior beyond restoring compilability in the `IBAPI_VENDOR` build mode.

### Testing
- Ran a targeted Python parenthesis-balance check against the four corrected lines (command: `python3` script) and it reported all four lines as balanced (passed). 
- Ran `git diff --check` to confirm there are no whitespace or diff issues (passed). 
- Ran `python3 build/python/cli/buildctl.py validation-status --summary` to verify local validation state (passed). 
- Attempted full CI and vendor build with `bash scripts/ci.sh` and `dotnet build -p:EnableIbApiVendor=true`, but these were blocked in this environment because `dotnet` is not installed; the syntactic fix is still self-contained and ready for CI verification in an environment with the .NET SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6289ea61448320a60f2be42b2b7359)