### PR TITLE
Add client-grade partners-capital statement to governed reporting

### DIFF
--- a/src/Meridian.Reporting/PartnersCapitalProjection.cs
+++ b/src/Meridian.Reporting/PartnersCapitalProjection.cs
@@ -1,0 +1,53 @@
+using Meridian.Contracts.Workstation;
+
+namespace Meridian.Reporting;
+
+/// <summary>
+/// One partner / capital-account row of a certified partners-capital roll-forward. All figures are
+/// derived from the same certified ledger scope as the run and are carried on the reporting manifest
+/// for the client-grade Capital Account Statement.
+/// </summary>
+public sealed record CertifiedPartnersCapitalAccount(
+    string CapitalAccountName,
+    string? InvestorId,
+    decimal BeginningCapital,
+    decimal Contributions,
+    decimal Distributions,
+    decimal AllocatedResult,
+    decimal OtherMovements,
+    decimal EndingCapital,
+    decimal ReconciliationVariance);
+
+/// <summary>
+/// Certified partners-capital roll-forward projection
+/// (opening → contributions → distributions → allocated result → other movements → ending) for the
+/// Capital Account Statement template: per-account rows plus the fund total and a reconciliation
+/// variance. Produced deterministically from the run's authoritative ledger scope and rendered into
+/// the governed report-pack artifacts (whose bytes are hash-retained), so the numbers stay provable.
+/// </summary>
+public sealed record CertifiedPartnersCapitalProjection(
+    DateTimeOffset PeriodStart,
+    DateTimeOffset AsOf,
+    decimal BeginningCapital,
+    decimal Contributions,
+    decimal Distributions,
+    decimal AllocatedResult,
+    decimal OtherMovements,
+    decimal EndingCapital,
+    decimal ReconciliationVariance,
+    bool IsReconciled,
+    IReadOnlyList<CertifiedPartnersCapitalAccount> Accounts);
+
+/// <summary>
+/// Sources the certified partners-capital roll-forward for a governed reporting run from the same
+/// authoritative ledger scope the run certifies. Returns <c>null</c> when the run scope cannot
+/// produce a roll-forward (e.g. no ledger book selected, unresolved period, or no partners' capital),
+/// in which case the Capital Account Statement falls back to the generic certified-dataset
+/// presentation. Implementations must be deterministic for a given scope + as-of.
+/// </summary>
+public interface IReportingPartnersCapitalSource
+{
+    Task<CertifiedPartnersCapitalProjection?> CaptureAsync(
+        ReportingRunParametersDto parameters,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Meridian.Reporting/ReportingContracts.cs
+++ b/src/Meridian.Reporting/ReportingContracts.cs
@@ -114,7 +114,8 @@ public sealed record ReportingOutputManifest(
     ReportingAccessScope? ImmutableAccessScope = null,
     ReportingCertifiedSnapshotScope? CertifiedSnapshot = null,
     ReportingAuthoritativeSourceCheckpoint? AuthoritativeSource = null,
-    ImmutableArray<IReadOnlyDictionary<string, string>> CertifiedDatasetRows = default);
+    ImmutableArray<IReadOnlyDictionary<string, string>> CertifiedDatasetRows = default,
+    CertifiedPartnersCapitalProjection? CertifiedPartnersCapital = null);
 
 public sealed record ReportingRunReportWriterGridArtifact(
     string GridId,

--- a/src/Meridian.Reporting/ReportingOrchestrationService.cs
+++ b/src/Meridian.Reporting/ReportingOrchestrationService.cs
@@ -74,6 +74,7 @@ public sealed class ReportingOrchestrationService : IReportingOrchestrationServi
     private readonly Func<DateTimeOffset> utcNow;
     private readonly IReportingRunStore? runStore;
     private readonly IReportingRunNotifier runNotifier;
+    private readonly IReportingPartnersCapitalSource? partnersCapitalSource;
     private readonly ConcurrentDictionary<string, ReportingOutputManifest> manifests = new();
     private readonly ConcurrentDictionary<string, object> auditLocks = new();
     private readonly ConcurrentDictionary<string, List<ReportingRunAuditEntry>> audits = new();
@@ -102,12 +103,44 @@ public sealed class ReportingOrchestrationService : IReportingOrchestrationServi
         Func<DateTimeOffset> utcNow,
         IReportingRunStore? runStore,
         IReportingRunNotifier? runNotifier)
+        : this(catalog, renderer, utcNow, runStore, runNotifier, partnersCapitalSource: null)
+    {
+    }
+
+    public ReportingOrchestrationService(
+        IReportingTemplateCatalog catalog,
+        IReportingSectionRenderer renderer,
+        Func<DateTimeOffset> utcNow,
+        IReportingRunStore? runStore,
+        IReportingRunNotifier? runNotifier,
+        IReportingPartnersCapitalSource? partnersCapitalSource)
     {
         this.catalog = catalog;
         this.renderer = renderer;
         this.utcNow = utcNow;
         this.runStore = runStore;
         this.runNotifier = runNotifier ?? NullReportingRunNotifier.Instance;
+        this.partnersCapitalSource = partnersCapitalSource;
+    }
+
+    // Sources the certified partners-capital roll-forward for Capital Account Statement runs from the
+    // same authoritative ledger scope. Null for every other template family (or when no source is
+    // registered), leaving the generic certified-dataset presentation unchanged.
+    private async Task<CertifiedPartnersCapitalProjection?> CapturePartnersCapitalAsync(
+        ReportingTemplateMetadata template,
+        ReportingJobContract contract,
+        CancellationToken cancellationToken)
+    {
+        if (partnersCapitalSource is null
+            || template.Family != ReportingTemplateFamily.CapitalAccountStatement
+            || contract.ResolvedParameters is not { } parameters)
+        {
+            return null;
+        }
+
+        return await partnersCapitalSource
+            .CaptureAsync(parameters, cancellationToken)
+            .ConfigureAwait(false);
     }
 
     public async Task<ReportingOutputManifest> ExecuteAsync(ReportingJobContract contract, CancellationToken cancellationToken)
@@ -155,6 +188,8 @@ public sealed class ReportingOrchestrationService : IReportingOrchestrationServi
                         : (int?)null;
                     var reportWriterGridDiffs = BuildReportWriterGridDiffs(version.PriorManifest, renderedReportWriterGrids);
                     var certifiedDatasetRows = FreezeCertifiedRows(contract);
+                    var certifiedPartnersCapital = await CapturePartnersCapitalAsync(
+                        template, contract, cancellationToken).ConfigureAwait(false);
 
                     var manifest = new ReportingOutputManifest(
                         runId,
@@ -188,7 +223,8 @@ public sealed class ReportingOrchestrationService : IReportingOrchestrationServi
                         ImmutableAccessScope: contract.ImmutableAccessScope,
                         CertifiedSnapshot: contract.CertifiedSnapshot,
                         AuthoritativeSource: contract.AuthoritativeSource,
-                        CertifiedDatasetRows: certifiedDatasetRows);
+                        CertifiedDatasetRows: certifiedDatasetRows,
+                        CertifiedPartnersCapital: certifiedPartnersCapital);
 
                     manifests[ScopedKey(manifest.OperationalScope?.TenantId, runId)] = manifest;
                     AppendAudit(

--- a/src/Meridian.Ui.Shared/Services/ReportingPartnersCapitalSource.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingPartnersCapitalSource.cs
@@ -1,0 +1,118 @@
+using Meridian.Contracts.Workstation;
+using Meridian.Ledger;
+using Meridian.Reporting;
+using Meridian.Storage.Ledger;
+
+namespace Meridian.Ui.Shared.Services;
+
+/// <summary>
+/// Produces the certified partners-capital roll-forward for a governed reporting run by hydrating the
+/// scoped ledger from the durable journal store and reusing the tested
+/// <see cref="LedgerFinancialStatementBuilder.BuildForPeriod"/> computation — the same
+/// hydrate-and-build pattern the live capital-account reconciliation resolver uses. Read-only: it
+/// posts nothing and mutates no state.
+/// </summary>
+public sealed class LedgerReportingPartnersCapitalSource : IReportingPartnersCapitalSource
+{
+    private readonly ILedgerJournalStore? _journalStore;
+
+    public LedgerReportingPartnersCapitalSource(ILedgerJournalStore? journalStore = null)
+        => _journalStore = journalStore;
+
+    public async Task<CertifiedPartnersCapitalProjection?> CaptureAsync(
+        ReportingRunParametersDto parameters,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(parameters);
+        if (_journalStore is null)
+        {
+            return null;
+        }
+
+        if (parameters.LedgerBook.LedgerBookId is not { } bookId || bookId == Guid.Empty)
+        {
+            return null;
+        }
+
+        var fundProfileId = NormalizeOptional(parameters.Scope.FundProfileId);
+        var periods = await _journalStore
+            .ListPeriodsAsync(bookId, fundProfileId: fundProfileId, ct: cancellationToken)
+            .ConfigureAwait(false);
+        var period = periods.FirstOrDefault(candidate => MatchesPeriod(candidate, parameters.PeriodId));
+        if (period is null)
+        {
+            return null;
+        }
+
+        var dimensions = new LedgerLineDimensionSet(
+            FundId: fundProfileId,
+            EntityId: NormalizeOptional(parameters.Scope.EntityId),
+            InvestorId: NormalizeOptional(parameters.Scope.InvestorId),
+            BookId: bookId.ToString("D"));
+
+        var periodStart = new DateTimeOffset(period.StartDate.ToDateTime(TimeOnly.MinValue), TimeSpan.Zero);
+        var asOf = new DateTimeOffset(parameters.AsOfDate.ToDateTime(TimeOnly.MaxValue), TimeSpan.Zero);
+
+        var ledger = await _journalStore
+            .HydrateLedgerAsOfAsync(bookId, asOf, dimensions, cancellationToken)
+            .ConfigureAwait(false);
+
+        var statements = LedgerFinancialStatementBuilder.BuildForPeriod(
+            ledger,
+            periodStart,
+            asOf,
+            chart: null,
+            financialAccountId: null,
+            lineDimensions: dimensions);
+
+        return statements.PartnersCapital is { } partnersCapital
+            ? Map(partnersCapital)
+            : null;
+    }
+
+    private static CertifiedPartnersCapitalProjection Map(LedgerPartnersCapitalStatement statement)
+        => new(
+            statement.PeriodStart,
+            statement.AsOf,
+            statement.BeginningCapital,
+            statement.Contributions,
+            statement.Distributions,
+            statement.AllocatedResult,
+            statement.OtherMovements,
+            statement.EndingCapital,
+            statement.ReconciliationVariance,
+            statement.IsReconciled,
+            statement.Accounts
+                .Select(static account => new CertifiedPartnersCapitalAccount(
+                    account.AccountName,
+                    NormalizeOptional(account.InvestorId),
+                    account.BeginningCapital,
+                    account.Contributions,
+                    account.Distributions,
+                    account.AllocatedResult,
+                    account.OtherMovements,
+                    account.EndingCapital,
+                    account.ReconciliationVariance))
+                .ToArray());
+
+    // Mirrors LedgerCapitalAccountReconciliationResolver.MatchesPeriod: a reporting PeriodId string
+    // can be the period label, the fiscal "YYYY-NN" token, or the raw period GUID.
+    private static bool MatchesPeriod(LedgerAccountingPeriod period, string periodId)
+    {
+        if (string.IsNullOrWhiteSpace(periodId))
+        {
+            return false;
+        }
+
+        var trimmed = periodId.Trim();
+        return string.Equals(period.Label, trimmed, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(
+                FormattableString.Invariant($"{period.FiscalYear:D4}-{period.PeriodNo:D2}"),
+                trimmed,
+                StringComparison.OrdinalIgnoreCase)
+            || string.Equals(period.PeriodId.ToString("D"), trimmed, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? NormalizeOptional(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/src/Meridian.Ui.Shared/Services/ReportingPrimaryDocumentRenderer.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingPrimaryDocumentRenderer.cs
@@ -41,6 +41,11 @@ public sealed class DocumentsReportingPrimaryDocumentRenderer : IReportingPrimar
         var rowHash = DeterministicReportingCertifiedArtifactProducer.ComputeCertifiedRowsHash(
             manifest.CertifiedDatasetRows);
 
+        if (manifest.CertifiedPartnersCapital is { } partnersCapital)
+        {
+            return BuildPartnersCapitalModel(manifest, partnersCapital, rowHash);
+        }
+
         var headerFields = new List<ReportDocumentField>
         {
             new("Run", manifest.RunId),
@@ -72,4 +77,78 @@ public sealed class DocumentsReportingPrimaryDocumentRenderer : IReportingPrimar
             Subtitle: $"Governed report · run {manifest.RunId}",
             FooterNote: $"Certified row hash {(rowHash.Length <= 16 ? rowHash : rowHash[..16])}");
     }
+
+    // Bespoke Capital Account Statement layout: a per-partner + Total roll-forward table
+    // (opening -> contributions -> distributions -> allocated -> other -> ending) sourced from the
+    // certified partners-capital projection. Figures are pre-formatted culture-invariant for
+    // deterministic bytes.
+    private static ReportDocumentModel BuildPartnersCapitalModel(
+        ReportingOutputManifest manifest,
+        CertifiedPartnersCapitalProjection projection,
+        string rowHash)
+    {
+        var template = manifest.ResolvedTemplate!;
+        var headerFields = new List<ReportDocumentField>
+        {
+            new("Run", manifest.RunId),
+            new("Template", $"{template.Name} v{template.Version.ToString(CultureInfo.InvariantCulture)}"),
+            new("Period", $"{projection.PeriodStart.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)} to {projection.AsOf.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}"),
+            new("As of", manifest.AsOfDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)),
+            new("Source checkpoint", manifest.AuthoritativeSource!.CheckpointId),
+            new("Snapshot", manifest.CertifiedSnapshot!.SnapshotId),
+            new("Reconciled", projection.IsReconciled
+                ? "Yes"
+                : $"No (variance {FormatMoney(projection.ReconciliationVariance)})"),
+        };
+
+        var headers = new[]
+        {
+            "Partner", "Beginning", "Contributions", "Distributions", "Allocated", "Other", "Ending",
+        };
+        var rows = new List<IReadOnlyList<string>>();
+        foreach (var account in projection.Accounts)
+        {
+            rows.Add(new[]
+            {
+                PartnerLabel(account),
+                FormatMoney(account.BeginningCapital),
+                FormatMoney(account.Contributions),
+                FormatMoney(account.Distributions),
+                FormatMoney(account.AllocatedResult),
+                FormatMoney(account.OtherMovements),
+                FormatMoney(account.EndingCapital),
+            });
+        }
+
+        rows.Add(new[]
+        {
+            "Total",
+            FormatMoney(projection.BeginningCapital),
+            FormatMoney(projection.Contributions),
+            FormatMoney(projection.Distributions),
+            FormatMoney(projection.AllocatedResult),
+            FormatMoney(projection.OtherMovements),
+            FormatMoney(projection.EndingCapital),
+        });
+
+        var tables = new List<ReportDocumentTable>
+        {
+            new("Statement of Changes in Partners' Capital", headers, rows),
+        };
+
+        return new ReportDocumentModel(
+            Title: template.Name,
+            HeaderFields: headerFields,
+            Tables: tables,
+            Subtitle: $"Partners' capital roll-forward - run {manifest.RunId}",
+            FooterNote: $"Certified row hash {(rowHash.Length <= 16 ? rowHash : rowHash[..16])}");
+    }
+
+    private static string PartnerLabel(CertifiedPartnersCapitalAccount account)
+        => string.IsNullOrWhiteSpace(account.InvestorId)
+            ? account.CapitalAccountName
+            : $"{account.CapitalAccountName} ({account.InvestorId})";
+
+    private static string FormatMoney(decimal value)
+        => value.ToString("N2", CultureInfo.InvariantCulture);
 }

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -542,6 +542,8 @@ public static class WorkstationServiceCollectionExtensions
         services.TryAddSingleton<ReportPackWorkflowService>();
         services.TryAddSingleton<ReportWriterDatasetSourceService>();
         services.TryAddSingleton<ReportWriterGridArtifactService>();
+        services.TryAddSingleton<IReportingPartnersCapitalSource>(sp =>
+            new LedgerReportingPartnersCapitalSource(sp.GetService<ILedgerJournalStore>()));
         services.TryAddSingleton<IReportingOrchestrationService>(sp =>
             new ReportingOrchestrationService(
                 sp.GetRequiredService<IReportingTemplateCatalog>(),
@@ -550,7 +552,8 @@ public static class WorkstationServiceCollectionExtensions
                 sp.GetRequiredService<IReportingRunStore>(),
                 // Null until the report-run stream broadcaster is registered (D1d); the null-object
                 // default keeps run execution unaffected in the meantime.
-                sp.GetService<IReportingRunNotifier>()));
+                sp.GetService<IReportingRunNotifier>(),
+                sp.GetService<IReportingPartnersCapitalSource>()));
         services.TryAddSingleton<ReportingScheduleStoreOptions>(sp =>
             new ReportingScheduleStoreOptions(Path.Combine(ResolveWorkstationDataDirectory(sp), "reporting", "reporting-schedules.json")));
         services.TryAddSingleton<IReportingScheduleStore>(sp =>

--- a/tests/Meridian.Tests/Ui/ReportingRunCertificationServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/ReportingRunCertificationServiceTests.cs
@@ -882,6 +882,71 @@ public sealed class ReportingRunCertificationServiceTests
     }
 
     [Fact]
+    public async Task ProduceAsync_ClientGradePartnersCapitalPdfIsValidAndByteStable()
+    {
+        var manifest = (await BuildCertifiedManifestAsync("run-pc-pdf", ReportingOutputFormatDto.Pdf))
+            with { CertifiedPartnersCapital = SamplePartnersCapital() };
+        var producer = new DeterministicReportingCertifiedArtifactProducer(
+            new DocumentsReportingPrimaryDocumentRenderer());
+
+        var first = await producer.ProduceAsync(manifest);
+        var second = await producer.ProduceAsync(manifest);
+
+        var firstPdf = first.Artifacts.Single(artifact => artifact.FileName == "run-pc-pdf.pdf").Content.ToArray();
+        var secondPdf = second.Artifacts.Single(artifact => artifact.FileName == "run-pc-pdf.pdf").Content.ToArray();
+
+        Encoding.ASCII.GetString(firstPdf, 0, 5).Should().Be("%PDF-");
+        firstPdf.Should().Equal(secondPdf, "partners-capital PDF bytes must be deterministic for hash verification");
+    }
+
+    [Fact]
+    public async Task ProduceAsync_ClientGradePartnersCapitalXlsxRendersRollForwardRows()
+    {
+        var manifest = (await BuildCertifiedManifestAsync("run-pc-xlsx", ReportingOutputFormatDto.Xlsx))
+            with { CertifiedPartnersCapital = SamplePartnersCapital() };
+        var producer = new DeterministicReportingCertifiedArtifactProducer(
+            new DocumentsReportingPrimaryDocumentRenderer());
+
+        var first = await producer.ProduceAsync(manifest);
+        var second = await producer.ProduceAsync(manifest);
+
+        var firstXlsx = first.Artifacts.Single(artifact => artifact.FileName == "run-pc-xlsx.xlsx").Content.ToArray();
+        var secondXlsx = second.Artifacts.Single(artifact => artifact.FileName == "run-pc-xlsx.xlsx").Content.ToArray();
+
+        using (var archive = new ZipArchive(new MemoryStream(firstXlsx), ZipArchiveMode.Read))
+        {
+            archive.GetEntry("xl/workbook.xml").Should().NotBeNull();
+            using var reader = new StreamReader(
+                archive.GetEntry("xl/sharedStrings.xml")!.Open(),
+                Encoding.UTF8);
+            var sharedStrings = await reader.ReadToEndAsync();
+            sharedStrings.Should().Contain("Partner");
+            sharedStrings.Should().Contain("LP One (investor-1)");
+            sharedStrings.Should().Contain("860.00");
+            sharedStrings.Should().Contain("Total");
+        }
+
+        firstXlsx.Should().Equal(secondXlsx, "partners-capital XLSX bytes must be deterministic for hash verification");
+    }
+
+    private static CertifiedPartnersCapitalProjection SamplePartnersCapital() => new(
+        new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero),
+        new DateTimeOffset(2026, 6, 30, 0, 0, 0, TimeSpan.Zero),
+        BeginningCapital: 1000m,
+        Contributions: 500m,
+        Distributions: 200m,
+        AllocatedResult: 100m,
+        OtherMovements: 0m,
+        EndingCapital: 1400m,
+        ReconciliationVariance: 0m,
+        IsReconciled: true,
+        Accounts: new[]
+        {
+            new CertifiedPartnersCapitalAccount("LP One", "investor-1", 600m, 300m, 100m, 60m, 0m, 860m, 0m),
+            new CertifiedPartnersCapitalAccount("LP Two", "investor-2", 400m, 200m, 100m, 40m, 0m, 540m, 0m),
+        });
+
+    [Fact]
     public async Task ProduceAsync_PdfPaginatesEveryAccountSummaryWithinVisiblePageBounds()
     {
         const int accountCount = 120;

--- a/tests/Meridian.Tests/Ui/ReportingRunCertificationServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/ReportingRunCertificationServiceTests.cs
@@ -884,8 +884,10 @@ public sealed class ReportingRunCertificationServiceTests
     [Fact]
     public async Task ProduceAsync_ClientGradePartnersCapitalPdfIsValidAndByteStable()
     {
-        var manifest = (await BuildCertifiedManifestAsync("run-pc-pdf", ReportingOutputFormatDto.Pdf))
-            with { CertifiedPartnersCapital = SamplePartnersCapital() };
+        var manifest = await BuildCertifiedManifestAsync(
+            "run-pc-pdf",
+            ReportingOutputFormatDto.Pdf,
+            partnersCapital: SamplePartnersCapital());
         var producer = new DeterministicReportingCertifiedArtifactProducer(
             new DocumentsReportingPrimaryDocumentRenderer());
 
@@ -902,8 +904,10 @@ public sealed class ReportingRunCertificationServiceTests
     [Fact]
     public async Task ProduceAsync_ClientGradePartnersCapitalXlsxRendersRollForwardRows()
     {
-        var manifest = (await BuildCertifiedManifestAsync("run-pc-xlsx", ReportingOutputFormatDto.Xlsx))
-            with { CertifiedPartnersCapital = SamplePartnersCapital() };
+        var manifest = await BuildCertifiedManifestAsync(
+            "run-pc-xlsx",
+            ReportingOutputFormatDto.Xlsx,
+            partnersCapital: SamplePartnersCapital());
         var producer = new DeterministicReportingCertifiedArtifactProducer(
             new DocumentsReportingPrimaryDocumentRenderer());
 
@@ -1188,7 +1192,8 @@ public sealed class ReportingRunCertificationServiceTests
     private static async Task<ReportingOutputManifest> BuildCertifiedManifestAsync(
         string runId,
         ReportingOutputFormatDto outputFormat,
-        ImmutableArray<IReadOnlyDictionary<string, string>> certifiedRows = default)
+        ImmutableArray<IReadOnlyDictionary<string, string>> certifiedRows = default,
+        CertifiedPartnersCapitalProjection? partnersCapital = null)
     {
         var rows = certifiedRows.IsDefault ? Rows() : certifiedRows;
         var template = Template(reportWriterGrid: false);
@@ -1199,13 +1204,14 @@ public sealed class ReportingRunCertificationServiceTests
                 template,
                 Readiness("evaluation-artifact", CapturedAt, outputFormat),
                 Access());
-        return BuildManifest(runId, template, certified);
+        return BuildManifest(runId, template, certified, partnersCapital);
     }
 
     private static ReportingOutputManifest BuildManifest(
         string runId,
         ReportingTemplateMetadata template,
-        CertifiedReportingRunContext certified)
+        CertifiedReportingRunContext certified,
+        CertifiedPartnersCapitalProjection? partnersCapital = null)
     {
         var declarations = ReportingArtifactDeclaration.Build(
             runId,
@@ -1229,7 +1235,8 @@ public sealed class ReportingRunCertificationServiceTests
             ImmutableAccessScope: certified.AccessScope,
             CertifiedSnapshot: certified.Snapshot,
             AuthoritativeSource: certified.AuthoritativeSource,
-            CertifiedDatasetRows: certified.DatasetRows);
+            CertifiedDatasetRows: certified.DatasetRows,
+            CertifiedPartnersCapital: partnersCapital);
     }
 
     private static ReconciliationBreakQueueItem ScopedBreak(string breakId, string fundId, Guid bookId) => new(


### PR DESCRIPTION
## Summary

The governed **Capital Account Statement** report now exports a bespoke, client-grade **partners-capital roll-forward** — per partner + Total: opening → contributions → distributions → allocated result → other movements → ending, with a reconciliation variance — instead of the generic certified-dataset table. Builds on the merged client-grade PDF/XLSX renderer (Phase 1).

The roll-forward math already existed and is tested (`LedgerFinancialStatementBuilder.BuildForPeriod` → `LedgerPartnersCapitalStatement`) but was reachable only via a test-only report-pack path. This wires it into the governed pipeline and **reuses** it rather than re-deriving it:

- **New `IReportingPartnersCapitalSource` seam** — interface in `Meridian.Reporting`, ledger-backed impl (`LedgerReportingPartnersCapitalSource`) in `Meridian.Ui.Shared`. It hydrates the scoped ledger from the durable journal store (`HydrateLedgerAsOfAsync`) and calls `BuildForPeriod` — the same hydrate-and-build pattern as the live capital-account reconciliation resolver. Read-only: it posts nothing and mutates no state.
- **`ReportingOrchestrationService`** sources the projection only for the `CapitalAccountStatement` template family and carries it on a new **optional** `ReportingOutputManifest.CertifiedPartnersCapital` member. The `CertifiedDatasetRows`/`LedgerLineCount` invariant, retained-manifest hashing, the job contract, and the certification call sites are all **untouched** — the numbers are rendered into the PDF/XLSX artifacts whose SHA-256 are already retained, so provenance holds.
- **`DocumentsReportingPrimaryDocumentRenderer`** renders the bespoke per-partner + Total roll-forward tables (culture-invariant, deterministic), falling back to the generic certified-dataset table when no projection is present.

This is Phase 2 of the client-grade deliverables work (`W9-REPORT-005`). Phase 3 (wiring NAV/fee/waterfall economics into governed ledger postings, `W9-NAV-006`) remains a separate, sequenced follow-up.

## Reason

From the adverse program review: fund accountants' partners-capital statement lived in Excel, and the governed report only emitted a generic ledger-line table. The correct roll-forward computation already existed but ran on a disjoint, test-only path. This makes the governed Capital Account Statement the actual client deliverable.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully — not run locally (no .NET SDK is installed in this environment); relies on the hosted `quality-gate`.
- [x] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated — the ledger hydrate-and-build path reuses the already golden-tested `BuildForPeriod`; the new source is thin read-only glue.
- [ ] GitHub Actions `quality-gate` passed — pending on this PR

Added to `tests/Meridian.Tests/Ui/ReportingRunCertificationServiceTests.cs`: a client-grade partners-capital PDF that is valid and byte-stable across renders, and a client-grade XLSX asserting the rendered per-partner + Total roll-forward rows. Existing runs without the projection continue to render the generic table (unchanged).

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KR4BGEhhu8m6JM7XcPvaQm

---
_Generated by [Claude Code](https://claude.ai/code/session_01KR4BGEhhu8m6JM7XcPvaQm)_