### PR TITLE
fix: ignore untracked IB data callbacks

### DIFF
--- a/docs/source/generated/source-hash-manifest.json
+++ b/docs/source/generated/source-hash-manifest.json
@@ -191,8 +191,8 @@
       "id": "SRC-INFRASTRUCTURE",
       "path": "src/Meridian.Infrastructure",
       "readme": "src/Meridian.Infrastructure/README.md",
-      "readme_hash": "e349a94db45f623ba5d83849b60333f03aaa3eaee56088f7fcb88180e78408cb",
-      "source_hash": "e92e51a1b847d24bb52189361d2983fe115d6e550d3adb403eba7310bf3f989c"
+      "readme_hash": "f246408ff8bb401ffe4f2b7b99dcfad0ee7cf5c770c2cb7b3cd02187b0c269d6",
+      "source_hash": "787009ab8d1f53400940f943ec18634000f6add48cec7fae4a201d1bf07cac62"
     },
     {
       "id": "SRC-LAUNCHER",

--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDataServices.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBDataServices.cs
@@ -388,22 +388,28 @@ public sealed class IBDataServices : IProviderDataReadService, IDisposable
             RecordMarketDataType(update.RequestId, update.MarketDataType);
     }
 
-    private void OnContractDetailsReceived(object? sender, (int RequestId, ProviderContractDetails Details) value) => RecordContractDetails(value.RequestId, value.Details);
-    private void OnOptionChainDefinitionReceived(object? sender, (int RequestId, ProviderOptionChainDefinition Definition) value) => RecordOptionChainDefinition(value.RequestId, value.Definition);
-    private void OnHistoricalNewsReceived(object? sender, (int RequestId, ProviderNewsHeadline Headline) value) => RecordNewsHeadline(value.RequestId, value.Headline);
-    private void OnNewsArticleReceived(object? sender, (int RequestId, ProviderNewsArticle Article) value) => RecordNewsArticle(value.RequestId, value.Article);
-    private void OnFundamentalReportReceived(object? sender, (int RequestId, ProviderFundamentalReport Report) value) => RecordFundamentalReport(value.RequestId, value.Report);
-    private void OnTickByTickReceived(object? sender, (int RequestId, ProviderTickByTickObservation Observation) value) => RecordTickByTick(value.RequestId, value.Observation);
-    private void OnDepthExchangesReceived(object? sender, (int RequestId, IReadOnlyList<ProviderDepthExchangeDescription> Exchanges) value) => RecordDepthExchanges(value.RequestId, value.Exchanges);
-    private void OnDividendEarningsReceived(object? sender, (int RequestId, ProviderDividendEarnings Payload) value) => RecordDividendEarnings(value.RequestId, value.Payload);
-    private void OnOptionContractReceived(object? sender, (int RequestId, ProviderOptionContract Contract) value) => RecordOptionContract(value.RequestId, value.Contract);
-    private void OnScannerResultReceived(object? sender, (int RequestId, ProviderScannerResult Result) value) => RecordScannerResult(value.RequestId, value.Result);
-    private void OnRealTimeBarReceived(object? sender, (int RequestId, ProviderRealTimeBar Bar) value) => RecordRealTimeBar(value.RequestId, value.Bar);
-    private void OnHistoricalTickReceived(object? sender, (int RequestId, ProviderHistoricalTick Tick, bool Completed) value) => RecordHistoricalTick(value.RequestId, value.Tick, value.Completed);
-    private void OnPnlReceived(object? sender, (int RequestId, ProviderAccountPnl Pnl) value) => RecordPnl(value.RequestId, value.Pnl);
-    private void OnMarketRuleReceived(object? sender, (int RequestId, IReadOnlyList<ProviderMarketRuleIncrement> Increments) value) => RecordMarketRule(value.RequestId, value.Increments);
-    private void OnRequestCompleted(object? sender, int requestId) => CompleteRequest(requestId);
-    private void OnRequestRejected(object? sender, (int RequestId, string Code, string Message) value) => RejectRequest(value.RequestId, value.Code, value.Message);
+    private void OnContractDetailsReceived(object? sender, (int RequestId, ProviderContractDetails Details) value) => HandleCallback(value.RequestId, () => RecordContractDetails(value.RequestId, value.Details));
+    private void OnOptionChainDefinitionReceived(object? sender, (int RequestId, ProviderOptionChainDefinition Definition) value) => HandleCallback(value.RequestId, () => RecordOptionChainDefinition(value.RequestId, value.Definition));
+    private void OnHistoricalNewsReceived(object? sender, (int RequestId, ProviderNewsHeadline Headline) value) => HandleCallback(value.RequestId, () => RecordNewsHeadline(value.RequestId, value.Headline));
+    private void OnNewsArticleReceived(object? sender, (int RequestId, ProviderNewsArticle Article) value) => HandleCallback(value.RequestId, () => RecordNewsArticle(value.RequestId, value.Article));
+    private void OnFundamentalReportReceived(object? sender, (int RequestId, ProviderFundamentalReport Report) value) => HandleCallback(value.RequestId, () => RecordFundamentalReport(value.RequestId, value.Report));
+    private void OnTickByTickReceived(object? sender, (int RequestId, ProviderTickByTickObservation Observation) value) => HandleCallback(value.RequestId, () => RecordTickByTick(value.RequestId, value.Observation));
+    private void OnDepthExchangesReceived(object? sender, (int RequestId, IReadOnlyList<ProviderDepthExchangeDescription> Exchanges) value) => HandleCallback(value.RequestId, () => RecordDepthExchanges(value.RequestId, value.Exchanges));
+    private void OnDividendEarningsReceived(object? sender, (int RequestId, ProviderDividendEarnings Payload) value) => HandleCallback(value.RequestId, () => RecordDividendEarnings(value.RequestId, value.Payload));
+    private void OnOptionContractReceived(object? sender, (int RequestId, ProviderOptionContract Contract) value) => HandleCallback(value.RequestId, () => RecordOptionContract(value.RequestId, value.Contract));
+    private void OnScannerResultReceived(object? sender, (int RequestId, ProviderScannerResult Result) value) => HandleCallback(value.RequestId, () => RecordScannerResult(value.RequestId, value.Result));
+    private void OnRealTimeBarReceived(object? sender, (int RequestId, ProviderRealTimeBar Bar) value) => HandleCallback(value.RequestId, () => RecordRealTimeBar(value.RequestId, value.Bar));
+    private void OnHistoricalTickReceived(object? sender, (int RequestId, ProviderHistoricalTick Tick, bool Completed) value) => HandleCallback(value.RequestId, () => RecordHistoricalTick(value.RequestId, value.Tick, value.Completed));
+    private void OnPnlReceived(object? sender, (int RequestId, ProviderAccountPnl Pnl) value) => HandleCallback(value.RequestId, () => RecordPnl(value.RequestId, value.Pnl));
+    private void OnMarketRuleReceived(object? sender, (int RequestId, IReadOnlyList<ProviderMarketRuleIncrement> Increments) value) => HandleCallback(value.RequestId, () => RecordMarketRule(value.RequestId, value.Increments));
+    private void OnRequestCompleted(object? sender, int requestId) => HandleCallback(requestId, () => CompleteRequest(requestId));
+    private void OnRequestRejected(object? sender, (int RequestId, string Code, string Message) value) => HandleCallback(value.RequestId, () => RejectRequest(value.RequestId, value.Code, value.Message));
+
+    private void HandleCallback(int requestId, Action callback)
+    {
+        if (_requests.ContainsKey(requestId))
+            callback();
+    }
 
     private int Issue(string service, string symbol, string? exchange, string? subscription, Action<int> send, CancellationToken ct)
     {

--- a/src/Meridian.Infrastructure/README.md
+++ b/src/Meridian.Infrastructure/README.md
@@ -130,8 +130,9 @@ it commits each `WatchAsync` update to `IIBDataResultStore` before making that u
 operator readers; successful request submission is not evidence of a live entitlement.
 Its richer request callbacks publish bounded, request-correlated ProviderSdk read-model updates for
 option discovery, scanners, real-time bars, historical ticks, account/model-account P&L, and market
-rules. Each returned request and observation carries required provenance: provider and configured
-connection identity, source and receipt times, reported entitlement/feed/availability, request descriptor,
+rules. Callbacks that do not correlate to an active `IBDataServices` request are ignored. Each returned
+request and observation carries required provenance: provider and configured connection identity, source
+and receipt times, reported entitlement/feed/availability, request descriptor,
 provider-native identity, correlation, and a deterministic de-duplication key. Vendor SDK absence remains simulation/fail-closed and cannot advertise live IB capability.
 The brokerage gateway template remains an obsolete copy-target, but its scaffold behavior is
 deterministic: provider-discovery metadata, option-backed identity/capabilities, configurable

--- a/tests/Meridian.Tests/Infrastructure/Providers/IBDataServicesTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/IBDataServicesTests.cs
@@ -286,6 +286,20 @@ public sealed class IBDataServicesTests
         services.GetRequests().Single(x => x.RequestId == rules).MarketRuleIncrements.Should().ContainSingle();
     }
 
+    [Fact]
+    public void CallbackSource_UnrelatedProviderRequestRejected_IsIgnoredWithoutAffectingTrackedRequests()
+    {
+        var transport = new CallbackTransport();
+        using var services = new IBDataServices(transport);
+        var requestId = services.RequestScanner(new IBScannerRequest("STK", "STK.US.MAJOR", "TOP_PERC_GAIN"));
+
+        var action = () => transport.RaiseRejected(12345, "354", "Requested market data is not subscribed.");
+
+        action.Should().NotThrow();
+        services.GetRequests().Single().Should().Match<ProviderDataRequestReadModel>(request =>
+            request.RequestId == requestId && request.Status == ProviderDataRequestStatus.Requested);
+    }
+
     private class RecordingTransport : IIBDataServiceTransport
     {
         public List<string> Calls { get; } = [];
@@ -303,10 +317,18 @@ public sealed class IBDataServicesTests
         public void CancelDataRequest(int requestId, string capability) => Calls.Add($"cancel:{requestId}:{capability}");
     }
 
-    private sealed class CallbackTransport : IIBDataServiceTransport, IIBDataLineageSource, IIBDataCallbackSource, IIBProviderConnectionIdentity
+    private sealed class CallbackTransport : RecordingTransport, IIBDataLineageSource, IIBDataCallbackSource, IIBProviderConnectionIdentity
     {
         public string ProviderConnectionId => "ib-gateway:live:7";
         public event EventHandler<IBMarketDataTypeUpdate>? MarketDataTypeReceived;
+        public event EventHandler<(int RequestId, ProviderContractDetails Details)>? ContractDetailsReceived;
+        public event EventHandler<(int RequestId, ProviderOptionChainDefinition Definition)>? OptionChainDefinitionReceived;
+        public event EventHandler<(int RequestId, ProviderNewsHeadline Headline)>? HistoricalNewsReceived;
+        public event EventHandler<(int RequestId, ProviderNewsArticle Article)>? NewsArticleReceived;
+        public event EventHandler<(int RequestId, ProviderFundamentalReport Report)>? FundamentalReportReceived;
+        public event EventHandler<(int RequestId, ProviderTickByTickObservation Observation)>? TickByTickReceived;
+        public event EventHandler<(int RequestId, IReadOnlyList<ProviderDepthExchangeDescription> Exchanges)>? DepthExchangesReceived;
+        public event EventHandler<(int RequestId, ProviderDividendEarnings Payload)>? DividendEarningsReceived;
         public event EventHandler<(int RequestId, ProviderOptionContract Contract)>? OptionContractReceived;
         public event EventHandler<(int RequestId, ProviderScannerResult Result)>? ScannerResultReceived;
         public event EventHandler<(int RequestId, ProviderRealTimeBar Bar)>? RealTimeBarReceived;
@@ -316,18 +338,20 @@ public sealed class IBDataServicesTests
         public event EventHandler<int>? RequestCompleted;
         public event EventHandler<(int RequestId, string Code, string Message)>? RequestRejected;
 
-        public void RequestScanner(int requestId, IBScannerRequest request) { }
-        public void RequestContractDetails(int requestId, SymbolConfig contract) { }
-        public void RequestOptionChain(int requestId, SymbolConfig underlying) { }
-        public void RequestHistoricalNews(int requestId, int conId, string providerCodes, DateTimeOffset start, DateTimeOffset end, int maximumResults) { }
-        public void RequestNewsArticle(int requestId, string providerCode, string articleId) { }
-        public void RequestFundamentals(int requestId, SymbolConfig contract, string reportType) { }
-        public void RequestDividendEarnings(int requestId, SymbolConfig contract) { }
-        public void RequestTickByTick(int requestId, SymbolConfig contract, string tickType, int numberOfTicks, bool ignoreSize) { }
-        public void RequestPnl(int requestId, string account, string? modelCode) { }
-        public void RequestMarketRule(int requestId, int marketRuleId) { }
-        public void RequestDepthExchanges(int requestId) { }
+        public void RaiseContract(int id, ProviderContractDetails value) => ContractDetailsReceived?.Invoke(this, (id, value));
+        public void RaiseChain(int id, ProviderOptionChainDefinition value) => OptionChainDefinitionReceived?.Invoke(this, (id, value));
+        public void RaiseHeadline(int id, ProviderNewsHeadline value) => HistoricalNewsReceived?.Invoke(this, (id, value));
+        public void RaiseArticle(int id, ProviderNewsArticle value) => NewsArticleReceived?.Invoke(this, (id, value));
+        public void RaiseFundamental(int id, ProviderFundamentalReport value) => FundamentalReportReceived?.Invoke(this, (id, value));
+        public void RaiseTick(int id, ProviderTickByTickObservation value) => TickByTickReceived?.Invoke(this, (id, value));
+        public void RaiseDepth(int id, IReadOnlyList<ProviderDepthExchangeDescription> value) => DepthExchangesReceived?.Invoke(this, (id, value));
+        public void RaiseDividend(int id, ProviderDividendEarnings value) => DividendEarningsReceived?.Invoke(this, (id, value));
         public void RaiseScannerResult(int requestId, ProviderScannerResult result) => ScannerResultReceived?.Invoke(this, (requestId, result));
         public void RaiseMarketDataType(int requestId, int marketDataType) => MarketDataTypeReceived?.Invoke(this, new IBMarketDataTypeUpdate(requestId, marketDataType));
+        public void RaiseScanner(int id, ProviderScannerResult value) => ScannerResultReceived?.Invoke(this, (id, value));
+        public void RaisePnl(int id, ProviderAccountPnl value) => PnlReceived?.Invoke(this, (id, value));
+        public void RaiseMarketRule(int id, IReadOnlyList<ProviderMarketRuleIncrement> value) => MarketRuleReceived?.Invoke(this, (id, value));
+        public void RaiseCompleted(int id) => RequestCompleted?.Invoke(this, id);
+        public void RaiseRejected(int id, string code, string message) => RequestRejected?.Invoke(this, (id, code, message));
     }
 }


### PR DESCRIPTION
### Motivation

- Prevent untrusted or unrelated Interactive Brokers callbacks from throwing `KeyNotFoundException` and faulting the IB reader loop by ensuring callbacks only update read-models when the request id is owned by the service. 

### Description

- Guarded all `IIBDataCallbackSource` handlers in `IBDataServices` by wrapping them with `HandleCallback(requestId, ...)` which checks `_requests.ContainsKey(requestId)` before applying state updates. 
- Added a regression test `CallbackSource_UnrelatedProviderRequestRejected_IsIgnoredWithoutAffectingTrackedRequests` in `tests/Meridian.Tests/Infrastructure/Providers/IBDataServicesTests.cs` that raises an untracked `RequestRejected` and asserts it does not throw or mutate a tracked request. 
- Extended the test callback transport helpers to expose `Raise*` methods used by the new test and documented the behavior in `src/Meridian.Infrastructure/README.md`. 
- Refreshed the Infrastructure source-hash manifest (`docs/source/generated/source-hash-manifest.json`) to reflect the README and code edits. 

### Testing

- Ran `python3 build/scripts/docs/validate-doc-hashes.py --write-module SRC-INFRASTRUCTURE --summary` which passed and updated the manifest. 
- Ran `git diff --check` which passed with no new issues reported. 
- Attempted `dotnet build src/Meridian.Infrastructure/Meridian.Infrastructure.csproj -c Release --no-restore /p:EnableWindowsTargeting=true -v:minimal` but the build was blocked by pre-existing `Meridian.ProviderSdk` compilation errors (duplicate `ProviderNewsArticle` definition and missing `ProviderDataRequestStatus`) unrelated to this change. 
- Ran the full CI script `bash scripts/ci.sh` but it stopped at the formatting gate due to unrelated whitespace formatting violations in other Infrastructure files; format enforcement prevented completing the gate in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a628e21a3648320b825365b7fcb7131)