### PR TITLE
Fix uncorrelated Interactive Brokers callbacks

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.IBApi.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.IBApi.cs
@@ -394,6 +394,11 @@ public sealed partial class EnhancedIBConnectionManager : EWrapper, IDisposable
                 NotifyConnectionLost(ex);
                 break;
             }
+            catch (Exception ex) when (!ct.IsCancellationRequested)
+            {
+                NotifyConnectionLost(ex);
+                break;
+            }
         }
     }
 

--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDataServices.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDataServices.cs
@@ -393,9 +393,17 @@ public sealed class IBDataServices : IProviderDataReadService, IDisposable
     private void OnHistoricalNewsReceived(object? sender, (int RequestId, ProviderNewsHeadline Headline) value) => RecordNewsHeadline(value.RequestId, value.Headline);
     private void OnNewsArticleReceived(object? sender, (int RequestId, ProviderNewsArticle Article) value) => RecordNewsArticle(value.RequestId, value.Article);
     private void OnFundamentalReportReceived(object? sender, (int RequestId, ProviderFundamentalReport Report) value) => RecordFundamentalReport(value.RequestId, value.Report);
-    private void OnTickByTickReceived(object? sender, (int RequestId, ProviderTickByTickObservation Observation) value) => RecordTickByTick(value.RequestId, value.Observation);
+    private void OnTickByTickReceived(object? sender, (int RequestId, ProviderTickByTickObservation Observation) value)
+    {
+        if (_requests.ContainsKey(value.RequestId))
+            RecordTickByTick(value.RequestId, value.Observation);
+    }
     private void OnDepthExchangesReceived(object? sender, (int RequestId, IReadOnlyList<ProviderDepthExchangeDescription> Exchanges) value) => RecordDepthExchanges(value.RequestId, value.Exchanges);
-    private void OnDividendEarningsReceived(object? sender, (int RequestId, ProviderDividendEarnings Payload) value) => RecordDividendEarnings(value.RequestId, value.Payload);
+    private void OnDividendEarningsReceived(object? sender, (int RequestId, ProviderDividendEarnings Payload) value)
+    {
+        if (_requests.ContainsKey(value.RequestId))
+            RecordDividendEarnings(value.RequestId, value.Payload);
+    }
     private void OnOptionContractReceived(object? sender, (int RequestId, ProviderOptionContract Contract) value) => RecordOptionContract(value.RequestId, value.Contract);
     private void OnScannerResultReceived(object? sender, (int RequestId, ProviderScannerResult Result) value) => RecordScannerResult(value.RequestId, value.Result);
     private void OnRealTimeBarReceived(object? sender, (int RequestId, ProviderRealTimeBar Bar) value) => RecordRealTimeBar(value.RequestId, value.Bar);

--- a/tests/Meridian.Tests/Infrastructure/Providers/IBDataServicesTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/IBDataServicesTests.cs
@@ -286,6 +286,20 @@ public sealed class IBDataServicesTests
         services.GetRequests().Single(x => x.RequestId == rules).MarketRuleIncrements.Should().ContainSingle();
     }
 
+    [Fact]
+    public void CallbackSource_UncorrelatedTickAndDividendCallbacksAreIgnored()
+    {
+        var transport = new CallbackTransport();
+        using var services = new IBDataServices(transport);
+
+        var tick = () => transport.RaiseTick(20_001, new ProviderTickByTickObservation(DateTimeOffset.UtcNow, "last", 200m, 10m));
+        var dividend = () => transport.RaiseDividend(20_002, new ProviderDividendEarnings(1m, 1.1m, new DateOnly(2027, 2, 1), .30m, 7m, 30m));
+
+        tick.Should().NotThrow();
+        dividend.Should().NotThrow();
+        services.GetRequests().Should().BeEmpty();
+    }
+
     private class RecordingTransport : IIBDataServiceTransport
     {
         public List<string> Calls { get; } = [];
@@ -307,6 +321,14 @@ public sealed class IBDataServicesTests
     {
         public string ProviderConnectionId => "ib-gateway:live:7";
         public event EventHandler<IBMarketDataTypeUpdate>? MarketDataTypeReceived;
+        public event EventHandler<(int RequestId, ProviderContractDetails Details)>? ContractDetailsReceived;
+        public event EventHandler<(int RequestId, ProviderOptionChainDefinition Definition)>? OptionChainDefinitionReceived;
+        public event EventHandler<(int RequestId, ProviderNewsHeadline Headline)>? HistoricalNewsReceived;
+        public event EventHandler<(int RequestId, ProviderNewsArticle Article)>? NewsArticleReceived;
+        public event EventHandler<(int RequestId, ProviderFundamentalReport Report)>? FundamentalReportReceived;
+        public event EventHandler<(int RequestId, ProviderTickByTickObservation Observation)>? TickByTickReceived;
+        public event EventHandler<(int RequestId, IReadOnlyList<ProviderDepthExchangeDescription> Exchanges)>? DepthExchangesReceived;
+        public event EventHandler<(int RequestId, ProviderDividendEarnings Payload)>? DividendEarningsReceived;
         public event EventHandler<(int RequestId, ProviderOptionContract Contract)>? OptionContractReceived;
         public event EventHandler<(int RequestId, ProviderScannerResult Result)>? ScannerResultReceived;
         public event EventHandler<(int RequestId, ProviderRealTimeBar Bar)>? RealTimeBarReceived;
@@ -327,6 +349,19 @@ public sealed class IBDataServicesTests
         public void RequestPnl(int requestId, string account, string? modelCode) { }
         public void RequestMarketRule(int requestId, int marketRuleId) { }
         public void RequestDepthExchanges(int requestId) { }
+        public void RaiseContract(int requestId, ProviderContractDetails details) => ContractDetailsReceived?.Invoke(this, (requestId, details));
+        public void RaiseChain(int requestId, ProviderOptionChainDefinition definition) => OptionChainDefinitionReceived?.Invoke(this, (requestId, definition));
+        public void RaiseHeadline(int requestId, ProviderNewsHeadline headline) => HistoricalNewsReceived?.Invoke(this, (requestId, headline));
+        public void RaiseArticle(int requestId, ProviderNewsArticle article) => NewsArticleReceived?.Invoke(this, (requestId, article));
+        public void RaiseFundamental(int requestId, ProviderFundamentalReport report) => FundamentalReportReceived?.Invoke(this, (requestId, report));
+        public void RaiseTick(int requestId, ProviderTickByTickObservation observation) => TickByTickReceived?.Invoke(this, (requestId, observation));
+        public void RaiseDepth(int requestId, IReadOnlyList<ProviderDepthExchangeDescription> exchanges) => DepthExchangesReceived?.Invoke(this, (requestId, exchanges));
+        public void RaiseDividend(int requestId, ProviderDividendEarnings payload) => DividendEarningsReceived?.Invoke(this, (requestId, payload));
+        public void RaiseScanner(int requestId, ProviderScannerResult result) => ScannerResultReceived?.Invoke(this, (requestId, result));
+        public void RaisePnl(int requestId, ProviderAccountPnl pnl) => PnlReceived?.Invoke(this, (requestId, pnl));
+        public void RaiseMarketRule(int requestId, IReadOnlyList<ProviderMarketRuleIncrement> increments) => MarketRuleReceived?.Invoke(this, (requestId, increments));
+        public void RaiseCompleted(int requestId) => RequestCompleted?.Invoke(this, requestId);
+        public void RaiseRejected(int requestId, string code, string message) => RequestRejected?.Invoke(this, (requestId, code, message));
         public void RaiseScannerResult(int requestId, ProviderScannerResult result) => ScannerResultReceived?.Invoke(this, (requestId, result));
         public void RaiseMarketDataType(int requestId, int marketDataType) => MarketDataTypeReceived?.Invoke(this, new IBMarketDataTypeUpdate(requestId, marketDataType));
     }


### PR DESCRIPTION
### Motivation
- Prevent uncorrelated vendor callbacks from throwing inside provider handlers and escaping the IB reader loop, which can lead to connection availability loss.
- Ensure callback emissions are correlated to `IBDataServices`-owned request ids and that unexpected handler failures are isolated and reported instead of letting the reader task fault.

### Description
- Guard `OnTickByTickReceived` and `OnDividendEarningsReceived` in `src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDataServices.cs` to ignore callback payloads whose `RequestId` is not present in `_requests` instead of calling `UpdateReadModel` and throwing on unknown ids.
- Add a catch-all exception handler to the reader loop in `src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.IBApi.cs` so any unexpected exception from callback processing triggers `NotifyConnectionLost` and breaks the loop rather than letting the reader task crash unobserved.
- Complete the test callback bridge in `tests/Meridian.Tests/Infrastructure/Providers/IBDataServicesTests.cs` by adding the missing event-raise helpers and wire-ups used by the correlated-callback tests, and add a new regression test `CallbackSource_UncorrelatedTickAndDividendCallbacksAreIgnored` that verifies uncorrelated tick/dividend callbacks do not throw and do not create requests.
- Files changed: `IBDataServices.cs`, `EnhancedIBConnectionManager.IBApi.cs`, and `tests/Meridian.Tests/Infrastructure/Providers/IBDataServicesTests.cs`.

### Testing
- `git diff --check` was run and reported no problems.
- `python build/python/cli/buildctl.py validation-status --summary` was run and returned a clean validation status (no blocked builds or active processes).
- `bash scripts/ci.sh` could not complete in this environment because `dotnet` is not installed, so full `dotnet` test execution and CI checks were not run here; the new unit test was added but not executed locally for the same reason.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6289ec06248320b452c0a01b6533aa)