### PR TITLE
Bespoke ledger-backed partners' capital statement layout

### DIFF
--- a/src/Meridian.Documents/FinancialReportDocumentRenderer.cs
+++ b/src/Meridian.Documents/FinancialReportDocumentRenderer.cs
@@ -170,7 +170,7 @@ public sealed class FinancialReportDocumentRenderer : ILedgerReportBinaryRendere
     private static readonly string[] PartnersCapitalPdfColumns =
     [
         "Partner", "Beginning", "Contributions", "Distributions",
-        "Income & Gains", "Expenses", "Fees", "Ending", "Ownership %"
+        "Income & Gains", "Expenses", "Fees", "Other", "Ending", "Ownership %"
     ];
 
     private static readonly string[] PartnersCapitalSheetColumns =
@@ -257,6 +257,7 @@ public sealed class FinancialReportDocumentRenderer : ILedgerReportBinaryRendere
         RenderPartnersCapitalNumber(grid, Money(line.IncomeGainAllocations), background, isTotal);
         RenderPartnersCapitalNumber(grid, Money(line.ExpenseAllocations), background, isTotal);
         RenderPartnersCapitalNumber(grid, Money(line.FeeAllocations), background, isTotal);
+        RenderPartnersCapitalNumber(grid, Money(line.OtherMovements), background, isTotal);
         RenderPartnersCapitalNumber(grid, Money(line.EndingCapital), background, isTotal);
         RenderPartnersCapitalNumber(grid, Percent(line.OwnershipPercent), background, isTotal);
     }

--- a/src/Meridian.Documents/FinancialReportDocumentRenderer.cs
+++ b/src/Meridian.Documents/FinancialReportDocumentRenderer.cs
@@ -24,6 +24,9 @@ public sealed class FinancialReportDocumentRenderer : ILedgerReportBinaryRendere
     {
         ArgumentNullException.ThrowIfNull(reportPack);
         var tables = LedgerReportPresentation.BuildTables(reportPack);
+        var partnersCapital = reportPack.Statements.PartnersCapital is null
+            ? null
+            : PartnersCapitalStatementLayoutBuilder.Build(reportPack);
         var request = reportPack.Request;
 
         var document = Document.Create(container =>
@@ -46,7 +49,17 @@ public sealed class FinancialReportDocumentRenderer : ILedgerReportBinaryRendere
                 {
                     column.Spacing(14);
                     foreach (var table in tables)
-                        RenderTable(column, table);
+                    {
+                        if (partnersCapital is not null
+                            && table.Title == LedgerReportPresentation.PartnersCapitalTableTitle)
+                        {
+                            RenderPartnersCapital(column, partnersCapital);
+                        }
+                        else
+                        {
+                            RenderTable(column, table);
+                        }
+                    }
                 });
 
                 page.Footer().Row(row =>
@@ -83,6 +96,9 @@ public sealed class FinancialReportDocumentRenderer : ILedgerReportBinaryRendere
     {
         ArgumentNullException.ThrowIfNull(reportPack);
         var tables = LedgerReportPresentation.BuildTables(reportPack);
+        var partnersCapital = reportPack.Statements.PartnersCapital is null
+            ? null
+            : PartnersCapitalStatementLayoutBuilder.Build(reportPack);
 
         byte[] rendered;
         using (var workbook = new XLWorkbook())
@@ -90,28 +106,15 @@ public sealed class FinancialReportDocumentRenderer : ILedgerReportBinaryRendere
             var usedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var table in tables)
             {
-                var sheet = workbook.Worksheets.Add(UniqueSheetName(table.Title, usedNames));
-                var headerRow = sheet.Row(1);
-                for (var column = 0; column < table.Headers.Count; column++)
+                if (partnersCapital is not null
+                    && table.Title == LedgerReportPresentation.PartnersCapitalTableTitle)
                 {
-                    var cell = sheet.Cell(1, column + 1);
-                    cell.Value = table.Headers[column];
-                    cell.Style.Font.Bold = true;
-                    cell.Style.Fill.BackgroundColor = XLColor.FromHtml("#0b7285");
-                    cell.Style.Font.FontColor = XLColor.White;
+                    WritePartnersCapitalSheet(workbook, partnersCapital, usedNames);
                 }
-
-                headerRow.Height = 18;
-                var rowNumber = 2;
-                foreach (var row in table.Rows)
+                else
                 {
-                    for (var column = 0; column < row.Count; column++)
-                        sheet.Cell(rowNumber, column + 1).Value = row[column];
-                    rowNumber++;
+                    WriteGenericSheet(workbook, table, usedNames);
                 }
-
-                sheet.Columns().AdjustToContents();
-                sheet.SheetView.FreezeRows(1);
             }
 
             workbook.Properties.Author = "Meridian";
@@ -163,6 +166,235 @@ public sealed class FinancialReportDocumentRenderer : ILedgerReportBinaryRendere
             }
         });
     }
+
+    private static readonly string[] PartnersCapitalPdfColumns =
+    [
+        "Partner", "Beginning", "Contributions", "Distributions",
+        "Income & Gains", "Expenses", "Fees", "Ending", "Ownership %"
+    ];
+
+    private static readonly string[] PartnersCapitalSheetColumns =
+    [
+        "Partner", "Role", "Beginning", "Contributions", "Distributions",
+        "Income & Gains", "Expenses", "Fees", "Allocated Result", "Other", "Ending", "Ownership %"
+    ];
+
+    private const string MoneyNumberFormat = "#,##0.00";
+    private const string PercentNumberFormat = "0.00%";
+
+    /// <summary>
+    /// Bespoke PDF layout for the statement of changes in partners' capital: a NAV (net-assets)
+    /// context strip, a role-labelled per-partner roll-forward with right-aligned figures and an
+    /// ownership-share column, a bold total row, and a ledger-backed reconciliation footnote. This
+    /// replaces the generic table layout for this one statement so the client deliverable reads like a
+    /// fund administrator's statement rather than a flat grid.
+    /// </summary>
+    private static void RenderPartnersCapital(ColumnDescriptor column, PartnersCapitalStatementLayout layout)
+    {
+        column.Item().Text(LedgerReportPresentation.PartnersCapitalTableTitle)
+            .FontSize(11).Bold().FontColor("#102a43");
+        column.Item().Text(
+                $"Net asset value {Money(layout.NetAssetValue)} {layout.BaseCurrency} · {layout.Lines.Count} capital accounts")
+            .FontSize(8).FontColor("#627d98");
+
+        column.Item().Table(grid =>
+        {
+            grid.ColumnsDefinition(columns =>
+            {
+                columns.RelativeColumn(2.2f);
+                for (var index = 1; index < PartnersCapitalPdfColumns.Length; index++)
+                    columns.RelativeColumn();
+            });
+
+            grid.Header(headerRow =>
+            {
+                // Partner heading left-aligned; every economic heading right-aligned to read as figures.
+                headerRow.Cell().Background("#d9e2ec").PaddingVertical(3).PaddingHorizontal(4)
+                    .Text(PartnersCapitalPdfColumns[0]).SemiBold().FontSize(8);
+                for (var index = 1; index < PartnersCapitalPdfColumns.Length; index++)
+                {
+                    headerRow.Cell().Background("#d9e2ec").AlignRight().PaddingVertical(3).PaddingHorizontal(4)
+                        .Text(PartnersCapitalPdfColumns[index]).SemiBold().FontSize(8);
+                }
+            });
+
+            var alternate = false;
+            foreach (var line in layout.Lines)
+            {
+                RenderPartnersCapitalRow(grid, line, alternate ? "#f0f4f8" : "#ffffff", isTotal: false);
+                alternate = !alternate;
+            }
+
+            RenderPartnersCapitalRow(grid, layout.Total, "#d9e2ec", isTotal: true);
+        });
+
+        var note = layout.TiesToNetAssets
+            ? $"Ending partners' capital of {Money(layout.Total.EndingCapital)} {layout.BaseCurrency} reconciles to the fund's ledger-backed net asset value."
+            : $"Reconciliation exception: ending partners' capital differs from net assets by {Money(layout.NetAssetVariance)} {layout.BaseCurrency}.";
+        column.Item().Text(note).FontSize(7).FontColor(layout.TiesToNetAssets ? "#627d98" : "#b91c1c");
+    }
+
+    private static void RenderPartnersCapitalRow(
+        TableDescriptor grid,
+        PartnersCapitalStatementLine line,
+        string background,
+        bool isTotal)
+    {
+        grid.Cell().Background(background).PaddingVertical(2).PaddingHorizontal(4).Column(cell =>
+        {
+            var name = cell.Item().Text(line.PartnerLabel).FontSize(8);
+            if (isTotal)
+                name.Bold();
+            else
+                name.SemiBold();
+            if (!isTotal)
+                cell.Item().Text(RoleLabel(line.Role)).FontSize(6).FontColor("#829ab1");
+        });
+
+        RenderPartnersCapitalNumber(grid, Money(line.BeginningCapital), background, isTotal);
+        RenderPartnersCapitalNumber(grid, Money(line.Contributions), background, isTotal);
+        RenderPartnersCapitalNumber(grid, Money(line.Distributions), background, isTotal);
+        RenderPartnersCapitalNumber(grid, Money(line.IncomeGainAllocations), background, isTotal);
+        RenderPartnersCapitalNumber(grid, Money(line.ExpenseAllocations), background, isTotal);
+        RenderPartnersCapitalNumber(grid, Money(line.FeeAllocations), background, isTotal);
+        RenderPartnersCapitalNumber(grid, Money(line.EndingCapital), background, isTotal);
+        RenderPartnersCapitalNumber(grid, Percent(line.OwnershipPercent), background, isTotal);
+    }
+
+    private static void RenderPartnersCapitalNumber(
+        TableDescriptor grid,
+        string value,
+        string background,
+        bool bold)
+    {
+        var text = grid.Cell().Background(background).AlignRight().PaddingVertical(2).PaddingHorizontal(4)
+            .Text(value).FontSize(8);
+        if (bold)
+            text.Bold();
+    }
+
+    private static void WriteGenericSheet(XLWorkbook workbook, LedgerReportTable table, HashSet<string> usedNames)
+    {
+        var sheet = workbook.Worksheets.Add(UniqueSheetName(table.Title, usedNames));
+        var headerRow = sheet.Row(1);
+        for (var column = 0; column < table.Headers.Count; column++)
+        {
+            var cell = sheet.Cell(1, column + 1);
+            cell.Value = table.Headers[column];
+            cell.Style.Font.Bold = true;
+            cell.Style.Fill.BackgroundColor = XLColor.FromHtml("#0b7285");
+            cell.Style.Font.FontColor = XLColor.White;
+        }
+
+        headerRow.Height = 18;
+        var rowNumber = 2;
+        foreach (var row in table.Rows)
+        {
+            for (var column = 0; column < row.Count; column++)
+                sheet.Cell(rowNumber, column + 1).Value = row[column];
+            rowNumber++;
+        }
+
+        sheet.Columns().AdjustToContents();
+        sheet.SheetView.FreezeRows(1);
+    }
+
+    /// <summary>
+    /// Bespoke XLSX sheet for the partners' capital statement. Unlike the generic sheet (whose every
+    /// cell is a pre-formatted string), the money and ownership cells are written as typed numeric
+    /// values with accounting/percent number formats, so an operator can SUM, pivot, and recompute the
+    /// statement without retyping. A NAV anchor block records the ledger-backed net asset value the
+    /// statement ties to.
+    /// </summary>
+    private static void WritePartnersCapitalSheet(
+        XLWorkbook workbook,
+        PartnersCapitalStatementLayout layout,
+        HashSet<string> usedNames)
+    {
+        var sheet = workbook.Worksheets.Add(UniqueSheetName("Partners' Capital", usedNames));
+
+        for (var column = 0; column < PartnersCapitalSheetColumns.Length; column++)
+        {
+            var cell = sheet.Cell(1, column + 1);
+            cell.Value = PartnersCapitalSheetColumns[column];
+            cell.Style.Font.Bold = true;
+            cell.Style.Fill.BackgroundColor = XLColor.FromHtml("#0b7285");
+            cell.Style.Font.FontColor = XLColor.White;
+        }
+
+        sheet.Row(1).Height = 18;
+
+        var rowNumber = 2;
+        foreach (var line in layout.Lines)
+        {
+            WritePartnersCapitalRow(sheet, rowNumber, line, RoleLabel(line.Role), bold: false);
+            rowNumber++;
+        }
+
+        var totalRowNumber = rowNumber;
+        WritePartnersCapitalRow(sheet, totalRowNumber, layout.Total, "Total", bold: true);
+
+        // Fund-economics anchor: the ledger-backed NAV the statement reconciles to, with an explicit
+        // tie flag, so the governed deliverable can prove the ending capital against net assets.
+        var navLabelRow = totalRowNumber + 2;
+        sheet.Cell(navLabelRow, 1).Value = "Net asset value (NAV base)";
+        sheet.Cell(navLabelRow, 1).Style.Font.Bold = true;
+        WriteMoneyCell(sheet.Cell(navLabelRow, 3), layout.NetAssetValue);
+
+        var tieRow = navLabelRow + 1;
+        sheet.Cell(tieRow, 1).Value = "Ending capital ties to NAV";
+        sheet.Cell(tieRow, 3).Value = layout.TiesToNetAssets
+            ? "Yes"
+            : $"No — variance {layout.NetAssetVariance.ToString(MoneyNumberFormat, CultureInfo.InvariantCulture)}";
+
+        sheet.Columns().AdjustToContents();
+        sheet.SheetView.FreezeRows(1);
+    }
+
+    private static void WritePartnersCapitalRow(
+        IXLWorksheet sheet,
+        int rowNumber,
+        PartnersCapitalStatementLine line,
+        string roleLabel,
+        bool bold)
+    {
+        sheet.Cell(rowNumber, 1).Value = line.PartnerLabel;
+        sheet.Cell(rowNumber, 2).Value = roleLabel;
+        WriteMoneyCell(sheet.Cell(rowNumber, 3), line.BeginningCapital);
+        WriteMoneyCell(sheet.Cell(rowNumber, 4), line.Contributions);
+        WriteMoneyCell(sheet.Cell(rowNumber, 5), line.Distributions);
+        WriteMoneyCell(sheet.Cell(rowNumber, 6), line.IncomeGainAllocations);
+        WriteMoneyCell(sheet.Cell(rowNumber, 7), line.ExpenseAllocations);
+        WriteMoneyCell(sheet.Cell(rowNumber, 8), line.FeeAllocations);
+        WriteMoneyCell(sheet.Cell(rowNumber, 9), line.AllocatedResult);
+        WriteMoneyCell(sheet.Cell(rowNumber, 10), line.OtherMovements);
+        WriteMoneyCell(sheet.Cell(rowNumber, 11), line.EndingCapital);
+
+        var ownership = sheet.Cell(rowNumber, 12);
+        ownership.Value = line.OwnershipPercent / 100m; // stored as a true fraction so Excel foots to 100%
+        ownership.Style.NumberFormat.Format = PercentNumberFormat;
+
+        if (bold)
+            sheet.Range(rowNumber, 1, rowNumber, PartnersCapitalSheetColumns.Length).Style.Font.Bold = true;
+    }
+
+    private static void WriteMoneyCell(IXLCell cell, decimal value)
+    {
+        cell.Value = value;
+        cell.Style.NumberFormat.Format = MoneyNumberFormat;
+    }
+
+    private static string RoleLabel(PartnersCapitalPartnerRole role) => role switch
+    {
+        PartnersCapitalPartnerRole.LimitedPartner => "Limited partner",
+        PartnersCapitalPartnerRole.GeneralPartner => "General partner",
+        PartnersCapitalPartnerRole.UndistributedResult => "Undistributed result",
+        _ => "Fund capital",
+    };
+
+    private static string Money(decimal value) => value.ToString(MoneyNumberFormat, CultureInfo.InvariantCulture);
+
+    private static string Percent(decimal value) => value.ToString("0.00", CultureInfo.InvariantCulture) + "%";
 
     private static string UniqueSheetName(string title, HashSet<string> used)
     {

--- a/src/Meridian.Documents/README.md
+++ b/src/Meridian.Documents/README.md
@@ -25,6 +25,12 @@ This module belongs to the Design Module layer. Keep changes within that ownersh
 - `FinancialReportDocumentRenderer.cs` - client-grade QuestPDF (PDF) + ClosedXML (XLSX) renderer that
   implements the ledger's `ILedgerReportBinaryRenderer` seam. Output is made deterministic (fixed
   document metadata/timestamps, canonical zip ordering) so re-rendering a pack reproduces the bytes.
+  The statement of changes in partners' capital renders through a bespoke layout (from the ledger's
+  `PartnersCapitalStatementLayout`) rather than the generic table: a fund-economics NAV context strip,
+  role-labelled per-partner rows, an ownership-share column, a bold total, and a reconciliation note in
+  the PDF, and a dedicated XLSX sheet whose money and ownership cells are typed numbers (accounting and
+  percent formats) so the deliverable can be summed and pivoted without retyping. Every other statement
+  keeps the generic tabular rendering.
 - `DocumentsServiceCollectionExtensions.cs` - `AddFinancialReportDocumentRenderer` composition helper
   that registers the renderer for the `ILedgerReportBinaryRenderer` seam. The workstation host calls
   it (see `WorkstationServiceCollectionExtensions`), flipping governed ledger exports off the

--- a/src/Meridian.Ledger/LedgerReportPresentation.cs
+++ b/src/Meridian.Ledger/LedgerReportPresentation.cs
@@ -14,6 +14,10 @@ public sealed record LedgerReportTable(
 /// </summary>
 public static class LedgerReportPresentation
 {
+    /// <summary>Title of the statement-of-changes-in-partners'-capital table, shared so a renderer can
+    /// substitute a bespoke layout for the generic table without matching a loose string.</summary>
+    public const string PartnersCapitalTableTitle = "Statement of Changes in Partners' Capital";
+
     public static IReadOnlyList<LedgerReportTable> BuildTables(LedgerFinancialReportPack reportPack)
     {
         ArgumentNullException.ThrowIfNull(reportPack);
@@ -135,7 +139,7 @@ public static class LedgerReportPresentation
         ]);
 
         return new LedgerReportTable(
-            "Statement of Changes in Partners' Capital",
+            PartnersCapitalTableTitle,
             ["Partner", "Beginning", "Contributions", "Distributions", "Income & Gains", "Expenses", "Fees", "Ending"],
             rows);
     }

--- a/src/Meridian.Ledger/PartnersCapitalStatementLayout.cs
+++ b/src/Meridian.Ledger/PartnersCapitalStatementLayout.cs
@@ -110,28 +110,36 @@ public static class PartnersCapitalStatementLayoutBuilder
     {
         ArgumentNullException.ThrowIfNull(statement);
 
-        // Ownership is a partner's share of total ending partners' capital. Dividing every line by
-        // the same total means the column foots to 100% (each line = lineEnding / totalEnding, and the
-        // line endings sum to the total by construction). A fully-distributed fund has no capital to
-        // apportion, so every share is zero.
-        var totalEnding = statement.EndingCapital;
+        // Classify each account once: role drives both the presentation label and whether the account
+        // participates in ownership.
+        var classified = statement.Accounts
+            .Select(account => (account, role: ClassifyRole(account.AccountName)))
+            .ToList();
 
-        var lines = statement.Accounts
-            .Select(account => new PartnersCapitalStatementLine(
-                PartnerLabel: string.IsNullOrWhiteSpace(account.InvestorId)
-                    ? account.AccountName
-                    : account.InvestorId,
-                Role: ClassifyRole(account.AccountName),
-                BeginningCapital: account.BeginningCapital,
-                Contributions: account.Contributions,
-                Distributions: account.Distributions,
-                IncomeGainAllocations: account.IncomeGainAllocations,
-                ExpenseAllocations: account.ExpenseAllocations,
-                FeeAllocations: account.FeeAllocations,
-                AllocatedResult: account.AllocatedResult,
-                OtherMovements: account.OtherMovements,
-                EndingCapital: account.EndingCapital,
-                OwnershipPercent: OwnershipShare(account.EndingCapital, totalEnding)))
+        // Ownership is a named partner's share of the capital held by named partners (LP + GP). Fund-level
+        // results not yet closed to a partner (undistributed net income) and undesignated fund capital are
+        // not partners: counting them let a partner exceed 100% while the undistributed line showed a
+        // negative share. They are excluded from both numerator and denominator and carry no ownership.
+        var partnerEndingCapital = classified
+            .Where(entry => IsNamedPartner(entry.role))
+            .Sum(entry => entry.account.EndingCapital);
+
+        var lines = classified
+            .Select(entry => new PartnersCapitalStatementLine(
+                PartnerLabel: PartnerLabelFor(entry.role, entry.account.InvestorId, entry.account.AccountName),
+                Role: entry.role,
+                BeginningCapital: entry.account.BeginningCapital,
+                Contributions: entry.account.Contributions,
+                Distributions: entry.account.Distributions,
+                IncomeGainAllocations: entry.account.IncomeGainAllocations,
+                ExpenseAllocations: entry.account.ExpenseAllocations,
+                FeeAllocations: entry.account.FeeAllocations,
+                AllocatedResult: entry.account.AllocatedResult,
+                OtherMovements: entry.account.OtherMovements,
+                EndingCapital: entry.account.EndingCapital,
+                OwnershipPercent: IsNamedPartner(entry.role)
+                    ? OwnershipShare(entry.account.EndingCapital, partnerEndingCapital)
+                    : 0m))
             .OrderBy(static line => line.Role)
             .ThenBy(static line => line.PartnerLabel, StringComparer.Ordinal)
             .ToList();
@@ -164,6 +172,19 @@ public static class PartnersCapitalStatementLayoutBuilder
 
     private static decimal OwnershipShare(decimal endingCapital, decimal totalEndingCapital)
         => totalEndingCapital == 0m ? 0m : endingCapital / totalEndingCapital * 100m;
+
+    // Only limited and general partners hold an ownership stake in the fund's capital.
+    private static bool IsNamedPartner(PartnersCapitalPartnerRole role)
+        => role is PartnersCapitalPartnerRole.LimitedPartner or PartnersCapitalPartnerRole.GeneralPartner;
+
+    // A limited-partner account carries a trustworthy investor identity, so it is labelled by that id.
+    // Every other role is labelled by its ledger account-name caption: the distribution-waterfall posting
+    // reuses the LP's investorId on the GP carried-interest line, so surfacing InvestorId for a non-LP
+    // role would print the LP's id as the general partner.
+    private static string PartnerLabelFor(PartnersCapitalPartnerRole role, string? investorId, string accountName)
+        => role == PartnersCapitalPartnerRole.LimitedPartner && !string.IsNullOrWhiteSpace(investorId)
+            ? investorId
+            : accountName;
 
     // Role is derived from the stable account names minted by LedgerAccounts. It is a caption only:
     // an unrecognized capital account falls back to GeneralCapital and its figures are untouched.

--- a/src/Meridian.Ledger/PartnersCapitalStatementLayout.cs
+++ b/src/Meridian.Ledger/PartnersCapitalStatementLayout.cs
@@ -1,0 +1,180 @@
+using Meridian.Contracts.Ledger;
+
+namespace Meridian.Ledger;
+
+/// <summary>
+/// The economic role a capital account plays in a partners' capital statement. This is a
+/// presentation label only — it groups and titles the roll-forward lines a fund administrator hands
+/// to investors and never alters any figure. Classification is derived from the ledger-owned account
+/// name produced by <see cref="LedgerAccounts"/>, so a mislabel can only change a caption, not a
+/// balance.
+/// </summary>
+public enum PartnersCapitalPartnerRole
+{
+    /// <summary>Limited-partner (investor) capital, e.g. <c>Investor Capital</c> accounts.</summary>
+    LimitedPartner,
+
+    /// <summary>General-partner economics, e.g. <c>Carried Interest Allocation</c> accounts.</summary>
+    GeneralPartner,
+
+    /// <summary>Period result not yet closed to a named partner (the undistributed net income line).</summary>
+    UndistributedResult,
+
+    /// <summary>Undesignated fund capital (a generic capital account or retained earnings).</summary>
+    GeneralCapital,
+}
+
+/// <summary>
+/// One bespoke-layout line of the statement of changes in partners' capital: a partner-oriented
+/// roll-forward carrying the income/expense/fee breakout plus the partner's ownership share of
+/// ending capital. Money fields stay typed (not pre-formatted) so a renderer can emit computable
+/// numeric cells rather than a text dump.
+/// </summary>
+public sealed record PartnersCapitalStatementLine(
+    string PartnerLabel,
+    PartnersCapitalPartnerRole Role,
+    decimal BeginningCapital,
+    decimal Contributions,
+    decimal Distributions,
+    decimal IncomeGainAllocations,
+    decimal ExpenseAllocations,
+    decimal FeeAllocations,
+    decimal AllocatedResult,
+    decimal OtherMovements,
+    decimal EndingCapital,
+    decimal OwnershipPercent);
+
+/// <summary>
+/// A bespoke, client-grade layout of the statement of changes in partners' capital. Unlike the
+/// generic <see cref="LedgerReportTable"/> projection, this model keeps money typed, classifies each
+/// account by partner role, computes each partner's ownership percentage of ending capital, and
+/// anchors the statement to the fund's ledger-backed net asset value (the unitized NAV base) with an
+/// explicit reconciliation flag. It is a pure projection over a
+/// <see cref="LedgerPartnersCapitalStatement"/> — it introduces no new ledger fact.
+/// </summary>
+public sealed record PartnersCapitalStatementLayout(
+    string FundId,
+    string PeriodId,
+    string BaseCurrency,
+    DateTimeOffset PeriodStart,
+    DateTimeOffset AsOf,
+    decimal NetAssetValue,
+    bool TiesToNetAssets,
+    IReadOnlyList<PartnersCapitalStatementLine> Lines,
+    PartnersCapitalStatementLine Total)
+{
+    /// <summary>Reconciliation gap between ending partners' capital and the fund's net asset value.</summary>
+    public decimal NetAssetVariance => Total.EndingCapital - NetAssetValue;
+}
+
+/// <summary>
+/// Builds a <see cref="PartnersCapitalStatementLayout"/> from ledger-backed statements. The layout is
+/// a deterministic function of its inputs so it renders to byte-stable governed artifacts.
+/// </summary>
+public static class PartnersCapitalStatementLayoutBuilder
+{
+    /// <summary>
+    /// Projects the partners' capital statement inside <paramref name="pack"/>, anchored to the same
+    /// pack's ledger-backed net assets (ending equity = total assets − total liabilities), which is
+    /// the unitized NAV base the statement reconciles to.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The pack carries no partners' capital statement to lay out.
+    /// </exception>
+    public static PartnersCapitalStatementLayout Build(LedgerFinancialReportPack pack)
+    {
+        ArgumentNullException.ThrowIfNull(pack);
+        var statement = pack.Statements.PartnersCapital
+            ?? throw new InvalidOperationException(
+                "Report pack has no partners' capital statement to lay out.");
+
+        return Build(
+            statement,
+            pack.Request.FundId,
+            pack.Request.PeriodId,
+            pack.Request.BaseCurrency,
+            pack.Statements.EndingEquity);
+    }
+
+    /// <summary>
+    /// Projects <paramref name="statement"/> into the bespoke layout, expressing each partner's
+    /// ownership share and anchoring the whole statement to <paramref name="netAssetValue"/> (the
+    /// fund's ledger-backed net asset value / NAV base).
+    /// </summary>
+    public static PartnersCapitalStatementLayout Build(
+        LedgerPartnersCapitalStatement statement,
+        string fundId,
+        string periodId,
+        string baseCurrency,
+        decimal netAssetValue)
+    {
+        ArgumentNullException.ThrowIfNull(statement);
+
+        // Ownership is a partner's share of total ending partners' capital. Dividing every line by
+        // the same total means the column foots to 100% (each line = lineEnding / totalEnding, and the
+        // line endings sum to the total by construction). A fully-distributed fund has no capital to
+        // apportion, so every share is zero.
+        var totalEnding = statement.EndingCapital;
+
+        var lines = statement.Accounts
+            .Select(account => new PartnersCapitalStatementLine(
+                PartnerLabel: string.IsNullOrWhiteSpace(account.InvestorId)
+                    ? account.AccountName
+                    : account.InvestorId,
+                Role: ClassifyRole(account.AccountName),
+                BeginningCapital: account.BeginningCapital,
+                Contributions: account.Contributions,
+                Distributions: account.Distributions,
+                IncomeGainAllocations: account.IncomeGainAllocations,
+                ExpenseAllocations: account.ExpenseAllocations,
+                FeeAllocations: account.FeeAllocations,
+                AllocatedResult: account.AllocatedResult,
+                OtherMovements: account.OtherMovements,
+                EndingCapital: account.EndingCapital,
+                OwnershipPercent: OwnershipShare(account.EndingCapital, totalEnding)))
+            .OrderBy(static line => line.Role)
+            .ThenBy(static line => line.PartnerLabel, StringComparer.Ordinal)
+            .ToList();
+
+        var total = new PartnersCapitalStatementLine(
+            PartnerLabel: "Total partners' capital",
+            Role: PartnersCapitalPartnerRole.GeneralCapital,
+            BeginningCapital: statement.BeginningCapital,
+            Contributions: statement.Contributions,
+            Distributions: statement.Distributions,
+            IncomeGainAllocations: statement.IncomeGainAllocations,
+            ExpenseAllocations: statement.ExpenseAllocations,
+            FeeAllocations: statement.FeeAllocations,
+            AllocatedResult: statement.AllocatedResult,
+            OtherMovements: statement.OtherMovements,
+            EndingCapital: statement.EndingCapital,
+            OwnershipPercent: lines.Sum(static line => line.OwnershipPercent));
+
+        return new PartnersCapitalStatementLayout(
+            FundId: fundId,
+            PeriodId: periodId,
+            BaseCurrency: baseCurrency,
+            PeriodStart: statement.PeriodStart,
+            AsOf: statement.AsOf,
+            NetAssetValue: netAssetValue,
+            TiesToNetAssets: Math.Abs(statement.EndingCapital - netAssetValue) <= LedgerToleranceConstants.Balance,
+            Lines: lines,
+            Total: total);
+    }
+
+    private static decimal OwnershipShare(decimal endingCapital, decimal totalEndingCapital)
+        => totalEndingCapital == 0m ? 0m : endingCapital / totalEndingCapital * 100m;
+
+    // Role is derived from the stable account names minted by LedgerAccounts. It is a caption only:
+    // an unrecognized capital account falls back to GeneralCapital and its figures are untouched.
+    private static PartnersCapitalPartnerRole ClassifyRole(string accountName)
+    {
+        if (accountName.Equals("Undistributed Net Income", StringComparison.Ordinal))
+            return PartnersCapitalPartnerRole.UndistributedResult;
+        if (accountName.Contains("Carried Interest", StringComparison.OrdinalIgnoreCase))
+            return PartnersCapitalPartnerRole.GeneralPartner;
+        if (accountName.Contains("Investor Capital", StringComparison.OrdinalIgnoreCase))
+            return PartnersCapitalPartnerRole.LimitedPartner;
+        return PartnersCapitalPartnerRole.GeneralCapital;
+    }
+}

--- a/src/Meridian.Ledger/README.md
+++ b/src/Meridian.Ledger/README.md
@@ -44,6 +44,14 @@ income/expense/fee drivers a fund accountant delivers rather than one lumped fig
 never disturbs the existing ending-capital reconciliation, and it flows through both the
 partners-capital CSV artifact and the shared `LedgerReportPresentation` table that drives the Xlsx/Pdf
 renderers.
+`PartnersCapitalStatementLayout` (built by `PartnersCapitalStatementLayoutBuilder`) is a bespoke,
+client-grade projection of that statement for the deliverable: it classifies each capital account by
+partner role (limited partner, general partner, undistributed result, or fund capital), computes each
+partner's ownership share of ending capital, and anchors the whole statement to the fund's
+ledger-backed net asset value (the unitized NAV base) with an explicit reconciliation flag. It keeps
+money typed (not pre-formatted) so `FinancialReportDocumentRenderer` can emit a purpose-built
+partners-capital PDF section and a typed-numeric XLSX sheet instead of the generic table. The
+projection is presentation only — it introduces no ledger fact and never changes a figure.
 `LedgerReportPackBuilder` emits those statements as CSV/JSON pack artifacts, and
 `LedgerScheduledReportExportPackageBuilder` now honors every declared `LedgerReportExportFormat`:
 Csv, Json, RegulatoryXml natively plus real binary Xlsx/Pdf through the

--- a/tests/Meridian.Tests/Ledger/PartnersCapitalBespokeRenderTests.cs
+++ b/tests/Meridian.Tests/Ledger/PartnersCapitalBespokeRenderTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+using ClosedXML.Excel;
+using FluentAssertions;
+using Meridian.Documents;
+using Meridian.Ledger;
+using Xunit;
+
+namespace Meridian.Tests.Ledger;
+
+/// <summary>
+/// Proves the client-grade renderer emits the bespoke partners' capital layout: a dedicated XLSX
+/// sheet whose money and ownership cells are typed numbers — so an operator can SUM/pivot without
+/// retyping, the exact program-review gap ("every cell is text") — plus a ledger-backed NAV anchor
+/// block, and a valid PDF. Both render deterministically for governed hash verification.
+/// </summary>
+public sealed class PartnersCapitalBespokeRenderTests
+{
+    [Fact]
+    public void Workbook_HasDedicatedPartnersCapitalSheet_WithTypedNumericCells()
+    {
+        var pack = LedgerReportPackTestData.BuildContributionPack();
+
+        var xlsx = new FinancialReportDocumentRenderer().RenderWorkbook(pack);
+
+        using var workbook = new XLWorkbook(new MemoryStream(xlsx));
+        workbook.Worksheets.Any(sheet => sheet.Name == "Partners' Capital").Should().BeTrue();
+        var sheet = workbook.Worksheet("Partners' Capital");
+
+        // Bespoke column set, distinct from the generic 8-column table.
+        sheet.Cell(1, 1).GetString().Should().Be("Partner");
+        sheet.Cell(1, 2).GetString().Should().Be("Role");
+
+        // Every data row's money cells are typed numbers with an accounting format — not text.
+        var beginning = sheet.Cell(2, 3);
+        beginning.DataType.Should().Be(XLDataType.Number);
+        beginning.Style.NumberFormat.Format.Should().Be("#,##0.00");
+        sheet.Cell(2, 11).DataType.Should().Be(XLDataType.Number);
+
+        // Ownership is a true percentage fraction so the column foots to 100% in Excel.
+        var ownership = sheet.Cell(2, 12);
+        ownership.DataType.Should().Be(XLDataType.Number);
+        ownership.Style.NumberFormat.Format.Should().Be("0.00%");
+    }
+
+    [Fact]
+    public void Workbook_PartnersCapitalSheet_CarriesLedgerBackedNavAnchor()
+    {
+        var pack = LedgerReportPackTestData.BuildContributionPack();
+
+        var xlsx = new FinancialReportDocumentRenderer().RenderWorkbook(pack);
+
+        using var workbook = new XLWorkbook(new MemoryStream(xlsx));
+        var cells = workbook.Worksheet("Partners' Capital").RangeUsed()!.CellsUsed().ToList();
+
+        cells.Should().Contain(cell => cell.GetString() == "Net asset value (NAV base)");
+        cells.Should().Contain(cell => cell.GetString() == "Ending capital ties to NAV");
+
+        // The NAV value is carried as a typed number equal to the pack's ledger-backed net assets.
+        var netAssets = (double)pack.Statements.EndingEquity;
+        cells.Should().Contain(cell => cell.DataType == XLDataType.Number && cell.GetDouble() == netAssets);
+    }
+
+    [Fact]
+    public void Renderer_BespokePath_IsDeterministicAndProducesValidPdf()
+    {
+        var pack = LedgerReportPackTestData.BuildContributionPack();
+        var renderer = new FinancialReportDocumentRenderer();
+
+        var firstPdf = renderer.RenderPdf(pack);
+        var secondPdf = renderer.RenderPdf(pack);
+        var firstXlsx = renderer.RenderWorkbook(pack);
+        var secondXlsx = renderer.RenderWorkbook(pack);
+
+        Encoding.ASCII.GetString(firstPdf, 0, 5).Should().Be("%PDF-");
+        firstPdf.Should().Equal(secondPdf);
+        firstXlsx.Should().Equal(secondXlsx);
+    }
+}

--- a/tests/Meridian.Tests/Ledger/PartnersCapitalStatementLayoutTests.cs
+++ b/tests/Meridian.Tests/Ledger/PartnersCapitalStatementLayoutTests.cs
@@ -57,26 +57,42 @@ public sealed class PartnersCapitalStatementLayoutTests
     }
 
     [Fact]
-    public void Build_OwnershipShares_FootToOneHundredPercent()
+    public void Build_Ownership_ExcludesNonPartnerEquityAndBoundsPartners()
     {
         var layout = PartnersCapitalStatementLayoutBuilder.Build(
             LedgerReportPackTestData.BuildContributionPack());
 
-        layout.Lines.Sum(line => line.OwnershipPercent).Should().BeApproximately(100m, 0.0001m);
+        // The undistributed net income line is a fund-level result, not a partner: it holds no ownership.
+        // (Before the fix its negative capital produced a negative "ownership" share.)
+        var undistributed = layout.Lines.Should()
+            .ContainSingle(line => line.Role == PartnersCapitalPartnerRole.UndistributedResult).Which;
+        undistributed.OwnershipPercent.Should().Be(0m);
+
+        // Named partners hold 100% between them and none is reported above 100%. (Before the fix the LP
+        // read ~102% because the negative undistributed line sat in the denominator.)
+        var lp = layout.Lines.Should()
+            .ContainSingle(line => line.Role == PartnersCapitalPartnerRole.LimitedPartner).Which;
+        lp.OwnershipPercent.Should().BeApproximately(100m, 0.0001m);
+        layout.Lines.Should().OnlyContain(line => line.OwnershipPercent <= 100m);
         layout.Total.OwnershipPercent.Should().BeApproximately(100m, 0.0001m);
     }
 
     [Fact]
-    public void Build_CarriedInterestAllocation_ClassifiedAsGeneralPartner()
+    public void Build_CarriedInterestAllocation_LabelledByCaptionNotTheLimitedPartnerId()
     {
+        // The distribution-waterfall factory posts the GP carried-interest line under the *LP's* investor
+        // id (BuildDistributionWaterfallDraft reuses its single investorId for both legs). Reproduce that
+        // by scoping the carry account to the LP id, then prove the layout never surfaces it as the GP.
+        const string lpId = "lp-1";
         var ledger = new Meridian.Ledger.Ledger();
         ledger.PostLines(new DateTimeOffset(2025, 6, 15, 0, 0, 0, TimeSpan.Zero), "opening contribution",
-            [(LedgerAccounts.Cash, 5_000_000m, 0m), (LedgerAccounts.InvestorCapitalFor("lp-1"), 0m, 5_000_000m)]);
+            [(LedgerAccounts.Cash, 5_000_000m, 0m), (LedgerAccounts.InvestorCapitalFor(lpId), 0m, 5_000_000m)]);
         ledger.PostLines(new DateTimeOffset(2026, 3, 31, 0, 0, 0, TimeSpan.Zero), "realized gain",
             [(LedgerAccounts.Cash, 1_000_000m, 0m), (LedgerAccounts.RealizedGainFor("fund-a"), 0m, 1_000_000m)]);
-        // Close part of the gain into the GP's carried-interest capital account.
+        // Close part of the gain into the carried-interest capital account, scoped to the LP id exactly
+        // as the waterfall factory posts it.
         ledger.PostLines(new DateTimeOffset(2026, 6, 30, 0, 0, 0, TimeSpan.Zero), "carry allocation",
-            [(LedgerAccounts.RealizedGainFor("fund-a"), 200_000m, 0m), (LedgerAccounts.CarriedInterestAllocationFor("gp-1"), 0m, 200_000m)]);
+            [(LedgerAccounts.RealizedGainFor("fund-a"), 200_000m, 0m), (LedgerAccounts.CarriedInterestAllocationFor(lpId), 0m, 200_000m)]);
 
         var statements = LedgerFinancialStatementBuilder.BuildForPeriod(ledger, PeriodStart, AsOf);
         var layout = PartnersCapitalStatementLayoutBuilder.Build(
@@ -84,8 +100,10 @@ public sealed class PartnersCapitalStatementLayoutTests
 
         var gp = layout.Lines.Should()
             .ContainSingle(line => line.Role == PartnersCapitalPartnerRole.GeneralPartner).Which;
-        gp.PartnerLabel.Should().Be("gp-1");
         gp.EndingCapital.Should().Be(200_000m);
+        // The GP row is labelled by its role caption, never the limited partner's investor id.
+        gp.PartnerLabel.Should().Be("Carried Interest Allocation");
+        gp.PartnerLabel.Should().NotBe(lpId);
         layout.Lines.Should().Contain(line => line.Role == PartnersCapitalPartnerRole.LimitedPartner);
         layout.TiesToNetAssets.Should().BeTrue();
     }

--- a/tests/Meridian.Tests/Ledger/PartnersCapitalStatementLayoutTests.cs
+++ b/tests/Meridian.Tests/Ledger/PartnersCapitalStatementLayoutTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Linq;
+
+using FluentAssertions;
+
+using Meridian.Ledger;
+
+using Xunit;
+
+namespace Meridian.Tests.Ledger;
+
+/// <summary>
+/// Coverage for the bespoke partners' capital statement layout projector: it classifies capital
+/// accounts by partner role, computes each partner's ownership share of ending capital, and anchors
+/// the statement to the fund's ledger-backed net asset value (the unitized NAV base) with an
+/// explicit reconciliation flag. The projection is presentation only — it never alters a figure.
+/// </summary>
+public sealed class PartnersCapitalStatementLayoutTests
+{
+    private static readonly DateTimeOffset PeriodStart = new(2025, 12, 31, 0, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset AsOf = new(2026, 12, 31, 0, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Build_FromContributionPack_ClassifiesLimitedPartnerAndAnchorsToNetAssets()
+    {
+        var pack = LedgerReportPackTestData.BuildContributionPack();
+        var statement = pack.Statements.PartnersCapital!;
+
+        var layout = PartnersCapitalStatementLayoutBuilder.Build(pack);
+
+        // Fund identity flows from the request.
+        layout.FundId.Should().Be(LedgerReportPackTestData.FundId);
+        layout.PeriodId.Should().Be(LedgerReportPackTestData.PeriodId);
+        layout.BaseCurrency.Should().Be("USD");
+
+        // The NAV anchor is the fund's ledger-backed net assets (ending equity), and the statement ties.
+        layout.NetAssetValue.Should().Be(pack.Statements.EndingEquity);
+        layout.Total.EndingCapital.Should().Be(statement.EndingCapital);
+        layout.TiesToNetAssets.Should().BeTrue();
+        layout.NetAssetVariance.Should().Be(0m);
+
+        // The investor-capital account is presented as a limited partner keyed by investor id.
+        var lp = layout.Lines.Should()
+            .ContainSingle(line => line.Role == PartnersCapitalPartnerRole.LimitedPartner).Which;
+        lp.PartnerLabel.Should().Be(LedgerReportPackTestData.InvestorId);
+        lp.Contributions.Should().Be(LedgerReportPackTestData.ContributionAmount);
+        lp.Distributions.Should().Be(LedgerReportPackTestData.DistributionAmount);
+
+        // The total line preserves the statement aggregate exactly (presentation never changes a figure).
+        layout.Total.BeginningCapital.Should().Be(statement.BeginningCapital);
+        layout.Total.Contributions.Should().Be(statement.Contributions);
+        layout.Total.Distributions.Should().Be(statement.Distributions);
+        layout.Total.IncomeGainAllocations.Should().Be(statement.IncomeGainAllocations);
+        layout.Total.ExpenseAllocations.Should().Be(statement.ExpenseAllocations);
+        layout.Total.FeeAllocations.Should().Be(statement.FeeAllocations);
+        layout.Total.EndingCapital.Should().Be(statement.EndingCapital);
+    }
+
+    [Fact]
+    public void Build_OwnershipShares_FootToOneHundredPercent()
+    {
+        var layout = PartnersCapitalStatementLayoutBuilder.Build(
+            LedgerReportPackTestData.BuildContributionPack());
+
+        layout.Lines.Sum(line => line.OwnershipPercent).Should().BeApproximately(100m, 0.0001m);
+        layout.Total.OwnershipPercent.Should().BeApproximately(100m, 0.0001m);
+    }
+
+    [Fact]
+    public void Build_CarriedInterestAllocation_ClassifiedAsGeneralPartner()
+    {
+        var ledger = new Meridian.Ledger.Ledger();
+        ledger.PostLines(new DateTimeOffset(2025, 6, 15, 0, 0, 0, TimeSpan.Zero), "opening contribution",
+            [(LedgerAccounts.Cash, 5_000_000m, 0m), (LedgerAccounts.InvestorCapitalFor("lp-1"), 0m, 5_000_000m)]);
+        ledger.PostLines(new DateTimeOffset(2026, 3, 31, 0, 0, 0, TimeSpan.Zero), "realized gain",
+            [(LedgerAccounts.Cash, 1_000_000m, 0m), (LedgerAccounts.RealizedGainFor("fund-a"), 0m, 1_000_000m)]);
+        // Close part of the gain into the GP's carried-interest capital account.
+        ledger.PostLines(new DateTimeOffset(2026, 6, 30, 0, 0, 0, TimeSpan.Zero), "carry allocation",
+            [(LedgerAccounts.RealizedGainFor("fund-a"), 200_000m, 0m), (LedgerAccounts.CarriedInterestAllocationFor("gp-1"), 0m, 200_000m)]);
+
+        var statements = LedgerFinancialStatementBuilder.BuildForPeriod(ledger, PeriodStart, AsOf);
+        var layout = PartnersCapitalStatementLayoutBuilder.Build(
+            statements.PartnersCapital!, "fund-a", "2026", "USD", statements.EndingEquity);
+
+        var gp = layout.Lines.Should()
+            .ContainSingle(line => line.Role == PartnersCapitalPartnerRole.GeneralPartner).Which;
+        gp.PartnerLabel.Should().Be("gp-1");
+        gp.EndingCapital.Should().Be(200_000m);
+        layout.Lines.Should().Contain(line => line.Role == PartnersCapitalPartnerRole.LimitedPartner);
+        layout.TiesToNetAssets.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Build_WithoutPartnersCapitalStatement_Throws()
+    {
+        var pack = LedgerReportPackTestData.BuildContributionPack();
+        var withoutPartnersCapital = pack with { Statements = pack.Statements with { PartnersCapital = null } };
+
+        var act = () => PartnersCapitalStatementLayoutBuilder.Build(withoutPartnersCapital);
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+}


### PR DESCRIPTION
<!-- phase:PR7 -->

## Summary

Sequenced follow-up to the client-grade governed reporting work (`W9-REPORT-005`). Phase 1 wired a client-grade PDF/XLSX renderer into the governed path but left "Ledger-backed fund economics and a bespoke partners-capital statement layout" as named follow-ups. Until now the statement of changes in partners' capital reached the client deliverable only as the generic 8-column table with **all-text cells** and **no fund-economics context** — the exact "re-type every deliverable into Excel" gap the program review flagged. This gives it a purpose-built, ledger-backed layout.

**`Meridian.Ledger`**
- New `PartnersCapitalStatementLayout` + `PartnersCapitalStatementLayoutBuilder`: a pure presentation projection over `LedgerPartnersCapitalStatement`. It
  - classifies each capital account by partner role (limited partner, general partner, undistributed result, fund capital) from the stable `LedgerAccounts` names,
  - computes each partner's **ownership share** of ending capital (the shares foot to 100%), and
  - anchors the whole statement to the fund's **ledger-backed net asset value** (the unitized NAV base) with an explicit reconciliation flag.
  - Money stays typed; the projection introduces no ledger fact and never changes a figure.
- Expose `LedgerReportPresentation.PartnersCapitalTableTitle` so a renderer can substitute the bespoke layout without matching a loose string.

**`Meridian.Documents` (`FinancialReportDocumentRenderer`)**
- Render the partners' capital statement through the bespoke layout instead of the generic table:
  - **PDF** — a NAV (net-assets) context strip, role-labelled per-partner rows, right-aligned figures, an ownership-share column, a bold total row, and a ledger-backed reconciliation footnote.
  - **XLSX** — a dedicated `Partners' Capital` sheet whose money and ownership cells are **typed numbers** with accounting/percent number formats (so operators can `SUM`/pivot without retyping), plus a NAV anchor block recording the net assets the statement ties to.
- Every other statement keeps the generic tabular rendering, and output stays deterministic (fixed metadata/timestamps, canonical zip ordering) for governed hash verification.

The posting-side fund economics (fee/NAV/waterfall kernels → governed journal drafts) already landed in `FundEconomicsJournalFactory` (merged W9-NAV-006), so this change completes the *presentation* half the phase-1 PR deferred: the governed client deliverable now presents the fund's ledger-backed economics — the NAV base, each partner's economic ownership, and the income/expense/fee allocation drivers — in a purpose-built statement, rather than re-posting kernels.

## Reason

The named primary customers (fund admins/CFOs) judge the platform by the deliverable they hand to LPs and auditors. The partners' capital statement is the flagship fund-accounting statement, but it was being emitted as an untyped generic grid. This makes the governed output the deliverable: a professionally-laid-out, computable statement anchored to the fund's ledger-backed net assets.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully — no .NET SDK is available in this environment; local build/test could not be run, so the hosted `quality-gate` is authoritative.
- [x] Relevant unit tests were added or updated
- [x] Relevant integration tests were added or updated — renderer tests exercise the full report-pack → client-grade PDF/XLSX pipeline and re-open the workbook to assert typed cells
- [ ] GitHub Actions `quality-gate` passed — pending CI

New tests:
- `PartnersCapitalStatementLayoutTests` — role classification, ownership shares foot to 100%, NAV tie/reconciliation, aggregate preservation, GP carried-interest classification, and the no-statement guard.
- `PartnersCapitalBespokeRenderTests` — the dedicated sheet exists with typed numeric money/ownership cells (accounting/percent formats) and the NAV anchor block, and PDF/XLSX render deterministically through the bespoke path.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNFrX2KQoocNc4diP1FgPt