### PR TITLE
Preserve live gap remediation opt-in across configuration saves

### DIFF
--- a/src/Meridian.Contracts/Configuration/AppConfigDto.cs
+++ b/src/Meridian.Contracts/Configuration/AppConfigDto.cs
@@ -213,6 +213,9 @@ public sealed class BackfillConfigDto
 /// <summary>Operator-facing automatic gap-remediation configuration.</summary>
 public sealed class AutoGapRemediationConfigDto
 {
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; set; }
+
     [JsonPropertyName("minimumGapDurationSeconds")]
     public int MinimumGapDurationSeconds { get; set; } = 120;
 

--- a/tests/Meridian.Tests/Contracts/AppConfigDtoRoundTripTests.cs
+++ b/tests/Meridian.Tests/Contracts/AppConfigDtoRoundTripTests.cs
@@ -8,6 +8,34 @@ namespace Meridian.Tests.Contracts;
 public sealed class AppConfigDtoRoundTripTests
 {
     [Fact]
+    public void AutoRemediationOptIn_SurvivesDeserializeSerializeRoundTrip()
+    {
+        const string json = """
+        {
+          "backfill": {
+            "autoRemediation": {
+              "enabled": true,
+              "defaultProvider": "polygon"
+            }
+          }
+        }
+        """;
+
+        var dto = JsonSerializer.Deserialize<AppConfigDto>(json);
+
+        dto.Should().NotBeNull();
+        dto!.Backfill.Should().NotBeNull();
+        dto.Backfill!.AutoRemediation.Should().NotBeNull();
+        dto.Backfill.AutoRemediation!.Enabled.Should().BeTrue();
+
+        var rewritten = JsonSerializer.Serialize(dto);
+        var reloaded = JsonSerializer.Deserialize<AppConfigDto>(rewritten);
+
+        reloaded!.Backfill!.AutoRemediation!.Enabled.Should().BeTrue();
+        reloaded.Backfill.AutoRemediation.DefaultProvider.Should().Be("polygon");
+    }
+
+    [Fact]
     public void UnmodeledTopLevelSections_SurviveDeserializeSerializeRoundTrip()
     {
         const string json = """


### PR DESCRIPTION
### Motivation
- Ensure an operator-configured, explicit opt-in for live gap remediation is not lost when the shared configuration DTO is deserialized and re-serialized by WPF or other consumers.

### Description
- Add a persisted `enabled` boolean to `AutoGapRemediationConfigDto` in `src/Meridian.Contracts/Configuration/AppConfigDto.cs` and add a `AutoRemediationOptIn_SurvivesDeserializeSerializeRoundTrip` unit test in `tests/Meridian.Tests/Contracts/AppConfigDtoRoundTripTests.cs` that verifies an `autoRemediation.enabled: true` + `defaultProvider` value survives a serialize/deserialize round trip.

### Testing
- A focused unit test was added (`AutoRemediationOptIn_SurvivesDeserializeSerializeRoundTrip`) but `dotnet test` could not be executed in this environment because the .NET SDK is not available (`dotnet: command not found`), so CI must run the new test; `git diff --check` passed locally before committing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63dd3f6f588320adce69f69284fbd3)