### PR TITLE
Harden statement-to-delivery reporting authority

### DIFF
--- a/docs/operators/statement-reconciliation-report-operations.md
+++ b/docs/operators/statement-reconciliation-report-operations.md
@@ -101,12 +101,15 @@ last-run timestamp.
 | `Failed` | Preserve `failureReason`; correct the named dependency and use the existing resume route. Do not begin an unrelated replacement import. |
 | `Completed` | Retrieve every retained artifact and retain the workflow response, exact accounting scope, Operations workflow link, and queue evidence. Do not treat it as posting, close, reporting certification, or delivery proof. |
 
-The coordinator persists the input before import and checkpoints a committed import before Evidence
-Vault linkage or rendering. After Evidence Vault retention, the intake authority starts or reuses
+The coordinator persists the input before import. In production, it checkpoints a committed import
+only after the raw statement, canonical statement records, and statement-run evidence have all
+been retained in the same durable reporting authority. The intake authority then starts or reuses
 the exact Operations Continuity workflow, attaches stable statement evidence, and projects every
 source break/case into the canonical queue with fund, book, period, and as-of scope. A retry after
 those checkpoints resumes from retained state rather than repeating the import. Concurrent
-processes serialize work on the same content-and-scope identity.
+processes serialize work on the same content-and-scope identity. Local file-backed compatibility
+composition retains source evidence through its existing Evidence Vault bridge and does not satisfy
+the production durable-composition readiness gate.
 
 Queue replay validates an already retained destination-scoped break directly. It does not seed an
 unscoped compatibility case when a process stops after the queue commit but before the statement
@@ -123,11 +126,13 @@ SHA-256 before workflow code receives bytes.
 
 Reporting deployment readiness remains blocked until the live schema probe verifies
 `reporting_statement_reconciliation_documents`,
-`reporting_statement_reconciliation_document_revisions`, all four migration-owned document and
-revision triggers, and the exact `reporting-statement-reconciliation-authority:v1` compatibility
-marker, and composition resolves the concrete
-`PostgresStatementReconciliationReportAuthorityStore`. The presence of migration 013 alone is not
-production-readiness evidence.
+`reporting_statement_reconciliation_document_revisions`, all six migration-owned document,
+revision, and truncate-guard triggers, both UTF-8 composite-identity constraints, and the exact
+`reporting-statement-reconciliation-authority:v1` compatibility marker. Composition must also
+resolve the concrete `PostgresStatementReconciliationReportAuthorityStore` together with the
+statement evidence retainer and workflow bound to that same PostgreSQL artifact authority. The
+presence of migration 013 or a durable store registration alone is not production-readiness
+evidence.
 
 Uploaded input, statement evidence, and historical artifact generations are immutable mappings.
 `workflow.json` and the current artifact mappings may advance, but each version points to immutable

--- a/src/Meridian.Reporting/ReportingReconciliationEvidenceContracts.cs
+++ b/src/Meridian.Reporting/ReportingReconciliationEvidenceContracts.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Security.Cryptography;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Meridian.Contracts.Workstation;
 
 namespace Meridian.Reporting;
@@ -44,6 +45,7 @@ public sealed record ReportingCloseWorkflowCompletionEvidence(
 /// Durable result of a reconciliation/close process. Reporting can consume only an exact retained
 /// receipt bound to the same authoritative source checkpoint; it must never synthesize one.
 /// </summary>
+[method: JsonConstructor]
 public sealed record ReportingReconciliationEvidenceReceipt(
     string TenantId,
     string OrganizationId,

--- a/src/Meridian.Storage/Reporting/PostgresReportingArtifactStore.cs
+++ b/src/Meridian.Storage/Reporting/PostgresReportingArtifactStore.cs
@@ -28,23 +28,70 @@ public sealed class PostgresReportingArtifactStore : IReportingArtifactStore
         ReportingArtifactWriteRequest request,
         CancellationToken ct = default)
     {
-        ArgumentNullException.ThrowIfNull(request);
-        var tenantId = NormalizeTenantId(request.TenantId);
-        if (request.Content.IsEmpty)
-        {
-            throw new ArgumentException("Reporting artifact content cannot be empty.", nameof(request));
-        }
-
-        // Clone caller-owned memory before hashing or awaiting so mutations cannot change the bytes
-        // between identity calculation and persistence.
-        var content = request.Content.ToArray();
-        var contentHash = ComputeSha256(content);
-        var identity = new ReportingArtifactIdentity(tenantId, contentHash);
+        var preparedWrite = PrepareWrite(request);
 
         await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
         await using var transaction = await connection
             .BeginTransactionAsync(IsolationLevel.ReadCommitted, ct)
             .ConfigureAwait(false);
+        var result = await StorePreparedWithinTransactionAsync(
+                preparedWrite,
+                connection,
+                transaction,
+                ct)
+            .ConfigureAwait(false);
+        await transaction.CommitAsync(ct).ConfigureAwait(false);
+        return result;
+    }
+
+    /// <summary>
+    /// Retains artifact bytes on a caller-owned PostgreSQL transaction. This is intentionally
+    /// internal: only Storage-owned authorities that atomically bind an artifact to durable
+    /// metadata may compose the blob insert with their own transaction.
+    /// </summary>
+    internal Task<ReportingArtifactWriteResult> StoreWithinTransactionAsync(
+        ReportingArtifactWriteRequest request,
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        ArgumentNullException.ThrowIfNull(transaction);
+        if (!ReferenceEquals(transaction.Connection, connection)
+            || connection.State != ConnectionState.Open)
+        {
+            throw new InvalidOperationException(
+                "The reporting artifact transaction must be active on the supplied open PostgreSQL connection.");
+        }
+
+        return StorePreparedWithinTransactionAsync(
+            PrepareWrite(request),
+            connection,
+            transaction,
+            ct);
+    }
+
+    internal bool SupportsTransactionalComposition(ReportingArtifactStoreOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (!string.Equals(_options.Schema, options.Schema, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var retainedTarget = new NpgsqlConnectionStringBuilder(_options.ConnectionString);
+        var authorityTarget = new NpgsqlConnectionStringBuilder(options.ConnectionString);
+        return HaveEquivalentConnectionSettings(retainedTarget, authorityTarget);
+    }
+
+    private async Task<ReportingArtifactWriteResult> StorePreparedWithinTransactionAsync(
+        PreparedArtifactWrite preparedWrite,
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        CancellationToken ct)
+    {
+        var identity = preparedWrite.Identity;
+        var content = preparedWrite.Content;
 
         await using var insert = connection.CreateCommand();
         insert.Transaction = transaction;
@@ -63,8 +110,11 @@ public sealed class PostgresReportingArtifactStore : IReportingArtifactStore
             on conflict (tenant_id, content_hash_sha256) do nothing
             returning stored_at_utc;
             """;
-        insert.Parameters.AddWithValue("tenant_id", NpgsqlDbType.Text, tenantId);
-        insert.Parameters.AddWithValue("content_hash_sha256", NpgsqlDbType.Text, contentHash);
+        insert.Parameters.AddWithValue("tenant_id", NpgsqlDbType.Text, identity.TenantId);
+        insert.Parameters.AddWithValue(
+            "content_hash_sha256",
+            NpgsqlDbType.Text,
+            identity.ContentHashSha256);
         insert.Parameters.AddWithValue("byte_size", NpgsqlDbType.Bigint, content.LongLength);
         insert.Parameters.AddWithValue("content", NpgsqlDbType.Bytea, content);
 
@@ -79,7 +129,6 @@ public sealed class PostgresReportingArtifactStore : IReportingArtifactStore
 
         if (insertedAtUtc is not null)
         {
-            await transaction.CommitAsync(ct).ConfigureAwait(false);
             return new ReportingArtifactWriteResult(
                 identity,
                 content.LongLength,
@@ -99,12 +148,50 @@ public sealed class PostgresReportingArtifactStore : IReportingArtifactStore
                 "different bytes were retained under the same content address");
         }
 
-        await transaction.CommitAsync(ct).ConfigureAwait(false);
         return new ReportingArtifactWriteResult(
             identity,
             existing.DeclaredByteSize,
             existing.StoredAtUtc,
             AlreadyExisted: true);
+    }
+
+    private static PreparedArtifactWrite PrepareWrite(ReportingArtifactWriteRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var tenantId = NormalizeTenantId(request.TenantId);
+        if (request.Content.IsEmpty)
+        {
+            throw new ArgumentException("Reporting artifact content cannot be empty.", nameof(request));
+        }
+
+        // Clone caller-owned memory before hashing or awaiting so mutations cannot change the bytes
+        // between identity calculation and persistence.
+        var content = request.Content.ToArray();
+        var contentHash = ComputeSha256(content);
+        return new PreparedArtifactWrite(
+            new ReportingArtifactIdentity(tenantId, contentHash),
+            content);
+    }
+
+    private static bool HaveEquivalentConnectionSettings(
+        NpgsqlConnectionStringBuilder retainedTarget,
+        NpgsqlConnectionStringBuilder authorityTarget)
+    {
+        if (retainedTarget.Keys.Count != authorityTarget.Keys.Count)
+        {
+            return false;
+        }
+
+        foreach (var key in retainedTarget.Keys.Cast<string>())
+        {
+            if (!authorityTarget.ContainsKey(key)
+                || !Equals(retainedTarget[key], authorityTarget[key]))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public async Task<ReportingArtifactReadResult> ReadAsync(
@@ -240,4 +327,8 @@ public sealed class PostgresReportingArtifactStore : IReportingArtifactStore
         long PhysicalByteSize,
         byte[] Content,
         DateTimeOffset StoredAtUtc);
+
+    private sealed record PreparedArtifactWrite(
+        ReportingArtifactIdentity Identity,
+        byte[] Content);
 }

--- a/src/Meridian.Storage/Reporting/PostgresStatementReconciliationReportAuthorityStore.cs
+++ b/src/Meridian.Storage/Reporting/PostgresStatementReconciliationReportAuthorityStore.cs
@@ -47,7 +47,7 @@ public sealed class PostgresStatementReconciliationReportAuthorityStore :
         ValidateIdentifier(_options.Schema, nameof(options.Schema));
         _transactionalArtifactStore = artifactStore as PostgresReportingArtifactStore;
         if (_transactionalArtifactStore is not null
-            && !_transactionalArtifactStore.SupportsTransactionalComposition(_options.Schema))
+            && !_transactionalArtifactStore.SupportsTransactionalComposition(_options))
         {
             _transactionalArtifactStore = null;
         }

--- a/src/Meridian.Ui.Shared/Evidence/ReportingStatementImportEvidenceRetainer.cs
+++ b/src/Meridian.Ui.Shared/Evidence/ReportingStatementImportEvidenceRetainer.cs
@@ -279,7 +279,7 @@ public sealed class ReportingStatementImportEvidenceRetainer(
                 source.Document,
                 canonical.Document,
                 runEvidence.Document);
-            return identity.Artifacts.SequenceEqual(expectedArtifacts);
+            return ArtifactsMatch(identity.Artifacts, expectedArtifacts);
         }
         catch (ReportingArtifactIntegrityException)
         {
@@ -315,6 +315,16 @@ public sealed class ReportingStatementImportEvidenceRetainer(
 
         return new VerifiedAuthorityDocument(document, content);
     }
+
+    private static bool ArtifactsMatch(
+        IReadOnlyList<EvidenceVaultArtifactDto> actual,
+        IReadOnlyList<EvidenceVaultArtifactDto> expected) =>
+        actual.Count == expected.Count
+        && actual.Zip(expected).All(static pair =>
+            JsonSerializer.Serialize(pair.First, JsonOptions)
+                .Equals(
+                    JsonSerializer.Serialize(pair.Second, JsonOptions),
+                    StringComparison.Ordinal));
 
     private string ResolveRetainedPath(string retainedPath, string kind)
     {

--- a/src/Meridian.Ui.Shared/Evidence/StatementReconciliationReportWorkflowService.Reconciliation.cs
+++ b/src/Meridian.Ui.Shared/Evidence/StatementReconciliationReportWorkflowService.Reconciliation.cs
@@ -1,0 +1,167 @@
+using Meridian.Contracts.Workstation;
+using Meridian.Domain.Reconciliation;
+
+namespace Meridian.Ui.Shared.Evidence;
+
+public sealed partial class StatementReconciliationReportWorkflowService
+{
+    private static bool IsOpenCase(ReconciliationCase item)
+        => !string.Equals(item.Status, "Resolved", StringComparison.OrdinalIgnoreCase)
+           && !string.Equals(item.Status, "Closed", StringComparison.OrdinalIgnoreCase)
+           && !string.Equals(item.Status, "Waived", StringComparison.OrdinalIgnoreCase)
+           && !string.Equals(item.Status, "Superseded", StringComparison.OrdinalIgnoreCase)
+           && !string.Equals(item.Status, "Dismissed", StringComparison.OrdinalIgnoreCase)
+           && !string.Equals(item.Status, "SignedOff", StringComparison.OrdinalIgnoreCase);
+
+    private async Task<CurrentReconciliationGate> EvaluateCurrentReconciliationAsync(
+        WorkflowSnapshot snapshot,
+        CancellationToken ct)
+    {
+        var import = snapshot.ImportResult
+            ?? throw new InvalidDataException(
+                $"Statement reconciliation report workflow '{snapshot.Workflow.WorkflowId}' has no retained import checkpoint.");
+        var reconciliation = await _statementRuns
+            .GetAsync(import.RunId, ct)
+            .ConfigureAwait(false);
+        var queueGate = await EvaluateCanonicalQueueHandoffAsync(
+                import,
+                snapshot.Workflow.TenantId,
+                snapshot.Workflow.CompanyId,
+                ct)
+            .ConfigureAwait(false);
+        if (reconciliation is null)
+        {
+            var durableEvidenceVerified = await HasVerifiedCanonicalRunEvidenceAsync(
+                    snapshot,
+                    ct)
+                .ConfigureAwait(false);
+            if (durableEvidenceVerified && queueGate.IsSatisfied)
+            {
+                return CurrentReconciliationGate.Satisfied(reconciliation);
+            }
+
+            var unavailableRecoveryActions = new List<string>(capacity: 2)
+            {
+                durableEvidenceVerified
+                    ? "The node-local statement run is unavailable. Complete every exact canonical queue obligation, then resume this workflow."
+                    : "The canonical statement run is unavailable and no matching durable raw, canonical, and run-evidence snapshot could be verified. Restore the run authority or its immutable evidence, then resume this workflow."
+            };
+            if (!queueGate.IsSatisfied
+                && (import.BreakCount > 0 || import.CaseCount > 0))
+            {
+                unavailableRecoveryActions.Add(
+                    "Resolve or disposition the linked reconciliation breaks and cases, then resume this workflow.");
+            }
+            if (!queueGate.IsSatisfied)
+            {
+                unavailableRecoveryActions.Add(queueGate.RecoveryAction);
+            }
+
+            return new CurrentReconciliationGate(
+                false,
+                reconciliation,
+                Math.Max(import.BreakCount, queueGate.OpenCaseCount),
+                Math.Max(import.CaseCount, queueGate.BlockingCaseCount),
+                string.Join(" ", unavailableRecoveryActions));
+        }
+
+        var openBreaks = reconciliation.Breaks.Count;
+        var openCases = reconciliation.Cases.Count(IsOpenCase);
+
+        if (openBreaks <= 0 && openCases <= 0 && queueGate.IsSatisfied)
+        {
+            return CurrentReconciliationGate.Satisfied(reconciliation);
+        }
+
+        var recoveryActions = new List<string>(capacity: 2);
+        if (openBreaks > 0 || openCases > 0)
+        {
+            recoveryActions.Add(
+                "Resolve or disposition the linked reconciliation breaks and cases, then resume this workflow.");
+        }
+
+        if (!queueGate.IsSatisfied)
+        {
+            recoveryActions.Add(queueGate.RecoveryAction);
+        }
+
+        return new CurrentReconciliationGate(
+            false,
+            reconciliation,
+            Math.Max(openBreaks, queueGate.OpenCaseCount),
+            Math.Max(openCases, queueGate.BlockingCaseCount),
+            string.Join(" ", recoveryActions));
+    }
+
+    private Task<bool> HasVerifiedCanonicalRunEvidenceAsync(
+        WorkflowSnapshot snapshot,
+        CancellationToken ct)
+    {
+        if (!IsDurablyComposed
+            || _evidence is not ReportingStatementImportEvidenceRetainer retainer
+            || snapshot.ImportResult is not { } import)
+        {
+            return Task.FromResult(false);
+        }
+
+        return retainer.HasVerifiedCanonicalRunEvidenceAsync(
+            import,
+            BuildEvidenceRetentionRequest(snapshot),
+            ct);
+    }
+
+    private static WorkflowSnapshot AwaitReconciliation(
+        WorkflowSnapshot snapshot,
+        CurrentReconciliationGate gate,
+        bool advanceVersion,
+        StatementReconciliationReportArtifactGenerationDto? archivedGeneration = null)
+    {
+        var import = snapshot.ImportResult;
+        var artifactHistory = (snapshot.Workflow.ArtifactHistory ?? []).ToList();
+        if (archivedGeneration is not null
+            && artifactHistory.All(item => item.Generation != archivedGeneration.Generation))
+        {
+            artifactHistory.Add(archivedGeneration);
+        }
+
+        artifactHistory.Sort(static (left, right) => left.Generation.CompareTo(right.Generation));
+        var evidenceReferences = snapshot.Workflow.EvidenceReferences
+            .Concat(import is null ? [] : BuildEvidenceReferences(import))
+            .Concat(archivedGeneration?.EvidenceReferences ?? [])
+            .Where(static item =>
+                !item.StartsWith("artifact:", StringComparison.Ordinal))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static item => item, StringComparer.Ordinal)
+            .ToArray();
+        var workflow = snapshot.Workflow with
+        {
+            Status = StatementReconciliationReportWorkflowStatusDto.AwaitingReconciliation,
+            Version = advanceVersion
+                ? snapshot.Workflow.Version + 1
+                : snapshot.Workflow.Version,
+            StatementRunId = import?.RunId ?? snapshot.Workflow.StatementRunId,
+            EvidenceVaultIdentity =
+                import?.EvidenceVaultIdentity ?? snapshot.Workflow.EvidenceVaultIdentity,
+            RetainedArtifacts = [],
+            EvidenceReferences = evidenceReferences,
+            BreakCount = gate.OpenBreakCount,
+            CaseCount = gate.OpenCaseCount,
+            UpdatedAtUtc = advanceVersion
+                ? DateTimeOffset.UtcNow
+                : snapshot.Workflow.UpdatedAtUtc,
+            CompletedAtUtc = null,
+            FailureReason = null,
+            RecoveryAction = gate.RecoveryAction,
+            ArtifactGeneration = Math.Max(
+                snapshot.Workflow.ArtifactGeneration,
+                archivedGeneration?.Generation ?? 0),
+            ArtifactHistory = artifactHistory
+        };
+        return snapshot with
+        {
+            Workflow = workflow,
+            ResumeStatus = StatementReconciliationReportWorkflowStatusDto.AwaitingReconciliation,
+            RenderingReconciliationReportAtUtc = null
+        };
+    }
+}

--- a/src/Meridian.Ui.Shared/Evidence/StatementReconciliationReportWorkflowService.cs
+++ b/src/Meridian.Ui.Shared/Evidence/StatementReconciliationReportWorkflowService.cs
@@ -68,6 +68,11 @@ public sealed partial class StatementReconciliationReportWorkflowService
         && retainer.RetainsCanonicalRunEvidence
         && ReferenceEquals(retainer.AuthorityStore, _authorityStore);
 
+    internal bool IsDurablyComposedWith(
+        IStatementReconciliationReportAuthorityStore authorityStore) =>
+        ReferenceEquals(_authorityStore, authorityStore)
+        && IsDurablyComposed;
+
     public StatementReconciliationReportWorkflowService(
         IStatementImportCommitService imports,
         IStatementImportEvidenceRetainer evidence,
@@ -1448,160 +1453,6 @@ public sealed partial class StatementReconciliationReportWorkflowService
         evidence.AddRange(import.BreakIds.Select(static id => $"reconciliation-break:{id}"));
         evidence.AddRange(import.CaseIds.Select(static id => $"reconciliation-case:{id}"));
         return evidence.Distinct(StringComparer.Ordinal).OrderBy(static item => item, StringComparer.Ordinal).ToArray();
-    }
-
-    private static bool IsOpenCase(ReconciliationCase item)
-        => !string.Equals(item.Status, "Resolved", StringComparison.OrdinalIgnoreCase)
-           && !string.Equals(item.Status, "Closed", StringComparison.OrdinalIgnoreCase)
-           && !string.Equals(item.Status, "Waived", StringComparison.OrdinalIgnoreCase)
-           && !string.Equals(item.Status, "Superseded", StringComparison.OrdinalIgnoreCase)
-           && !string.Equals(item.Status, "Dismissed", StringComparison.OrdinalIgnoreCase)
-           && !string.Equals(item.Status, "SignedOff", StringComparison.OrdinalIgnoreCase);
-
-    private async Task<CurrentReconciliationGate> EvaluateCurrentReconciliationAsync(
-        WorkflowSnapshot snapshot,
-        CancellationToken ct)
-    {
-        var import = snapshot.ImportResult
-            ?? throw new InvalidDataException(
-                $"Statement reconciliation report workflow '{snapshot.Workflow.WorkflowId}' has no retained import checkpoint.");
-        var reconciliation = await _statementRuns
-            .GetAsync(import.RunId, ct)
-            .ConfigureAwait(false);
-        var queueGate = await EvaluateCanonicalQueueHandoffAsync(
-                import,
-                snapshot.Workflow.TenantId,
-                snapshot.Workflow.CompanyId,
-                ct)
-            .ConfigureAwait(false);
-        if (reconciliation is null)
-        {
-            var durableEvidenceVerified = await HasVerifiedCanonicalRunEvidenceAsync(
-                    snapshot,
-                    ct)
-                .ConfigureAwait(false);
-            if (durableEvidenceVerified && queueGate.IsSatisfied)
-            {
-                return CurrentReconciliationGate.Satisfied(reconciliation);
-            }
-
-            var unavailableRecoveryActions = new List<string>(capacity: 2)
-            {
-                durableEvidenceVerified
-                    ? "The node-local statement run is unavailable. Complete every exact canonical queue obligation, then resume this workflow."
-                    : "The canonical statement run is unavailable and no matching durable raw, canonical, and run-evidence snapshot could be verified. Restore the run authority or its immutable evidence, then resume this workflow."
-            };
-            if (!queueGate.IsSatisfied)
-            {
-                unavailableRecoveryActions.Add(queueGate.RecoveryAction);
-            }
-
-            return new CurrentReconciliationGate(
-                false,
-                reconciliation,
-                Math.Max(import.BreakCount, queueGate.OpenCaseCount),
-                Math.Max(import.CaseCount, queueGate.BlockingCaseCount),
-                string.Join(" ", unavailableRecoveryActions));
-        }
-
-        var openBreaks = reconciliation.Breaks.Count;
-        var openCases = reconciliation.Cases.Count(IsOpenCase);
-
-        if (openBreaks <= 0 && openCases <= 0 && queueGate.IsSatisfied)
-        {
-            return CurrentReconciliationGate.Satisfied(reconciliation);
-        }
-
-        var recoveryActions = new List<string>(capacity: 2);
-        if (openBreaks > 0 || openCases > 0)
-        {
-            recoveryActions.Add(
-                "Resolve or disposition the linked reconciliation breaks and cases, then resume this workflow.");
-        }
-
-        if (!queueGate.IsSatisfied)
-        {
-            recoveryActions.Add(queueGate.RecoveryAction);
-        }
-
-        return new CurrentReconciliationGate(
-            false,
-            reconciliation,
-            Math.Max(openBreaks, queueGate.OpenCaseCount),
-            Math.Max(openCases, queueGate.BlockingCaseCount),
-            string.Join(" ", recoveryActions));
-    }
-
-    private Task<bool> HasVerifiedCanonicalRunEvidenceAsync(
-        WorkflowSnapshot snapshot,
-        CancellationToken ct)
-    {
-        if (!IsDurablyComposed
-            || _evidence is not ReportingStatementImportEvidenceRetainer retainer
-            || snapshot.ImportResult is not { } import)
-        {
-            return Task.FromResult(false);
-        }
-
-        return retainer.HasVerifiedCanonicalRunEvidenceAsync(
-            import,
-            BuildEvidenceRetentionRequest(snapshot),
-            ct);
-    }
-
-    private static WorkflowSnapshot AwaitReconciliation(
-        WorkflowSnapshot snapshot,
-        CurrentReconciliationGate gate,
-        bool advanceVersion,
-        StatementReconciliationReportArtifactGenerationDto? archivedGeneration = null)
-    {
-        var import = snapshot.ImportResult;
-        var artifactHistory = (snapshot.Workflow.ArtifactHistory ?? []).ToList();
-        if (archivedGeneration is not null
-            && artifactHistory.All(item => item.Generation != archivedGeneration.Generation))
-        {
-            artifactHistory.Add(archivedGeneration);
-        }
-
-        artifactHistory.Sort(static (left, right) => left.Generation.CompareTo(right.Generation));
-        var evidenceReferences = snapshot.Workflow.EvidenceReferences
-            .Concat(import is null ? [] : BuildEvidenceReferences(import))
-            .Concat(archivedGeneration?.EvidenceReferences ?? [])
-            .Where(static item =>
-                !item.StartsWith("artifact:", StringComparison.Ordinal))
-            .Distinct(StringComparer.Ordinal)
-            .OrderBy(static item => item, StringComparer.Ordinal)
-            .ToArray();
-        var workflow = snapshot.Workflow with
-        {
-            Status = StatementReconciliationReportWorkflowStatusDto.AwaitingReconciliation,
-            Version = advanceVersion
-                ? snapshot.Workflow.Version + 1
-                : snapshot.Workflow.Version,
-            StatementRunId = import?.RunId ?? snapshot.Workflow.StatementRunId,
-            EvidenceVaultIdentity =
-                import?.EvidenceVaultIdentity ?? snapshot.Workflow.EvidenceVaultIdentity,
-            RetainedArtifacts = [],
-            EvidenceReferences = evidenceReferences,
-            BreakCount = gate.OpenBreakCount,
-            CaseCount = gate.OpenCaseCount,
-            UpdatedAtUtc = advanceVersion
-                ? DateTimeOffset.UtcNow
-                : snapshot.Workflow.UpdatedAtUtc,
-            CompletedAtUtc = null,
-            FailureReason = null,
-            RecoveryAction = gate.RecoveryAction,
-            ArtifactGeneration = Math.Max(
-                snapshot.Workflow.ArtifactGeneration,
-                archivedGeneration?.Generation ?? 0),
-            ArtifactHistory = artifactHistory
-        };
-        return snapshot with
-        {
-            Workflow = workflow,
-            ResumeStatus = StatementReconciliationReportWorkflowStatusDto.AwaitingReconciliation,
-            RenderingReconciliationReportAtUtc = null
-        };
     }
 
     private static StatementReconciliationReportWorkflowExecution RequireExecution(WorkflowSnapshot snapshot)

--- a/src/Meridian.Ui.Shared/Services/ReportingDeploymentReadinessService.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingDeploymentReadinessService.cs
@@ -3,6 +3,7 @@ using Meridian.FinancialOperations.AccountingClose;
 using Meridian.Reporting;
 using Meridian.Storage.Reporting;
 using Meridian.Strategies.Services;
+using Meridian.Ui.Shared.Evidence;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Meridian.Ui.Shared.Services;
@@ -262,9 +263,13 @@ public sealed class ReportingDeploymentReadinessService(
                     ],
                     [
                         PostgresReportingDeploymentProbe.StatementDocumentGuardTriggerName,
+                        PostgresReportingDeploymentProbe
+                            .StatementDocumentTruncateGuardTriggerName,
                         PostgresReportingDeploymentProbe.StatementDocumentRevisionTriggerName,
                         PostgresReportingDeploymentProbe.StatementRevisionAppendTriggerName,
-                        PostgresReportingDeploymentProbe.StatementRevisionGuardTriggerName
+                        PostgresReportingDeploymentProbe.StatementRevisionGuardTriggerName,
+                        PostgresReportingDeploymentProbe
+                            .StatementRevisionTruncateGuardTriggerName
                     ],
                     Columns:
                     [
@@ -297,9 +302,11 @@ public sealed class ReportingDeploymentReadinessService(
                     [
                         "reporting_statement_reconciliation_documents.fk_reporting_statement_document_blob",
                         "reporting_statement_reconciliation_documents.ck_reporting_statement_document_key",
+                        "reporting_statement_reconciliation_documents.ck_reporting_statement_document_identity_utf8_bytes",
                         "reporting_statement_reconciliation_document_revisions.fk_reporting_statement_revision_blob",
                         "reporting_statement_reconciliation_document_revisions.fk_reporting_statement_revision_previous_blob",
-                        "reporting_statement_reconciliation_document_revisions.ck_reporting_statement_revision_chain"
+                        "reporting_statement_reconciliation_document_revisions.ck_reporting_statement_revision_chain",
+                        "reporting_statement_reconciliation_document_revisions.ck_reporting_statement_revision_identity_utf8_bytes"
                     ],
                     CompatibilityMarkers:
                     [
@@ -450,13 +457,19 @@ public sealed class ReportingDeploymentReadinessService(
         var durableReconciliationEvidence =
             durableReconciliationEvidenceStore
             && reconciliationCaseworkAuthority;
+        var statementReconciliationAuthority =
+            Resolve<IStatementReconciliationReportAuthorityStore>();
+        var statementReconciliationWorkflow =
+            Resolve<StatementReconciliationReportWorkflowService>();
         var durableStatementReconciliationAuthority =
             HasRequiredSchema(persistenceProbe, "statement-reconciliation-authority")
-            && Resolve<IStatementReconciliationReportAuthorityStore>()
+            && statementReconciliationAuthority
                 is PostgresStatementReconciliationReportAuthorityStore
             {
                 IsDurableAuthority: true
-            };
+            }
+            && statementReconciliationWorkflow?
+                .IsDurablyComposedWith(statementReconciliationAuthority) == true;
         var durableRuns =
             HasRequiredSchema(persistenceProbe, "runs")
             && IsImplementation<IReportingRunStore, PostgresReportingRunStore>();
@@ -554,8 +567,8 @@ public sealed class ReportingDeploymentReadinessService(
                 "statement-reconciliation-authority",
                 "Statement reconciliation authority",
                 durableStatementReconciliationAuthority,
-                "Statement workflow documents and revisions use the durable PostgreSQL reporting authority.",
-                "Statement workflow documents, immutable revision controls, or their PostgreSQL authority are not fully configured."),
+                "The statement workflow and its raw, canonical, and run evidence use one durable PostgreSQL authority.",
+                "The statement workflow, immutable raw/canonical/run evidence, revision controls, or their shared PostgreSQL authority are not fully configured."),
             Component(
                 "reconciliation-casework",
                 "Reconciliation casework authority",

--- a/tests/Meridian.Tests/Storage/Reporting/FileReportingReconciliationEvidenceStoreMigrationTests.cs
+++ b/tests/Meridian.Tests/Storage/Reporting/FileReportingReconciliationEvidenceStoreMigrationTests.cs
@@ -194,9 +194,11 @@ public sealed class FileReportingReconciliationEvidenceStoreMigrationTests
 
         alreadyExisted.Should().BeFalse();
         retained.Should().BeEquivalentTo(receipt, options => options.WithStrictOrdering());
+        retained!.CloseWorkflowCompletion.Should().BeEquivalentTo(receipt.CloseWorkflowCompletion);
         (await File.ReadAllTextAsync(fixtureFile.Path)).Should()
             .Contain("meridian.reporting.reconciliation-evidence.v2")
-            .And.Contain("breakEvidence");
+            .And.Contain("breakEvidence")
+            .And.Contain("closeWorkflowCompletion");
     }
 
     private static string SerializeLegacySnapshot(LegacyReceipt receipt)
@@ -265,6 +267,8 @@ public sealed class FileReportingReconciliationEvidenceStoreMigrationTests
 
     private static ReportingReconciliationEvidenceReceipt NewCurrentReceipt()
     {
+        const string ledgerBookId = "2f0a909f-0d18-4b0a-8070-a239451de115";
+        const string accountingPeriodId = "94a253d0-a892-40fd-a419-15051be09125";
         var completedAt = new DateTimeOffset(2026, 7, 15, 12, 0, 0, TimeSpan.Zero);
         var source = new ReportingAuthoritativeSourceCheckpoint(
             "ledger-journal",
@@ -273,8 +277,8 @@ public sealed class FileReportingReconciliationEvidenceStoreMigrationTests
             "organization-v2",
             "company-v2",
             "fund-v2",
-            "book-v2",
-            "period-v2",
+            ledgerBookId,
+            accountingPeriodId,
             "Gaap",
             new DateOnly(2026, 6, 30),
             completedAt,
@@ -291,7 +295,20 @@ public sealed class FileReportingReconciliationEvidenceStoreMigrationTests
             completedAt,
             HasOpenBreaks: false,
             ImmutableArray.Create("period-close:v2:hard-closed"),
-            ImmutableArray<ReportingReconciliationBreakEvidence>.Empty);
+            ImmutableArray<ReportingReconciliationBreakEvidence>.Empty,
+            new ReportingCloseWorkflowCompletionEvidence(
+                "0acdf53a-6311-4448-9691-d10a1676c089",
+                WorkflowVersion: 7,
+                "ea4be56c-a534-458b-bb32-c92fb55e2d03",
+                ledgerBookId,
+                accountingPeriodId,
+                "approval-v2",
+                new string('c', 64),
+                new string('d', 64),
+                "close-package-v2",
+                new string('e', 64),
+                "b93d4291-ea1e-4cb5-865a-4f039a92f8ca",
+                new string('f', 64)));
         return ReportingReconciliationEvidenceValidation.CreateReceipt(source, completion);
     }
 

--- a/tests/Meridian.Tests/Storage/Reporting/StatementReconciliationReportAuthorityStoreTests.cs
+++ b/tests/Meridian.Tests/Storage/Reporting/StatementReconciliationReportAuthorityStoreTests.cs
@@ -898,6 +898,100 @@ public sealed class StatementReconciliationReportAuthorityStoreValidationTests
         artifactStore.StoreCallCount.Should().Be(0);
     }
 
+    [Fact]
+    public async Task WriteDocumentAsync_PostgresArtifactStoreForDifferentDatabaseFailsClosed()
+    {
+        var artifactStore = new PostgresReportingArtifactStore(
+            new ReportingArtifactStoreOptions
+            {
+                ConnectionString =
+                    "Host=127.0.0.1;Database=other_meridian;Username=meridian;Password=meridian",
+                Schema = Options.Schema
+            });
+        var store = new PostgresStatementReconciliationReportAuthorityStore(
+            Options,
+            artifactStore);
+        var scope = new StatementReconciliationReportAuthorityScope(
+            "tenant",
+            "company",
+            "workflow");
+
+        var write = () => store.WriteDocumentAsync(
+            scope,
+            "workflow.json",
+            Encoding.UTF8.GetBytes("statement"),
+            isImmutable: false).AsTask();
+
+        store.IsDurableAuthority.Should().BeFalse();
+        await write.Should()
+            .ThrowAsync<StatementReconciliationReportAuthorityUnavailableException>()
+            .WithMessage("*transactionally compose immutable bytes*");
+    }
+
+    [Theory]
+    [InlineData(
+        "Host=primary.example,standby.example;Database=meridian;Username=meridian;Password=meridian;Target Session Attributes=standby;SSL Mode=Require")]
+    [InlineData(
+        "Host=primary.example,standby.example;Database=meridian;Username=meridian;Password=meridian;Target Session Attributes=read-write;SSL Mode=Disable")]
+    public async Task WriteDocumentAsync_PostgresArtifactStoreForDifferentConnectionPolicyFailsClosed(
+        string artifactConnectionString)
+    {
+        var authorityOptions = new ReportingArtifactStoreOptions
+        {
+            ConnectionString =
+                "Host=primary.example,standby.example;Database=meridian;Username=meridian;Password=meridian;Target Session Attributes=read-write;SSL Mode=Require",
+            Schema = Options.Schema
+        };
+        var artifactStore = new PostgresReportingArtifactStore(
+            new ReportingArtifactStoreOptions
+            {
+                ConnectionString = artifactConnectionString,
+                Schema = Options.Schema
+            });
+        var store = new PostgresStatementReconciliationReportAuthorityStore(
+            authorityOptions,
+            artifactStore);
+        var scope = new StatementReconciliationReportAuthorityScope(
+            "tenant",
+            "company",
+            "workflow");
+
+        var write = () => store.WriteDocumentAsync(
+            scope,
+            "workflow.json",
+            Encoding.UTF8.GetBytes("statement"),
+            isImmutable: false).AsTask();
+
+        store.IsDurableAuthority.Should().BeFalse();
+        await write.Should()
+            .ThrowAsync<StatementReconciliationReportAuthorityUnavailableException>()
+            .WithMessage("*transactionally compose immutable bytes*");
+    }
+
+    [Fact]
+    public void Constructor_PostgresArtifactStoreWithEquivalentReorderedSettingsIsDurable()
+    {
+        var authorityOptions = new ReportingArtifactStoreOptions
+        {
+            ConnectionString =
+                "Host=primary.example,standby.example;Database=meridian;Username=meridian;Password=meridian;Target Session Attributes=read-write;SSL Mode=Require",
+            Schema = Options.Schema
+        };
+        var artifactStore = new PostgresReportingArtifactStore(
+            new ReportingArtifactStoreOptions
+            {
+                ConnectionString =
+                    "Password=meridian;SSL Mode=Require;Username=meridian;Host=primary.example,standby.example;Target Session Attributes=read-write;Database=meridian",
+                Schema = Options.Schema
+            });
+
+        var store = new PostgresStatementReconciliationReportAuthorityStore(
+            authorityOptions,
+            artifactStore);
+
+        store.IsDurableAuthority.Should().BeTrue();
+    }
+
     private sealed class UnsupportedArtifactStore : IReportingArtifactStore
     {
         public int StoreCallCount { get; private set; }

--- a/tests/Meridian.Tests/Ui/ProviderLedgerReconciliationServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/ProviderLedgerReconciliationServiceTests.cs
@@ -1597,17 +1597,26 @@ public sealed class ProviderLedgerReconciliationServiceTests
             var createCalls = 0;
             var intentExistedBeforeFirstCase = false;
 
-            repository.GetByIdAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            repository.GetByIdAsync(
+                    Arg.Any<ReconciliationBreakQueueScope>(),
+                    Arg.Any<string>(),
+                    Arg.Any<CancellationToken>())
                 .Returns(call => Task.FromResult(
-                    cases.TryGetValue(call.ArgAt<string>(0), out var item)
+                    cases.TryGetValue(call.ArgAt<string>(1), out var item)
                         ? item
                         : null));
-            repository.GetAllAsync(Arg.Any<ReconciliationBreakQueueStatus?>(), Arg.Any<CancellationToken>())
+            repository.GetAllAsync(
+                    Arg.Any<ReconciliationBreakQueueScope>(),
+                    Arg.Any<ReconciliationBreakQueueStatus?>(),
+                    Arg.Any<CancellationToken>())
                 .Returns(_ => Task.FromResult<IReadOnlyList<ReconciliationBreakQueueItem>>(cases.Values.ToArray()));
-            repository.CreateIfMissingAsync(Arg.Any<ReconciliationBreakQueueItem>(), Arg.Any<CancellationToken>())
+            repository.CreateIfMissingAsync(
+                    Arg.Any<ReconciliationBreakQueueScope>(),
+                    Arg.Any<ReconciliationBreakQueueItem>(),
+                    Arg.Any<CancellationToken>())
                 .Returns(call =>
                 {
-                    var item = call.ArgAt<ReconciliationBreakQueueItem>(0);
+                    var item = call.ArgAt<ReconciliationBreakQueueItem>(1);
                     createCalls++;
                     var operationKey = Convert.ToHexString(
                             System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(operationId)))
@@ -2077,7 +2086,7 @@ public sealed class ProviderLedgerReconciliationServiceTests
                 component.Key == "security-master-completeness" &&
                 component.Status == FundAccountCloseReadinessStatusDto.Blocked);
             readiness.Blockers.Should().Contain(blocker =>
-                blocker.Code == "close.security_master.blocked" &&
+                blocker.Code == "close.security_master.casework_blocked" &&
                 blocker.Category == "SecurityMaster" &&
                 blocker.Severity == "Critical");
         }
@@ -2450,9 +2459,13 @@ public sealed class ProviderLedgerReconciliationServiceTests
                 includeBreakQueue: true,
                 capabilityRouter: new FixedCapabilityRouter(IsRoutable: true));
             await BackdateBrokerageProjectionAsync(fixture, TimeSpan.FromHours(2));
-            await fixture.RunReconciliationAsync(
+            var reconciliation = await fixture.RunReconciliationAsync(
                 fixture.AccountId,
                 new ProviderLedgerReconciliationRequestDto(ProviderStaleAfterMinutes: 30, RequestedBy: "ops-user"));
+            reconciliation.SecurityMasterPassports.Should().ContainSingle(passport =>
+                passport.Symbol == "AAPL" &&
+                passport.Status == ProviderSecurityMasterPassportStatusDto.Resolved &&
+                passport.ProviderIsStale);
 
             var readiness = await fixture.CloseReadiness.GetAsync(fixture.AccountId, fixture.QueueScope);
 
@@ -2462,14 +2475,14 @@ public sealed class ProviderLedgerReconciliationServiceTests
             readiness.Components.Should().Contain(component =>
                 component.Key == "security-master-completeness" &&
                 component.Status == FundAccountCloseReadinessStatusDto.ReviewRequired &&
-                component.BlockingReason.Contains("stale provider evidence", StringComparison.OrdinalIgnoreCase));
+                component.BlockingReason.Contains("remain open for steward review", StringComparison.OrdinalIgnoreCase));
             readiness.Blockers.Should().Contain(blocker =>
-                blocker.Code == "close.security_master.stale_provider_mapping" &&
+                blocker.Code == "close.security_master.casework_review" &&
                 blocker.Category == "SecurityMaster" &&
                 blocker.Severity == "Warning" &&
                 blocker.EvidenceLink == $"/api/fund-accounts/{fixture.AccountId}/brokerage-sync/reconciliation/latest");
             readiness.NextActions.Should().Contain(action =>
-                action.Code == "close.security_master.stale_provider_mapping" &&
+                action.Code == "close.security_master.casework_review" &&
                 action.Label == "Resolve Security Master coverage");
         }
         finally

--- a/tests/Meridian.Tests/Ui/ReportPackWorkflowServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/ReportPackWorkflowServiceTests.cs
@@ -32,6 +32,7 @@ namespace Meridian.Tests.Ui;
 /// </summary>
 public sealed class ReportPackWorkflowServiceTests
 {
+    private const string CertifiedAccountingPeriodId = "66666666-6666-6666-6666-666666666666";
     private const string TestTenantId = "tenant-a";
     private const string TestCompanyId = "company-a";
 
@@ -1516,7 +1517,7 @@ public sealed class ReportPackWorkflowServiceTests
         var record = workflow.Create(
             "fund-alpha",
             "acct-main",
-            "2026-05",
+            CertifiedAccountingPeriodId,
             new VersionedReportTemplateIdDto("shadow-nav-pack", 1),
             "report.author",
             accessContext: new ReportAccessQueryContext(
@@ -1531,7 +1532,7 @@ public sealed class ReportPackWorkflowServiceTests
             "company-a",
             "fund-alpha",
             "book-main",
-            "2026-05");
+            CertifiedAccountingPeriodId);
         var access = new ReportingAccessScope(
             "legacy-pack-binding",
             "1",
@@ -1726,7 +1727,7 @@ public sealed class ReportPackWorkflowServiceTests
             "company-a",
             "fund-alpha",
             "book-main",
-            "2026-05");
+            CertifiedAccountingPeriodId);
         var access = new ReportingAccessScope(
             "policy-company-a",
             "1",
@@ -4612,33 +4613,46 @@ public sealed class ReportPackWorkflowServiceTests
                         Metrics: [new ReportWriterMetricDefinitionDto("pnl", "pnl")])
                 ],
                 AccessPolicy: new ReportAccessPolicyDto(ReportAccessModeDto.Private, OwnerPrincipalId: "owner.user")),
-            "owner.user");
-        registry.Submit(draft.Definition.TemplateId, "owner.user", "ready");
-        registry.Approve(draft.Definition.TemplateId, new ReportTemplateDecisionRequestDto("approved", "APP-GRID-PRIVATE-1"), "controller.admin");
+            "owner.user",
+            companyId: TestCompanyId,
+            tenantId: TestTenantId);
+        registry.Submit(
+            draft.Definition.TemplateId,
+            "owner.user",
+            "ready",
+            BoundAccessContext("owner.user"));
+        registry.Approve(
+            draft.Definition.TemplateId,
+            new ReportTemplateDecisionRequestDto("approved", "APP-GRID-PRIVATE-1"),
+            "controller.admin",
+            BoundAccessContext("controller.admin"));
+        var client = app.GetTestClient();
+        client.DefaultRequestHeaders.Add("X-Meridian-Test-User", "owner.user");
 
-        var orchestration = app.Services.GetRequiredService<IReportingOrchestrationService>();
-        var manifest = await orchestration.ExecuteAsync(
-            new ReportingJobContract(
-                "private-retained-grid",
+        var runResponse = await client.PostAsJsonAsync(
+            "/api/fund-structure/reporting/runs",
+            new ReportingRunRequestDto(
                 draft.Definition.TemplateId.Name,
                 new DateOnly(2026, 5, 5),
-                ReportingRunTrigger.AdHoc,
-                0,
-                "owner.user",
-                new DateTimeOffset(2026, 5, 5, 9, 0, 0, TimeSpan.Zero),
-                DatasetRows:
-                [
-                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                    {
-                        ["sector"] = "Technology",
-                        ["pnl"] = "250"
-                    }
-                ]),
-            CancellationToken.None);
-        manifest.RenderedReportWriterGrids.Should().ContainSingle(grid => grid.GridId == "private-sector-pnl");
-        var client = app.GetTestClient();
+                JobId: "private-retained-grid",
+                Parameters: BuildEndpointScheduleRunParameters() with
+                {
+                    PeriodId = CertifiedAccountingPeriodId
+                }),
+            ServerJsonOptions);
 
-        var response = await client.GetAsync($"/api/fund-structure/reporting/runs/{manifest.RunId}/report-writer-grids/private-sector-pnl");
+        runResponse.StatusCode.Should().Be(
+            HttpStatusCode.Created,
+            "the private template owner should be able to create the governed run: {0}",
+            await runResponse.Content.ReadAsStringAsync());
+        var run = await runResponse.Content.ReadFromJsonAsync<ReportingRunResultDto>(ServerJsonOptions);
+        run.Should().NotBeNull();
+        run!.Run.GeneratedReportWriterGrids.Should().ContainSingle(grid => grid.GridId == "private-sector-pnl");
+
+        client.DefaultRequestHeaders.Remove("X-Meridian-Test-User");
+        client.DefaultRequestHeaders.Add("X-Meridian-Test-User", "viewer.user");
+
+        var response = await client.GetAsync($"/api/fund-structure/reporting/runs/{run.Run.RunId}/report-writer-grids/private-sector-pnl");
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }

--- a/tests/Meridian.Tests/Ui/ReportingDeploymentReadinessServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/ReportingDeploymentReadinessServiceTests.cs
@@ -1,7 +1,10 @@
 using FluentAssertions;
 using Meridian.Contracts.Workstation;
+using Meridian.FinancialOperations.Reconciliation;
+using Meridian.FinancialOperations.Reconciliation.Connectors;
 using Meridian.Reporting;
 using Meridian.Storage.Reporting;
+using Meridian.Ui.Shared.Evidence;
 using Meridian.Ui.Shared.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -50,6 +53,9 @@ public sealed class ReportingDeploymentReadinessServiceTests
         PostgresReportingDeploymentProbe.StatementDocumentGuardTriggerName)]
     [InlineData(
         "statement-reconciliation-authority",
+        PostgresReportingDeploymentProbe.StatementDocumentTruncateGuardTriggerName)]
+    [InlineData(
+        "statement-reconciliation-authority",
         PostgresReportingDeploymentProbe.StatementDocumentRevisionTriggerName)]
     [InlineData(
         "statement-reconciliation-authority",
@@ -57,6 +63,9 @@ public sealed class ReportingDeploymentReadinessServiceTests
     [InlineData(
         "statement-reconciliation-authority",
         PostgresReportingDeploymentProbe.StatementRevisionGuardTriggerName)]
+    [InlineData(
+        "statement-reconciliation-authority",
+        PostgresReportingDeploymentProbe.StatementRevisionTruncateGuardTriggerName)]
     [InlineData("delivery", "trg_reporting_delivery_receipts_immutable")]
     public void HasRequiredSchema_MissingImmutableControlTrigger_ShouldFailClosed(
         string componentId,
@@ -143,6 +152,9 @@ public sealed class ReportingDeploymentReadinessServiceTests
         "reporting_statement_reconciliation_documents.ck_reporting_statement_document_key")]
     [InlineData(
         "statement-reconciliation-authority",
+        "reporting_statement_reconciliation_documents.ck_reporting_statement_document_identity_utf8_bytes")]
+    [InlineData(
+        "statement-reconciliation-authority",
         "reporting_statement_reconciliation_document_revisions.fk_reporting_statement_revision_blob")]
     [InlineData(
         "statement-reconciliation-authority",
@@ -150,6 +162,9 @@ public sealed class ReportingDeploymentReadinessServiceTests
     [InlineData(
         "statement-reconciliation-authority",
         "reporting_statement_reconciliation_document_revisions.ck_reporting_statement_revision_chain")]
+    [InlineData(
+        "statement-reconciliation-authority",
+        "reporting_statement_reconciliation_document_revisions.ck_reporting_statement_revision_identity_utf8_bytes")]
     public void HasRequiredSchema_MissingAuthorityConstraint_ShouldFailClosed(
         string componentId,
         string missingConstraint)
@@ -191,7 +206,7 @@ public sealed class ReportingDeploymentReadinessServiceTests
     }
 
     [Fact]
-    public void Evaluate_StatementAuthorityRequiresMarkerAndConcretePostgresStore()
+    public void Evaluate_StatementAuthorityRequiresMarkerStoreAndDurablyComposedWorkflow()
     {
         var probe = Substitute.For<IReportingDeploymentProbe>();
         probe.Probe().Returns(CompleteProbe());
@@ -201,13 +216,17 @@ public sealed class ReportingDeploymentReadinessServiceTests
                 "Host=localhost;Database=meridian_readiness;Username=meridian",
             Schema = "reporting"
         };
-        var artifactStore = Substitute.For<IReportingArtifactStore>();
+        var authority = new PostgresStatementReconciliationReportAuthorityStore(
+            options,
+            new PostgresReportingArtifactStore(options));
+        var evidence = new ReportingStatementImportEvidenceRetainer(
+            authority,
+            Path.GetTempPath());
         var services = new ServiceCollection();
         services.AddSingleton(probe);
-        services.AddSingleton<IStatementReconciliationReportAuthorityStore>(
-            new PostgresStatementReconciliationReportAuthorityStore(
-                options,
-                artifactStore));
+        services.AddSingleton<IStatementReconciliationReportAuthorityStore>(authority);
+        services.AddSingleton<IStatementImportEvidenceRetainer>(evidence);
+        services.AddSingleton(CreateDurableStatementWorkflow(authority, evidence));
         using var provider = services.BuildServiceProvider();
         var readiness = new ReportingDeploymentReadinessService(provider);
 
@@ -238,6 +257,72 @@ public sealed class ReportingDeploymentReadinessServiceTests
             .Single(static component =>
                 component.ComponentId == "statement-reconciliation-authority")
             .IsReady.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Evaluate_PostgresStatementStoreWithoutDurablyComposedWorkflow_ShouldFailClosed()
+    {
+        var probe = Substitute.For<IReportingDeploymentProbe>();
+        probe.Probe().Returns(CompleteProbe());
+        var options = new ReportingArtifactStoreOptions
+        {
+            ConnectionString =
+                "Host=localhost;Database=meridian_readiness;Username=meridian",
+            Schema = "reporting"
+        };
+        var services = new ServiceCollection();
+        services.AddSingleton(probe);
+        services.AddSingleton<IStatementReconciliationReportAuthorityStore>(
+            new PostgresStatementReconciliationReportAuthorityStore(
+                options,
+                new PostgresReportingArtifactStore(options)));
+        using var provider = services.BuildServiceProvider();
+
+        var capability = new ReportingDeploymentReadinessService(provider).Evaluate();
+
+        capability.Components
+            .Single(static component =>
+                component.ComponentId == "statement-reconciliation-authority")
+            .IsReady.Should().BeFalse(
+                "a durable store registration alone does not prove the workflow retains canonical run evidence through that exact authority");
+    }
+
+    [Fact]
+    public void Evaluate_WorkflowUsingDifferentDurableAuthorityInstance_ShouldFailClosed()
+    {
+        var probe = Substitute.For<IReportingDeploymentProbe>();
+        probe.Probe().Returns(CompleteProbe());
+        var options = new ReportingArtifactStoreOptions
+        {
+            ConnectionString =
+                "Host=localhost;Database=meridian_readiness;Username=meridian",
+            Schema = "reporting"
+        };
+        var registeredAuthority = new PostgresStatementReconciliationReportAuthorityStore(
+            options,
+            new PostgresReportingArtifactStore(options));
+        var workflowAuthority = new PostgresStatementReconciliationReportAuthorityStore(
+            options,
+            new PostgresReportingArtifactStore(options));
+        var workflowEvidence = new ReportingStatementImportEvidenceRetainer(
+            workflowAuthority,
+            Path.GetTempPath());
+        var services = new ServiceCollection();
+        services.AddSingleton(probe);
+        services.AddSingleton<IStatementReconciliationReportAuthorityStore>(
+            registeredAuthority);
+        services.AddSingleton<IStatementImportEvidenceRetainer>(workflowEvidence);
+        services.AddSingleton(
+            CreateDurableStatementWorkflow(workflowAuthority, workflowEvidence));
+        using var provider = services.BuildServiceProvider();
+
+        var capability = new ReportingDeploymentReadinessService(provider).Evaluate();
+
+        capability.Components
+            .Single(static component =>
+                component.ComponentId == "statement-reconciliation-authority")
+            .IsReady.Should().BeFalse(
+                "the probed store and workflow must share the exact authority instance");
     }
 
     [Fact]
@@ -934,6 +1019,19 @@ public sealed class ReportingDeploymentReadinessServiceTests
                 .StatementReconciliationAuthorityCompatibilityMarker
         ]
     };
+
+    private static StatementReconciliationReportWorkflowService CreateDurableStatementWorkflow(
+        IStatementReconciliationReportAuthorityStore authority,
+        ReportingStatementImportEvidenceRetainer evidence) =>
+        new(
+            Substitute.For<IStatementImportCommitService>(),
+            evidence,
+            Substitute.For<IStatementRunWorkflowService>(),
+            Path.GetTempPath(),
+            authority,
+            NullLogger<StatementReconciliationReportWorkflowService>.Instance,
+            breakQueue: null,
+            intakeAuthority: Substitute.For<IStatementReconciliationIntakeAuthority>());
 
     private static async Task WaitUntilAsync(Func<bool> predicate)
     {

--- a/tests/Meridian.Tests/Ui/ReportingOperationalConcurrencyTests.cs
+++ b/tests/Meridian.Tests/Ui/ReportingOperationalConcurrencyTests.cs
@@ -19,6 +19,8 @@ namespace Meridian.Tests.Ui;
 /// </summary>
 public sealed class ReportingOperationalConcurrencyTests
 {
+    private const string CertifiedAccountingPeriodId = "66666666-6666-6666-6666-666666666666";
+
     private static readonly DateTimeOffset FixedNow =
         new(2026, 7, 26, 12, 0, 0, TimeSpan.Zero);
 
@@ -99,7 +101,7 @@ public sealed class ReportingOperationalConcurrencyTests
             "tenant-a",
             "company-a",
             "fund-a",
-            "2026-07",
+            CertifiedAccountingPeriodId,
             new string('a', 64));
 
         try
@@ -110,7 +112,7 @@ public sealed class ReportingOperationalConcurrencyTests
                 "tenant-a",
                 "company-b",
                 "fund-b",
-                "2026-07",
+                CertifiedAccountingPeriodId,
                 new string('b', 64));
             await store.SaveAsync(foreign.Manifest, foreign.AuditTrail);
 
@@ -1055,7 +1057,7 @@ public sealed class ReportingOperationalConcurrencyTests
             tenantId: "tenant-a",
             companyId: "company-a",
             fundId: "fund-a",
-            periodId: "2026-07",
+            periodId: CertifiedAccountingPeriodId,
             policyHash: new string('a', 64)).Manifest;
         return new ReportingJobContract(
             jobId,

--- a/tests/Meridian.Tests/Ui/StatementReconciliationAuthorityCompositionTests.cs
+++ b/tests/Meridian.Tests/Ui/StatementReconciliationAuthorityCompositionTests.cs
@@ -1,0 +1,104 @@
+using FluentAssertions;
+using Meridian.FinancialOperations.Reconciliation;
+using Meridian.FinancialOperations.Reconciliation.Connectors;
+using Meridian.Reporting;
+using Meridian.Storage.Reporting;
+using Meridian.Ui.Shared.Evidence;
+using Meridian.Ui.Shared.Services;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using CoreConfigStore = Meridian.Application.UI.ConfigStore;
+
+namespace Meridian.Tests.Ui;
+
+[Collection("Sequential")]
+public sealed class StatementReconciliationAuthorityCompositionTests : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(),
+        "Meridian.Tests",
+        nameof(StatementReconciliationAuthorityCompositionTests),
+        Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void ConfiguredStagingPostgresAuthority_UsesReportingEvidenceRetainer()
+    {
+        using var quietProductionEnvironment =
+            new Meridian.Tests.Application.Composition.ProductionEnvironmentQuietScope();
+        using var environment = new Meridian.Tests.Application.Composition.EnvironmentVariableScope(
+            "ASPNETCORE_ENVIRONMENT",
+            "Staging");
+        using var unified = new Meridian.Tests.Application.Composition.EnvironmentVariableScope(
+            Meridian.Storage.MeridianDatabaseEnvironment.UnifiedVariable,
+            null);
+        using var reporting = new Meridian.Tests.Application.Composition.EnvironmentVariableScope(
+            "MERIDIAN_REPORTING_CONNECTION_STRING",
+            "Host=127.0.0.1;Port=1;Database=meridian;Username=test;Password=test;Timeout=1");
+        using var ledger = new Meridian.Tests.Application.Composition.EnvironmentVariableScope(
+            "MERIDIAN_LEDGER_CONNECTION_STRING",
+            null);
+        var services = CreateMinimalWorkstationServices();
+
+        services.AddWorkstationSharedServices();
+
+        using var provider = services.BuildServiceProvider();
+        var authority = provider.GetRequiredService<IStatementReconciliationReportAuthorityStore>();
+        authority.Should().BeOfType<PostgresStatementReconciliationReportAuthorityStore>();
+        authority.IsDurableAuthority.Should().BeTrue();
+        provider.GetRequiredService<IStatementImportEvidenceRetainer>()
+            .Should().BeOfType<ReportingStatementImportEvidenceRetainer>();
+        provider.GetRequiredService<StatementReconciliationReportWorkflowService>()
+            .IsDurablyComposedWith(authority).Should().BeTrue();
+    }
+
+    [Fact]
+    public void UnconfiguredNonProductionAuthority_UsesFileEvidenceBridge()
+    {
+        using var quietProductionEnvironment =
+            new Meridian.Tests.Application.Composition.ProductionEnvironmentQuietScope();
+        using var unified = new Meridian.Tests.Application.Composition.EnvironmentVariableScope(
+            Meridian.Storage.MeridianDatabaseEnvironment.UnifiedVariable,
+            null);
+        using var reporting = new Meridian.Tests.Application.Composition.EnvironmentVariableScope(
+            "MERIDIAN_REPORTING_CONNECTION_STRING",
+            null);
+        using var ledger = new Meridian.Tests.Application.Composition.EnvironmentVariableScope(
+            "MERIDIAN_LEDGER_CONNECTION_STRING",
+            null);
+        var services = CreateMinimalWorkstationServices();
+
+        services.AddWorkstationSharedServices();
+
+        using var provider = services.BuildServiceProvider();
+        var authority = provider.GetRequiredService<IStatementReconciliationReportAuthorityStore>();
+        authority.Should().BeOfType<FileStatementReconciliationReportAuthorityStore>();
+        authority.IsDurableAuthority.Should().BeFalse();
+        provider.GetRequiredService<IStatementImportEvidenceRetainer>()
+            .Should().BeSameAs(provider.GetRequiredService<StatementImportEvidenceBridge>());
+        provider.GetRequiredService<StatementReconciliationReportWorkflowService>()
+            .IsDurablyComposed.Should().BeFalse();
+    }
+
+    private ServiceCollection CreateMinimalWorkstationServices()
+    {
+        var configPath = Path.Combine(_root, "appsettings.json");
+        Directory.CreateDirectory(_root);
+        File.WriteAllText(configPath, "{}");
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(new CoreConfigStore(configPath));
+        services.AddSingleton(Substitute.For<IStatementImportCommitService>());
+        services.AddSingleton(Substitute.For<IStatementRunWorkflowService>());
+        services.AddSingleton(Substitute.For<IStatementReconciliationIntakeAuthority>());
+        return services;
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+}

--- a/tests/Meridian.Tests/Ui/StatementReconciliationProductionAuthorityTests.cs
+++ b/tests/Meridian.Tests/Ui/StatementReconciliationProductionAuthorityTests.cs
@@ -403,6 +403,82 @@ public sealed class StatementReconciliationProductionAuthorityTests : IDisposabl
     }
 
     [Fact]
+    public async Task EvidenceRetainer_UnmanifestedArtifactMetadata_IsNotAcceptedAsVerifiedIdentity()
+    {
+        var authority = new InMemoryDurableStatementAuthority();
+        var source = WriteRetainedSource();
+        var request = BuildEvidenceRequest();
+        var retainer = new ReportingStatementImportEvidenceRetainer(authority, _root);
+        var retained = await retainer.RetainAsync(
+            BuildImportResult() with { RetainedSourcePath = source },
+            request);
+        var identity = retained.EvidenceVaultIdentity!;
+        var artifact = identity.Artifacts[0];
+        EvidenceVaultArtifactDto[] tamperedArtifacts =
+        [
+            artifact with
+            {
+                Capture = new EvidenceArtifactCaptureDto(
+                    "tampered",
+                    "unmanifested",
+                    DateTimeOffset.Parse("2026-07-01T12:00:00Z"),
+                    "operator",
+                    "source",
+                    new string('b', 64),
+                    EvidenceDocumentIntakeChannelDto.Api)
+            },
+            artifact with
+            {
+                ExtractedFields =
+                [
+                    new EvidenceArtifactExtractionFieldDto(
+                        "tampered",
+                        "value",
+                        null,
+                        1m,
+                        "Unreviewed",
+                        EvidenceStatusDto.Ready,
+                        null,
+                        null,
+                        null)
+                ]
+            },
+            artifact with
+            {
+                Document = new EvidenceDocumentDto(
+                    "tampered-document",
+                    "tampered.pdf",
+                    EvidenceDocumentClassificationDto.Statement,
+                    new string('c', 64),
+                    DateTimeOffset.Parse("2026-07-01T12:00:00Z"),
+                    "api",
+                    null,
+                    "tenant-alpha",
+                    "company-alpha",
+                    EvidenceExtractionStatusDto.NotExtracted,
+                    [],
+                    new EvidenceDocumentReviewStateDto(
+                        EvidenceDocumentReviewStatusDto.Unreviewed),
+                    [])
+            }
+        ];
+
+        foreach (var tamperedArtifact in tamperedArtifacts)
+        {
+            var artifacts = identity.Artifacts.ToArray();
+            artifacts[0] = tamperedArtifact;
+            var tampered = retained with
+            {
+                EvidenceVaultIdentity = identity with { Artifacts = artifacts }
+            };
+
+            (await retainer.HasVerifiedCanonicalRunEvidenceAsync(tampered, request))
+                .Should().BeFalse(
+                    "canonical recovery must reject artifact metadata not retained by its manifest");
+        }
+    }
+
+    [Fact]
     public async Task EvidenceRetainer_RetainedSourceFileLink_IsRejectedWithoutReadingExternalTarget()
     {
         var authority = new InMemoryDurableStatementAuthority();

--- a/tests/Meridian.Tests/Ui/StatementReconciliationReportWorkflowServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/StatementReconciliationReportWorkflowServiceTests.cs
@@ -223,7 +223,10 @@ public sealed class StatementReconciliationReportWorkflowServiceTests : IDisposa
         started.Workflow.EvidenceVaultIdentity!.SubjectId.Should().Be("statement-run-alpha");
         started.Workflow.EvidenceReferences.Should().Contain("statement-run:statement-run-alpha");
         started.Workflow.RetainedArtifacts.Should().BeEmpty();
-        started.Workflow.RecoveryAction.Should().Contain("Resolve or disposition");
+        started.Workflow.RecoveryAction.Should().Contain("canonical statement run is unavailable");
+        started.Workflow.RecoveryAction.Should().NotContain(
+            "Resolve or disposition",
+            "the exact queue obligation is already resolved with a completed handoff");
 
         runs.ReturnReconciled = true;
         var restarted = CreateService(imports, evidence, runs, queue);


### PR DESCRIPTION
## Summary

- closes the remaining authority gaps in the existing statement reconciliation report chain from retained statement evidence through reconciliation casework, posting/close evidence, certified package approval, release, delivery receipt, and audit history
- reuses the existing partners-capital/client-document PDF and XLSX package path; no renderer or parallel workflow is introduced
- makes PostgreSQL artifact bytes and authority metadata transactional, and fails closed unless readiness and execution use the same durable authority and equivalent database, routing, and TLS target
- preserves complete nested reconciliation/close evidence across restart and keeps recovery guidance from repeating already-completed casework
- keeps the public operation named statement reconciliation report until the full deployment authority is configured and healthy

## Validation

- `bash scripts/ci.sh` — passed on clean commit 65ae5c3eb
  - all 19 non-integration .NET test projects passed
  - core UI: 1,586 passed, 5 environment-dependent skips
  - core storage: 1,046 passed, 9 environment-dependent skips
  - reporting: 134 passed
  - all 33 dashboard batches passed; strict null checking and production bundle passed
  - documentation/source drift, lane manifest, workflow hygiene, and 399 active script tests passed
- focused statement authority, readiness, migration, reporting fixture, and provider-ledger suites passed before the full gate
- `git diff --check` passed

## Hosted evidence still required

Local PostgreSQL integration tests are environment-skipped. The Production Certification workflow will be dispatched for this branch to exercise the PostgreSQL-backed integration and recovery lanes; GitHub Actions remains authoritative.

Nine repository script-test modules remain in the pre-existing quarantine inventory and were reported by the quality gate; no quarantine or CI-governance files are changed here.