### PR TITLE
docs: refresh README with current W8/W9 delivery state and repository map

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,17 @@ For an end user, Meridian is intended to reduce disconnected spreadsheets, inbox
 
 Meridian's current baseline is the closed W1-W5 operational record plus completed W5X shared
 explorer, Financial Operations, statement connector, and bounded W7 live-readiness governance
-milestones. Evidence Vault productization, statement reconciliation onboarding, and WPF workstation
-parity are active delivery work.
+milestones. Evidence Vault productization, statement reconciliation onboarding, browser workstation
+screen consolidation, WPF workstation parity, and the Asset Accounting Event Spine are active
+delivery work, and the ranked W9 first-order improvement slate (`W9-TRUTH-001` through
+`W9-INGEST-009`) is the accepted planned priority order for the next delivery decisions.
 
 These are bounded roadmap acceptance claims, not blanket production certification. A completed row
 means its named scope closed with linked evidence; release and support decisions still require fresh
-operator preflight, packaging, deployment, and required GitHub Actions evidence.
+operator preflight, packaging, deployment, and required GitHub Actions evidence. Production
+readiness is tracked in the canonical
+[Implementation and Readiness Tracker](docs/product/implementation-todo-list.md), whose release gate
+requires every P0 row to be complete on the same release commit.
 
 That means the repository contains accepted evidence for:
 
@@ -37,8 +42,9 @@ That means the repository contains accepted evidence for:
 | Financial Operations control center | Complete W5X milestone. Operations Continuity and Fund Ledger surfaces expose reconciliation queues, exception casework, close readiness, workflow controls, approval policy, audit evidence, checklist state, and governed reopen posture. |
 | Statement connector library | Complete W5X milestone. Declarative CSV and OFX mapping profiles, IB Flex XML, OFX bank/investment files, and Alpaca activity/portfolio statements normalize into canonical statement records with preview, confidence, drift warning, and reconciliation handoff support. |
 | Evidence Vault and statement onboarding | In progress. Evidence Vault primitives exist for retained source documents, manifests, review state, object links, and audit trails; the first acceptance path is browser-first statement reconciliation onboarding. |
-| Browser and WPF workstation delivery | In progress. Both operator clients are active, co-equal product lanes over shared contracts and read models. `W8-WPF-PARITY-001` tracks browser-first screens that still need a WPF equivalent or an explicit parity decision. |
+| Browser and WPF workstation delivery | In progress. Both operator clients are active, co-equal product lanes over shared contracts and read models. `W8-UX-CONSOL-001` folds closely related browser screens into deeper host screens behind the seven root workspaces, and `W8-WPF-PARITY-001` tracks browser-first screens that still need a WPF equivalent or an explicit parity decision. |
 | Live-readiness governance | Complete bounded W7 milestone. Paper-to-live promotion requires trusted-data review, paper-validation evidence, reconciliation evidence, accounting-record evidence, governed-reporting evidence, governance sign-off, exception-handling evidence, rollback/kill-switch evidence, audit retention, live brokerage enablement, and an active manual override. This is governance, not full live execution productization. |
+| Asset accounting event spine | In progress. `W9-ASSET-010` establishes one evidence-backed Asset Accounting Event Spine across acquisition, capitalization, valuation, income, corporate action, impairment, depreciation/amortization, and disposal, with acquisition lot creation and versioned selected-lot disposal joined to the governed journal append in one atomic transaction. |
 
 Active operator UI work spans both:
 
@@ -81,6 +87,9 @@ Near-term work:
 | Evidence Vault productization | Turn retained documents, source manifests, request lists, extracted-field review, object links, and audit primitives into a reusable evidence layer for Accounting, Reporting, and Data workflows. |
 | Statement reconciliation onboarding | Make statement import the first browser-first onboarding path: import, preview, commit, retain Evidence Vault proof, route reconciliation breaks, and guide the operator to next actions. |
 | WPF workstation parity | Close tracked browser-first screen gaps through shared DTOs, endpoints, and read models while preserving desktop MVVM, validation, and release workflows. |
+| Browser workstation screen consolidation | Fold closely related browser workstation screens into deeper host screens behind the seven root workspaces (`W8-UX-CONSOL-001`), keeping retired routes as scope-preserving redirects and refreshing the WPF parity matrix with each fold. |
+| Asset Accounting Event Spine | Establish the evidence-backed asset accounting event lifecycle with atomic lot posting (`W9-ASSET-010`) so only a retained immutable journal can establish Posted impact. |
+| Ranked W9 improvement slate | Execute the accepted `W9-TRUTH-001` through `W9-INGEST-009` priority order: truthful simulation posture, seeded demo evaluation, paper-trading realism, live fill streaming, client-grade reporting, fund economics, execution safety, governance hardening, and institutional statement ingestion. |
 
 Longer-term or explicitly deferred lanes:
 
@@ -120,13 +129,15 @@ Major solution areas include:
 | Area | Paths |
 | --- | --- |
 | Host, application, domain, contracts, infrastructure, and storage | `src/Meridian`, `src/Meridian.Application`, `src/Meridian.Domain`, `src/Meridian.Core`, `src/Meridian.Contracts`, `src/Meridian.Infrastructure`, `src/Meridian.Storage` |
+| Bounded-context domain modules | `src/Meridian.Entities`, `src/Meridian.Identity`, `src/Meridian.Instruments`, `src/Meridian.PortfolioRecords`, `src/Meridian.ReferenceData`, `src/Meridian.DataIntegration`, `src/Meridian.Documents`, `src/Meridian.Workflow`, `src/Meridian.Platform` |
 | Providers, execution, risk, and strategies | `src/Meridian.ProviderSdk`, `src/Meridian.Execution`, `src/Meridian.Execution.Sdk`, `src/Meridian.Risk`, `src/Meridian.Strategies` |
 | Backtesting and replay | `src/Meridian.Backtesting`, `src/Meridian.Backtesting.Sdk` |
-| Accounting, financial operations, audit, and F# domain work | `src/Meridian.Ledger`, `src/Meridian.FinancialOperations`, `src/Meridian.Audit`, `src/Meridian.FSharp.Ledger`, `src/Meridian.FSharp.DirectLending.Aggregates` |
+| Accounting, financial operations, audit, and F# domain work | `src/Meridian.Ledger`, `src/Meridian.FinancialOperations`, `src/Meridian.Audit`, `src/Meridian.FSharp`, `src/Meridian.FSharp.Ledger`, `src/Meridian.FSharp.Trading`, `src/Meridian.FSharp.DirectLending.Aggregates` |
 | Reporting and analytics support | `src/Meridian.Reporting`, `src/Meridian.QuantScript` |
 | MCP tooling | `src/Meridian.Mcp` |
 | Browser workstation and shared UI/API read models | `src/Meridian.Ui/dashboard`, `src/Meridian.Ui/wwwroot/workstation`, `src/Meridian.Ui.Services`, `src/Meridian.Ui.Shared` |
 | Windows desktop workstation | `src/Meridian.Wpf` |
+| Installed workstation launch, lifecycle, and setup | `src/Meridian.Launcher`, `src/Meridian.LifecycleSupervisor`, `src/Meridian.Setup` |
 | Tests and benchmarks | `tests/`, `benchmarks/` |
 
 For maintained ownership and dependency boundaries, use [Project Structure](docs/architecture/project-structure.md), [Module Map](docs/architecture/module-map.md), and the generated [repository structure](docs/generated/repository-structure.md).


### PR DESCRIPTION
## Summary

Documentation-only refresh of the root `README.md` so it matches the current roadmap registry snapshot (2026-07-21) and the actual `src/` layout:

- **Current Product Status**: adds browser workstation screen consolidation (`W8-UX-CONSOL-001`) and the Asset Accounting Event Spine (`W9-ASSET-010`) to active delivery work, records the ranked W9 first-order improvement slate (`W9-TRUTH-001` through `W9-INGEST-009`) as the accepted planned priority order, and points production-readiness claims at the canonical [Implementation and Readiness Tracker](docs/product/implementation-todo-list.md) and its P0 release gate.
- **Status table**: the workstation-delivery row now names both `W8-UX-CONSOL-001` and `W8-WPF-PARITY-001`; a new in-progress row covers the `W9-ASSET-010` asset accounting event spine.
- **Future Plans**: near-term table gains rows for screen consolidation, the Asset Accounting Event Spine, and the ranked W9 slate.
- **Repository Map**: adds the bounded-context domain module projects (`Meridian.Entities`, `Meridian.Identity`, `Meridian.Instruments`, `Meridian.PortfolioRecords`, `Meridian.ReferenceData`, `Meridian.DataIntegration`, `Meridian.Documents`, `Meridian.Workflow`, `Meridian.Platform`), the installed-workstation launch/lifecycle/setup projects (`Meridian.Launcher`, `Meridian.LifecycleSupervisor`, `Meridian.Setup`), and the missing `Meridian.FSharp` / `Meridian.FSharp.Trading` projects.

No behavior, code, or command changes; all existing command and link claims in the README were verified against the current tree (`make` targets, dashboard npm scripts, CLI flags, script paths, and all linked docs resolve).

## Reason

The README's product status predated the W9 wave and W8 browser screen consolidation now recorded in `docs/roadmap/data/*.yml` / `docs/roadmap/generated/ROADMAP_SUMMARY.md`, and its repository map omitted a dozen projects that exist under `src/` (per `docs/source/data/source-modules.yml`). This reconciles the front-door doc with that evidence.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [ ] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Docs-only change: validated with `git diff --check -- README.md` (clean) and verified every referenced path, command, and roadmap ID against the current tree. No unit/integration tests apply; `quality-gate` will run on this PR and remains the authoritative merge gate.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

Check every governance file modified:

- [x] No governance files changed
- [ ] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGSDmRdd6XQ3QQ3wSgmDBN

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGSDmRdd6XQ3QQ3wSgmDBN)_