### PR TITLE
Fix headless hosted-service lifecycle

### DIFF
--- a/docs/source/generated/source-hash-manifest.json
+++ b/docs/source/generated/source-hash-manifest.json
@@ -9,8 +9,8 @@
       "id": "SRC-APP",
       "path": "src/Meridian.Application",
       "readme": "src/Meridian.Application/README.md",
-      "readme_hash": "00e73ef4d96ff4f744ec98adf2eb16520b778f0771dea882b04055d3e4968957",
-      "source_hash": "64839aae12c8f33d9c813eff804317559b59a3e5ee9d322206716770d7b09659"
+      "readme_hash": "0ebee869e1cedc4f22770f412b22682891c5e72b8591bb015bb0ff10fd860a39",
+      "source_hash": "02eedf5f5b5e58a2ab6b2185ab2d9e867c5f3cc78e451d1c69a831206fa9b732"
     },
     {
       "id": "SRC-BACKTESTING",

--- a/src/Meridian.Application/Commands/EtlCommands.cs
+++ b/src/Meridian.Application/Commands/EtlCommands.cs
@@ -13,11 +13,25 @@ internal sealed class EtlCommands : ICliCommand
     private readonly string _configPath;
     private readonly ILogger _log;
     private readonly CliCommandRouteTable _routes;
+    private readonly EtlHostFactory _hostFactory;
 
     public EtlCommands(string configPath, ILogger log)
+        : this(
+            configPath,
+            log,
+            static (path, cancellationToken) =>
+                HostStartup.CreateForEtlAsync(path, cancellationToken))
+    {
+    }
+
+    internal EtlCommands(
+        string configPath,
+        ILogger log,
+        EtlHostFactory hostFactory)
     {
         _configPath = configPath;
         _log = log;
+        _hostFactory = hostFactory;
         _routes = new CliCommandRouteTable(
             CliCommandRoute.Flag("--etl-resume", RunResumeAsync),
             CliCommandRoute.Flags(
@@ -42,7 +56,8 @@ internal sealed class EtlCommands : ICliCommand
 
     private async Task<CliResult> RunResumeAsync(string[] args, CancellationToken ct)
     {
-        await using var startup = HostStartup.CreateDefault(_configPath);
+        await using var startup = await _hostFactory(_configPath, ct)
+            .ConfigureAwait(false);
         var svc = startup.GetRequiredService<IEtlJobService>();
 
         var jobId = CliArguments.RequireValue(args, "--etl-resume", "--etl-resume <job-id>");
@@ -54,7 +69,8 @@ internal sealed class EtlCommands : ICliCommand
 
     private async Task<CliResult> RunJobAsync(string[] args, CancellationToken ct)
     {
-        await using var startup = HostStartup.CreateDefault(_configPath);
+        await using var startup = await _hostFactory(_configPath, ct)
+            .ConfigureAwait(false);
         var svc = startup.GetRequiredService<IEtlJobService>();
         if (!TryBuildDefinition(args, out var definition))
             return CliResult.Fail(ErrorCode.RequiredFieldMissing);
@@ -197,6 +213,10 @@ internal sealed class EtlCommands : ICliCommand
 
         return ToCliResult(result);
     }
+
+    internal delegate Task<HostStartup> EtlHostFactory(
+        string configPath,
+        CancellationToken cancellationToken);
 
     internal static EtlInspectionMode ResolveInspectionMode(string[] args)
     {

--- a/src/Meridian.Application/Composition/Features/CoordinationFeatureRegistration.cs
+++ b/src/Meridian.Application/Composition/Features/CoordinationFeatureRegistration.cs
@@ -44,11 +44,16 @@ internal sealed class CoordinationFeatureRegistration : IServiceFeatureRegistrat
         services.AddSingleton<ClusterCoordinatorService>();
         services.AddSingleton<IClusterCoordinator>(sp =>
             sp.GetRequiredService<ClusterCoordinatorService>());
-        services.AddSingleton<IHostedService>(sp =>
-            sp.GetRequiredService<ClusterCoordinatorService>());
 
-        // Split-brain detection runs as a background service on every cluster member.
-        services.AddHostedService<SplitBrainDetector>();
+        if (options.EnableProcessWideHostedServices)
+        {
+            services.AddSingleton<IHostedService>(sp =>
+                sp.GetRequiredService<ClusterCoordinatorService>());
+
+            // Split-brain detection runs as a background service on every independently hosted
+            // cluster member. Desktop child graphs share the parent member and must not duplicate it.
+            services.AddHostedService<SplitBrainDetector>();
+        }
 
         return services;
     }

--- a/src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs
+++ b/src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs
@@ -141,7 +141,11 @@ internal sealed class StorageFeatureRegistration : IServiceFeatureRegistration
                 new PostgresScopedAccessAssignmentStore(sp.GetRequiredService<ScopedAccessStoreOptions>()));
             services.TryAddSingleton<IScopedAccessAssignmentStore>(sp =>
                 sp.GetRequiredService<PostgresScopedAccessAssignmentStore>());
-            services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, ScopedAccessAssignmentStoreMigrationHostedService>());
+            if (options.EnableProcessWideHostedServices)
+            {
+                services.TryAddEnumerable(
+                    ServiceDescriptor.Singleton<IHostedService, ScopedAccessAssignmentStoreMigrationHostedService>());
+            }
         }
         else
         {
@@ -302,9 +306,17 @@ internal sealed class StorageFeatureRegistration : IServiceFeatureRegistration
             services.AddSingleton<ICertificateOfDepositReferenceService, CertificateOfDepositProjectionService>();
             services.AddSingleton<ISecurityResolver, SecurityResolver>();
             services.AddHostedService<SecurityMasterProjectionWarmupService>();
-            services.AddSingleton<IPolygonCorporateActionFetcher, PolygonCorporateActionFetcher>();
-            services.AddSingleton<PolygonCorporateActionFetcher>(sp => (PolygonCorporateActionFetcher)sp.GetRequiredService<IPolygonCorporateActionFetcher>());
-            services.AddHostedService<PolygonCorporateActionFetcher>(sp => sp.GetRequiredService<PolygonCorporateActionFetcher>());
+            if (options.EnableHttpClientFactory)
+            {
+                services.AddSingleton<IPolygonCorporateActionFetcher, PolygonCorporateActionFetcher>();
+                services.AddSingleton<PolygonCorporateActionFetcher>(
+                    sp => (PolygonCorporateActionFetcher)sp.GetRequiredService<IPolygonCorporateActionFetcher>());
+                if (options.EnableProcessWideHostedServices)
+                {
+                    services.AddHostedService<PolygonCorporateActionFetcher>(
+                        sp => sp.GetRequiredService<PolygonCorporateActionFetcher>());
+                }
+            }
             services.AddSingleton<ITradingParametersBackfillService, TradingParametersBackfillService>();
 
             // Security Master bulk import services
@@ -440,8 +452,11 @@ internal sealed class StorageFeatureRegistration : IServiceFeatureRegistration
             services.AddSingleton<IAccrualLedgerService, AccrualLedgerService>();
             services.AddSingleton<IDirectLendingCommandService, PostgresDirectLendingCommandService>();
             services.AddSingleton<IDirectLendingService, PostgresDirectLendingService>();
-            services.AddHostedService<DirectLendingOutboxDispatcher>();
-            services.AddHostedService<DailyAccrualWorker>();
+            if (options.EnableProcessWideHostedServices)
+            {
+                services.AddHostedService<DirectLendingOutboxDispatcher>();
+                services.AddHostedService<DailyAccrualWorker>();
+            }
         }
 
         var useInMemoryGovernanceServices = IsInMemoryGovernanceProfileEnabled();
@@ -595,7 +610,11 @@ internal sealed class StorageFeatureRegistration : IServiceFeatureRegistration
                 _ => new NoOpDomainProjectionReconciliationJob(FundOperationsDomain.Banking));
             services.AddSingleton<IDomainProjectionReconciliationJob>(
                 _ => new NoOpDomainProjectionReconciliationJob(FundOperationsDomain.MoneyMarket));
-            services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, ProjectionReconciliationHostedService>());
+            if (options.EnableProcessWideHostedServices)
+            {
+                services.TryAddEnumerable(
+                    ServiceDescriptor.Singleton<IHostedService, ProjectionReconciliationHostedService>());
+            }
         }
         return services;
     }

--- a/src/Meridian.Application/Composition/HostStartup.cs
+++ b/src/Meridian.Application/Composition/HostStartup.cs
@@ -15,10 +15,8 @@ using Meridian.Infrastructure.Http;
 using Meridian.Platform.Monitoring;
 using Meridian.Storage;
 using Meridian.Storage.Policies;
-using Meridian.Storage.Sinks;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Serilog;
 using DeploymentContext = Meridian.Platform.Runtime.DeploymentContext;
@@ -42,82 +40,228 @@ namespace Meridian.Application.Composition;
 [ImplementsAdr("ADR-001", "Unified host startup for all deployment modes")]
 public sealed class HostStartup : IAsyncDisposable
 {
-    private readonly IServiceProvider _serviceProvider;
+    private static readonly TimeSpan StopTimeout = TimeSpan.FromSeconds(30);
+
+    private readonly IHost _host;
     private readonly CompositionOptions _options;
     private readonly Serilog.ILogger _log;
+    private readonly SemaphoreSlim _disposeGate = new(1, 1);
     private bool _disposed;
 
-    private HostStartup(IServiceProvider serviceProvider, CompositionOptions options, Serilog.ILogger log)
+    private HostStartup(IHost host, CompositionOptions options, Serilog.ILogger log)
     {
-        _serviceProvider = serviceProvider;
+        _host = host;
         _options = options;
         _log = log;
     }
 
-    private static HostStartup Create(CompositionOptions options)
+    internal static async Task<HostStartup> CreateStartedHostAsync(
+        CompositionOptions options,
+        bool enableProcessWideHostedServices,
+        Action<IServiceCollection>? configureServices,
+        CancellationToken cancellationToken)
     {
         Meridian.Storage.MeridianDatabaseEnvironment.ApplyUnifiedDatabaseUrl();
 
         var log = LoggingSetup.ForContext<HostStartup>();
-        var services = new ServiceCollection();
-        services.AddLogging(builder => builder.AddSerilog());
-        services.AddMarketDataServices(options);
+        var aspNetCoreEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        var dotnetEnvironment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
+        var environmentName = !string.IsNullOrWhiteSpace(aspNetCoreEnvironment)
+            ? aspNetCoreEnvironment
+            : !string.IsNullOrWhiteSpace(dotnetEnvironment)
+                ? dotnetEnvironment
+                : Environments.Production;
+        var builder = new Microsoft.Extensions.Hosting.HostBuilder()
+            .UseEnvironment(environmentName)
+            // Preserve the former raw-provider validation behavior. The Meridian final-graph guard
+            // remains authoritative; enabling Generic Host's Development-only ValidateOnBuild
+            // would reject unrelated lazy registrations that these executable profiles never use.
+            .UseDefaultServiceProvider((_, providerOptions) =>
+            {
+                providerOptions.ValidateOnBuild = false;
+                providerOptions.ValidateScopes = false;
+            })
+            .ConfigureServices(services =>
+            {
+                services.AddLogging(logging => logging.AddSerilog());
+                var effectiveOptions = options with
+                {
+                    EnableProcessWideHostedServices = enableProcessWideHostedServices
+                };
+                services.AddMarketDataServices(effectiveOptions);
 
-        var serviceProvider = services.BuildServiceProvider();
-        InitializeHttpClientFactory(serviceProvider, log);
-        LedgerStartup.EnsureDatabaseReady(serviceProvider);
-        SecurityMasterStartup.EnsureDatabaseReady(serviceProvider);
-        AssetOperationsStartup.EnsureDatabaseReady(serviceProvider);
+                // AddMarketDataServices inserts the final-graph production guard at index 0.
+                // Database initialization must run immediately after that guard and before
+                // coordination or any other hosted service starts. Desktop child graphs retain
+                // their local storage/symbol initialization while the parent owns process-wide
+                // coordinators and accounting workers.
+                services.Insert(
+                    1,
+                    ServiceDescriptor.Singleton<IHostedService>(
+                        serviceProvider => new DatabaseInitializationHostedService(serviceProvider)));
 
-        return new HostStartup(serviceProvider, options, log);
+                configureServices?.Invoke(services);
+            });
+
+        var host = builder.Build();
+        try
+        {
+            // The production guard resolves factory-backed singletons while validating the final
+            // graph. Initialize these static routers before StartAsync so those factories cannot
+            // permanently capture fallback HTTP clients.
+            InitializeHttpClientFactory(host.Services, log);
+            await host.StartAsync(cancellationToken).ConfigureAwait(false);
+            return new HostStartup(host, options, log);
+        }
+        catch
+        {
+            await StopAndDisposeFailedHostAsync(host, log).ConfigureAwait(false);
+            throw;
+        }
     }
 
     /// <summary>
     /// Creates a host startup for streaming data collection (CLI headless mode).
     /// </summary>
     /// <param name="configPath">Path to configuration file.</param>
+    /// <param name="cancellationToken">Token that cancels host startup.</param>
     /// <returns>Configured HostStartup instance.</returns>
-    public static HostStartup CreateForStreaming(string configPath)
-        => Create(CompositionOptions.Streaming with { ConfigPath = configPath });
+    public static Task<HostStartup> CreateForStreamingAsync(
+        string configPath,
+        CancellationToken cancellationToken = default)
+        => CreateStartedHostAsync(
+            CompositionOptions.Streaming with { ConfigPath = configPath },
+            enableProcessWideHostedServices: true,
+            configureServices: null,
+            cancellationToken);
+
+    internal static Task<HostStartup> CreateForStreamingAsync(
+        string configPath,
+        Action<IServiceCollection> configureServices,
+        CancellationToken cancellationToken = default)
+        => CreateStartedHostAsync(
+            CompositionOptions.Streaming with { ConfigPath = configPath },
+            enableProcessWideHostedServices: true,
+            configureServices,
+            cancellationToken);
 
     /// <summary>
     /// Creates a host startup for the default/full host profile.
     /// </summary>
-    public static HostStartup CreateDefault(string configPath)
-        => Create(CompositionOptions.Default with { ConfigPath = configPath });
+    /// <param name="configPath">Path to configuration file.</param>
+    /// <param name="cancellationToken">Token that cancels host startup.</param>
+    /// <returns>Configured HostStartup instance.</returns>
+    public static Task<HostStartup> CreateDefaultAsync(
+        string configPath,
+        CancellationToken cancellationToken = default)
+        => CreateStartedHostAsync(
+            CompositionOptions.Default with { ConfigPath = configPath },
+            enableProcessWideHostedServices: true,
+            configureServices: null,
+            cancellationToken);
+
+    internal static Task<HostStartup> CreateDefaultAsync(
+        string configPath,
+        Action<IServiceCollection> configureServices,
+        CancellationToken cancellationToken = default)
+        => CreateStartedHostAsync(
+            CompositionOptions.Default with { ConfigPath = configPath },
+            enableProcessWideHostedServices: true,
+            configureServices,
+            cancellationToken);
+
+    /// <summary>
+    /// Creates a default-profile host for a one-shot ETL command without unrelated process-wide
+    /// coordination, reconciliation, polling, or accounting workers.
+    /// </summary>
+    /// <param name="configPath">Path to configuration file.</param>
+    /// <param name="cancellationToken">Token that cancels host startup.</param>
+    /// <returns>Configured HostStartup instance.</returns>
+    public static Task<HostStartup> CreateForEtlAsync(
+        string configPath,
+        CancellationToken cancellationToken = default)
+        => CreateStartedHostAsync(
+            CompositionOptions.Default with { ConfigPath = configPath },
+            enableProcessWideHostedServices: false,
+            configureServices: null,
+            cancellationToken);
+
+    internal static Task<HostStartup> CreateForEtlAsync(
+        string configPath,
+        Action<IServiceCollection> configureServices,
+        CancellationToken cancellationToken = default)
+        => CreateStartedHostAsync(
+            CompositionOptions.Default with { ConfigPath = configPath },
+            enableProcessWideHostedServices: false,
+            configureServices,
+            cancellationToken);
 
     /// <summary>
     /// Creates a host startup for backfill-only operation.
     /// </summary>
     /// <param name="configPath">Path to configuration file.</param>
+    /// <param name="cancellationToken">Token that cancels host startup.</param>
     /// <returns>Configured HostStartup instance.</returns>
-    public static HostStartup CreateForBackfill(string configPath)
-        => Create(CompositionOptions.BackfillOnly with { ConfigPath = configPath });
+    public static Task<HostStartup> CreateForBackfillAsync(
+        string configPath,
+        CancellationToken cancellationToken = default)
+        => CreateStartedHostAsync(
+            CompositionOptions.BackfillOnly with { ConfigPath = configPath },
+            enableProcessWideHostedServices: true,
+            configureServices: null,
+            cancellationToken);
+
+    internal static Task<HostStartup> CreateForBackfillAsync(
+        string configPath,
+        Action<IServiceCollection> configureServices,
+        CancellationToken cancellationToken = default)
+        => CreateStartedHostAsync(
+            CompositionOptions.BackfillOnly with { ConfigPath = configPath },
+            enableProcessWideHostedServices: true,
+            configureServices,
+            cancellationToken);
 
     /// <summary>
     /// Creates a host startup for minimal utility commands (validation, config checks, etc.).
     /// </summary>
     /// <param name="configPath">Path to configuration file.</param>
+    /// <param name="cancellationToken">Token that cancels host startup.</param>
     /// <returns>Configured HostStartup instance.</returns>
-    public static HostStartup CreateForUtility(string configPath)
-        => Create(CompositionOptions.Minimal with { ConfigPath = configPath });
+    public static Task<HostStartup> CreateForUtilityAsync(
+        string configPath,
+        CancellationToken cancellationToken = default)
+        => CreateStartedHostAsync(
+            CompositionOptions.Minimal with { ConfigPath = configPath },
+            enableProcessWideHostedServices: false,
+            configureServices: null,
+            cancellationToken);
+
+    internal static Task<HostStartup> CreateForUtilityAsync(
+        string configPath,
+        Action<IServiceCollection> configureServices,
+        CancellationToken cancellationToken = default)
+        => CreateStartedHostAsync(
+            CompositionOptions.Minimal with { ConfigPath = configPath },
+            enableProcessWideHostedServices: false,
+            configureServices,
+            cancellationToken);
 
     /// <summary>
     /// Gets a required service from the DI container.
     /// </summary>
     public T GetRequiredService<T>() where T : notnull
-        => _serviceProvider.GetRequiredService<T>();
+        => _host.Services.GetRequiredService<T>();
 
     /// <summary>
     /// Gets a service from the DI container, or null if not registered.
     /// </summary>
     public T? GetService<T>() where T : class
-        => _serviceProvider.GetService<T>();
+        => _host.Services.GetService<T>();
 
     /// <summary>
     /// Gets the service provider for advanced scenarios.
     /// </summary>
-    public IServiceProvider ServiceProvider => _serviceProvider;
+    public IServiceProvider ServiceProvider => _host.Services;
 
     /// <summary>
     /// Gets the ConfigStore from the DI container.
@@ -259,35 +403,102 @@ public sealed class HostStartup : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        if (_disposed)
-            return;
-        _disposed = true;
-
-        // Dispose pipeline if it exists
-        if (_options.EnablePipelineServices)
+        await _disposeGate.WaitAsync().ConfigureAwait(false);
+        try
         {
-            var pipeline = GetService<EventPipeline>();
-            if (pipeline != null)
+            if (_disposed)
+                return;
+
+            _disposed = true;
+
+            using var stopCts = new CancellationTokenSource(StopTimeout);
+            try
             {
-                await pipeline.FlushAsync();
-                await pipeline.DisposeAsync();
+                await _host.StopAsync(stopCts.Token).ConfigureAwait(false);
             }
-
-            var sink = GetService<JsonlStorageSink>();
-            if (sink != null)
+            catch (OperationCanceledException) when (stopCts.IsCancellationRequested)
             {
-                await sink.DisposeAsync();
+                _log.Warning(
+                    "Generic Host stop did not complete within {StopTimeoutSeconds} seconds",
+                    StopTimeout.TotalSeconds);
+            }
+            finally
+            {
+                try
+                {
+                    if (_options.EnablePipelineServices)
+                    {
+                        var pipeline = GetService<EventPipeline>();
+                        if (pipeline != null)
+                            await pipeline.FlushAsync().ConfigureAwait(false);
+                    }
+                }
+                finally
+                {
+                    await DisposeHostAsync(_host).ConfigureAwait(false);
+                }
             }
         }
+        finally
+        {
+            _disposeGate.Release();
+        }
+    }
 
-        if (_serviceProvider is IAsyncDisposable asyncDisposable)
+    private static async Task StopAndDisposeFailedHostAsync(IHost host, Serilog.ILogger log)
+    {
+        using var stopCts = new CancellationTokenSource(StopTimeout);
+        try
         {
-            await asyncDisposable.DisposeAsync();
+            await host.StopAsync(stopCts.Token).ConfigureAwait(false);
         }
-        else if (_serviceProvider is IDisposable disposable)
+        catch (Exception ex)
         {
-            disposable.Dispose();
+            log.Warning(ex, "Generic Host cleanup raised an error after startup failed");
         }
+        finally
+        {
+            try
+            {
+                await DisposeHostAsync(host).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                log.Warning(ex, "Generic Host disposal raised an error after startup failed");
+            }
+        }
+    }
+
+    private static ValueTask DisposeHostAsync(IHost host)
+    {
+        if (host is IAsyncDisposable asyncDisposable)
+            return asyncDisposable.DisposeAsync();
+
+        host.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    private sealed class DatabaseInitializationHostedService : IHostedService
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public DatabaseInitializationHostedService(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            LedgerStartup.EnsureDatabaseReady(_serviceProvider);
+            SecurityMasterStartup.EnsureDatabaseReady(_serviceProvider);
+            DirectLendingStartup.EnsureDatabaseReady(_serviceProvider);
+            AssetOperationsStartup.EnsureDatabaseReady(_serviceProvider);
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+            => Task.CompletedTask;
     }
 }
 
@@ -314,27 +525,91 @@ public static class HostStartupFactory
     /// </summary>
     /// <param name="deployment">Deployment context from command line arguments.</param>
     /// <param name="configPath">Path to configuration file.</param>
+    /// <param name="cancellationToken">Token that cancels host startup.</param>
     /// <returns>Configured HostStartup instance.</returns>
-    public static HostStartup Create(DeploymentContext deployment, string configPath)
-        => deployment.Mode switch
-        {
-            DeploymentMode.Desktop => HostStartup.CreateDefault(configPath),
-            _ => HostStartup.CreateForStreaming(configPath)
-        };
+    public static Task<HostStartup> CreateAsync(
+        DeploymentContext deployment,
+        string configPath,
+        CancellationToken cancellationToken = default)
+        => CreateCoreAsync(deployment, configPath, configureServices: null, cancellationToken);
+
+    internal static Task<HostStartup> CreateAsync(
+        DeploymentContext deployment,
+        string configPath,
+        Action<IServiceCollection> configureServices,
+        CancellationToken cancellationToken = default)
+        => CreateCoreAsync(deployment, configPath, configureServices, cancellationToken);
+
+    private static Task<HostStartup> CreateCoreAsync(
+        DeploymentContext deployment,
+        string configPath,
+        Action<IServiceCollection>? configureServices,
+        CancellationToken cancellationToken)
+        => HostStartup.CreateStartedHostAsync(
+            ResolveProfile(deployment) with { ConfigPath = configPath },
+            enableProcessWideHostedServices: deployment.Mode != DeploymentMode.Desktop,
+            configureServices,
+            cancellationToken);
 
     /// <summary>
     /// Creates a HostStartup for backfill operations.
     /// </summary>
     /// <param name="configPath">Path to configuration file.</param>
+    /// <param name="cancellationToken">Token that cancels host startup.</param>
     /// <returns>Configured HostStartup for backfill.</returns>
-    public static HostStartup CreateForBackfill(string configPath)
-        => HostStartup.CreateForBackfill(configPath);
+    public static Task<HostStartup> CreateForBackfillAsync(
+        string configPath,
+        CancellationToken cancellationToken = default)
+        => HostStartup.CreateForBackfillAsync(configPath, cancellationToken);
+
+    /// <summary>
+    /// Creates a backfill HostStartup while respecting background-service ownership for the
+    /// supplied deployment context.
+    /// </summary>
+    /// <param name="deployment">Deployment context that identifies the parent host.</param>
+    /// <param name="configPath">Path to configuration file.</param>
+    /// <param name="cancellationToken">Token that cancels host startup.</param>
+    /// <returns>Configured HostStartup for backfill.</returns>
+    public static Task<HostStartup> CreateForBackfillAsync(
+        DeploymentContext deployment,
+        string configPath,
+        CancellationToken cancellationToken = default)
+        => CreateForBackfillCoreAsync(
+            deployment,
+            configPath,
+            configureServices: null,
+            cancellationToken);
+
+    internal static Task<HostStartup> CreateForBackfillAsync(
+        DeploymentContext deployment,
+        string configPath,
+        Action<IServiceCollection> configureServices,
+        CancellationToken cancellationToken = default)
+        => CreateForBackfillCoreAsync(
+            deployment,
+            configPath,
+            configureServices,
+            cancellationToken);
+
+    private static Task<HostStartup> CreateForBackfillCoreAsync(
+        DeploymentContext deployment,
+        string configPath,
+        Action<IServiceCollection>? configureServices,
+        CancellationToken cancellationToken)
+        => HostStartup.CreateStartedHostAsync(
+            CompositionOptions.BackfillOnly with { ConfigPath = configPath },
+            enableProcessWideHostedServices: deployment.Mode != DeploymentMode.Desktop,
+            configureServices,
+            cancellationToken);
 
     /// <summary>
     /// Creates a HostStartup for utility commands (validation, config checks, etc.).
     /// </summary>
     /// <param name="configPath">Path to configuration file.</param>
+    /// <param name="cancellationToken">Token that cancels host startup.</param>
     /// <returns>Configured HostStartup for utilities.</returns>
-    public static HostStartup CreateForUtility(string configPath)
-        => HostStartup.CreateForUtility(configPath);
+    public static Task<HostStartup> CreateForUtilityAsync(
+        string configPath,
+        CancellationToken cancellationToken = default)
+        => HostStartup.CreateForUtilityAsync(configPath, cancellationToken);
 }

--- a/src/Meridian.Application/Composition/ServiceCompositionRoot.cs
+++ b/src/Meridian.Application/Composition/ServiceCompositionRoot.cs
@@ -314,6 +314,12 @@ public sealed record CompositionOptions
     public bool EnableCanonicalizationServices { get; init; }
 
     /// <summary>
+    /// Whether this graph owns process-wide hosted loops and workers. Desktop child graphs disable
+    /// this while retaining guards, migrations, and child-local storage/symbol initialization.
+    /// </summary>
+    public bool EnableProcessWideHostedServices { get; init; } = true;
+
+    /// <summary>
     /// Whether to enable OpenTelemetry tracing and metrics instrumentation.
     /// </summary>
     public bool EnableOpenTelemetry { get; init; }

--- a/src/Meridian.Application/Composition/Startup/ModeRunners/BackfillModeRunner.cs
+++ b/src/Meridian.Application/Composition/Startup/ModeRunners/BackfillModeRunner.cs
@@ -18,8 +18,23 @@ namespace Meridian.Application.Composition.Startup.ModeRunners;
 public sealed class BackfillModeRunner
 {
     private readonly ILogger _log;
+    private readonly BackfillHostFactory _hostFactory;
 
-    public BackfillModeRunner(ILogger log) => _log = log;
+    public BackfillModeRunner(ILogger log)
+        : this(
+            log,
+            static (deployment, configPath, ct) =>
+                HostStartupFactory.CreateForBackfillAsync(deployment, configPath, ct))
+    {
+    }
+
+    internal BackfillModeRunner(
+        ILogger log,
+        BackfillHostFactory hostFactory)
+    {
+        _log = log;
+        _hostFactory = hostFactory;
+    }
 
     /// <summary>
     /// Executes the backfill from a resolved startup context.
@@ -35,27 +50,34 @@ public sealed class BackfillModeRunner
             statusPath,
             () => ctx.ConfigurationService.LoadAndPrepareConfig(ctx.ConfigPath));
 
-        await using var hostStartup = HostStartupFactory.Create(ctx.Deployment, ctx.ConfigPath);
+        await using var hostStartup = await _hostFactory(ctx.Deployment, ctx.ConfigPath, ct)
+            .ConfigureAwait(false);
         var pipeline = hostStartup.Pipeline;
-        await pipeline.RecoverAsync();
+        await pipeline.RecoverAsync(ct);
         _log.Information("WAL enabled for pipeline durability");
 
-        return await RunBackfillAsync(ctx, pipeline, statusWriter, ct);
+        return await RunBackfillAsync(ctx, hostStartup, pipeline, statusWriter, ct);
     }
 
     /// <summary>
-    /// Executes the backfill using a pre-existing <paramref name="pipeline"/> and <paramref name="statusWriter"/>
-    /// created by the caller (e.g. <see cref="CollectorModeRunner"/> or <see cref="DesktopModeRunner"/>).
+    /// Executes the backfill using the caller-owned <paramref name="backfillHost"/>,
+    /// <paramref name="pipeline"/>, and <paramref name="statusWriter"/>.
     /// </summary>
+    /// <param name="ctx">Prepared startup context.</param>
+    /// <param name="backfillHost">Started backfill host that owns providers and hosted services.</param>
+    /// <param name="pipeline">Pipeline owned by <paramref name="backfillHost"/>.</param>
+    /// <param name="statusWriter">Status writer for the current process.</param>
+    /// <param name="ct">Token that cancels the backfill.</param>
+    /// <returns>The process exit code.</returns>
     internal async Task<int> RunBackfillAsync(
         StartupContext ctx,
+        HostStartup backfillHost,
         EventPipeline pipeline,
         StatusWriter statusWriter,
         CancellationToken ct = default)
     {
         var backfillRequest = SharedStartupHelpers.BuildBackfillRequest(ctx.Config, ctx.CliArgs);
 
-        await using var backfillHost = HostStartupFactory.CreateForBackfill(ctx.ConfigPath);
         var backfillProviders = backfillHost.CreateBackfillProviders();
 
         IHistoricalDataProvider[] providersArray;
@@ -76,7 +98,7 @@ public sealed class BackfillModeRunner
         }
 
         var backfill = new HistoricalBackfillService(providersArray, _log);
-        var result = await backfill.RunAsync(backfillRequest, pipeline);
+        var result = await backfill.RunAsync(backfillRequest, pipeline, ct);
         var statusStore = BackfillStatusStore.FromConfig(ctx.Config);
         await statusStore.WriteAsync(result);
         await pipeline.FlushAsync();
@@ -84,4 +106,10 @@ public sealed class BackfillModeRunner
 
         return result.Success ? 0 : ErrorCode.ProviderError.ToExitCode();
     }
+
+    internal delegate Task<HostStartup> BackfillHostFactory(
+        Meridian.Platform.Runtime.DeploymentContext deployment,
+        string configPath,
+        CancellationToken cancellationToken);
+
 }

--- a/src/Meridian.Application/Composition/Startup/ModeRunners/CollectorModeRunner.cs
+++ b/src/Meridian.Application/Composition/Startup/ModeRunners/CollectorModeRunner.cs
@@ -51,11 +51,13 @@ public sealed class CollectorModeRunner
 
         ConfigWatcher? watcher = null;
 
-        await using var hostStartup = HostStartupFactory.Create(ctx.Deployment, ctx.ConfigPath);
+        await using var hostStartup = await HostStartupFactory
+            .CreateAsync(ctx.Deployment, ctx.ConfigPath, ct)
+            .ConfigureAwait(false);
         var storageOpt = hostStartup.StorageOptions;
         var pipeline = hostStartup.Pipeline;
 
-        await pipeline.RecoverAsync();
+        await pipeline.RecoverAsync(ct);
         _log.Information("WAL enabled for pipeline durability");
 
         var policy = hostStartup.GetRequiredService<JsonlStoragePolicy>();

--- a/src/Meridian.Application/README.md
+++ b/src/Meridian.Application/README.md
@@ -419,6 +419,16 @@ and UI presentation concerns in their owning layers.
   data-quality monitoring live in `Meridian.Ui.Shared.Endpoints`. `BackfillCoordinator` lives
   in `Backfill/` alongside the rest of the backfill pipeline.
 - `Composition/` - application feature registration and service wiring.
+  Headless collector, backfill, ETL, and utility profiles build and start a Generic Host so the
+  final production-registration guard, database initialization, coordination, and other registered
+  hosted services enter the normal start/stop lifecycle. The guard starts first, database
+  initialization for Ledger, Security Master, Direct Lending, and Asset Operations follows before
+  background workers start, and host disposal stops hosted services before flushing the event
+  pipeline. Desktop child composition keeps the same final guard and child-local storage/symbol
+  initialization, while delegating process-wide coordinator and accounting-worker ownership to its
+  parent WebApplication to avoid duplicates. One-shot ETL hosts likewise retain guard and local
+  initialization without activating unrelated polling, reconciliation, or daily-accrual workers.
+  Backfill mode uses one backfill-profile host for both its pipeline and providers.
   `StorageFeatureRegistration` keeps production-safe governance composition explicit: production
   startup requires `MERIDIAN_DATABASE_URL` (or the per-domain
   `MERIDIAN_FUND_ACCOUNTS_CONNECTION_STRING` and `MERIDIAN_FUND_STRUCTURE_CONNECTION_STRING`)

--- a/tests/Meridian.Tests/Application/Composition/HostStartupLifecycleTests.cs
+++ b/tests/Meridian.Tests/Application/Composition/HostStartupLifecycleTests.cs
@@ -1,0 +1,487 @@
+using System.Text.Json;
+using FluentAssertions;
+using Meridian.Application.Commands;
+using Meridian.Application.Composition;
+using Meridian.Application.Composition.Startup;
+using Meridian.Application.Composition.Startup.ModeRunners;
+using Meridian.Application.Composition.Startup.StartupModels;
+using Meridian.Application.Services;
+using Meridian.Core.Config;
+using Meridian.Platform.Runtime;
+using Meridian.Storage;
+using Meridian.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Serilog.Core;
+using Xunit;
+
+namespace Meridian.Tests.Application.Composition;
+
+/// <summary>
+/// Guards the executable-host failure mode where a built service graph never enters the
+/// Generic Host lifecycle, leaving production guards and background coordination dormant.
+/// </summary>
+[Collection("Sequential")]
+public sealed class HostStartupLifecycleTests
+{
+    [Theory]
+    [InlineData(ExecutableProfile.HeadlessCollector)]
+    [InlineData(ExecutableProfile.HeadlessBackfill)]
+    [InlineData(ExecutableProfile.DesktopCollector)]
+    [InlineData(ExecutableProfile.DesktopBackfill)]
+    [InlineData(ExecutableProfile.EtlCommand)]
+    [InlineData(ExecutableProfile.UtilityCommand)]
+    public async Task CreateAsync_ExecutableProfile_StartsAndStopsHostedService(
+        ExecutableProfile profile)
+    {
+        using var environment = HostStartupTestEnvironment.Enable();
+        using var artifacts = TestArtifactDirectory.Create($"{nameof(HostStartupLifecycleTests)}-{profile}");
+        var configPath = await WriteConfigAsync(artifacts.RootPath);
+        var probe = new RecordingHostedService();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var startup = await CreateAsync(
+            profile,
+            configPath,
+            services =>
+            {
+                services.AddSingleton(probe);
+                services.AddSingleton<IHostedService>(
+                    serviceProvider => serviceProvider.GetRequiredService<RecordingHostedService>());
+            },
+            timeout.Token);
+        try
+        {
+            probe.StartCount.Should().Be(1, $"{profile} must enter the Generic Host lifecycle");
+            probe.StopCount.Should().Be(0);
+            probe.Events.Should().Equal("start");
+            startup.ServiceProvider.GetRequiredService<RecordingHostedService>()
+                .Should().BeSameAs(probe);
+            startup.ServiceProvider.GetRequiredService<IHostEnvironment>().EnvironmentName
+                .Should().Be(Environments.Development);
+
+            var hostedServices = startup.ServiceProvider.GetServices<IHostedService>().ToArray();
+            hostedServices[0].Should().BeOfType<ProductionRegistrationGuardService>();
+            hostedServices.Count(service => ReferenceEquals(service, probe)).Should().Be(1);
+            var hostedServiceNames = hostedServices
+                .Select(service => service.GetType().Name)
+                .ToArray();
+            if (profile is ExecutableProfile.DesktopCollector
+                or ExecutableProfile.DesktopBackfill
+                or ExecutableProfile.EtlCommand
+                or ExecutableProfile.UtilityCommand)
+            {
+                hostedServiceNames.Should().NotContain(
+                    "ClusterCoordinatorService",
+                    "desktop parents own coordination and one-shot ETL must not activate it");
+                hostedServiceNames.Should().NotContain(
+                    "SplitBrainDetector",
+                    "desktop parents own detection and one-shot ETL must not activate it");
+                hostedServiceNames.Should().Contain(
+                    "StorageCatalogInitializationHostedService",
+                    "the child graph has its own storage catalog instance");
+                hostedServiceNames.Should().Contain(
+                    "SymbolRegistryInitializationHostedService",
+                    "the child graph has its own symbol registry instance");
+                if (profile == ExecutableProfile.UtilityCommand)
+                {
+                    hostedServiceNames.Should().NotContain(
+                        "CanonicalSymbolRegistryMigrationService",
+                        "the minimal utility profile does not enable symbol management");
+                }
+                else
+                {
+                    hostedServiceNames.Should().Contain(
+                        "CanonicalSymbolRegistryMigrationService",
+                        "desktop, backfill, collector, and ETL providers need initialized canonical aliases");
+                }
+            }
+            else
+            {
+                hostedServiceNames.Should().Contain("ClusterCoordinatorService");
+                hostedServiceNames.Should().Contain("SplitBrainDetector");
+            }
+        }
+        finally
+        {
+            await startup.DisposeAsync();
+        }
+
+        await startup.DisposeAsync();
+        probe.StartCount.Should().Be(1);
+        probe.StopCount.Should().Be(
+            1,
+            $"{profile} must stop hosted services exactly once during disposal");
+        probe.Events.Should().Equal("start", "stop");
+    }
+
+    [Fact]
+    public async Task CreateAsync_FinalProductionGuardRunsBeforeProbeStarts()
+    {
+        using var environment = HostStartupTestEnvironment.Enable();
+        using var artifacts = TestArtifactDirectory.Create(
+            $"{nameof(HostStartupLifecycleTests)}-production-guard");
+        var configPath = await WriteConfigAsync(artifacts.RootPath);
+        var probe = new RecordingHostedService();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        Func<Task> act = async () =>
+        {
+            await using var _ = await HostStartup.CreateForUtilityAsync(
+                configPath,
+                services =>
+                {
+                    services.DeclareMeridianDeploymentPosture(MeridianDeploymentPosture.ProductionApi);
+                    services.AddSingleton<NonProductionProbeService>();
+                    services.AddSingleton(probe);
+                    services.AddSingleton<IHostedService>(
+                        serviceProvider => serviceProvider.GetRequiredService<RecordingHostedService>());
+                },
+                timeout.Token);
+        };
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*Production startup policy*");
+        probe.StartCount.Should().Be(0, "the final production guard is the first hosted service");
+        probe.StopCount.Should().Be(
+            1,
+            "failed Generic Host startup must run one bounded cleanup pass");
+        probe.Events.Should().Equal("stop");
+    }
+
+    [Fact]
+    public async Task CreateAsync_DisposalFailureDoesNotMaskStartupFailure()
+    {
+        using var environment = HostStartupTestEnvironment.Enable();
+        using var artifacts = TestArtifactDirectory.Create(
+            $"{nameof(HostStartupLifecycleTests)}-startup-failure");
+        var configPath = await WriteConfigAsync(artifacts.RootPath);
+        var probe = new RecordingHostedService();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        Func<Task> act = async () =>
+        {
+            await using var _ = await HostStartup.CreateForUtilityAsync(
+                configPath,
+                services =>
+                {
+                    services.AddSingleton(probe);
+                    services.AddSingleton<IHostedService>(
+                        serviceProvider =>
+                            serviceProvider.GetRequiredService<RecordingHostedService>());
+                    services.AddSingleton<IHostedService, ThrowOnStartAndDisposeHostedService>();
+                },
+                timeout.Token);
+        };
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage(ThrowOnStartAndDisposeHostedService.StartupFailureMessage);
+        probe.StartCount.Should().Be(1);
+        probe.StopCount.Should().Be(1);
+        probe.Events.Should().Equal("start", "stop");
+    }
+
+    [Theory]
+    [InlineData(DeploymentMode.Headless)]
+    [InlineData(DeploymentMode.Desktop)]
+    public async Task BackfillRunner_UsesOneStartedHostForPipelineAndExecution(
+        DeploymentMode deploymentMode)
+    {
+        using var environment = HostStartupTestEnvironment.Enable();
+        using var artifacts = TestArtifactDirectory.Create(
+            $"{nameof(HostStartupLifecycleTests)}-backfill-runner-{deploymentMode}");
+        var backfillDate = new DateOnly(2025, 1, 2);
+        var config = CreateConfig(artifacts.RootPath) with
+        {
+            Backfill = new BackfillConfig(
+                Enabled: true,
+                Provider: "synthetic",
+                Symbols: ["SPY"],
+                From: backfillDate,
+                To: backfillDate,
+                EnableFallback: false,
+                Providers: new BackfillProvidersConfig(
+                    Synthetic: new SyntheticMarketDataConfig(
+                        Enabled: true,
+                        Scenario: new SyntheticScenarioConfig(
+                            Enabled: true,
+                            BackfillBarsLimit: 1))))
+        };
+        var configPath = await WriteConfigAsync(config);
+        await using var configurationService = new ConfigurationService(Logger.None);
+        using var lifecycle = ApplicationLifecycleCoordinator.Create(Logger.None);
+        var deployment = CreateDeployment(deploymentMode, configPath);
+        var context = new StartupContext
+        {
+            CliArgs = CliArguments.Parse(["--backfill"]),
+            ConfigPath = configPath,
+            Config = config,
+            Deployment = deployment,
+            ConfigurationService = configurationService,
+            DashboardServerFactory = static (_, _, _) =>
+                throw new NotSupportedException("Backfill runner must not create a dashboard server."),
+            Lifecycle = lifecycle,
+            Log = Logger.None,
+            CancellationToken = CancellationToken.None
+        };
+        var probe = new RecordingHostedService();
+        var hostFactoryCalls = 0;
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var runner = new BackfillModeRunner(
+            Logger.None,
+            async (requestedDeployment, requestedConfigPath, cancellationToken) =>
+            {
+                Interlocked.Increment(ref hostFactoryCalls);
+                return await HostStartupFactory.CreateForBackfillAsync(
+                    requestedDeployment,
+                    requestedConfigPath,
+                    services =>
+                    {
+                        services.AddSingleton(probe);
+                        services.AddSingleton<IHostedService>(
+                            serviceProvider =>
+                                serviceProvider.GetRequiredService<RecordingHostedService>());
+                    },
+                    cancellationToken);
+            });
+
+        var exitCode = await runner.RunAsync(context, timeout.Token);
+
+        exitCode.Should().Be(0);
+        hostFactoryCalls.Should().Be(1, "backfill must not create separate pipeline and provider hosts");
+        probe.StartCount.Should().Be(1);
+        probe.StopCount.Should().Be(1);
+        probe.Events.Should().Equal("start", "stop");
+    }
+
+    [Theory]
+    [InlineData("--etl-resume")]
+    [InlineData("--etl-import")]
+    public async Task EtlCommandRoute_UsesStartedOneShotHostAndDisposesIt(string route)
+    {
+        using var environment = HostStartupTestEnvironment.Enable();
+        using var artifacts = TestArtifactDirectory.Create(
+            $"{nameof(HostStartupLifecycleTests)}-etl-route-{route.TrimStart('-')}");
+        var configPath = await WriteConfigAsync(artifacts.RootPath);
+        var probe = new RecordingHostedService();
+        var hostFactoryCalls = 0;
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var command = new EtlCommands(
+            configPath,
+            Logger.None,
+            async (requestedConfigPath, cancellationToken) =>
+            {
+                Interlocked.Increment(ref hostFactoryCalls);
+                requestedConfigPath.Should().Be(configPath);
+                return await HostStartup.CreateForEtlAsync(
+                    requestedConfigPath,
+                    services =>
+                    {
+                        services.AddSingleton(probe);
+                        services.AddSingleton<IHostedService>(
+                            serviceProvider =>
+                                serviceProvider.GetRequiredService<RecordingHostedService>());
+                    },
+                    cancellationToken);
+            });
+
+        _ = await command.ExecuteAsync([route], timeout.Token);
+
+        hostFactoryCalls.Should().Be(1);
+        probe.StartCount.Should().Be(1);
+        probe.StopCount.Should().Be(1);
+        probe.Events.Should().Equal("start", "stop");
+    }
+
+    private static Task<HostStartup> CreateAsync(
+        ExecutableProfile profile,
+        string configPath,
+        Action<IServiceCollection> configureServices,
+        CancellationToken cancellationToken)
+        => profile switch
+        {
+            ExecutableProfile.HeadlessCollector => HostStartupFactory.CreateAsync(
+                CreateDeployment(DeploymentMode.Headless, configPath),
+                configPath,
+                configureServices,
+                cancellationToken),
+            ExecutableProfile.HeadlessBackfill => HostStartupFactory.CreateForBackfillAsync(
+                CreateDeployment(DeploymentMode.Headless, configPath),
+                configPath,
+                configureServices,
+                cancellationToken),
+            ExecutableProfile.DesktopCollector => HostStartupFactory.CreateAsync(
+                CreateDeployment(DeploymentMode.Desktop, configPath),
+                configPath,
+                configureServices,
+                cancellationToken),
+            ExecutableProfile.DesktopBackfill => HostStartupFactory.CreateForBackfillAsync(
+                CreateDeployment(DeploymentMode.Desktop, configPath),
+                configPath,
+                configureServices,
+                cancellationToken),
+            ExecutableProfile.EtlCommand => HostStartup.CreateForEtlAsync(
+                configPath,
+                configureServices,
+                cancellationToken),
+            ExecutableProfile.UtilityCommand => HostStartup.CreateForUtilityAsync(
+                configPath,
+                configureServices,
+                cancellationToken),
+            _ => throw new ArgumentOutOfRangeException(nameof(profile), profile, null)
+        };
+
+    private static DeploymentContext CreateDeployment(DeploymentMode mode, string configPath)
+        => new()
+        {
+            Mode = mode,
+            ConfigPath = configPath
+        };
+
+    private static async Task<string> WriteConfigAsync(string dataRoot)
+        => await WriteConfigAsync(CreateConfig(dataRoot));
+
+    private static async Task<string> WriteConfigAsync(AppConfig config)
+    {
+        var configPath = Path.Combine(config.DataRoot, "appsettings.json");
+        await File.WriteAllTextAsync(
+            configPath,
+            JsonSerializer.Serialize(config, AppConfigJsonOptions.Write));
+        return configPath;
+    }
+
+    private static AppConfig CreateConfig(string dataRoot)
+        => new(
+            DataRoot: dataRoot,
+            Compress: false,
+            Storage: new StorageConfig(),
+            Backfill: new BackfillConfig(Enabled: false),
+            Coordination: new CoordinationConfig(Enabled: false));
+
+    public enum ExecutableProfile : byte
+    {
+        HeadlessCollector,
+        HeadlessBackfill,
+        DesktopCollector,
+        DesktopBackfill,
+        EtlCommand,
+        UtilityCommand
+    }
+
+    private sealed class RecordingHostedService : IHostedService
+    {
+        private readonly object _gate = new();
+        private readonly List<string> _events = [];
+        private int _startCount;
+        private int _stopCount;
+
+        public int StartCount => Volatile.Read(ref _startCount);
+        public int StopCount => Volatile.Read(ref _stopCount);
+
+        public IReadOnlyList<string> Events
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _events.ToArray();
+                }
+            }
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _startCount);
+            lock (_gate)
+            {
+                _events.Add("start");
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _stopCount);
+            lock (_gate)
+            {
+                _events.Add("stop");
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class NonProductionProbeService : INonProductionOnlyService;
+
+    private sealed class ThrowOnStartAndDisposeHostedService : IHostedService, IAsyncDisposable
+    {
+        public const string StartupFailureMessage = "hosted-service startup sentinel";
+
+        public Task StartAsync(CancellationToken cancellationToken)
+            => throw new InvalidOperationException(StartupFailureMessage);
+
+        public Task StopAsync(CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
+        public ValueTask DisposeAsync()
+            => ValueTask.FromException(new ApplicationException("hosted-service disposal sentinel"));
+    }
+
+    private sealed class HostStartupTestEnvironment : IDisposable
+    {
+        private static readonly string[] VariableNames =
+        [
+            "DOTNET_ENVIRONMENT",
+            "ASPNETCORE_ENVIRONMENT",
+            "MERIDIAN_ENVIRONMENT",
+            "MERIDIAN_DEPLOYMENT_ENVIRONMENT",
+            "MERIDIAN_MODE",
+            "MERIDIAN_API_DEPLOYMENT_MODE",
+            "MERIDIAN_USE_INMEMORY_GOVERNANCE",
+            MeridianDatabaseEnvironment.UnifiedVariable,
+            .. MeridianDatabaseEnvironment.PropagatedConnectionStringVariables,
+            SecurityMasterStartup.SchemaVariable,
+            AssetOperationsStartup.SchemaVariable,
+            DirectLendingStartup.SchemaVariable,
+            LedgerStartup.SchemaVariable,
+            FundAccountsStartup.SchemaVariable,
+            FundStructureStartup.SchemaVariable,
+            BankingStartup.SchemaVariable,
+            MoneyMarketStartup.SchemaVariable,
+            "MERIDIAN_SCOPED_ACCESS_CONNECTION_STRING",
+            "MERIDIAN_SCOPED_ACCESS_SCHEMA"
+        ];
+
+        private readonly IReadOnlyDictionary<string, string?> _originalValues;
+
+        private HostStartupTestEnvironment()
+        {
+            _originalValues = VariableNames
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(
+                    name => name,
+                    Environment.GetEnvironmentVariable,
+                    StringComparer.OrdinalIgnoreCase);
+
+            foreach (var name in _originalValues.Keys)
+            {
+                Environment.SetEnvironmentVariable(name, null);
+            }
+
+            Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", Environments.Development);
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", Environments.Development);
+            Environment.SetEnvironmentVariable("MERIDIAN_USE_INMEMORY_GOVERNANCE", "true");
+        }
+
+        public static HostStartupTestEnvironment Enable() => new();
+
+        public void Dispose()
+        {
+            foreach (var (name, value) in _originalValues)
+            {
+                Environment.SetEnvironmentVariable(name, value);
+            }
+        }
+    }
+}

--- a/tests/Meridian.Tests/Application/Composition/ProcessWideHostedServiceRegistrationTests.cs
+++ b/tests/Meridian.Tests/Application/Composition/ProcessWideHostedServiceRegistrationTests.cs
@@ -1,0 +1,185 @@
+using System.Text.Json;
+using FluentAssertions;
+using Meridian.Application.Composition;
+using Meridian.Core.Config;
+using Meridian.Storage;
+using Meridian.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Meridian.Tests.Application.Composition;
+
+/// <summary>
+/// Guards child and one-shot host graphs from duplicating process-wide coordination and database
+/// workers while preserving the graph-local storage and symbol initialization they still own.
+/// </summary>
+[Collection("Sequential")]
+public sealed class ProcessWideHostedServiceRegistrationTests
+{
+    private static readonly string[] ProcessWideHostedServiceNames =
+    [
+        "ScopedAccessAssignmentStoreMigrationHostedService",
+        "PolygonCorporateActionFetcher",
+        "DirectLendingOutboxDispatcher",
+        "DailyAccrualWorker",
+        "ProjectionReconciliationHostedService",
+        "ClusterCoordinatorService",
+        "SplitBrainDetector"
+    ];
+
+    private static readonly string[] LocalInitializerHostedServiceNames =
+    [
+        "StorageCatalogInitializationHostedService",
+        "SymbolRegistryInitializationHostedService",
+        "CanonicalSymbolRegistryMigrationService"
+    ];
+
+    [Fact]
+    public async Task AddMarketDataServices_ProcessWideWorkersDisabled_OmitsOnlyProcessOwnedHostedServices()
+    {
+        using var environment = CompositionRegistrationTestEnvironment.Enable();
+        using var artifacts = TestArtifactDirectory.Create(nameof(ProcessWideHostedServiceRegistrationTests));
+        var configPath = WriteConfig(artifacts.RootPath);
+
+        var processOwnerGraph = await ResolveHostedServiceNamesAsync(
+            configPath,
+            enableProcessWideHostedServices: true);
+        var childGraph = await ResolveHostedServiceNamesAsync(
+            configPath,
+            enableProcessWideHostedServices: false);
+
+        processOwnerGraph
+            .Except(childGraph, StringComparer.Ordinal)
+            .Should()
+            .BeEquivalentTo(
+                ProcessWideHostedServiceNames,
+                "the ownership flag must gate every process-wide database and coordination worker");
+        childGraph
+            .Except(processOwnerGraph, StringComparer.Ordinal)
+            .Should()
+            .BeEmpty("disabling process-wide workers must not add a divergent child-only graph");
+
+        foreach (var processWideServiceName in ProcessWideHostedServiceNames)
+        {
+            processOwnerGraph.Should().Contain(processWideServiceName);
+            childGraph.Should().NotContain(processWideServiceName);
+        }
+
+        foreach (var localInitializerServiceName in LocalInitializerHostedServiceNames)
+        {
+            processOwnerGraph.Should().Contain(localInitializerServiceName);
+            childGraph.Should().Contain(
+                localInitializerServiceName,
+                "child graphs retain their local catalog and symbol initialization");
+        }
+    }
+
+    private static async Task<HashSet<string>> ResolveHostedServiceNamesAsync(
+        string configPath,
+        bool enableProcessWideHostedServices)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddMarketDataServices(
+            CompositionOptions.Default with
+            {
+                ConfigPath = configPath,
+                EnableProcessWideHostedServices = enableProcessWideHostedServices
+            });
+
+        await using var provider = services.BuildServiceProvider();
+
+        // Resolve registrations to expose factory-backed hosted-service types (Polygon and the
+        // coordinator), but deliberately never start an IHost or call any worker's StartAsync.
+        return provider
+            .GetServices<IHostedService>()
+            .Select(service => service.GetType().Name)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    private static string WriteConfig(string dataRoot)
+    {
+        var configPath = Path.Combine(dataRoot, "appsettings.json");
+        var config = new AppConfig(
+            DataRoot: dataRoot,
+            Compress: false,
+            Storage: new StorageConfig(),
+            Backfill: new BackfillConfig(Enabled: false),
+            Coordination: new CoordinationConfig(Enabled: false));
+        File.WriteAllText(
+            configPath,
+            JsonSerializer.Serialize(config, AppConfigJsonOptions.Write));
+        return configPath;
+    }
+
+    private sealed class CompositionRegistrationTestEnvironment : IDisposable
+    {
+        private const string ScopedAccessConnectionStringVariable =
+            "MERIDIAN_SCOPED_ACCESS_CONNECTION_STRING";
+        private const string ScopedAccessSchemaVariable = "MERIDIAN_SCOPED_ACCESS_SCHEMA";
+        private const string DummyPostgresConnectionString =
+            "Host=registration-test.invalid;Port=5432;Database=meridian;Username=test;Password=test";
+
+        private static readonly string[] VariableNames =
+        [
+            "DOTNET_ENVIRONMENT",
+            "ASPNETCORE_ENVIRONMENT",
+            "MERIDIAN_ENVIRONMENT",
+            "MERIDIAN_DEPLOYMENT_ENVIRONMENT",
+            "MERIDIAN_MODE",
+            "MERIDIAN_API_DEPLOYMENT_MODE",
+            "MERIDIAN_USE_INMEMORY_GOVERNANCE",
+            MeridianDatabaseEnvironment.UnifiedVariable,
+            .. MeridianDatabaseEnvironment.PropagatedConnectionStringVariables,
+            ScopedAccessConnectionStringVariable,
+            DirectLendingStartup.ConnectionStringVariable,
+            SecurityMasterStartup.SchemaVariable,
+            AssetOperationsStartup.SchemaVariable,
+            DirectLendingStartup.SchemaVariable,
+            LedgerStartup.SchemaVariable,
+            ScopedAccessSchemaVariable
+        ];
+
+        private readonly IReadOnlyDictionary<string, string?> _originalValues;
+
+        private CompositionRegistrationTestEnvironment()
+        {
+            _originalValues = VariableNames
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(
+                    variableName => variableName,
+                    Environment.GetEnvironmentVariable,
+                    StringComparer.OrdinalIgnoreCase);
+
+            foreach (var variableName in _originalValues.Keys)
+            {
+                Environment.SetEnvironmentVariable(variableName, null);
+            }
+
+            Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", Environments.Development);
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", Environments.Development);
+            Environment.SetEnvironmentVariable("MERIDIAN_USE_INMEMORY_GOVERNANCE", "true");
+            Environment.SetEnvironmentVariable(
+                SecurityMasterStartup.ConnectionStringVariable,
+                DummyPostgresConnectionString);
+            Environment.SetEnvironmentVariable(
+                LedgerStartup.ConnectionStringVariable,
+                DummyPostgresConnectionString);
+            Environment.SetEnvironmentVariable(
+                ScopedAccessConnectionStringVariable,
+                DummyPostgresConnectionString);
+            Environment.SetEnvironmentVariable(ScopedAccessSchemaVariable, "identity_access_test");
+        }
+
+        public static CompositionRegistrationTestEnvironment Enable() => new();
+
+        public void Dispose()
+        {
+            foreach (var (variableName, value) in _originalValues)
+            {
+                Environment.SetEnvironmentVariable(variableName, value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace raw ServiceProvider construction with a started Generic Host for collector, backfill, ETL, and utility composition paths
- await host start/stop, preserve final production-guard ordering, initialize databases before workers, and collapse backfill pipeline/provider ownership to one host
- suppress duplicate process-wide coordinators and database workers in desktop child and one-shot ETL graphs while retaining graph-local initializers
- add hosted-service lifecycle probes for every executable profile, real synthetic backfill and ETL route coverage, startup-failure cleanup coverage, and conditional worker-registration coverage

## Validation
- PASS: focused isolated lifecycle harness, 13/13 tests
- PASS: Meridian.Application build with no dependent rebuild, 0 errors (30 existing warnings)
- PASS: dotnet format on changed Application and test files
- PASS: SRC-APP documentation/source hash refreshed and rechecked with 0 further changes
- PASS: git diff --check
- BLOCKED (pre-existing origin/main failure): filtered Meridian.Tests build and scripts/ci.sh both stop at src/Meridian.ProviderSdk/ITradingCalendarProvider.cs:123 CS1061 because ProviderDataProvenance has no DataProvenance member; this branch does not touch ProviderSdk
- BASELINE: global documentation hash validation also reports 36 unrelated drift errors outside SRC-APP

GitHub Actions remains the integration authority; this PR should not be represented as merge-ready until the inherited main-branch compile blocker is repaired and required checks pass.

<!-- phase:PR9 -->
