### PR TITLE
Fix ProviderSdk calendar provenance contract

### DIFF
--- a/docs/source/generated/source-hash-manifest.json
+++ b/docs/source/generated/source-hash-manifest.json
@@ -226,8 +226,8 @@
       "id": "SRC-PROVIDER-SDK",
       "path": "src/Meridian.ProviderSdk",
       "readme": "src/Meridian.ProviderSdk/README.md",
-      "readme_hash": "d23062cc46eefe79804be6f5b29a48c1b38991cbb5d98ea2082c288622296012",
-      "source_hash": "8ec0959419ff7275c0ab1a30b1f70cf4d5c26bc719504eecfcdc27de3c7c18ad"
+      "readme_hash": "5283dd07b5f0954a13ed92cc0325bb706e753d32741ed94f8f5c32497d24dcb8",
+      "source_hash": "43005904e814832f9e10f2d1a6a4816163be988bda8f5a6c383c398637453be6"
     },
     {
       "id": "SRC-QUANTSCRIPT",

--- a/src/Meridian.ProviderSdk/IProviderDataReadService.cs
+++ b/src/Meridian.ProviderSdk/IProviderDataReadService.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using Meridian.Contracts.Operations;
 
 namespace Meridian.ProviderSdk;
 
@@ -16,10 +17,19 @@ public sealed record ProviderDataProvenance(
     string CorrelationId,
     string StableDeduplicationKey)
 {
+    /// <summary>
+    /// Explicitly identifies whether the data is real, simulated, seeded, or sample. Calendar
+    /// responses require this value so placeholder evidence cannot be presented as real data.
+    /// </summary>
+    public DataProvenance? DataProvenance { get; init; }
+
     /// <summary>Creates explicit placeholder provenance for callback bridges before their request context is known.</summary>
     public static ProviderDataProvenance Unattributed(DateTimeOffset sourceTimestamp) => new(
         "unknown", "unknown", sourceTimestamp, DateTimeOffset.UtcNow, "unknown", "unknown", "unknown",
-        "unknown", "unknown", "unknown", "unknown");
+        "unknown", "unknown", "unknown", "unknown")
+    {
+        DataProvenance = Meridian.Contracts.Operations.DataProvenance.Sample
+    };
 }
 
 /// <summary>Provider-neutral lifecycle state for a correlated data request.</summary>


### PR DESCRIPTION
<!-- phase:PR9 -->
## Summary

- Restore the shared `ProviderDataProvenance.DataProvenance` classification consumed by `ProviderTradingCalendarResponse.EnsureProvenanceComplete()`.
- Classify `Unattributed(...)` callback placeholders as `Sample`, preserving the calendar contract's fail-closed behavior.
- Refresh only the generated `SRC-PROVIDER-SDK` source-hash entry.

## Reason

`origin/main` contains the calendar provenance validation and its contract tests, but the corresponding shared provenance-record hunk was dropped during integration. That leaves `ITradingCalendarProvider.cs:123` uncompilable with CS1061. This PR restores the exact missing hunk from the originating provenance-enforcement commit.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
  - Executed. Restore, formatting, warning-suppression, API-client, and file-size checks passed; ProviderSdk built successfully. The lane then failed on 12 unrelated, pre-existing missing dimension helpers in `Meridian.Ui.Shared/Endpoints/LedgerEndpoints.cs` (`BuildDimensionReportFilter`, `BuildDimensionSignature`, and `BuildDimensionFilterSignature`).
- [ ] Relevant unit tests were added or updated
  - The relevant calendar contract tests already exist on `origin/main`; this repair restores the contract member they compile against. A direct compiled-assembly smoke accepted complete provenance and rejected both missing classification and unattributed placeholder evidence.
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Additional focused evidence:

- [x] `dotnet build src/Meridian.ProviderSdk/Meridian.ProviderSdk.csproj --configuration Release --no-restore --property:ContinuousIntegrationBuild=true --property:UseSharedCompilation=false --property:BuildInParallel=false`
- [x] Direct compiled-assembly calendar provenance smoke
- [x] `python build/scripts/docs/validate-doc-hashes.py --write-module SRC-PROVIDER-SDK --summary` (idempotent on rerun)
- [x] `git diff --check`

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed
- [ ] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`