### PR TITLE
Stabilize WPF workflow summary fixture

### DIFF
--- a/docs/status/wpf-screen-development-tracker.json
+++ b/docs/status/wpf-screen-development-tracker.json
@@ -7,7 +7,7 @@
     "name": "scripts/generate-diagrams.mjs --tracker-only",
     "version": "1.0.0"
   },
-  "sourceFingerprint": "cfde770415dd",
+  "sourceFingerprint": "8378b50b4b7d",
   "baselineDate": "2026-06-17",
   "summary": {
     "screenCount": 93,
@@ -3023,6 +3023,7 @@
         "tests/Meridian.Wpf.Tests/Services/StrategyRunWorkspaceServiceTests.cs",
         "tests/Meridian.Wpf.Tests/Services/WorkstationOperatingContextServiceTests.cs",
         "tests/Meridian.Wpf.Tests/Services/WorkstationWorkflowSummaryServiceTests.cs",
+        "tests/Meridian.Wpf.Tests/Support/RunMatUiAutomationFacade.cs",
         "tests/Meridian.Wpf.Tests/ViewModels/AccountingConfigureViewModelTests.cs",
         "tests/Meridian.Wpf.Tests/ViewModels/ActivityLogViewModelTests.cs",
         "tests/Meridian.Wpf.Tests/ViewModels/AdminMaintenanceViewModelTests.cs",
@@ -3059,7 +3060,7 @@
         },
         {
           "done": true,
-          "text": "WPF route/view-model test reference found in tests/Meridian.Wpf.Tests/Features/Accounting/AccountingFeatureModuleTests.cs, tests/Meridian.Wpf.Tests/Features/Data/DataFeatureModuleTests.cs, tests/Meridian.Wpf.Tests/Features/Data/DataFeatureServiceRegistrationTests.cs, +37 more."
+          "text": "WPF route/view-model test reference found in tests/Meridian.Wpf.Tests/Features/Accounting/AccountingFeatureModuleTests.cs, tests/Meridian.Wpf.Tests/Features/Data/DataFeatureModuleTests.cs, tests/Meridian.Wpf.Tests/Features/Data/DataFeatureServiceRegistrationTests.cs, +38 more."
         }
       ],
       "openTaskCount": 0

--- a/docs/status/wpf-screen-development-tracker.md
+++ b/docs/status/wpf-screen-development-tracker.md
@@ -15,7 +15,7 @@ do_not_edit: true
 
 This tracker is generated from the live WPF shell registry, the maintained desktop screenshot index, and a text scan of `tests/Meridian.Wpf.Tests` for route, page, and view-model references. It tracks source-derived evidence only; roadmap priority and product scope still belong in `docs/roadmap/data/*.yml` and the design document.
 
-- Source fingerprint: `cfde770415dd`
+- Source fingerprint: `8378b50b4b7d`
 - Baseline date for open Gantt tasks: `2026-06-17`
 - Registered WPF screens: `93`
 - Open automated tasks: `1`
@@ -675,7 +675,7 @@ gantt
 - Status: `Evidence current`.
 - [x] Registered in the WPF shell registry as Storage (StoragePage).
 - [x] Screenshot evidence is committed at docs/screenshots/desktop/wpf-storage.png (2026-06-26).
-- [x] WPF route/view-model test reference found in tests/Meridian.Wpf.Tests/Features/Accounting/AccountingFeatureModuleTests.cs, tests/Meridian.Wpf.Tests/Features/Data/DataFeatureModuleTests.cs, tests/Meridian.Wpf.Tests/Features/Data/DataFeatureServiceRegistrationTests.cs, +37 more.
+- [x] WPF route/view-model test reference found in tests/Meridian.Wpf.Tests/Features/Accounting/AccountingFeatureModuleTests.cs, tests/Meridian.Wpf.Tests/Features/Data/DataFeatureModuleTests.cs, tests/Meridian.Wpf.Tests/Features/Data/DataFeatureServiceRegistrationTests.cs, +38 more.
 
 #### Data export (`DataExport`)
 

--- a/tests/Meridian.Wpf.Tests/Support/RunMatUiAutomationFacade.cs
+++ b/tests/Meridian.Wpf.Tests/Support/RunMatUiAutomationFacade.cs
@@ -13,6 +13,9 @@ using Meridian.Contracts.FundStructure;
 using Meridian.Contracts.Services;
 using Meridian.Contracts.SecurityMaster;
 using Meridian.Infrastructure.Adapters.Polygon;
+using Meridian.Strategies.Services;
+using Meridian.Strategies.Storage;
+using Meridian.Ui.Shared.Services;
 using Meridian.Ui.Services;
 using Meridian.Ui.Services.Contracts;
 using Meridian.Wpf.Contracts;
@@ -290,6 +293,11 @@ internal sealed class RunMatUiAutomationFacade : IDisposable
             StrategyRunWorkspaceService.SetInstance(service);
             return service;
         });
+        services.AddSingleton(_ => new WorkstationWorkflowSummaryService(
+            new StrategyRunReadService(
+                new StrategyRunStore(),
+                new PortfolioReadService(),
+                new LedgerReadService())));
         services.AddSingleton<IWorkstationStrategyBriefingApiClient, FakeWorkstationStrategyBriefingApiClient>();
         services.AddSingleton<IStrategyBriefingWorkspaceService, StrategyBriefingWorkspaceService>();
         services.AddSingleton<InMemoryFundAccountService>(_ => new InMemoryFundAccountService(Path.Combine(serviceRoot, "fund-accounts.json")));


### PR DESCRIPTION
## Summary
- isolate the WPF UI automation facade from production workflow-summary continuity and configuration dependencies
- register a deterministic in-memory WorkstationWorkflowSummaryService after production registrations
- preserve the original event-driven UI assertion; no product behavior or expected result was weakened
- regenerate the WPF screen development tracker with its owning script

Follow-up to #2516. The Windows Desktop job exposed that the test facade selected the production workflow-summary registration after a fund context was chosen, causing the UI to fall back to Open Trading Shell instead of the deterministic strategy-run summary.

## Validation
- exact failing WPF workflow-summary test: 1 passed
- MainPageUiWorkflowTests: 19 passed
- bash scripts/ci.sh: passed (12,442 .NET tests, 14 skipped; 2,502 dashboard tests; 398 repository-script tests; production bundle built)
- GitHub Actions: all final-head checks passed, including Windows Desktop, regenerated docs, CodeQL, browser, .NET, and quality-gate