### PR TITLE
Reconciliation floor follow-up: business-day settlement windows, N-way exact cash groups, terminal non-cooperative captures

### DIFF
--- a/src/Meridian.FinancialOperations/Reconciliation/DefaultReconciliationIngestionScheduler.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/DefaultReconciliationIngestionScheduler.cs
@@ -13,7 +13,10 @@ namespace Meridian.FinancialOperations.Reconciliation;
 /// deterministic order (source type, then registration order) regardless of completion order, and
 /// a source that exhausts its attempts fails the run by rethrowing its final attempt's exception
 /// with the original type and stack intact — retry telemetry is carried in structured logs, not in
-/// wrapper exception types.
+/// wrapper exception types. Adapters are invoked behind the deadline fence (their synchronous
+/// prefixes cannot stall the run), cooperative timeouts retry, and a source that ignores
+/// cancellation past the grace period fails terminally rather than stacking further live captures
+/// outside the concurrency accounting.
 /// </summary>
 public sealed class DefaultReconciliationIngestionScheduler : IReconciliationIngestionScheduler
 {
@@ -107,12 +110,14 @@ public sealed class DefaultReconciliationIngestionScheduler : IReconciliationIng
             Task<DataSourceSnapshot>? captureTask = null;
             try
             {
-                captureTask = adapter.CaptureSnapshotAsync(request, attemptCts.Token);
-                // The linked token asks the adapter to stop cooperatively; WaitAsync enforces the
-                // deadline even when an adapter ignores its token or blocks in non-cancellable
-                // I/O, so a stuck source times the attempt out instead of hanging the run.
+                // Task.Run puts even a fully synchronous adapter prefix (a blocking vendor-SDK call
+                // before its first await) behind the deadline fence instead of letting it run
+                // inline where neither timeout nor cancellation could reach it. The linked token
+                // asks the adapter to stop cooperatively at PerSourceTimeout; WaitAsync enforces a
+                // hard deadline of timeout + grace for adapters that never observe their token.
+                captureTask = Task.Run(() => adapter.CaptureSnapshotAsync(request, attemptCts.Token), attemptCts.Token);
                 var snapshot = _options.PerSourceTimeout is { } deadline
-                    ? await captureTask.WaitAsync(deadline, ct).ConfigureAwait(false)
+                    ? await captureTask.WaitAsync(deadline + _options.CancellationGracePeriod, ct).ConfigureAwait(false)
                     : await captureTask.WaitAsync(ct).ConfigureAwait(false);
                 _log.LogInformation(
                     "Captured reconciliation snapshot from {SourceType} in {ElapsedMs}ms on attempt {Attempt}",
@@ -129,14 +134,24 @@ public sealed class DefaultReconciliationIngestionScheduler : IReconciliationIng
             }
             catch (TimeoutException hardTimeout) when (_options.PerSourceTimeout is not null)
             {
-                // WaitAsync hit the hard deadline while the adapter kept running.
+                // The adapter blew through the cooperative timeout AND the grace period without
+                // observing its token: its capture is still live and cannot be stopped. Retrying
+                // would stack another concurrent request onto an unresponsive source outside the
+                // concurrency accounting, so a non-cooperative timeout is terminal for this run.
                 ObserveAbandonedCapture(captureTask);
-                lastFailure = ExceptionDispatchInfo.Capture(new TimeoutException(
-                    $"Reconciliation source {adapter.SourceType} exceeded the per-source capture timeout of {_options.PerSourceTimeout} on attempt {attempt}.",
-                    hardTimeout));
+                _log.LogError(
+                    "Reconciliation source {SourceType} ignored cancellation for {ElapsedMs}ms on attempt {Attempt}; failing the source without retry",
+                    adapter.SourceType,
+                    stopwatch.ElapsedMilliseconds,
+                    attempt);
+                throw new TimeoutException(
+                    $"Reconciliation source {adapter.SourceType} exceeded the per-source capture timeout of {_options.PerSourceTimeout} and did not honor cancellation within the {_options.CancellationGracePeriod} grace period on attempt {attempt}; treating the source as non-cooperative and not retrying.",
+                    hardTimeout);
             }
             catch (OperationCanceledException timedOut) when (attemptCts.IsCancellationRequested)
             {
+                // Cooperative timeout: the adapter observed its token and the attempt actually
+                // ended, so no capture is left running and a retry is safe.
                 lastFailure = ExceptionDispatchInfo.Capture(new TimeoutException(
                     $"Reconciliation source {adapter.SourceType} exceeded the per-source capture timeout of {_options.PerSourceTimeout} on attempt {attempt}.",
                     timedOut));

--- a/src/Meridian.FinancialOperations/Reconciliation/ReconciliationIngestionOptions.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/ReconciliationIngestionOptions.cs
@@ -22,6 +22,14 @@ public sealed record ReconciliationIngestionOptions
     /// <summary>Per-attempt timeout; <c>null</c> disables the timeout.</summary>
     public TimeSpan? PerSourceTimeout { get; init; } = TimeSpan.FromSeconds(30);
 
+    /// <summary>
+    /// Extra time past <see cref="PerSourceTimeout"/> for an adapter to observe its cancellation
+    /// token before the attempt is declared non-cooperative. A cooperative cancellation inside the
+    /// grace window is retryable; blowing through it is terminal for the source — retrying would
+    /// stack another live request on a vendor call that is neither finishing nor cancellable.
+    /// </summary>
+    public TimeSpan CancellationGracePeriod { get; init; } = TimeSpan.FromSeconds(5);
+
     public void Validate()
     {
         if (MaxConcurrentCaptures < 1)
@@ -42,6 +50,11 @@ public sealed record ReconciliationIngestionOptions
         if (PerSourceTimeout is { } timeout && timeout <= TimeSpan.Zero)
         {
             throw new ArgumentOutOfRangeException(nameof(PerSourceTimeout), timeout, "Per-source timeout must be positive when set.");
+        }
+
+        if (CancellationGracePeriod < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(CancellationGracePeriod), CancellationGracePeriod, "Cancellation grace period cannot be negative.");
         }
     }
 }

--- a/src/Meridian.FinancialOperations/Reconciliation/ReconciliationMatchingEngine.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/ReconciliationMatchingEngine.cs
@@ -16,7 +16,10 @@ namespace Meridian.FinancialOperations.Reconciliation;
 /// <item>unmatched residuals are probed for bounded <b>one-to-many / many-to-one split groups</b>
 /// whose shape (anchor, legs, residual) is recorded in <see cref="MatchEvidence"/> attributes;</item>
 /// <item>cash timing consults the <see cref="IAccountingCalendar"/>: the exact stage requires the
-/// same accounting period and evidence carries business-day distance alongside wall-clock deltas;</item>
+/// same accounting period, settlement windows of a day or longer also admit counterparts within
+/// the window measured in business days (a Friday wire and its Monday posting are one business
+/// day apart, not three calendar days), and evidence carries business-day distance alongside
+/// wall-clock deltas;</item>
 /// <item>currencies must agree before amounts are compared, so fail-closed FX normalization (a line
 /// kept in its source currency because no rate was available) surfaces as a break instead of a
 /// cross-currency mismatch;</item>
@@ -36,6 +39,8 @@ public sealed class ReconciliationMatchingEngine
     private const string CashBreakRuleId = "true-break-v1";
 
     private const int MaxSplitLegs = 4;
+
+    private static readonly TimeSpan OneDay = TimeSpan.FromDays(1);
 
     // Beyond this many unmatched entries in one account bucket, the comment-containment probe of
     // the fuzzy stage is skipped (reference-equality probes still run): comment containment is the
@@ -478,7 +483,7 @@ public sealed class ReconciliationMatchingEngine
                 .ToArray();
             var consumed = new HashSet<string>(StringComparer.Ordinal);
 
-            MatchExactCashPairs(entries, consumed, accumulator);
+            MatchExactCash(entries, consumed, accumulator);
             MatchScoredCashPairs(entries, consumed, profile, accumulator);
             MatchCashSplits(entries, consumed, profile, accumulator);
             MatchFuzzyCashReferences(entries, consumed, accumulator);
@@ -486,21 +491,81 @@ public sealed class ReconciliationMatchingEngine
         }
     }
 
-    private void MatchExactCashPairs(SidedCash[] entries, HashSet<string> consumed, MatchAccumulator accumulator)
+    private static void MatchExactCash(SidedCash[] entries, HashSet<string> consumed, MatchAccumulator accumulator)
     {
         var candidates = new List<CashPairCandidate>();
-        // Entries are amount-sorted, so equal-amount runs are contiguous.
-        for (var i = 0; i < entries.Length; i++)
+        foreach (var amountGroup in entries
+            .GroupBy(static c => (c.Entry.AmountBase, c.Period))
+            .OrderBy(static g => g.Key.AmountBase)
+            .ThenBy(static g => g.Key.Period))
         {
-            for (var j = i + 1; j < entries.Length && entries[j].Entry.AmountBase == entries[i].Entry.AmountBase; j++)
+            var members = amountGroup.ToArray();
+            var snapshotCount = members.Select(static m => m.SnapshotId).Distinct(StringComparer.Ordinal).Count();
+            if (members.Length < 2 || snapshotCount < 2)
             {
-                var (left, right) = OrderCashPair(entries[i], entries[j]);
-                if (string.Equals(left.SnapshotId, right.SnapshotId, StringComparison.Ordinal) || left.Period != right.Period)
+                continue;
+            }
+
+            if (snapshotCount == 2)
+            {
+                for (var i = 0; i < members.Length; i++)
                 {
-                    continue;
+                    for (var j = i + 1; j < members.Length; j++)
+                    {
+                        var (left, right) = OrderCashPair(members[i], members[j]);
+                        if (string.Equals(left.SnapshotId, right.SnapshotId, StringComparison.Ordinal))
+                        {
+                            continue;
+                        }
+
+                        candidates.Add(new CashPairCandidate(left, right, Rule: null, Score: 0m, AmountDelta: 0m, AllowedTolerance: 0m));
+                    }
                 }
 
-                candidates.Add(new CashPairCandidate(left, right, Rule: null, Score: 0m, AmountDelta: 0m, AllowedTolerance: 0m));
+                continue;
+            }
+
+            // Three or more institutions report the identical amount in the same period: balance
+            // the group one-row-per-snapshot per round, exactly like the exact-position stage, so
+            // a prime/custodian/administrator triple reconciles as one cross-source group instead
+            // of an arbitrary pair plus a false break. Reference-level disambiguation across 3+
+            // sources with repeated rows is casework, not floor pairing.
+            var queues = members
+                .GroupBy(static c => c.SnapshotId, StringComparer.Ordinal)
+                .Select(static g => new Queue<SidedCash>(g
+                    .OrderBy(static c => c.Entry.CashEntryId, StringComparer.Ordinal)))
+                .OrderBy(static q => q.Peek().SourceOrder)
+                .ToArray();
+            while (queues.Count(static q => q.Count > 0) >= 2)
+            {
+                var round = queues
+                    .Where(static q => q.Count > 0)
+                    .Select(static q => q.Dequeue())
+                    .OrderBy(static c => c.Entry.CashEntryId, StringComparer.Ordinal)
+                    .ToArray();
+                var roundIds = round.Select(static c => c.Entry.CashEntryId).ToArray();
+                var roundKeys = round.Select(static c => c.Key).ToArray();
+                var postedSpanMinutes =
+                    (round.Max(static c => c.Entry.PostedAtUtc) - round.Min(static c => c.Entry.PostedAtUtc)).TotalMinutes;
+                var roundEvidence = accumulator.AddEvidence(
+                    "Exact",
+                    ExactCashRuleId,
+                    "Cash amounts are equal within the same accounting period.",
+                    0m,
+                    roundKeys,
+                    new Dictionary<string, string>
+                    {
+                        ["matchShape"] = roundIds.Length == 2 ? "one-to-one" : "cross-source-group",
+                        ["accountingPeriod"] = amountGroup.Key.Period.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                        ["businessDayDelta"] = "0",
+                        ["postedSpanMinutes"] = postedSpanMinutes.ToString(CultureInfo.InvariantCulture),
+                        ["sources"] = string.Join(",", round.Select(static c => c.Source.ToString()).Distinct())
+                    });
+                accumulator.AddMatch(BreakClassification.Matched, "Exact", ExactCashRuleId, null, [], roundIds, roundKeys, roundEvidence);
+                foreach (var member in round)
+                {
+                    consumed.Add(member.Key);
+                }
             }
         }
 
@@ -576,7 +641,7 @@ public sealed class ReconciliationMatchingEngine
 
                 foreach (var rule in profile.CashRules)
                 {
-                    if (!rule.Allows(left.Entry.AmountBase, right.Entry.AmountBase, right.Entry.PostedAtUtc - left.Entry.PostedAtUtc, out var allowed))
+                    if (!TryAllowCashPair(rule, left, right, out var allowed, out var windowBasis))
                     {
                         continue;
                     }
@@ -585,10 +650,12 @@ public sealed class ReconciliationMatchingEngine
                     var deltaMinutes = Math.Abs((right.Entry.PostedAtUtc - left.Entry.PostedAtUtc).TotalMinutes);
                     var windowMinutes = Math.Abs(rule.SettlementDateTolerance.TotalMinutes);
                     var amountComponent = allowed == 0m ? 0m : amountDelta / allowed;
-                    var timeComponent = windowMinutes == 0d ? 0m : (decimal)(deltaMinutes / windowMinutes);
+                    // Business-day-admitted pairs exceed the wall-clock window by construction;
+                    // clamping keeps their timing penalty at the maximum instead of unbounded.
+                    var timeComponent = windowMinutes == 0d ? 0m : Math.Min(1m, (decimal)(deltaMinutes / windowMinutes));
                     var referenceBonus = HasReferenceAgreement(left.Entry, right.Entry) ? 0.2m : 0m;
                     var score = Math.Max(0m, (0.7m * amountComponent) + (0.3m * timeComponent) - referenceBonus);
-                    candidates.Add(new CashPairCandidate(left, right, rule, score, amountDelta, allowed));
+                    candidates.Add(new CashPairCandidate(left, right, rule, score, amountDelta, allowed, windowBasis));
                     break; // Profile order is rule precedence: the first admissible rule governs.
                 }
             }
@@ -617,6 +684,7 @@ public sealed class ReconciliationMatchingEngine
                 {
                     ["allowedTolerance"] = Invariant(pair.AllowedTolerance),
                     ["settlementDateDeltaMinutes"] = deltaMinutes.ToString(CultureInfo.InvariantCulture),
+                    ["settlementWindowBasis"] = pair.WindowBasis,
                     ["businessDayDelta"] = businessDayDelta.ToString(CultureInfo.InvariantCulture),
                     ["amountDeltaBase"] = Invariant(pair.AmountDelta),
                     ["score"] = Invariant(pair.Score),
@@ -697,7 +765,7 @@ public sealed class ReconciliationMatchingEngine
                         var legPool = entries
                             .Where(c => string.Equals(c.SnapshotId, legSnapshot.SnapshotId, StringComparison.Ordinal)
                                 && !consumed.Contains(c.Key)
-                                && (c.Entry.PostedAtUtc - anchor.Entry.PostedAtUtc).Duration() <= settlementWindow)
+                                && WithinSettlementWindow(settlementWindow, anchor, c))
                             .ToArray();
                         if (legPool.Length < 2)
                         {
@@ -871,6 +939,43 @@ public sealed class ReconciliationMatchingEngine
             : (second, first);
     }
 
+    /// <summary>
+    /// Admits a cash pair under a rule. The wall-clock settlement window applies first, keeping
+    /// minute precision for intraday windows; windows of a day or longer also admit counterparts
+    /// whose accounting periods sit within the window measured in business days, so a Friday wire
+    /// and its Monday posting reconcile under a one-day rule instead of failing a ~72-hour
+    /// wall-clock comparison.
+    /// </summary>
+    private bool TryAllowCashPair(CashToleranceRule rule, SidedCash left, SidedCash right, out decimal allowed, out string windowBasis)
+    {
+        var wallClockDelta = right.Entry.PostedAtUtc - left.Entry.PostedAtUtc;
+        if (rule.Allows(left.Entry.AmountBase, right.Entry.AmountBase, wallClockDelta, out allowed))
+        {
+            windowBasis = "wall-clock";
+            return true;
+        }
+
+        if (WithinBusinessDayWindow(rule.SettlementDateTolerance.Duration(), left, right)
+            && rule.Allows(left.Entry.AmountBase, right.Entry.AmountBase, TimeSpan.Zero, out allowed))
+        {
+            windowBasis = "business-day";
+            return true;
+        }
+
+        windowBasis = "wall-clock";
+        return false;
+    }
+
+    // Sub-day windows keep strict wall-clock semantics (intraday matching), so the default
+    // five-minute profile is unaffected by the business-day relaxation.
+    private bool WithinBusinessDayWindow(TimeSpan window, SidedCash left, SidedCash right) =>
+        window >= OneDay
+        && Math.Abs(_calendar.CountBusinessDaysBetween(left.Period, right.Period)) <= (int)window.TotalDays;
+
+    private bool WithinSettlementWindow(TimeSpan window, SidedCash anchor, SidedCash leg) =>
+        (leg.Entry.PostedAtUtc - anchor.Entry.PostedAtUtc).Duration() <= window
+        || WithinBusinessDayWindow(window, anchor, leg);
+
     private static bool HasReferenceAgreement(NormalizedCashEntry left, NormalizedCashEntry right) =>
         (!string.IsNullOrWhiteSpace(left.CounterpartyReference)
             && string.Equals(left.CounterpartyReference, right.CounterpartyReference, StringComparison.OrdinalIgnoreCase))
@@ -957,7 +1062,8 @@ public sealed class ReconciliationMatchingEngine
         CashToleranceRule? Rule,
         decimal Score,
         decimal AmountDelta,
-        decimal AllowedTolerance);
+        decimal AllowedTolerance,
+        string WindowBasis = "wall-clock");
 
     /// <summary>
     /// Collects matches, breaks, and evidence with content-derived identifiers: every artifact id is

--- a/tests/Meridian.Tests/Application/Reconciliation/DefaultReconciliationIngestionSchedulerTests.cs
+++ b/tests/Meridian.Tests/Application/Reconciliation/DefaultReconciliationIngestionSchedulerTests.cs
@@ -110,21 +110,43 @@ public sealed class DefaultReconciliationIngestionSchedulerTests
     }
 
     [Fact]
-    public async Task CaptureAsync_AdapterIgnoringCancellation_TimesOutViaHardDeadline()
+    public async Task CaptureAsync_AdapterIgnoringCancellation_IsTerminalWithoutRetry()
     {
         var adapter = new StubbornAdapter(ReconciliationSourceType.Prime);
         var scheduler = CreateScheduler(new ReconciliationIngestionOptions
         {
-            MaxAttemptsPerSource = 2,
+            MaxAttemptsPerSource = 5,
             RetryBaseDelay = TimeSpan.FromMilliseconds(1),
-            PerSourceTimeout = TimeSpan.FromMilliseconds(40)
+            PerSourceTimeout = TimeSpan.FromMilliseconds(40),
+            CancellationGracePeriod = TimeSpan.FromMilliseconds(25)
         });
 
         var act = async () => await scheduler.CaptureAsync([adapter], Request, CancellationToken.None);
 
         await act.Should().ThrowAsync<TimeoutException>(
-            "the deadline must hold even when an adapter never observes its cancellation token");
-        adapter.Attempts.Should().Be(2);
+            "the hard deadline must hold even when an adapter never observes its cancellation token");
+        adapter.Attempts.Should().Be(1,
+            "retrying a source whose capture is still live would stack concurrent requests outside the concurrency accounting");
+    }
+
+    [Fact]
+    public async Task CaptureAsync_BlockingSynchronousAdapter_IsFencedByHardDeadline()
+    {
+        var adapter = new BlockingSynchronousAdapter(ReconciliationSourceType.Prime);
+        var scheduler = CreateScheduler(new ReconciliationIngestionOptions
+        {
+            MaxAttemptsPerSource = 3,
+            RetryBaseDelay = TimeSpan.FromMilliseconds(1),
+            PerSourceTimeout = TimeSpan.FromMilliseconds(40),
+            CancellationGracePeriod = TimeSpan.FromMilliseconds(25)
+        });
+
+        var act = async () => await scheduler.CaptureAsync([adapter], Request, CancellationToken.None);
+
+        // A vendor SDK that blocks before returning its task must not stall the run inline: the
+        // pool dispatch keeps the deadline fence in control, and the blocked capture is terminal.
+        await act.Should().ThrowAsync<TimeoutException>();
+        adapter.Attempts.Should().Be(1);
     }
 
     [Fact]
@@ -141,7 +163,9 @@ public sealed class DefaultReconciliationIngestionSchedulerTests
         var act = async () => await scheduler.CaptureAsync([adapter], Request, cts.Token);
 
         await act.Should().ThrowAsync<OperationCanceledException>();
-        adapter.Attempts.Should().Be(1, "run cancellation must never be retried");
+        // Zero attempts is legal (cancellation can win the pool-dispatch race and stop the attempt
+        // before the adapter ever runs); what run cancellation must never do is retry.
+        adapter.Attempts.Should().BeLessThanOrEqualTo(1, "run cancellation must never be retried");
     }
 
     [Fact]
@@ -216,8 +240,24 @@ public sealed class DefaultReconciliationIngestionSchedulerTests
         public async Task<DataSourceSnapshot> CaptureSnapshotAsync(ReconciliationIngestionRequest request, CancellationToken ct)
         {
             Attempts++;
-            await Task.Delay(TimeSpan.FromSeconds(30), CancellationToken.None);
+            await Task.Delay(TimeSpan.FromSeconds(5), CancellationToken.None);
             throw new InvalidOperationException("unreachable");
+        }
+    }
+
+    // Simulates a vendor SDK that blocks synchronously before ever returning a task — the worst
+    // case for a deadline: without a pool dispatch, the call would stall the capture loop inline.
+    private sealed class BlockingSynchronousAdapter(ReconciliationSourceType sourceType) : IReconciliationSourceAdapter
+    {
+        public ReconciliationSourceType SourceType { get; } = sourceType;
+
+        public int Attempts { get; private set; }
+
+        public Task<DataSourceSnapshot> CaptureSnapshotAsync(ReconciliationIngestionRequest request, CancellationToken ct)
+        {
+            Attempts++;
+            Thread.Sleep(TimeSpan.FromSeconds(2));
+            return Task.FromResult(CreateSnapshot(SourceType));
         }
     }
 

--- a/tests/Meridian.Tests/Application/Reconciliation/ReconciliationMatchingFloorTests.cs
+++ b/tests/Meridian.Tests/Application/Reconciliation/ReconciliationMatchingFloorTests.cs
@@ -123,6 +123,92 @@ public sealed class ReconciliationMatchingFloorTests
     }
 
     [Fact]
+    public void Run_CashAcrossWeekendUnderDayWindow_MatchesOnBusinessDayBasis()
+    {
+        var engine = new ReconciliationMatchingEngine();
+        var profile = CashProfile(new CashToleranceRule("cash-t1-v1", 5m, null, TimeSpan.FromDays(1)));
+        var run = CreateRun([
+            // Friday 16:00 vs Monday 14:00 is ~70 wall-clock hours but one business day.
+            CreateSnapshot("prime", ReconciliationSourceType.Prime, cash: [CreateCash("c1", 9000m, new DateTimeOffset(2026, 5, 29, 16, 0, 0, TimeSpan.Zero))]),
+            CreateSnapshot("custodian", ReconciliationSourceType.Custodian, cash: [CreateCash("c2", 9000m, new DateTimeOffset(2026, 6, 1, 14, 0, 0, TimeSpan.Zero))])
+        ]);
+
+        var result = engine.Run(run, profile);
+
+        result.breaks.Should().BeEmpty("a one-day settlement rule must span an ordinary weekend");
+        var match = result.matches.Should().ContainSingle().Subject;
+        match.Classification.Should().Be(BreakClassification.MatchedWithinTolerance);
+        var evidence = result.evidence.Single(e => e.EvidenceId == match.EvidenceIds.Single());
+        evidence.Attributes["settlementWindowBasis"].Should().Be("business-day");
+        evidence.Attributes["businessDayDelta"].Should().Be("1");
+    }
+
+    [Fact]
+    public void Run_CashAcrossWeekendUnderIntradayWindow_StaysBroken()
+    {
+        var engine = new ReconciliationMatchingEngine();
+        var profile = CashProfile(new CashToleranceRule("cash-intraday-v1", 5m, null, TimeSpan.FromMinutes(5)));
+        var run = CreateRun([
+            CreateSnapshot("prime", ReconciliationSourceType.Prime, cash: [CreateCash("c1", 9000m, new DateTimeOffset(2026, 5, 29, 16, 0, 0, TimeSpan.Zero))]),
+            CreateSnapshot("custodian", ReconciliationSourceType.Custodian, cash: [CreateCash("c2", 9000m, new DateTimeOffset(2026, 6, 1, 14, 0, 0, TimeSpan.Zero))])
+        ]);
+
+        var result = engine.Run(run, profile);
+
+        result.matches.Should().BeEmpty("sub-day windows keep strict wall-clock semantics");
+        result.breaks.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Run_CashSplitAcrossWeekend_LegsAdmittedOnBusinessDayBasis()
+    {
+        var engine = new ReconciliationMatchingEngine();
+        var profile = CashProfile(new CashToleranceRule("cash-t1-v1", 0.01m, null, TimeSpan.FromDays(1)));
+        var run = CreateRun([
+            CreateSnapshot("prime", ReconciliationSourceType.Prime, cash: [CreateCash("c1", 1000m, new DateTimeOffset(2026, 5, 29, 16, 0, 0, TimeSpan.Zero))]),
+            CreateSnapshot("custodian", ReconciliationSourceType.Custodian, cash:
+            [
+                CreateCash("c2", 400m, new DateTimeOffset(2026, 6, 1, 10, 0, 0, TimeSpan.Zero)),
+                CreateCash("c3", 600m, new DateTimeOffset(2026, 6, 1, 11, 0, 0, TimeSpan.Zero))
+            ])
+        ]);
+
+        var result = engine.Run(run, profile);
+
+        result.breaks.Should().BeEmpty("Monday ledger postings settle a Friday wire under a one-day rule");
+        var match = result.matches.Should().ContainSingle().Subject;
+        match.RuleId.Should().Be("cash-split-v1");
+        match.CashEntryIds.Should().BeEquivalentTo(["c1", "c2", "c3"]);
+    }
+
+    [Fact]
+    public void Run_ExactCashAcrossThreeSnapshots_FormsSingleGroupAndFlagsExcess()
+    {
+        var engine = new ReconciliationMatchingEngine();
+        var profile = CashProfile(new CashToleranceRule("cash-abs-001-v1", 0.01m, null, TimeSpan.FromDays(1)));
+        var run = CreateRun([
+            CreateSnapshot("prime", ReconciliationSourceType.Prime, cash:
+            [
+                CreateCash("c1", 5000m, Thursday),
+                CreateCash("c1b", 5000m, Thursday.AddHours(1))
+            ]),
+            CreateSnapshot("custodian", ReconciliationSourceType.Custodian, cash: [CreateCash("c2", 5000m, Thursday.AddHours(2))]),
+            CreateSnapshot("admin", ReconciliationSourceType.Administrator, cash: [CreateCash("c3", 5000m, Thursday.AddHours(3))])
+        ]);
+
+        var result = engine.Run(run, profile);
+
+        var match = result.matches.Should().ContainSingle(m => m.Classification == BreakClassification.Matched).Subject;
+        match.CashEntryIds.Should().BeEquivalentTo(["c1", "c2", "c3"],
+            "an identical amount reported by three institutions is one cross-source group, not a pair plus a false break");
+        var evidence = result.evidence.Single(e => e.EvidenceId == match.EvidenceIds.Single());
+        evidence.Attributes["matchShape"].Should().Be("cross-source-group");
+        var breakRecord = result.breaks.Should().ContainSingle().Subject;
+        var breakEvidence = result.evidence.Single(e => e.EvidenceId == breakRecord.EvidenceIds.Single());
+        breakEvidence.Attributes["cashEntryId"].Should().Be("c1b", "the prime-side excess duplicate stays a break");
+    }
+
+    [Fact]
     public void Run_CashSplit_OneToMany_RecordsSplitShapeInEvidence()
     {
         var engine = new ReconciliationMatchingEngine();


### PR DESCRIPTION
<!-- phase:PR7 -->
## Summary

Follow-up to the reconciliation matching floor (#2538, merged) addressing the four findings of the second automated review round, which landed just before that PR merged:

- **Business-day settlement windows (P1)** — cash settlement windows of a day or longer now admit counterparts within the window measured in *business days* between accounting periods, in both the scored pair stage and the split-leg filter. A Friday wire and its Monday ledger posting reconcile under a one-day rule instead of failing a ~72-hour wall-clock comparison and surfacing as false breaks. Sub-day windows keep strict wall-clock semantics, so intraday profiles (including the default 5-minute rule) are unchanged; evidence records `settlementWindowBasis` (`wall-clock` / `business-day`).
- **N-way exact cash groups (P1)** — identical amount/period rows reported by three or more snapshots now balance into cross-source rounds (one row per contributing source), matching the exact-position semantics, instead of consuming an arbitrary pair and emitting a false break for the third institution's row. Two-snapshot groups keep the reference-agreement-ranked pairing introduced in the prior round.
- **Adapters invoked behind the deadline fence (P1)** — the ingestion scheduler dispatches adapter invocations to the thread pool, so a vendor SDK that blocks synchronously before returning its task can no longer stall the capture loop inline where neither timeout nor cancellation could reach it.
- **Terminal non-cooperative timeouts (P2)** — a capture that ignores cancellation past the new configurable `CancellationGracePeriod` fails the source terminally instead of retrying: retrying would stack additional live requests onto an unresponsive source outside the concurrency accounting. Cooperative timeouts (the adapter honors its token) remain retryable.

## Reason

The second Codex review round on #2538 arrived immediately before merge; all four findings verified as genuine against the merged code. The wall-clock settlement window contradicted the floor's documented business-day semantics on the single most common reconciliation timing case (weekend settlement), and the scheduler findings closed real availability holes in the capture path.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully (not run in this environment; solution-wide `dotnet build Meridian.sln -c Release` is clean)
- [x] Relevant unit tests were added or updated (weekend/business-day matching, intraday non-relaxation, weekend split legs, three-snapshot exact cash group with same-side excess, blocking-synchronous-adapter fencing, terminal non-cooperative timeout; reconciliation suite 124/124 across three consecutive runs)
- [x] Relevant integration tests were added or updated (scheduler policy tests exercise dispatch, deadline, grace, and cancellation end-to-end)
- [ ] GitHub Actions `quality-gate` passed (pending on this PR)

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

Check every governance file modified:

- [x] No governance files changed
- [ ] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`

Governance-file changes require explicit human approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179oe9HfMUerHtsD6AnQ9re

---
_Generated by [Claude Code](https://claude.ai/code/session_0179oe9HfMUerHtsD6AnQ9re)_