### PR TITLE
Activate the wash-sale engine and give realized gains a tax character

### DIFF
--- a/src/Meridian.Application/SecurityMaster/SecurityMasterCostBasisAdjustmentService.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityMasterCostBasisAdjustmentService.cs
@@ -100,6 +100,10 @@ public sealed class SecurityMasterCostBasisAdjustmentService : ISecurityMasterCo
         // ahead of the ones sourced from the Security Master.
         var combined = baseInput.BasisAdjustments.Concat(adjustments).ToArray();
 
+        // Every field of the base input has to be carried forward, not just the adjustments: the
+        // wash-sale policy and replacement acquisitions were previously dropped here, so a caller
+        // that resolved replacements lost them the moment it routed through Security Master
+        // enrichment and silently recognized a loss the policy meant to defer.
         var enrichedInput = new LedgerTaxLotReliefInput(
             baseInput.Account,
             baseInput.SaleDate,
@@ -109,7 +113,9 @@ public sealed class SecurityMasterCostBasisAdjustmentService : ISecurityMasterCo
             baseInput.OpenLots,
             baseInput.FinancialAccountId,
             baseInput.SpecificLotIds,
-            combined);
+            combined,
+            baseInput.WashSalePolicy,
+            baseInput.ReplacementAcquisitions);
 
         return LedgerTaxLotReliefProjector.Project(enrichedInput);
     }

--- a/src/Meridian.Ledger/IWashSaleReplacementResolver.cs
+++ b/src/Meridian.Ledger/IWashSaleReplacementResolver.cs
@@ -1,0 +1,69 @@
+namespace Meridian.Ledger;
+
+/// <summary>
+/// The question a wash-sale replacement search answers: for this loss-generating disposal, which
+/// acquisitions of the same security fall inside the policy window, and which prior deferrals have
+/// already been capitalized into the lots being relieved?
+/// </summary>
+/// <param name="LedgerBookId">The disposing ledger book; also the search boundary for <see cref="WashSaleReplacementScope.LedgerBook"/>.</param>
+/// <param name="DisposingAccount">The account the disposal relieves lots from.</param>
+/// <param name="SecurityId">Security Master identity of the sold security. Replacements must be substantially identical.</param>
+/// <param name="SaleDate">Sale date the ±<see cref="WashSalePolicy.WindowDays"/> window centres on.</param>
+/// <param name="Policy">The policy in force for this sale; supplies the window and the account scope.</param>
+/// <param name="RelievedLotIds">
+/// Lots being relieved by this disposal. They are excluded from the replacement candidates — a lot
+/// cannot be its own replacement, and matching one would disallow a loss against itself.
+/// </param>
+public sealed record WashSaleReplacementQuery(
+    Guid LedgerBookId,
+    LedgerAccount DisposingAccount,
+    Guid SecurityId,
+    DateOnly SaleDate,
+    WashSalePolicy Policy,
+    IReadOnlyList<string> RelievedLotIds);
+
+/// <summary>
+/// What a <see cref="IWashSaleReplacementResolver"/> found for one disposal.
+/// </summary>
+/// <param name="Replacements">
+/// Candidate replacement acquisitions inside the policy window. The relief engine still filters
+/// these by window and security, so a resolver may return a slightly wider set without changing the
+/// computed deferral.
+/// </param>
+/// <param name="PriorDeferrals">
+/// Wash-sale deferrals already capitalized into the lots this disposal is relieving, expressed as
+/// <see cref="LedgerTaxLotBasisAdjustmentKind.WashSale"/> basis adjustments. Feeding these back in
+/// is what makes a deferral survive to the sale that finally recognizes it: the replacement lot is
+/// relieved at its increased basis and with the carried holding period, rather than at the raw
+/// price it was bought for.
+/// </param>
+public sealed record WashSaleReplacementLookup(
+    IReadOnlyList<WashSaleReplacementAcquisition> Replacements,
+    IReadOnlyList<LedgerTaxLotBasisAdjustment> PriorDeferrals)
+{
+    /// <summary>Nothing found; relief proceeds exactly as if wash-sale matching were disabled.</summary>
+    public static WashSaleReplacementLookup Empty { get; } = new([], []);
+
+    /// <summary>True when neither a replacement nor a prior deferral affects this disposal.</summary>
+    public bool IsEmpty => Replacements.Count == 0 && PriorDeferrals.Count == 0;
+}
+
+/// <summary>
+/// Resolves the replacement acquisitions a wash-sale evaluation needs. This is the seam that was
+/// missing between the relief engine and durable tax-lot history: <see cref="LedgerTaxLotReliefProjector"/>
+/// has always been able to compute a deferral, but only if someone handed it the replacements to
+/// match against.
+/// <para>
+/// Implementations run one indexed query per loss-generating disposal, so the search is scoped by
+/// <see cref="WashSaleReplacementQuery.SecurityId"/> and the policy window rather than scanning
+/// lot history.
+/// </para>
+/// </summary>
+public interface IWashSaleReplacementResolver
+{
+    /// <summary>
+    /// Finds replacement acquisitions and prior deferrals for <paramref name="query"/>. Returns
+    /// <see cref="WashSaleReplacementLookup.Empty"/> when the policy does not govern the sale date.
+    /// </summary>
+    Task<WashSaleReplacementLookup> ResolveAsync(WashSaleReplacementQuery query, CancellationToken ct = default);
+}

--- a/src/Meridian.Ledger/LedgerReportPackBuilder.cs
+++ b/src/Meridian.Ledger/LedgerReportPackBuilder.cs
@@ -67,7 +67,12 @@ public static class LedgerReportPackBuilder
         IReadOnlyList<LedgerTaxLotReliefProjection> projections)
     {
         var builder = new StringBuilder();
-        builder.AppendLine("SaleDate,AccountName,Symbol,FinancialAccountId,ReliefMethod,LotId,AcquiredDate,QuantityRelieved,UnitCost,Proceeds,CostBasis,RealizedGainOrLoss,DisallowedWashSaleLoss,RecognizedGainOrLoss");
+        builder.AppendLine(
+            "SaleDate,AccountName,Symbol,FinancialAccountId,ReliefMethod,LotId,AcquiredDate," +
+            "HoldingPeriodStartDate,HoldingPeriodDays,TaxCharacter,HoldingPeriodExtendedByWashSale," +
+            "QuantityRelieved,UnitCost,Proceeds,CostBasis," +
+            "RealizedGainOrLoss,DisallowedWashSaleLoss,RecognizedGainOrLoss," +
+            "ShortTermRecognizedGainOrLoss,LongTermRecognizedGainOrLoss");
 
         foreach (var projection in projections
             .OrderBy(static projection => projection.Input.SaleDate)
@@ -84,15 +89,13 @@ public static class LedgerReportPackBuilder
             // Spread the disallowed amount across the relieved lots by quantity so each row's
             // recognized gain/loss nets to what was actually booked (residual on the final row),
             // instead of the export overstating the current-period realized loss.
-            var disallowedTotal = projection.WashSale?.DisallowedLoss ?? 0m;
+            var disallowedTotal = projection.DisallowedWashSaleLoss;
             var totalQuantity = orderedSelections.Sum(static selection => selection.QuantityRelieved);
             var allocatedDisallowed = 0m;
 
             for (var index = 0; index < orderedSelections.Count; index++)
             {
                 var selection = orderedSelections[index];
-                var proceeds = RoundCurrency(selection.QuantityRelieved * projection.Input.SalePrice);
-                var realizedGainOrLoss = proceeds - selection.CostBasis;
 
                 decimal disallowed;
                 if (disallowedTotal == 0m)
@@ -117,7 +120,12 @@ public static class LedgerReportPackBuilder
 
                 // Disallowed loss is a positive amount that reduces the recognized loss (a realized
                 // loss is negative, so adding the deferred portion moves it toward zero).
-                var recognizedGainOrLoss = realizedGainOrLoss + disallowed;
+                var recognizedGainOrLoss = selection.RealizedGainOrLoss + disallowed;
+
+                // The recognized amount lands in exactly one of the two character columns, so a
+                // reader can total short- and long-term results by summing a column rather than
+                // pivoting on the character label. The two columns sum back to RecognizedGainOrLoss.
+                var isLongTerm = selection.TaxCharacter == TaxCharacter.LongTerm;
 
                 builder.Append(projection.Input.SaleDate.ToString("O", CultureInfo.InvariantCulture));
                 builder.Append(',');
@@ -133,19 +141,31 @@ public static class LedgerReportPackBuilder
                 builder.Append(',');
                 builder.Append(selection.Lot.AcquiredDate.ToString("O", CultureInfo.InvariantCulture));
                 builder.Append(',');
+                builder.Append(selection.Lot.HoldingPeriodStart.ToString("O", CultureInfo.InvariantCulture));
+                builder.Append(',');
+                builder.Append(selection.HoldingPeriodDays.ToString(CultureInfo.InvariantCulture));
+                builder.Append(',');
+                builder.Append(selection.TaxCharacter);
+                builder.Append(',');
+                builder.Append(selection.HoldingPeriodExtendedByWashSale ? "true" : "false");
+                builder.Append(',');
                 builder.Append(FormatDecimal(selection.QuantityRelieved));
                 builder.Append(',');
                 builder.Append(FormatDecimal(selection.UnitCost));
                 builder.Append(',');
-                builder.Append(FormatDecimal(proceeds));
+                builder.Append(FormatDecimal(selection.Proceeds));
                 builder.Append(',');
                 builder.Append(FormatDecimal(selection.CostBasis));
                 builder.Append(',');
-                builder.Append(FormatDecimal(realizedGainOrLoss));
+                builder.Append(FormatDecimal(selection.RealizedGainOrLoss));
                 builder.Append(',');
                 builder.Append(FormatDecimal(disallowed));
                 builder.Append(',');
-                builder.AppendLine(FormatDecimal(recognizedGainOrLoss));
+                builder.Append(FormatDecimal(recognizedGainOrLoss));
+                builder.Append(',');
+                builder.Append(FormatDecimal(isLongTerm ? 0m : recognizedGainOrLoss));
+                builder.Append(',');
+                builder.AppendLine(FormatDecimal(isLongTerm ? recognizedGainOrLoss : 0m));
             }
         }
 

--- a/src/Meridian.Ledger/LedgerTaxLot.cs
+++ b/src/Meridian.Ledger/LedgerTaxLot.cs
@@ -10,7 +10,8 @@ public sealed record LedgerTaxLot
         DateOnly acquiredDate,
         decimal quantity,
         decimal unitCost,
-        Guid? securityId = null)
+        Guid? securityId = null,
+        DateOnly? holdingPeriodStartDate = null)
     {
         if (string.IsNullOrWhiteSpace(lotId))
             throw new ArgumentException("Tax lot identifier must not be null or whitespace.", nameof(lotId));
@@ -18,12 +19,20 @@ public sealed record LedgerTaxLot
             throw new ArgumentOutOfRangeException(nameof(quantity), quantity, "Tax lot quantity must be positive.");
         if (unitCost < 0m)
             throw new ArgumentOutOfRangeException(nameof(unitCost), unitCost, "Tax lot unit cost cannot be negative.");
+        if (holdingPeriodStartDate is { } holdingStart && holdingStart > acquiredDate)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(holdingPeriodStartDate),
+                holdingStart,
+                "A carried holding-period start cannot be later than the lot's acquisition date; a wash sale only ever extends a holding period backward.");
+        }
 
         LotId = lotId.Trim();
         AcquiredDate = acquiredDate;
         Quantity = quantity;
         UnitCost = unitCost;
         SecurityId = securityId;
+        HoldingPeriodStartDate = holdingPeriodStartDate;
     }
 
     public string LotId { get; }
@@ -41,4 +50,18 @@ public sealed record LedgerTaxLot
     /// authoritative reference data instead of relying on quantity/unit-cost alone.
     /// </summary>
     public Guid? SecurityId { get; }
+
+    /// <summary>
+    /// Holding-period start carried onto this lot by a prior wash sale, when one applied. Under
+    /// IRC §1223(3) a replacement lot inherits the disallowed sale's holding period, so a lot that
+    /// absorbed a wash sale starts its clock before it was actually acquired. Null for a lot whose
+    /// holding period simply starts at <see cref="AcquiredDate"/>.
+    /// </summary>
+    public DateOnly? HoldingPeriodStartDate { get; }
+
+    /// <summary>
+    /// The date the lot's holding period actually starts: <see cref="HoldingPeriodStartDate"/> when
+    /// a wash sale extended it, otherwise <see cref="AcquiredDate"/>.
+    /// </summary>
+    public DateOnly HoldingPeriodStart => HoldingPeriodStartDate ?? AcquiredDate;
 }

--- a/src/Meridian.Ledger/LedgerTaxLotBasisAdjuster.cs
+++ b/src/Meridian.Ledger/LedgerTaxLotBasisAdjuster.cs
@@ -37,6 +37,7 @@ public static class LedgerTaxLotBasisAdjuster
         {
             var quantity = lot.Quantity;
             var unitCost = lot.UnitCost;
+            var holdingPeriodStart = lot.HoldingPeriodStartDate;
 
             foreach (var adjustment in ordered)
             {
@@ -44,6 +45,16 @@ public static class LedgerTaxLotBasisAdjuster
                     continue;
 
                 (quantity, unitCost) = ApplyOne(adjustment, quantity, unitCost);
+
+                // A wash sale also carries the disallowed sale's holding period onto the
+                // replacement lot (IRC §1223(3)). Several deferrals can land on one lot, so the
+                // earliest carried start wins — a holding period only ever extends backward.
+                if (adjustment.Kind == LedgerTaxLotBasisAdjustmentKind.WashSale
+                    && adjustment.HoldingPeriodCarryDate is { } carryDate
+                    && carryDate < (holdingPeriodStart ?? lot.AcquiredDate))
+                {
+                    holdingPeriodStart = carryDate;
+                }
             }
 
             quantity = RoundQuantity(quantity);
@@ -55,7 +66,8 @@ public static class LedgerTaxLotBasisAdjuster
                 lot.AcquiredDate,
                 quantity,
                 RoundUnitCost(Math.Max(0m, unitCost)),
-                lot.SecurityId));
+                lot.SecurityId,
+                holdingPeriodStart));
         }
 
         return effective;
@@ -79,6 +91,14 @@ public static class LedgerTaxLotBasisAdjuster
 
             // Premium amortization (negative) / discount accretion (positive) moves basis toward par.
             LedgerTaxLotBasisAdjustmentKind.Amortization => (quantity, Math.Max(0m, unitCost + adjustment.Value)),
+
+            // A deferred wash-sale loss is a total amount capitalized into the replacement lot, so
+            // it is spread across the lot's quantity to reach a per-unit basis increase. A lot with
+            // no remaining quantity has nothing to capitalize into and is left alone (the
+            // zero-quantity guard in Apply drops it from the effective set anyway).
+            LedgerTaxLotBasisAdjustmentKind.WashSale => (
+                quantity,
+                quantity > 0m ? unitCost + (adjustment.Value / quantity) : unitCost),
 
             _ => throw new ArgumentOutOfRangeException(nameof(adjustment), adjustment.Kind, "Unsupported basis-adjustment kind."),
         };

--- a/src/Meridian.Ledger/LedgerTaxLotBasisAdjustment.cs
+++ b/src/Meridian.Ledger/LedgerTaxLotBasisAdjustment.cs
@@ -27,13 +27,19 @@ namespace Meridian.Ledger;
 /// a null value applies to every lot matched by <paramref name="SecurityId"/>.
 /// </param>
 /// <param name="Reference">Optional provenance reference (e.g. corporate-action id or source tag).</param>
+/// <param name="HoldingPeriodCarryDate">
+/// For <see cref="LedgerTaxLotBasisAdjustmentKind.WashSale"/>, the disallowed sale's earliest
+/// relieved acquisition date, carried onto the replacement lot's holding period under IRC
+/// §1223(3). Ignored by every other kind.
+/// </param>
 public sealed record LedgerTaxLotBasisAdjustment(
     LedgerTaxLotBasisAdjustmentKind Kind,
     decimal Value,
     DateOnly EffectiveDate,
     Guid? SecurityId = null,
     string? LotId = null,
-    string? Reference = null)
+    string? Reference = null,
+    DateOnly? HoldingPeriodCarryDate = null)
 {
     /// <summary>Validates the <see cref="Value"/> magnitude against the <see cref="Kind"/>.</summary>
     public LedgerTaxLotBasisAdjustment EnsureValid()
@@ -46,6 +52,12 @@ public sealed record LedgerTaxLotBasisAdjustment(
                 throw new ArgumentOutOfRangeException(nameof(Value), Value, "Factor ratio must be positive.");
             case LedgerTaxLotBasisAdjustmentKind.ReturnOfCapital when Value < 0m:
                 throw new ArgumentOutOfRangeException(nameof(Value), Value, "Return-of-capital amount cannot be negative.");
+            case LedgerTaxLotBasisAdjustmentKind.WashSale when Value < 0m:
+                throw new ArgumentOutOfRangeException(nameof(Value), Value, "Deferred wash-sale loss cannot be negative.");
+            case LedgerTaxLotBasisAdjustmentKind.WashSale when string.IsNullOrWhiteSpace(LotId):
+                throw new ArgumentException(
+                    "A wash-sale basis adjustment must name the replacement lot it capitalizes into.",
+                    nameof(LotId));
         }
 
         return this;
@@ -60,6 +72,14 @@ public sealed record LedgerTaxLotBasisAdjustment(
             return false;
         if (!string.IsNullOrWhiteSpace(LotId) && !string.Equals(LotId, lot.LotId, StringComparison.OrdinalIgnoreCase))
             return false;
+
+        // A wash-sale deferral capitalizes into a named replacement lot that is, by construction,
+        // often acquired *after* the disallowed sale — the §1091 window is symmetric. The
+        // acquired-before-effective-date guard below protects reference-data restatements but would
+        // reject exactly those forward replacements, so wash-sale adjustments match on lot identity
+        // alone (EnsureValid guarantees LotId is present).
+        if (Kind == LedgerTaxLotBasisAdjustmentKind.WashSale)
+            return !string.IsNullOrWhiteSpace(LotId);
 
         // Only lots that existed before the adjustment's economic effect are restated; a lot
         // acquired on or after the ex-date already reflects the post-event terms.

--- a/src/Meridian.Ledger/LedgerTaxLotBasisAdjustmentKind.cs
+++ b/src/Meridian.Ledger/LedgerTaxLotBasisAdjustmentKind.cs
@@ -39,4 +39,15 @@ public enum LedgerTaxLotBasisAdjustmentKind
     /// toward par (floored at zero).
     /// </summary>
     Amortization,
+
+    /// <summary>
+    /// A wash-sale loss deferred from an earlier disposal and capitalized into this replacement lot
+    /// under IRC §1091(d). <see cref="LedgerTaxLotBasisAdjustment.Value"/> is the total (not
+    /// per-unit) disallowed amount added to the lot's basis, spread across the lot's quantity, and
+    /// <see cref="LedgerTaxLotBasisAdjustment.HoldingPeriodCarryDate"/> carries the disallowed
+    /// sale's holding-period start onto the replacement under §1223(3). Unlike the reference-data
+    /// kinds this adjustment targets one named lot and applies whether the replacement was acquired
+    /// before or after the sale, because the §1091 window is symmetric.
+    /// </summary>
+    WashSale,
 }

--- a/src/Meridian.Ledger/LedgerTaxLotReliefHistoryProjector.cs
+++ b/src/Meridian.Ledger/LedgerTaxLotReliefHistoryProjector.cs
@@ -1,0 +1,147 @@
+namespace Meridian.Ledger;
+
+/// <summary>One lot relieved by a retained disposal, as recorded at the time it was booked.</summary>
+/// <param name="HoldingPeriodStart">
+/// The lot's effective holding-period start — its acquisition date unless an earlier wash sale
+/// carried a start onto it.
+/// </param>
+public sealed record LedgerTaxLotDisposalHistoryLot(
+    string LotId,
+    DateOnly AcquiredDate,
+    DateOnly HoldingPeriodStart,
+    decimal Quantity,
+    decimal UnitCost,
+    decimal CostBasis);
+
+/// <summary>
+/// A disposal as retained in durable tax-lot history, with enough of the original economics to
+/// rebuild the relief projection that produced it.
+/// </summary>
+/// <param name="RecognizedGainOrLoss">
+/// The gain or loss actually booked to the ledger by this disposal (gain credits less loss debits).
+/// It excludes any wash-sale deferral, which is why <paramref name="WashSaleBasisIncreases"/> is
+/// needed to recover the full economic result.
+/// </param>
+/// <param name="WashSaleBasisIncreases">Deferrals retained against this disposal, empty when none applied.</param>
+/// <param name="MatchedReplacementQuantity">Replacement shares that drove the deferral, or zero when none applied.</param>
+public sealed record LedgerTaxLotDisposalHistory(
+    Guid MutationBatchId,
+    Guid JournalEntryId,
+    LedgerAccount Account,
+    DateOnly SaleDate,
+    LedgerTaxLotReliefMethod ReliefMethod,
+    IReadOnlyList<LedgerTaxLotDisposalHistoryLot> Lots,
+    decimal RecognizedGainOrLoss,
+    IReadOnlyList<WashSaleBasisIncrease> WashSaleBasisIncreases,
+    decimal MatchedReplacementQuantity)
+{
+    /// <summary>Total wash-sale loss deferred out of this disposal.</summary>
+    public decimal DisallowedWashSaleLoss
+        => WashSaleBasisIncreases.Sum(static increase => increase.Amount);
+}
+
+/// <summary>
+/// Rebuilds <see cref="LedgerTaxLotReliefProjection"/>s from retained disposal history so a governed
+/// report pack can carry real realized-gain rows.
+/// <para>
+/// The pack's tax-lot artifact accepts projections but production never supplied any, so it shipped
+/// as a header with no rows — including a <c>DisallowedWashSaleLoss</c> column that could never
+/// report anything. This projector closes that gap from durable history rather than requiring the
+/// original in-memory projection to have been kept.
+/// </para>
+/// </summary>
+public static class LedgerTaxLotReliefHistoryProjector
+{
+    /// <summary>
+    /// Rebuilds one disposal's projection, or returns <c>null</c> when the retained economics cannot
+    /// produce a well-formed one. Returning null rather than throwing is deliberate: a report pack
+    /// must not fail to generate because a single historical row is unreconstructable — the caller
+    /// reports the omission instead.
+    /// </summary>
+    public static LedgerTaxLotReliefProjection? Project(LedgerTaxLotDisposalHistory history)
+    {
+        ArgumentNullException.ThrowIfNull(history);
+
+        if (history.Lots.Count == 0)
+            return null;
+
+        var quantitySold = history.Lots.Sum(static lot => lot.Quantity);
+        if (quantitySold <= 0m)
+            return null;
+
+        // Proceeds are recovered rather than stored: recognized = proceeds - basis - deferred, so
+        // proceeds = basis + recognized + deferred. Deriving them from the booked gain/loss keeps the
+        // rebuilt rows tied to the journal instead of to a separately-recorded price that could drift.
+        var retainedCostBasis = history.Lots.Sum(static lot => lot.CostBasis);
+        var disallowed = history.DisallowedWashSaleLoss;
+        var proceeds = retainedCostBasis + history.RecognizedGainOrLoss - disallowed;
+        if (proceeds < 0m)
+            return null;
+
+        var salePrice = proceeds / quantitySold;
+
+        LedgerTaxLotReliefProjection projection;
+        try
+        {
+            projection = LedgerTaxLotReliefProjector.Project(BuildInput(history, quantitySold, salePrice));
+        }
+        catch (Exception exception) when (exception is ArgumentException or InvalidOperationException)
+        {
+            // Retained history that no longer satisfies the relief engine's invariants (a zero-quantity
+            // lot, a duplicate SpecificId selection) is skipped rather than aborting the whole pack.
+            return null;
+        }
+
+        if (history.WashSaleBasisIncreases.Count == 0)
+            return projection;
+
+        // The retained outcome is attached rather than recomputed: the pack must report the deferral
+        // that was actually booked, not one re-derived from today's replacement history.
+        var economicLoss = projection.RealizedGainOrLoss < 0m ? -projection.RealizedGainOrLoss : 0m;
+        return projection with
+        {
+            WashSale = new WashSaleOutcome(
+                disallowed,
+                Math.Max(0m, economicLoss - disallowed),
+                history.MatchedReplacementQuantity,
+                history.WashSaleBasisIncreases),
+        };
+    }
+
+    private static LedgerTaxLotReliefInput BuildInput(
+        LedgerTaxLotDisposalHistory history,
+        decimal quantitySold,
+        decimal salePrice)
+        => new(
+            history.Account,
+            history.SaleDate,
+            quantitySold,
+            RoundUnitPrice(salePrice),
+            history.ReliefMethod,
+            history.Lots
+                .Select(static lot => new LedgerTaxLot(
+                    lot.LotId,
+                    lot.AcquiredDate,
+                    lot.Quantity,
+                    lot.UnitCost,
+                    securityId: null,
+                    // Guard the invariant rather than trusting history: a start later than
+                    // acquisition would throw, and it can only mean the row predates the carry.
+                    holdingPeriodStartDate: lot.HoldingPeriodStart <= lot.AcquiredDate
+                        ? lot.HoldingPeriodStart
+                        : null))
+                .ToArray(),
+            financialAccountId: history.Account.FinancialAccountId,
+            // Every retained lot is fully consumed by this disposal, so lot-discrete methods all
+            // select the same set; SpecificId additionally needs them named in relief order.
+            specificLotIds: history.ReliefMethod == LedgerTaxLotReliefMethod.SpecificId
+                ? history.Lots.Select(static lot => lot.LotId).ToArray()
+                : null);
+
+    /// <summary>
+    /// Rounds a recovered per-unit price to a precision that survives re-multiplication by the sold
+    /// quantity. Currency rounding would lose too much on a low-priced, high-quantity disposal.
+    /// </summary>
+    private static decimal RoundUnitPrice(decimal salePrice)
+        => decimal.Round(salePrice, 10, MidpointRounding.AwayFromZero);
+}

--- a/src/Meridian.Ledger/LedgerTaxLotReliefProjection.cs
+++ b/src/Meridian.Ledger/LedgerTaxLotReliefProjection.cs
@@ -28,10 +28,38 @@ public sealed record LedgerTaxLotReliefProjection(
 
     /// <summary>
     /// Wash-sale deferral outcome when a realized loss was disallowed against replacement
-    /// acquisitions. Null when no wash sale applied (a gain, no replacements, or a disabled policy).
-    /// When present, <see cref="RealizedGainOrLoss"/> still reports the full economic loss, while
-    /// <see cref="Lines"/> recognize only <see cref="WashSaleOutcome.AllowedLoss"/> and capitalize
+    /// acquisitions. Null when no wash sale applied (a gain, no replacements, or a policy that does
+    /// not govern this sale date). When present, <see cref="RealizedGainOrLoss"/> still reports the
+    /// full economic loss, while <see cref="Lines"/> recognize only
+    /// <see cref="WashSaleOutcome.AllowedLoss"/> and capitalize
     /// <see cref="WashSaleOutcome.DisallowedLoss"/> into the replacement lot's basis.
     /// </summary>
     public WashSaleOutcome? WashSale { get; init; }
+
+    /// <summary>
+    /// The wash-sale loss deferred out of this period, or zero when no deferral applied. Convenience
+    /// accessor for exports and read models that would otherwise repeat the null coalesce.
+    /// </summary>
+    public decimal DisallowedWashSaleLoss => WashSale?.DisallowedLoss ?? 0m;
+
+    /// <summary>
+    /// The gain or loss actually recognized on the ledger this period: the full economic result less
+    /// any deferred wash-sale portion. A realized loss is negative, so adding back the (positive)
+    /// disallowed amount moves it toward zero.
+    /// </summary>
+    public decimal RecognizedGainOrLoss => RealizedGainOrLoss + DisallowedWashSaleLoss;
+
+    /// <summary>
+    /// Economic result from parcels held one year or less. Parcel amounts are allocated so this and
+    /// <see cref="LongTermRealizedGainOrLoss"/> sum exactly to <see cref="RealizedGainOrLoss"/>.
+    /// </summary>
+    public decimal ShortTermRealizedGainOrLoss => SumByCharacter(TaxCharacter.ShortTerm);
+
+    /// <summary>Economic result from parcels held more than one year.</summary>
+    public decimal LongTermRealizedGainOrLoss => SumByCharacter(TaxCharacter.LongTerm);
+
+    private decimal SumByCharacter(TaxCharacter character)
+        => Selections
+            .Where(selection => selection.TaxCharacter == character)
+            .Sum(static selection => selection.RealizedGainOrLoss);
 }

--- a/src/Meridian.Ledger/LedgerTaxLotReliefProjector.cs
+++ b/src/Meridian.Ledger/LedgerTaxLotReliefProjector.cs
@@ -20,8 +20,9 @@ public static class LedgerTaxLotReliefProjector
 
         var orderedLots = OrderLots(input, effectiveLots).ToList();
         var averageUnitCost = ResolveAverageUnitCost(input.ReliefMethod, effectiveLots);
-        var selections = SelectLots(input.QuantitySold, orderedLots, averageUnitCost);
+        var parcels = SelectLots(input.QuantitySold, orderedLots, averageUnitCost);
         var proceeds = RoundCurrency(input.QuantitySold * input.SalePrice);
+        var selections = BuildSelections(parcels, input.SalePrice, proceeds, input.SaleDate);
         var costBasis = selections.Sum(static selection => selection.CostBasis);
         var realizedGainOrLoss = proceeds - costBasis;
         var washSale = ComputeWashSale(input, selections, realizedGainOrLoss);
@@ -97,7 +98,18 @@ public static class LedgerTaxLotReliefProjector
         }
     }
 
-    private static IReadOnlyList<LedgerTaxLotReliefSelection> SelectLots(
+    /// <summary>
+    /// One lot's share of the sale, priced but not yet attributed proceeds or holding-period
+    /// character. Splitting parcel pricing from parcel attribution keeps the average-cost residual
+    /// logic (which works on cost) separate from the proceeds residual logic (which works on price).
+    /// </summary>
+    private readonly record struct ReliefParcel(
+        LedgerTaxLot Lot,
+        decimal Quantity,
+        decimal CostBasis,
+        decimal UnitCost);
+
+    private static IReadOnlyList<ReliefParcel> SelectLots(
         decimal quantitySold,
         IReadOnlyList<LedgerTaxLot> orderedLots,
         decimal? averageUnitCost)
@@ -114,7 +126,7 @@ public static class LedgerTaxLotReliefProjector
         if (averageUnitCost is not { } pooledUnitCost)
         {
             return slices
-                .Select(static slice => new LedgerTaxLotReliefSelection(
+                .Select(static slice => new ReliefParcel(
                     slice.Lot,
                     slice.Quantity,
                     RoundCurrency(slice.Quantity * slice.Lot.UnitCost),
@@ -127,7 +139,7 @@ public static class LedgerTaxLotReliefProjector
         // sum exactly to the rounded pooled basis (no cent drift across lots). Each slice reports the
         // unit cost implied by its rounded basis so the realized-gain export ties per row.
         var totalCostBasis = RoundCurrency(slices.Sum(static slice => slice.Quantity) * pooledUnitCost);
-        var selections = new List<LedgerTaxLotReliefSelection>(slices.Count);
+        var parcels = new List<ReliefParcel>(slices.Count);
         var allocated = 0m;
 
         for (var index = 0; index < slices.Count; index++)
@@ -145,7 +157,54 @@ public static class LedgerTaxLotReliefProjector
             }
 
             var reportedUnitCost = slice.Quantity != 0m ? costBasis / slice.Quantity : pooledUnitCost;
-            selections.Add(new LedgerTaxLotReliefSelection(slice.Lot, slice.Quantity, costBasis, reportedUnitCost));
+            parcels.Add(new ReliefParcel(slice.Lot, slice.Quantity, costBasis, reportedUnitCost));
+        }
+
+        return parcels;
+    }
+
+    /// <summary>
+    /// Attributes proceeds and holding-period character to each priced parcel. Proceeds are
+    /// allocated with the rounding residual on the final parcel so the per-parcel amounts sum
+    /// exactly to <paramref name="totalProceeds"/>; a realized-gain export can then report row
+    /// amounts that tie to the journal instead of re-deriving them and drifting a cent.
+    /// </summary>
+    private static IReadOnlyList<LedgerTaxLotReliefSelection> BuildSelections(
+        IReadOnlyList<ReliefParcel> parcels,
+        decimal salePrice,
+        decimal totalProceeds,
+        DateOnly saleDate)
+    {
+        var selections = new List<LedgerTaxLotReliefSelection>(parcels.Count);
+        var allocatedProceeds = 0m;
+
+        for (var index = 0; index < parcels.Count; index++)
+        {
+            var parcel = parcels[index];
+            decimal parcelProceeds;
+            if (index == parcels.Count - 1)
+            {
+                parcelProceeds = totalProceeds - allocatedProceeds;
+            }
+            else
+            {
+                parcelProceeds = RoundCurrency(parcel.Quantity * salePrice);
+                allocatedProceeds += parcelProceeds;
+            }
+
+            // The holding period runs from the lot's effective start, which an earlier wash sale may
+            // have moved before the lot was actually acquired (IRC §1223(3)).
+            var holdingPeriodStart = parcel.Lot.HoldingPeriodStart;
+            selections.Add(new LedgerTaxLotReliefSelection(
+                parcel.Lot,
+                parcel.Quantity,
+                parcel.CostBasis,
+                parcel.UnitCost,
+                parcelProceeds,
+                parcelProceeds - parcel.CostBasis,
+                TaxCharacterRule.Classify(holdingPeriodStart, saleDate),
+                TaxCharacterRule.HoldingPeriodDays(holdingPeriodStart, saleDate),
+                parcel.Lot.HoldingPeriodStartDate is not null));
         }
 
         return selections;
@@ -168,7 +227,9 @@ public static class LedgerTaxLotReliefProjector
         IReadOnlyList<LedgerTaxLotReliefSelection> selections,
         decimal realizedGainOrLoss)
     {
-        if (!input.WashSalePolicy.Enabled || realizedGainOrLoss >= 0m || input.ReplacementAcquisitions.Count == 0)
+        // AppliesOn (not Enabled) gates the policy so a dated activation leaves sales before its
+        // effective date reporting exactly the numbers they were originally closed with.
+        if (!input.WashSalePolicy.AppliesOn(input.SaleDate) || realizedGainOrLoss >= 0m || input.ReplacementAcquisitions.Count == 0)
             return null;
 
         var soldSecurityId = ResolveSoldSecurityId(selections);
@@ -197,10 +258,13 @@ public static class LedgerTaxLotReliefProjector
         // Never disallow more than the recognized loss after rounding.
         disallowedLoss = Math.Min(disallowedLoss, totalLoss);
         var allowedLoss = totalLoss - disallowedLoss;
-        // Earliest relieved acquisition date carries the sold shares' holding period onto the
-        // replacement lot. Min over DayNumber keeps the result an unambiguous DateOnly.
+        // The earliest relieved holding-period start carries the sold shares' holding period onto
+        // the replacement lot (IRC §1223(3)). Using the effective start rather than the raw
+        // acquisition date is what lets deferrals chain: a replacement lot that already absorbed an
+        // earlier wash sale passes that older start along instead of resetting it to its own
+        // purchase date. Min over DayNumber keeps the result an unambiguous DateOnly.
         var holdingPeriodCarryDate = DateOnly.FromDayNumber(
-            selections.Min(static selection => selection.Lot.AcquiredDate.DayNumber));
+            selections.Min(static selection => selection.Lot.HoldingPeriodStart.DayNumber));
         var basisIncreases = DistributeBasisIncreases(matching, matchedQuantity, disallowedLoss, holdingPeriodCarryDate);
 
         return new WashSaleOutcome(disallowedLoss, allowedLoss, matchedQuantity, basisIncreases);
@@ -241,7 +305,10 @@ public static class LedgerTaxLotReliefProjector
         DateOnly holdingPeriodCarryDate)
     {
         // Consume replacement shares oldest-first up to the matched quantity, aggregating per lot.
-        var consumedByLot = new List<(string LotId, decimal Quantity)>();
+        // The replacement's account travels with it so a deferral can be traced to the exact account
+        // that absorbed it — which is the whole point of a book-wide replacement scope, where the
+        // absorbing account is frequently not the one that sold.
+        var consumedByLot = new List<(string LotId, decimal Quantity, LedgerAccount? Account)>();
         var remainingToMatch = matchedQuantity;
         foreach (var replacement in matching
             .OrderBy(static replacement => replacement.AcquiredDate)
@@ -255,9 +322,16 @@ public static class LedgerTaxLotReliefProjector
 
             var existing = consumedByLot.FindIndex(lot => string.Equals(lot.LotId, replacement.LotId, StringComparison.OrdinalIgnoreCase));
             if (existing >= 0)
-                consumedByLot[existing] = (replacement.LotId, consumedByLot[existing].Quantity + consumed);
+            {
+                consumedByLot[existing] = (
+                    replacement.LotId,
+                    consumedByLot[existing].Quantity + consumed,
+                    consumedByLot[existing].Account ?? replacement.Account);
+            }
             else
-                consumedByLot.Add((replacement.LotId, consumed));
+            {
+                consumedByLot.Add((replacement.LotId, consumed, replacement.Account));
+            }
         }
 
         var totalConsumed = consumedByLot.Sum(static lot => lot.Quantity);
@@ -275,7 +349,13 @@ public static class LedgerTaxLotReliefProjector
                 : Math.Min(remaining, RoundCurrency(disallowedLoss * (consumedByLot[index].Quantity / totalConsumed)));
             allocated += amount;
             if (amount != 0m)
-                increases.Add(new WashSaleBasisIncrease(consumedByLot[index].LotId, amount, holdingPeriodCarryDate));
+            {
+                increases.Add(new WashSaleBasisIncrease(
+                    consumedByLot[index].LotId,
+                    amount,
+                    holdingPeriodCarryDate,
+                    consumedByLot[index].Account));
+            }
         }
 
         return increases;

--- a/src/Meridian.Ledger/LedgerTaxLotReliefSelection.cs
+++ b/src/Meridian.Ledger/LedgerTaxLotReliefSelection.cs
@@ -1,17 +1,44 @@
 namespace Meridian.Ledger;
 
 /// <summary>
-/// Quantity and cost relieved from one tax lot. <see cref="UnitCost"/> is the effective per-share
-/// cost used to relieve the shares: each lot's own recorded unit cost for lot-discrete methods
-/// (FIFO/LIFO/HIFO/SpecificId), or the unit cost implied by the rounded pooled basis
+/// Quantity, proceeds, and cost relieved from one tax lot. <see cref="UnitCost"/> is the effective
+/// per-share cost used to relieve the shares: each lot's own recorded unit cost for lot-discrete
+/// methods (FIFO/LIFO/HIFO/SpecificId), or the unit cost implied by the rounded pooled basis
 /// (<see cref="CostBasis"/> / <see cref="QuantityRelieved"/>) for
 /// <see cref="LedgerTaxLotReliefMethod.AverageCost"/>. Reporting the implied unit cost keeps a
 /// realized-gain row consistent with its cost basis instead of showing a raw lot cost against a
 /// pooled basis. For a repeating pooled average the implied unit cost is the nearest per-share value
 /// to the rounded basis; <see cref="CostBasis"/> is always the authoritative amount.
 /// </summary>
+/// <param name="Lot">The lot the shares were relieved from.</param>
+/// <param name="QuantityRelieved">Shares relieved from <paramref name="Lot"/>.</param>
+/// <param name="CostBasis">Authoritative rounded cost basis for the relieved shares.</param>
+/// <param name="UnitCost">Effective per-share cost described above.</param>
+/// <param name="Proceeds">
+/// Sale proceeds attributed to this parcel. Parcel proceeds are allocated so they sum exactly to
+/// the projection's rounded total, with the rounding residual carried onto the final parcel — a
+/// per-row export therefore ties to the journal rather than drifting a cent across lots.
+/// </param>
+/// <param name="RealizedGainOrLoss">
+/// <paramref name="Proceeds"/> less <paramref name="CostBasis"/> for this parcel. This is the full
+/// economic result; any wash-sale deferral is reported separately on the projection.
+/// </param>
+/// <param name="TaxCharacter">
+/// Short- or long-term character of this parcel, classified from the lot's effective
+/// holding-period start (which a prior wash sale may have moved earlier than acquisition).
+/// </param>
+/// <param name="HoldingPeriodDays">Whole days from the effective holding-period start to the sale date.</param>
+/// <param name="HoldingPeriodExtendedByWashSale">
+/// True when a prior wash sale carried an earlier holding-period start onto this lot, so the
+/// character reflects the disallowed sale's holding period rather than the lot's own acquisition.
+/// </param>
 public sealed record LedgerTaxLotReliefSelection(
     LedgerTaxLot Lot,
     decimal QuantityRelieved,
     decimal CostBasis,
-    decimal UnitCost);
+    decimal UnitCost,
+    decimal Proceeds,
+    decimal RealizedGainOrLoss,
+    TaxCharacter TaxCharacter,
+    int HoldingPeriodDays,
+    bool HoldingPeriodExtendedByWashSale);

--- a/src/Meridian.Ledger/TaxCharacter.cs
+++ b/src/Meridian.Ledger/TaxCharacter.cs
@@ -1,0 +1,46 @@
+namespace Meridian.Ledger;
+
+/// <summary>
+/// Capital-gain character of a relieved tax lot. This is the split every downstream statement
+/// (1099-B box, K-1 line, investor tax letter) needs, so the ledger carries it on the relief
+/// projection rather than leaving it to be re-derived per report.
+/// </summary>
+public enum TaxCharacter
+{
+    /// <summary>Held for one year or less; taxed at ordinary rates.</summary>
+    ShortTerm,
+
+    /// <summary>Held for more than one year.</summary>
+    LongTerm,
+}
+
+/// <summary>
+/// Holding-period classification for realized gains and losses.
+/// </summary>
+public static class TaxCharacterRule
+{
+    /// <summary>
+    /// Classifies a disposal by holding period under IRC §1222/§1223: the holding period starts the
+    /// day after acquisition and must exceed one year to be long-term, so a lot acquired on
+    /// 2025-01-01 becomes long-term only when sold on 2026-01-02 or later.
+    /// <para>
+    /// The comparison uses calendar years rather than a 365-day count so a holding period spanning
+    /// a leap day is not silently promoted a day early.
+    /// </para>
+    /// </summary>
+    /// <param name="holdingPeriodStart">
+    /// The lot's effective holding-period start — its acquisition date, or an earlier date carried
+    /// forward from a prior wash sale (see <see cref="LedgerTaxLot.HoldingPeriodStart"/>).
+    /// </param>
+    /// <param name="disposalDate">The sale date.</param>
+    public static TaxCharacter Classify(DateOnly holdingPeriodStart, DateOnly disposalDate)
+        => disposalDate > holdingPeriodStart.AddYears(1) ? TaxCharacter.LongTerm : TaxCharacter.ShortTerm;
+
+    /// <summary>
+    /// Whole days held, measured from the effective holding-period start to the disposal date.
+    /// Reported alongside <see cref="Classify"/> so an operator can see how close a lot sits to the
+    /// long-term boundary. Negative spans (a disposal dated before the start) clamp to zero.
+    /// </summary>
+    public static int HoldingPeriodDays(DateOnly holdingPeriodStart, DateOnly disposalDate)
+        => Math.Max(0, disposalDate.DayNumber - holdingPeriodStart.DayNumber);
+}

--- a/src/Meridian.Ledger/WashSale.cs
+++ b/src/Meridian.Ledger/WashSale.cs
@@ -1,6 +1,28 @@
 namespace Meridian.Ledger;
 
 /// <summary>
+/// Which accounts are searched for replacement acquisitions when matching a wash sale. The scope
+/// is a policy decision rather than a fixed rule because it materially changes the disallowed
+/// amount: a repurchase booked into a sibling custody account is a wash sale under IRC §1091 but
+/// is invisible to an account-local search.
+/// </summary>
+public enum WashSaleReplacementScope
+{
+    /// <summary>
+    /// Only the account the loss-generating disposal relieved lots from. Narrowest scope; a
+    /// repurchase booked into a sibling account under the same book does not defer the loss.
+    /// </summary>
+    DisposingAccount,
+
+    /// <summary>
+    /// Every account in the disposing ledger book. A ledger book is the accounting boundary for one
+    /// taxable entity, so this is the closest available analogue to the §1091 rule that looks
+    /// across all of a taxpayer's accounts rather than a single custodian. This is the default.
+    /// </summary>
+    LedgerBook,
+}
+
+/// <summary>
 /// Wash-sale deferral policy applied when relieving a tax lot at a loss (US IRC §1091 and
 /// equivalent regimes). When enabled, a realized loss that coincides with the acquisition of a
 /// substantially-identical security within <see cref="WindowDays"/> days before or after the sale
@@ -9,7 +31,17 @@ namespace Meridian.Ledger;
 /// </summary>
 /// <param name="Enabled">When false (the default) no wash-sale adjustment is applied and relief behaves exactly as before.</param>
 /// <param name="WindowDays">Symmetric window, in days, around the sale date within which a replacement acquisition triggers deferral. Defaults to the US 30-day rule.</param>
-public sealed record WashSalePolicy(bool Enabled, int WindowDays = 30)
+/// <param name="Scope">Which accounts are searched for replacements. Defaults to the whole ledger book.</param>
+/// <param name="EffectiveDate">
+/// First sale date the policy governs. Enabling wash-sale deferral changes reported realized
+/// losses, so a policy is dated rather than flipped globally: sales before this date keep the
+/// numbers they were originally reported with. A null value applies the policy to every sale.
+/// </param>
+public sealed record WashSalePolicy(
+    bool Enabled,
+    int WindowDays = 30,
+    WashSaleReplacementScope Scope = WashSaleReplacementScope.LedgerBook,
+    DateOnly? EffectiveDate = null)
 {
     /// <summary>No wash-sale deferral; realized losses are always recognized in full.</summary>
     public static WashSalePolicy Disabled { get; } = new(false);
@@ -17,13 +49,22 @@ public sealed record WashSalePolicy(bool Enabled, int WindowDays = 30)
     /// <summary>The US IRC §1091 default: enabled with a 30-day symmetric replacement window.</summary>
     public static WashSalePolicy UnitedStates { get; } = new(true, 30);
 
-    /// <summary>Validates the window magnitude.</summary>
+    /// <summary>Validates the window magnitude and scope.</summary>
     public WashSalePolicy EnsureValid()
     {
         if (WindowDays < 0)
             throw new ArgumentOutOfRangeException(nameof(WindowDays), WindowDays, "Wash-sale window days cannot be negative.");
+        if (!Enum.IsDefined(Scope))
+            throw new ArgumentOutOfRangeException(nameof(Scope), Scope, "Unsupported wash-sale replacement scope.");
         return this;
     }
+
+    /// <summary>
+    /// True when this policy governs a sale on <paramref name="saleDate"/>. A dated policy leaves
+    /// sales before its effective date untouched so historical report packs stay reproducible.
+    /// </summary>
+    public bool AppliesOn(DateOnly saleDate)
+        => Enabled && (EffectiveDate is not { } effective || saleDate >= effective);
 }
 
 /// <summary>
@@ -36,11 +77,18 @@ public sealed record WashSalePolicy(bool Enabled, int WindowDays = 30)
 /// <param name="AcquiredDate">Acquisition date of the replacement shares.</param>
 /// <param name="Quantity">Replacement quantity acquired (must be positive to count).</param>
 /// <param name="SecurityId">Optional Security Master identity used to confirm the replacement is substantially identical to the sold shares.</param>
+/// <param name="Account">
+/// Optional account the replacement lot sits in. Populated by
+/// <see cref="IWashSaleReplacementResolver"/> so a deferral can be traced back to the exact
+/// account that absorbed it, which matters when <see cref="WashSaleReplacementScope.LedgerBook"/>
+/// pulls replacements from an account other than the disposing one.
+/// </param>
 public sealed record WashSaleReplacementAcquisition(
     string LotId,
     DateOnly AcquiredDate,
     decimal Quantity,
-    Guid? SecurityId = null);
+    Guid? SecurityId = null,
+    LedgerAccount? Account = null);
 
 /// <summary>
 /// The outcome of applying a <see cref="WashSalePolicy"/> to a loss-generating relief. Present on a
@@ -64,7 +112,9 @@ public sealed record WashSaleOutcome(
 /// <param name="ReplacementLotId">The replacement lot whose basis increases.</param>
 /// <param name="Amount">The deferred loss amount added to the replacement lot's basis.</param>
 /// <param name="HoldingPeriodCarryDate">The earliest acquisition date of the relieved (sold) lots, used to extend the replacement lot's holding period.</param>
+/// <param name="ReplacementAccount">The account holding the replacement lot, when the resolver supplied it.</param>
 public sealed record WashSaleBasisIncrease(
     string ReplacementLotId,
     decimal Amount,
-    DateOnly HoldingPeriodCarryDate);
+    DateOnly HoldingPeriodCarryDate,
+    LedgerAccount? ReplacementAccount = null);

--- a/src/Meridian.Storage/Ledger/ILedgerJournalStore.cs
+++ b/src/Meridian.Storage/Ledger/ILedgerJournalStore.cs
@@ -325,7 +325,8 @@ public sealed record LedgerAccountTaxLotPolicyRecord(
     WashSalePolicy? WashSalePolicy = null)
 {
     /// <summary>The configured wash-sale policy, or the disabled default.</summary>
-    public WashSalePolicy EffectiveWashSalePolicy => WashSalePolicy ?? Meridian.Ledger.WashSalePolicy.Disabled;
+    public WashSalePolicy EffectiveWashSalePolicy
+        => WashSalePolicy ?? global::Meridian.Ledger.WashSalePolicy.Disabled;
 }
 
 public sealed record LedgerTaxLotRecord(

--- a/src/Meridian.Storage/Ledger/ILedgerJournalStore.cs
+++ b/src/Meridian.Storage/Ledger/ILedgerJournalStore.cs
@@ -307,6 +307,11 @@ public sealed record PeriodCloseEventRecord(
     string Notes,
     DateTimeOffset RecordedAt);
 
+/// <param name="WashSalePolicy">
+/// Wash-sale deferral policy for this account, effective from the same date as the relief method.
+/// Defaults to <see cref="Meridian.Ledger.WashSalePolicy.Disabled"/> so an account that has never
+/// been configured keeps recognizing losses in full, exactly as before.
+/// </param>
 public sealed record LedgerAccountTaxLotPolicyRecord(
     Guid PolicyRecordId,
     Guid LedgerBookId,
@@ -316,7 +321,12 @@ public sealed record LedgerAccountTaxLotPolicyRecord(
     DateOnly EffectiveDate,
     DateTimeOffset CreatedAt,
     DateTimeOffset UpdatedAt,
-    string? Rationale = null);
+    string? Rationale = null,
+    WashSalePolicy? WashSalePolicy = null)
+{
+    /// <summary>The configured wash-sale policy, or the disabled default.</summary>
+    public WashSalePolicy EffectiveWashSalePolicy => WashSalePolicy ?? Meridian.Ledger.WashSalePolicy.Disabled;
+}
 
 public sealed record LedgerTaxLotRecord(
     Guid TaxLotRecordId,

--- a/src/Meridian.Storage/Ledger/Migrations/V_ledger_028__wash_sale_activation.sql
+++ b/src/Meridian.Storage/Ledger/Migrations/V_ledger_028__wash_sale_activation.sql
@@ -58,6 +58,7 @@ create table if not exists __SCHEMA__.wash_sale_deferrals (
     replacement_tax_lot_record_id uuid not null references __SCHEMA__.tax_lots(tax_lot_record_id),
     replacement_lot_id text not null,
     disallowed_amount numeric(38, 12) not null,
+    matched_quantity numeric(38, 12) not null,
     holding_period_carry_date date not null,
     policy_id text not null,
     window_days integer not null,
@@ -65,6 +66,8 @@ create table if not exists __SCHEMA__.wash_sale_deferrals (
     recorded_at timestamptz not null,
     constraint ck_wash_sale_deferrals_amount
         check (disallowed_amount > 0),
+    constraint ck_wash_sale_deferrals_matched_quantity
+        check (matched_quantity > 0),
     constraint ck_wash_sale_deferrals_security
         check (security_id <> '00000000-0000-0000-0000-000000000000'::uuid),
     constraint ck_wash_sale_deferrals_window

--- a/src/Meridian.Storage/Ledger/Migrations/V_ledger_028__wash_sale_activation.sql
+++ b/src/Meridian.Storage/Ledger/Migrations/V_ledger_028__wash_sale_activation.sql
@@ -1,0 +1,89 @@
+-- Activates the wash-sale engine that Meridian.Ledger has carried but production never fed.
+--
+-- Three things were missing durably: an effective-dated policy per account (so enabling deferral
+-- does not silently restate already-closed periods), an index that makes "find replacement
+-- acquisitions of this security within +/-30 days" cheap enough to run on every loss disposal, and
+-- retention of each deferral so a disallowed loss can be traced to the replacement lot whose basis
+-- absorbed it.
+
+-- Wash-sale policy rides on the existing effective-dated tax-lot policy so relief method and
+-- deferral policy resolve together from one row rather than drifting apart.
+alter table if exists __SCHEMA__.tax_lot_policies
+    add column if not exists wash_sale_enabled boolean not null default false,
+    add column if not exists wash_sale_window_days integer not null default 30,
+    add column if not exists wash_sale_scope text not null default 'LedgerBook',
+    add column if not exists wash_sale_effective_date date null;
+
+do $$
+begin
+    if not exists (
+        select 1
+        from pg_constraint
+        where conrelid = '__SCHEMA__.tax_lot_policies'::regclass
+          and conname = 'ck_tax_lot_policies_wash_sale') then
+        alter table __SCHEMA__.tax_lot_policies
+            add constraint ck_tax_lot_policies_wash_sale check (
+                wash_sale_window_days >= 0 and
+                wash_sale_scope in ('DisposingAccount', 'LedgerBook'));
+    end if;
+end $$;
+
+-- A replacement lot's increased basis and inherited holding period (IRC 1091(d)/1223(3)) are NOT
+-- denormalized onto tax_lots. wash_sale_deferrals below is the single source of truth: the relief
+-- engine replays retained deferrals as basis adjustments when the replacement is later relieved, so
+-- a lot's effective basis and holding-period start are always derived from the deferrals that
+-- produced them rather than from a copy that can drift out of step with a correction.
+
+-- The replacement search runs once per loss-generating disposal and is keyed by book + security +
+-- acquisition window. ix_tax_lots_asset_scope_open cannot serve it: it is partial on open quantity
+-- (a fully-disposed lot is still a valid replacement) and orders book_position_id ahead of
+-- acquired_date, which a book-wide scope does not constrain.
+create index if not exists ix_tax_lots_book_security_acquired
+    on __SCHEMA__.tax_lots (ledger_book_id, security_id, acquired_date, lot_id);
+
+-- One row per (disposal, replacement lot) pair. Retaining the deferral is what lets a later sale of
+-- the replacement relieve it at its increased basis, and what lets the report pack show which lot
+-- absorbed the loss instead of only that some amount was disallowed.
+create table if not exists __SCHEMA__.wash_sale_deferrals (
+    deferral_id uuid primary key,
+    ledger_book_id uuid not null references __SCHEMA__.ledger_books(ledger_book_id) on delete cascade,
+    disposal_mutation_batch_id uuid not null
+        references __SCHEMA__.atomic_tax_lot_posting_batches(mutation_batch_id),
+    security_id uuid not null,
+    sale_date date not null,
+    disposal_account_name text not null,
+    disposal_account_type text not null,
+    disposal_symbol text null,
+    disposal_financial_account_id text null,
+    replacement_tax_lot_record_id uuid not null references __SCHEMA__.tax_lots(tax_lot_record_id),
+    replacement_lot_id text not null,
+    disallowed_amount numeric(38, 12) not null,
+    holding_period_carry_date date not null,
+    policy_id text not null,
+    window_days integer not null,
+    scope text not null,
+    recorded_at timestamptz not null,
+    constraint ck_wash_sale_deferrals_amount
+        check (disallowed_amount > 0),
+    constraint ck_wash_sale_deferrals_security
+        check (security_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    constraint ck_wash_sale_deferrals_window
+        check (window_days >= 0),
+    constraint ck_wash_sale_deferrals_scope
+        check (scope in ('DisposingAccount', 'LedgerBook')),
+    constraint ck_wash_sale_deferrals_lot
+        check (length(trim(replacement_lot_id)) > 0)
+);
+
+-- A disposal defers at most once into any single replacement lot, so a replayed or retried batch
+-- cannot double-capitalize the same loss.
+create unique index if not exists ux_wash_sale_deferrals_batch_replacement
+    on __SCHEMA__.wash_sale_deferrals (disposal_mutation_batch_id, replacement_tax_lot_record_id);
+
+-- Serves the "what has already been capitalized into the lots I am about to relieve?" lookup.
+create index if not exists ix_wash_sale_deferrals_replacement
+    on __SCHEMA__.wash_sale_deferrals (ledger_book_id, replacement_tax_lot_record_id);
+
+-- Serves report-pack retrieval for a period.
+create index if not exists ix_wash_sale_deferrals_book_sale_date
+    on __SCHEMA__.wash_sale_deferrals (ledger_book_id, sale_date);

--- a/src/Meridian.Storage/Ledger/PostgresLedgerJournalStore.AtomicTaxLots.cs
+++ b/src/Meridian.Storage/Ledger/PostgresLedgerJournalStore.AtomicTaxLots.cs
@@ -790,7 +790,11 @@ public sealed partial class PostgresLedgerJournalStore
                    effective_date,
                    rationale,
                    created_at,
-                   updated_at
+                   updated_at,
+                   wash_sale_enabled,
+                   wash_sale_window_days,
+                   wash_sale_scope,
+                   wash_sale_effective_date
             from {Qualified("tax_lot_policies")}
             where ledger_book_id = @ledger_book_id
               and account_name = @account_name

--- a/src/Meridian.Storage/Ledger/PostgresLedgerJournalStore.TaxLotDisposalHistory.cs
+++ b/src/Meridian.Storage/Ledger/PostgresLedgerJournalStore.TaxLotDisposalHistory.cs
@@ -1,0 +1,226 @@
+using Meridian.Ledger;
+using Npgsql;
+
+namespace Meridian.Storage.Ledger;
+
+/// <summary>
+/// A retained disposal as durable history, without the two facts that live on the journal rather
+/// than in tax-lot storage: the sale's effective date and the gain or loss actually booked. The
+/// caller supplies those from the journal entries it already holds, which keeps the rebuilt rows
+/// tied to the same journals a report pack was certified over.
+/// </summary>
+public sealed record LedgerTaxLotDisposalHistoryRecord(
+    Guid MutationBatchId,
+    Guid JournalEntryId,
+    LedgerAccount Account,
+    LedgerTaxLotReliefMethod ReliefMethod,
+    IReadOnlyList<LedgerTaxLotDisposalHistoryLot> Lots,
+    IReadOnlyList<WashSaleBasisIncrease> WashSaleBasisIncreases,
+    decimal MatchedReplacementQuantity);
+
+/// <summary>
+/// Reads retained tax-lot disposal history so realized-gain reporting can be rebuilt from the
+/// durable record instead of requiring the original in-memory projection to have been kept.
+/// </summary>
+public interface ILedgerTaxLotDisposalHistory
+{
+    /// <summary>
+    /// Returns the disposals recorded against <paramref name="journalEntryIds"/>, one entry per
+    /// atomic tax-lot batch, ordered by batch. Journal ids that produced no disposal are absent.
+    /// </summary>
+    Task<IReadOnlyList<LedgerTaxLotDisposalHistoryRecord>> GetTaxLotDisposalHistoryAsync(
+        Guid ledgerBookId,
+        IReadOnlyList<Guid> journalEntryIds,
+        CancellationToken ct = default);
+}
+
+public sealed partial class PostgresLedgerJournalStore : ILedgerTaxLotDisposalHistory
+{
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<LedgerTaxLotDisposalHistoryRecord>> GetTaxLotDisposalHistoryAsync(
+        Guid ledgerBookId,
+        IReadOnlyList<Guid> journalEntryIds,
+        CancellationToken ct = default)
+    {
+        if (ledgerBookId == Guid.Empty)
+        {
+            throw new ArgumentException("Ledger book id is required.", nameof(ledgerBookId));
+        }
+
+        ArgumentNullException.ThrowIfNull(journalEntryIds);
+        var journalIds = journalEntryIds.Where(static id => id != Guid.Empty).Distinct().ToArray();
+        if (journalIds.Length == 0)
+        {
+            return [];
+        }
+
+        await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        var lotsByBatch = await LoadDisposalLotsAsync(connection, ledgerBookId, journalIds, ct).ConfigureAwait(false);
+        if (lotsByBatch.Count == 0)
+        {
+            return [];
+        }
+
+        var deferralsByBatch = await LoadDeferralsByBatchAsync(
+                connection,
+                ledgerBookId,
+                lotsByBatch.Keys.ToArray(),
+                ct)
+            .ConfigureAwait(false);
+
+        return lotsByBatch
+            .Select(batch =>
+            {
+                var hasDeferrals = deferralsByBatch.TryGetValue(batch.Key, out var retained);
+                return new LedgerTaxLotDisposalHistoryRecord(
+                    batch.Key,
+                    batch.Value.JournalEntryId,
+                    batch.Value.Account,
+                    batch.Value.ReliefMethod,
+                    batch.Value.Lots,
+                    hasDeferrals ? retained.Increases : Array.Empty<WashSaleBasisIncrease>(),
+                    hasDeferrals ? retained.MatchedQuantity : 0m);
+            })
+            .OrderBy(static record => record.MutationBatchId)
+            .ToArray();
+    }
+
+    private async Task<Dictionary<Guid, DisposalBatchAccumulator>> LoadDisposalLotsAsync(
+        NpgsqlConnection connection,
+        Guid ledgerBookId,
+        Guid[] journalIds,
+        CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            $"""
+            select batch.mutation_batch_id,
+                   batch.journal_entry_id,
+                   batch.relief_method,
+                   mutation.lot_id,
+                   mutation.quantity_delta,
+                   mutation.unit_cost,
+                   mutation.cost_basis,
+                   lot.acquired_date,
+                   lot.account_name,
+                   lot.account_type,
+                   lot.symbol,
+                   lot.financial_account_id,
+                   (select min(carried.holding_period_carry_date)
+                    from {Qualified("wash_sale_deferrals")} carried
+                    where carried.replacement_tax_lot_record_id = mutation.tax_lot_record_id) as holding_period_start
+            from {Qualified("tax_lot_mutations")} mutation
+            join {Qualified("atomic_tax_lot_posting_batches")} batch
+              on batch.mutation_batch_id = mutation.mutation_batch_id
+            join {Qualified("tax_lots")} lot
+              on lot.tax_lot_record_id = mutation.tax_lot_record_id
+            where batch.ledger_book_id = @ledger_book_id
+              and mutation.mutation_kind = 'Disposal'
+              and batch.journal_entry_id = any(@journal_entry_ids)
+            order by batch.mutation_batch_id, mutation.selection_ordinal;
+            """;
+        command.Parameters.AddWithValue("ledger_book_id", ledgerBookId);
+        command.Parameters.AddWithValue("journal_entry_ids", journalIds);
+
+        var batches = new Dictionary<Guid, DisposalBatchAccumulator>();
+        await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            var batchId = reader.GetGuid(0);
+            var acquiredDate = DateOnly.FromDateTime(reader.GetDateTime(7));
+
+            // A disposal mutation records a negative quantity delta; relief works in positive
+            // relieved quantities.
+            var quantity = Math.Abs(reader.GetDecimal(4));
+
+            // A carried holding-period start earlier than acquisition means an earlier wash sale
+            // capitalized into this lot; anything else leaves the period starting at acquisition.
+            var carriedStart = reader.IsDBNull(12) ? (DateOnly?)null : DateOnly.FromDateTime(reader.GetDateTime(12));
+            var holdingPeriodStart = carriedStart is { } carried && carried < acquiredDate ? carried : acquiredDate;
+
+            var lot = new LedgerTaxLotDisposalHistoryLot(
+                reader.GetString(3),
+                acquiredDate,
+                holdingPeriodStart,
+                quantity,
+                reader.GetDecimal(5),
+                reader.GetDecimal(6));
+
+            if (batches.TryGetValue(batchId, out var accumulator))
+            {
+                accumulator.Lots.Add(lot);
+                continue;
+            }
+
+            // relief_method is nullable on the batch; a disposal without one predates the
+            // authoritative relief-method requirement, so FIFO is assumed for presentation only.
+            var reliefMethod = reader.IsDBNull(2)
+                || !Enum.TryParse<LedgerTaxLotReliefMethod>(reader.GetString(2), ignoreCase: true, out var parsed)
+                    ? LedgerTaxLotReliefMethod.Fifo
+                    : parsed;
+
+            batches[batchId] = new DisposalBatchAccumulator(
+                reader.GetGuid(1),
+                ReadLedgerAccount(reader, 8),
+                reliefMethod,
+                new List<LedgerTaxLotDisposalHistoryLot> { lot });
+        }
+
+        return batches;
+    }
+
+    private async Task<Dictionary<Guid, (IReadOnlyList<WashSaleBasisIncrease> Increases, decimal MatchedQuantity)>>
+        LoadDeferralsByBatchAsync(
+            NpgsqlConnection connection,
+            Guid ledgerBookId,
+            Guid[] batchIds,
+            CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            $"""
+            select disposal_mutation_batch_id,
+                   replacement_lot_id,
+                   disallowed_amount,
+                   matched_quantity,
+                   holding_period_carry_date
+            from {Qualified("wash_sale_deferrals")}
+            where ledger_book_id = @ledger_book_id
+              and disposal_mutation_batch_id = any(@batch_ids)
+            order by disposal_mutation_batch_id, replacement_lot_id;
+            """;
+        command.Parameters.AddWithValue("ledger_book_id", ledgerBookId);
+        command.Parameters.AddWithValue("batch_ids", batchIds);
+
+        var byBatch = new Dictionary<Guid, (List<WashSaleBasisIncrease> Increases, decimal MatchedQuantity)>();
+        await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            var batchId = reader.GetGuid(0);
+            var increase = new WashSaleBasisIncrease(
+                reader.GetString(1),
+                reader.GetDecimal(2),
+                DateOnly.FromDateTime(reader.GetDateTime(4)));
+
+            if (byBatch.TryGetValue(batchId, out var existing))
+            {
+                existing.Increases.Add(increase);
+                continue;
+            }
+
+            // Every deferral row from one disposal records the same matched quantity, so the first
+            // row establishes it rather than the rows summing to a multiple of it.
+            byBatch[batchId] = (new List<WashSaleBasisIncrease> { increase }, reader.GetDecimal(3));
+        }
+
+        return byBatch.ToDictionary(
+            static entry => entry.Key,
+            static entry => ((IReadOnlyList<WashSaleBasisIncrease>)entry.Value.Increases, entry.Value.MatchedQuantity));
+    }
+
+    private sealed record DisposalBatchAccumulator(
+        Guid JournalEntryId,
+        LedgerAccount Account,
+        LedgerTaxLotReliefMethod ReliefMethod,
+        List<LedgerTaxLotDisposalHistoryLot> Lots);
+}

--- a/src/Meridian.Storage/Ledger/PostgresLedgerJournalStore.WashSale.cs
+++ b/src/Meridian.Storage/Ledger/PostgresLedgerJournalStore.WashSale.cs
@@ -205,6 +205,7 @@ public sealed partial class PostgresLedgerJournalStore : IWashSaleReplacementRes
                 replacement_tax_lot_record_id,
                 replacement_lot_id,
                 disallowed_amount,
+                matched_quantity,
                 holding_period_carry_date,
                 policy_id,
                 window_days,
@@ -223,6 +224,7 @@ public sealed partial class PostgresLedgerJournalStore : IWashSaleReplacementRes
                 @replacement_tax_lot_record_id,
                 @replacement_lot_id,
                 @disallowed_amount,
+                @matched_quantity,
                 @holding_period_carry_date,
                 @policy_id,
                 @window_days,
@@ -239,6 +241,7 @@ public sealed partial class PostgresLedgerJournalStore : IWashSaleReplacementRes
         command.Parameters.AddWithValue("replacement_tax_lot_record_id", deferral.ReplacementTaxLotRecordId);
         command.Parameters.AddWithValue("replacement_lot_id", deferral.ReplacementLotId.Trim());
         command.Parameters.AddWithValue("disallowed_amount", deferral.DisallowedAmount);
+        command.Parameters.AddWithValue("matched_quantity", deferral.MatchedReplacementQuantity);
         command.Parameters.AddWithValue("holding_period_carry_date", deferral.HoldingPeriodCarryDate);
         command.Parameters.AddWithValue("policy_id", RequireLineageText(deferral.PolicyId, nameof(deferral.PolicyId)));
         command.Parameters.AddWithValue("window_days", deferral.WindowDays);
@@ -283,6 +286,7 @@ public sealed partial class PostgresLedgerJournalStore : IWashSaleReplacementRes
                    replacement_tax_lot_record_id,
                    replacement_lot_id,
                    disallowed_amount,
+                   matched_quantity,
                    holding_period_carry_date,
                    policy_id,
                    window_days,
@@ -312,11 +316,12 @@ public sealed partial class PostgresLedgerJournalStore : IWashSaleReplacementRes
                 reader.GetGuid(9),
                 reader.GetString(10),
                 reader.GetDecimal(11),
-                DateOnly.FromDateTime(reader.GetDateTime(12)),
-                reader.GetString(13),
-                reader.GetInt32(14),
-                Enum.Parse<WashSaleReplacementScope>(reader.GetString(15), ignoreCase: true),
-                ReadUtcDateTimeOffset(reader, 16)));
+                reader.GetDecimal(12),
+                DateOnly.FromDateTime(reader.GetDateTime(13)),
+                reader.GetString(14),
+                reader.GetInt32(15),
+                Enum.Parse<WashSaleReplacementScope>(reader.GetString(16), ignoreCase: true),
+                ReadUtcDateTimeOffset(reader, 17)));
         }
 
         return deferrals;
@@ -365,6 +370,14 @@ public sealed partial class PostgresLedgerJournalStore : IWashSaleReplacementRes
                 nameof(deferral),
                 deferral.DisallowedAmount,
                 "A retained wash-sale deferral must carry a positive disallowed amount.");
+        }
+
+        if (deferral.MatchedReplacementQuantity <= 0m)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(deferral),
+                deferral.MatchedReplacementQuantity,
+                "A retained wash-sale deferral must carry the positive replacement quantity it matched.");
         }
 
         if (deferral.WindowDays < 0)

--- a/src/Meridian.Storage/Ledger/PostgresLedgerJournalStore.WashSale.cs
+++ b/src/Meridian.Storage/Ledger/PostgresLedgerJournalStore.WashSale.cs
@@ -1,0 +1,392 @@
+using Meridian.Ledger;
+using Npgsql;
+
+namespace Meridian.Storage.Ledger;
+
+/// <summary>
+/// Wash-sale activation: resolves the replacement acquisitions the relief engine needs and retains
+/// the deferrals it produces. Without this the engine's policy gate is never satisfied in
+/// production, so every realized loss is recognized in full regardless of a repurchase.
+/// </summary>
+public sealed partial class PostgresLedgerJournalStore : IWashSaleReplacementResolver, IWashSaleDeferralStore
+{
+    /// <inheritdoc />
+    public async Task<WashSaleReplacementLookup> ResolveAsync(
+        WashSaleReplacementQuery query,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        if (query.LedgerBookId == Guid.Empty)
+        {
+            throw new ArgumentException("Ledger book id is required.", nameof(query));
+        }
+
+        // A policy that does not govern this sale date must not change the numbers the sale would
+        // otherwise report, so the search is skipped rather than run and discarded.
+        if (!query.Policy.AppliesOn(query.SaleDate))
+        {
+            return WashSaleReplacementLookup.Empty;
+        }
+
+        // Matching requires an unambiguous "substantially identical" identity. An unidentified
+        // security cannot supply one, so no deferral is asserted rather than guessing by symbol.
+        if (query.SecurityId == Guid.Empty)
+        {
+            return WashSaleReplacementLookup.Empty;
+        }
+
+        query.Policy.EnsureValid();
+
+        await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        var replacements = await LoadReplacementAcquisitionsAsync(connection, query, ct).ConfigureAwait(false);
+        var priorDeferrals = await LoadPriorDeferralAdjustmentsAsync(connection, query, ct).ConfigureAwait(false);
+        return new WashSaleReplacementLookup(replacements, priorDeferrals);
+    }
+
+    private async Task<IReadOnlyList<WashSaleReplacementAcquisition>> LoadReplacementAcquisitionsAsync(
+        NpgsqlConnection connection,
+        WashSaleReplacementQuery query,
+        CancellationToken ct)
+    {
+        // Scope predicate is composed rather than branched into two queries so the window, security,
+        // and self-exclusion rules cannot drift between the two scopes.
+        var accountScoped = query.Policy.Scope == WashSaleReplacementScope.DisposingAccount;
+        var scopePredicate = accountScoped
+            ? "and account_name = @account_name "
+                + "and account_type = @account_type "
+                + "and symbol is not distinct from @symbol "
+                + "and financial_account_id is not distinct from @financial_account_id"
+            : string.Empty;
+
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            $"""
+            select lot_id,
+                   acquired_date,
+                   original_quantity,
+                   security_id,
+                   account_name,
+                   account_type,
+                   symbol,
+                   financial_account_id
+            from {Qualified("tax_lots")}
+            where ledger_book_id = @ledger_book_id
+              and security_id = @security_id
+              and acquired_date >= @window_start
+              and acquired_date <= @window_end
+              and original_quantity > 0
+              and lower(lot_id) <> all(@relieved_lot_ids)
+            {scopePredicate}
+            order by acquired_date, lot_id;
+            """;
+        command.Parameters.AddWithValue("ledger_book_id", query.LedgerBookId);
+        command.Parameters.AddWithValue("security_id", query.SecurityId);
+        command.Parameters.AddWithValue("window_start", query.SaleDate.AddDays(-query.Policy.WindowDays));
+        command.Parameters.AddWithValue("window_end", query.SaleDate.AddDays(query.Policy.WindowDays));
+        command.Parameters.AddWithValue("relieved_lot_ids", NormalizeLotIds(query.RelievedLotIds));
+        if (accountScoped)
+        {
+            AddAccountParameters(command, query.DisposingAccount);
+        }
+
+        var replacements = new List<WashSaleReplacementAcquisition>();
+        await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            replacements.Add(new WashSaleReplacementAcquisition(
+                reader.GetString(0),
+                DateOnly.FromDateTime(reader.GetDateTime(1)),
+                // Replacement magnitude is the quantity *acquired*, not what remains open: a lot
+                // bought and partly sold again inside the window still replaced the loss shares.
+                reader.GetDecimal(2),
+                reader.IsDBNull(3) ? null : reader.GetGuid(3),
+                ReadLedgerAccount(reader, 4)));
+        }
+
+        return replacements;
+    }
+
+    private async Task<IReadOnlyList<LedgerTaxLotBasisAdjustment>> LoadPriorDeferralAdjustmentsAsync(
+        NpgsqlConnection connection,
+        WashSaleReplacementQuery query,
+        CancellationToken ct)
+    {
+        var relievedLotIds = NormalizeLotIds(query.RelievedLotIds);
+        if (relievedLotIds.Length == 0)
+        {
+            return [];
+        }
+
+        // Deferrals previously capitalized into the lots this disposal is about to relieve. Replaying
+        // them as basis adjustments is what finally recognizes a deferred loss: the replacement is
+        // relieved at its increased basis and with the holding period it inherited, rather than at
+        // the raw price it was bought for.
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            $"""
+            select deferral.deferral_id,
+                   deferral.replacement_lot_id,
+                   deferral.disallowed_amount,
+                   deferral.sale_date,
+                   deferral.holding_period_carry_date,
+                   deferral.security_id
+            from {Qualified("wash_sale_deferrals")} deferral
+            join {Qualified("tax_lots")} lot
+              on lot.tax_lot_record_id = deferral.replacement_tax_lot_record_id
+            where deferral.ledger_book_id = @ledger_book_id
+              and deferral.security_id = @security_id
+              and lower(lot.lot_id) = any(@relieved_lot_ids)
+            order by deferral.sale_date, deferral.deferral_id;
+            """;
+        command.Parameters.AddWithValue("ledger_book_id", query.LedgerBookId);
+        command.Parameters.AddWithValue("security_id", query.SecurityId);
+        command.Parameters.AddWithValue("relieved_lot_ids", relievedLotIds);
+
+        var adjustments = new List<LedgerTaxLotBasisAdjustment>();
+        await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            adjustments.Add(new LedgerTaxLotBasisAdjustment(
+                LedgerTaxLotBasisAdjustmentKind.WashSale,
+                reader.GetDecimal(2),
+                DateOnly.FromDateTime(reader.GetDateTime(3)),
+                reader.GetGuid(5),
+                reader.GetString(1),
+                $"wash-sale-deferral:{reader.GetGuid(0):D}",
+                DateOnly.FromDateTime(reader.GetDateTime(4)))
+                .EnsureValid());
+        }
+
+        return adjustments;
+    }
+
+    /// <inheritdoc />
+    public async Task SaveWashSaleDeferralsAsync(
+        IReadOnlyList<WashSaleDeferralRecord> deferrals,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(deferrals);
+        if (deferrals.Count == 0)
+        {
+            return;
+        }
+
+        await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var transaction = await connection.BeginTransactionAsync(ct).ConfigureAwait(false);
+        foreach (var deferral in deferrals)
+        {
+            ValidateWashSaleDeferral(deferral);
+            await InsertWashSaleDeferralAsync(connection, transaction, deferral, ct).ConfigureAwait(false);
+        }
+
+        await transaction.CommitAsync(ct).ConfigureAwait(false);
+    }
+
+    private async Task InsertWashSaleDeferralAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        WashSaleDeferralRecord deferral,
+        CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText =
+            $"""
+            insert into {Qualified("wash_sale_deferrals")} (
+                deferral_id,
+                ledger_book_id,
+                disposal_mutation_batch_id,
+                security_id,
+                sale_date,
+                disposal_account_name,
+                disposal_account_type,
+                disposal_symbol,
+                disposal_financial_account_id,
+                replacement_tax_lot_record_id,
+                replacement_lot_id,
+                disallowed_amount,
+                holding_period_carry_date,
+                policy_id,
+                window_days,
+                scope,
+                recorded_at)
+            values (
+                @deferral_id,
+                @ledger_book_id,
+                @disposal_mutation_batch_id,
+                @security_id,
+                @sale_date,
+                @account_name,
+                @account_type,
+                @symbol,
+                @financial_account_id,
+                @replacement_tax_lot_record_id,
+                @replacement_lot_id,
+                @disallowed_amount,
+                @holding_period_carry_date,
+                @policy_id,
+                @window_days,
+                @scope,
+                @recorded_at)
+            on conflict (disposal_mutation_batch_id, replacement_tax_lot_record_id) do nothing;
+            """;
+        command.Parameters.AddWithValue("deferral_id", deferral.DeferralId);
+        command.Parameters.AddWithValue("ledger_book_id", deferral.LedgerBookId);
+        command.Parameters.AddWithValue("disposal_mutation_batch_id", deferral.DisposalMutationBatchId);
+        command.Parameters.AddWithValue("security_id", deferral.SecurityId);
+        command.Parameters.AddWithValue("sale_date", deferral.SaleDate);
+        AddAccountParameters(command, deferral.DisposalAccount);
+        command.Parameters.AddWithValue("replacement_tax_lot_record_id", deferral.ReplacementTaxLotRecordId);
+        command.Parameters.AddWithValue("replacement_lot_id", deferral.ReplacementLotId.Trim());
+        command.Parameters.AddWithValue("disallowed_amount", deferral.DisallowedAmount);
+        command.Parameters.AddWithValue("holding_period_carry_date", deferral.HoldingPeriodCarryDate);
+        command.Parameters.AddWithValue("policy_id", RequireLineageText(deferral.PolicyId, nameof(deferral.PolicyId)));
+        command.Parameters.AddWithValue("window_days", deferral.WindowDays);
+        command.Parameters.AddWithValue("scope", deferral.Scope.ToString());
+        command.Parameters.AddWithValue("recorded_at", deferral.RecordedAt.UtcDateTime);
+
+        await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<WashSaleDeferralRecord>> ListWashSaleDeferralsAsync(
+        Guid ledgerBookId,
+        DateOnly fromSaleDate,
+        DateOnly toSaleDate,
+        CancellationToken ct = default)
+    {
+        if (ledgerBookId == Guid.Empty)
+        {
+            throw new ArgumentException("Ledger book id is required.", nameof(ledgerBookId));
+        }
+
+        if (toSaleDate < fromSaleDate)
+        {
+            throw new ArgumentException(
+                "The deferral sale-date range end cannot precede its start.",
+                nameof(toSaleDate));
+        }
+
+        await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            $"""
+            select deferral_id,
+                   ledger_book_id,
+                   disposal_mutation_batch_id,
+                   security_id,
+                   sale_date,
+                   disposal_account_name,
+                   disposal_account_type,
+                   disposal_symbol,
+                   disposal_financial_account_id,
+                   replacement_tax_lot_record_id,
+                   replacement_lot_id,
+                   disallowed_amount,
+                   holding_period_carry_date,
+                   policy_id,
+                   window_days,
+                   scope,
+                   recorded_at
+            from {Qualified("wash_sale_deferrals")}
+            where ledger_book_id = @ledger_book_id
+              and sale_date >= @from_sale_date
+              and sale_date <= @to_sale_date
+            order by sale_date, disposal_mutation_batch_id, replacement_lot_id;
+            """;
+        command.Parameters.AddWithValue("ledger_book_id", ledgerBookId);
+        command.Parameters.AddWithValue("from_sale_date", fromSaleDate);
+        command.Parameters.AddWithValue("to_sale_date", toSaleDate);
+
+        var deferrals = new List<WashSaleDeferralRecord>();
+        await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            deferrals.Add(new WashSaleDeferralRecord(
+                reader.GetGuid(0),
+                reader.GetGuid(1),
+                reader.GetGuid(2),
+                reader.GetGuid(3),
+                DateOnly.FromDateTime(reader.GetDateTime(4)),
+                ReadLedgerAccount(reader, 5),
+                reader.GetGuid(9),
+                reader.GetString(10),
+                reader.GetDecimal(11),
+                DateOnly.FromDateTime(reader.GetDateTime(12)),
+                reader.GetString(13),
+                reader.GetInt32(14),
+                Enum.Parse<WashSaleReplacementScope>(reader.GetString(15), ignoreCase: true),
+                ReadUtcDateTimeOffset(reader, 16)));
+        }
+
+        return deferrals;
+    }
+
+    private static void ValidateWashSaleDeferral(WashSaleDeferralRecord deferral)
+    {
+        ArgumentNullException.ThrowIfNull(deferral);
+        if (deferral.DeferralId == Guid.Empty)
+        {
+            throw new ArgumentException("Deferral id is required.", nameof(deferral));
+        }
+
+        if (deferral.LedgerBookId == Guid.Empty)
+        {
+            throw new ArgumentException("Ledger book id is required.", nameof(deferral));
+        }
+
+        if (deferral.DisposalMutationBatchId == Guid.Empty)
+        {
+            throw new ArgumentException("Disposal mutation batch id is required.", nameof(deferral));
+        }
+
+        if (deferral.SecurityId == Guid.Empty)
+        {
+            throw new ArgumentException(
+                "A wash-sale deferral must identify the security it defers a loss on.",
+                nameof(deferral));
+        }
+
+        if (deferral.ReplacementTaxLotRecordId == Guid.Empty)
+        {
+            throw new ArgumentException(
+                "A wash-sale deferral must identify the replacement lot whose basis absorbed the loss.",
+                nameof(deferral));
+        }
+
+        if (string.IsNullOrWhiteSpace(deferral.ReplacementLotId))
+        {
+            throw new ArgumentException("Replacement lot identifier is required.", nameof(deferral));
+        }
+
+        if (deferral.DisallowedAmount <= 0m)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(deferral),
+                deferral.DisallowedAmount,
+                "A retained wash-sale deferral must carry a positive disallowed amount.");
+        }
+
+        if (deferral.WindowDays < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(deferral),
+                deferral.WindowDays,
+                "Wash-sale window days cannot be negative.");
+        }
+    }
+
+    /// <summary>
+    /// Lower-cases and de-duplicates lot identifiers for SQL array comparison. Lot identity is
+    /// compared case-insensitively everywhere else in relief, so the database predicate has to
+    /// agree or a replacement would match itself under a different casing.
+    /// </summary>
+    private static string[] NormalizeLotIds(IReadOnlyList<string>? lotIds)
+        => lotIds is null
+            ? []
+            : lotIds
+                .Where(static lotId => !string.IsNullOrWhiteSpace(lotId))
+                .Select(static lotId => lotId.Trim().ToLowerInvariant())
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+}

--- a/src/Meridian.Storage/Ledger/PostgresLedgerJournalStore.cs
+++ b/src/Meridian.Storage/Ledger/PostgresLedgerJournalStore.cs
@@ -702,7 +702,11 @@ public sealed partial class PostgresLedgerJournalStore :
                 effective_date,
                 rationale,
                 created_at,
-                updated_at)
+                updated_at,
+                wash_sale_enabled,
+                wash_sale_window_days,
+                wash_sale_scope,
+                wash_sale_effective_date)
             values (
                 @policy_record_id,
                 @ledger_book_id,
@@ -715,7 +719,11 @@ public sealed partial class PostgresLedgerJournalStore :
                 @effective_date,
                 @rationale,
                 @created_at,
-                @updated_at)
+                @updated_at,
+                @wash_sale_enabled,
+                @wash_sale_window_days,
+                @wash_sale_scope,
+                @wash_sale_effective_date)
             on conflict (policy_record_id) do update
             set ledger_book_id = excluded.ledger_book_id,
                 account_name = excluded.account_name,
@@ -726,7 +734,11 @@ public sealed partial class PostgresLedgerJournalStore :
                 policy_id = excluded.policy_id,
                 effective_date = excluded.effective_date,
                 rationale = excluded.rationale,
-                updated_at = excluded.updated_at
+                updated_at = excluded.updated_at,
+                wash_sale_enabled = excluded.wash_sale_enabled,
+                wash_sale_window_days = excluded.wash_sale_window_days,
+                wash_sale_scope = excluded.wash_sale_scope,
+                wash_sale_effective_date = excluded.wash_sale_effective_date
             returning policy_record_id,
                       ledger_book_id,
                       account_name,
@@ -738,7 +750,11 @@ public sealed partial class PostgresLedgerJournalStore :
                       effective_date,
                       rationale,
                       created_at,
-                      updated_at;
+                      updated_at,
+                      wash_sale_enabled,
+                      wash_sale_window_days,
+                      wash_sale_scope,
+                      wash_sale_effective_date;
             """;
         command.Parameters.AddWithValue("policy_record_id", policy.PolicyRecordId);
         command.Parameters.AddWithValue("ledger_book_id", policy.LedgerBookId);
@@ -749,6 +765,7 @@ public sealed partial class PostgresLedgerJournalStore :
         command.Parameters.AddWithValue("rationale", (object?)NormalizeOptional(policy.Rationale) ?? DBNull.Value);
         command.Parameters.AddWithValue("created_at", policy.CreatedAt.UtcDateTime);
         command.Parameters.AddWithValue("updated_at", policy.UpdatedAt.UtcDateTime);
+        AddWashSalePolicyParameters(command, policy.EffectiveWashSalePolicy);
 
         await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
         if (!await reader.ReadAsync(ct).ConfigureAwait(false))
@@ -783,7 +800,11 @@ public sealed partial class PostgresLedgerJournalStore :
                    effective_date,
                    rationale,
                    created_at,
-                   updated_at
+                   updated_at,
+                   wash_sale_enabled,
+                   wash_sale_window_days,
+                   wash_sale_scope,
+                   wash_sale_effective_date
             from {Qualified("tax_lot_policies")}
             where ledger_book_id = @ledger_book_id
             order by account_name, effective_date desc, policy_id;
@@ -1766,6 +1787,17 @@ public sealed partial class PostgresLedgerJournalStore :
         command.Parameters.AddWithValue("financial_account_id", (object?)NormalizeOptional(account.FinancialAccountId) ?? DBNull.Value);
     }
 
+    private static void AddWashSalePolicyParameters(NpgsqlCommand command, WashSalePolicy policy)
+    {
+        policy.EnsureValid();
+        command.Parameters.AddWithValue("wash_sale_enabled", policy.Enabled);
+        command.Parameters.AddWithValue("wash_sale_window_days", policy.WindowDays);
+        command.Parameters.AddWithValue("wash_sale_scope", policy.Scope.ToString());
+        command.Parameters.AddWithValue(
+            "wash_sale_effective_date",
+            policy.EffectiveDate is { } effectiveDate ? effectiveDate : (object)DBNull.Value);
+    }
+
     private static LedgerAccount ReadLedgerAccount(NpgsqlDataReader reader, int nameOrdinal)
         => new(
             reader.GetString(nameOrdinal),
@@ -1773,6 +1805,9 @@ public sealed partial class PostgresLedgerJournalStore :
             reader.IsDBNull(nameOrdinal + 2) ? null : reader.GetString(nameOrdinal + 2),
             reader.IsDBNull(nameOrdinal + 3) ? null : reader.GetString(nameOrdinal + 3));
 
+    // Wash-sale columns are appended after the original twelve so every existing ordinal keeps its
+    // meaning; callers that do not select them pass a reader with only 12 fields, which
+    // TryReadWashSalePolicy detects and treats as an unconfigured (disabled) policy.
     private static LedgerAccountTaxLotPolicyRecord ReadTaxLotPolicy(NpgsqlDataReader reader)
         => new(
             reader.GetGuid(0),
@@ -1783,7 +1818,26 @@ public sealed partial class PostgresLedgerJournalStore :
             DateOnly.FromDateTime(reader.GetDateTime(8)),
             ReadUtcDateTimeOffset(reader, 10),
             ReadUtcDateTimeOffset(reader, 11),
-            reader.IsDBNull(9) ? null : reader.GetString(9));
+            reader.IsDBNull(9) ? null : reader.GetString(9),
+            TryReadWashSalePolicy(reader));
+
+    private static WashSalePolicy? TryReadWashSalePolicy(NpgsqlDataReader reader)
+    {
+        const int enabledOrdinal = 12;
+        if (reader.FieldCount <= enabledOrdinal || reader.IsDBNull(enabledOrdinal))
+        {
+            return null;
+        }
+
+        return new WashSalePolicy(
+            reader.GetBoolean(enabledOrdinal),
+            reader.GetInt32(enabledOrdinal + 1),
+            Enum.Parse<WashSaleReplacementScope>(reader.GetString(enabledOrdinal + 2), ignoreCase: true),
+            reader.IsDBNull(enabledOrdinal + 3)
+                ? null
+                : DateOnly.FromDateTime(reader.GetDateTime(enabledOrdinal + 3)))
+            .EnsureValid();
+    }
 
     private static LedgerTaxLotRecord ReadTaxLot(NpgsqlDataReader reader)
         => new(

--- a/src/Meridian.Storage/Ledger/WashSaleDeferralRecord.cs
+++ b/src/Meridian.Storage/Ledger/WashSaleDeferralRecord.cs
@@ -12,6 +12,10 @@ namespace Meridian.Storage.Ledger;
 /// <param name="DisposalMutationBatchId">The atomic tax-lot batch that recorded the disposal.</param>
 /// <param name="DisposalAccount">The account that sold at a loss (not necessarily the account holding the replacement).</param>
 /// <param name="ReplacementTaxLotRecordId">Durable identity of the lot whose basis absorbed the loss.</param>
+/// <param name="MatchedReplacementQuantity">
+/// Replacement shares this disposal matched against, retained so a rebuilt projection reports the
+/// deferral that was actually booked rather than one re-derived from later lot history.
+/// </param>
 /// <param name="HoldingPeriodCarryDate">Holding-period start carried onto the replacement under IRC §1223(3).</param>
 /// <param name="PolicyId">The tax-lot policy revision in force when the deferral was computed.</param>
 /// <param name="WindowDays">Replacement window the deferral was matched under, retained for audit.</param>
@@ -26,6 +30,7 @@ public sealed record WashSaleDeferralRecord(
     Guid ReplacementTaxLotRecordId,
     string ReplacementLotId,
     decimal DisallowedAmount,
+    decimal MatchedReplacementQuantity,
     DateOnly HoldingPeriodCarryDate,
     string PolicyId,
     int WindowDays,

--- a/src/Meridian.Storage/Ledger/WashSaleDeferralRecord.cs
+++ b/src/Meridian.Storage/Ledger/WashSaleDeferralRecord.cs
@@ -1,0 +1,56 @@
+using Meridian.Ledger;
+
+namespace Meridian.Storage.Ledger;
+
+/// <summary>
+/// A retained wash-sale deferral: one loss-generating disposal capitalized
+/// <see cref="DisallowedAmount"/> into one replacement lot. Retention is what makes the deferral
+/// survive past the period it was computed in — a later sale of the replacement lot replays these
+/// rows as basis adjustments, so the deferred loss is finally recognized at the right time and with
+/// the carried holding period, instead of disappearing.
+/// </summary>
+/// <param name="DisposalMutationBatchId">The atomic tax-lot batch that recorded the disposal.</param>
+/// <param name="DisposalAccount">The account that sold at a loss (not necessarily the account holding the replacement).</param>
+/// <param name="ReplacementTaxLotRecordId">Durable identity of the lot whose basis absorbed the loss.</param>
+/// <param name="HoldingPeriodCarryDate">Holding-period start carried onto the replacement under IRC §1223(3).</param>
+/// <param name="PolicyId">The tax-lot policy revision in force when the deferral was computed.</param>
+/// <param name="WindowDays">Replacement window the deferral was matched under, retained for audit.</param>
+/// <param name="Scope">Account scope the replacement was matched under, retained for audit.</param>
+public sealed record WashSaleDeferralRecord(
+    Guid DeferralId,
+    Guid LedgerBookId,
+    Guid DisposalMutationBatchId,
+    Guid SecurityId,
+    DateOnly SaleDate,
+    LedgerAccount DisposalAccount,
+    Guid ReplacementTaxLotRecordId,
+    string ReplacementLotId,
+    decimal DisallowedAmount,
+    DateOnly HoldingPeriodCarryDate,
+    string PolicyId,
+    int WindowDays,
+    WashSaleReplacementScope Scope,
+    DateTimeOffset RecordedAt);
+
+/// <summary>
+/// Durable retention for wash-sale deferrals.
+/// </summary>
+public interface IWashSaleDeferralStore
+{
+    /// <summary>
+    /// Retains the deferrals produced by one disposal. Idempotent per
+    /// (<see cref="WashSaleDeferralRecord.DisposalMutationBatchId"/>,
+    /// <see cref="WashSaleDeferralRecord.ReplacementTaxLotRecordId"/>) so a replayed batch cannot
+    /// capitalize the same loss twice.
+    /// </summary>
+    Task SaveWashSaleDeferralsAsync(
+        IReadOnlyList<WashSaleDeferralRecord> deferrals,
+        CancellationToken ct = default);
+
+    /// <summary>Lists deferrals recorded against disposals in a book, ordered by sale date.</summary>
+    Task<IReadOnlyList<WashSaleDeferralRecord>> ListWashSaleDeferralsAsync(
+        Guid ledgerBookId,
+        DateOnly fromSaleDate,
+        DateOnly toSaleDate,
+        CancellationToken ct = default);
+}

--- a/src/Meridian.Ui.Shared/Services/LedgerReportingAuthoritativeSource.cs
+++ b/src/Meridian.Ui.Shared/Services/LedgerReportingAuthoritativeSource.cs
@@ -87,17 +87,24 @@ public sealed class LedgerReportingAuthoritativeSource : IReportingAuthoritative
     private readonly IFundProfileTenancyRegistry _tenancyRegistry;
     private readonly IFundStructureService _fundStructure;
     private readonly TimeProvider _timeProvider;
+    private readonly ILedgerTaxLotDisposalHistory? _taxLotDisposalHistory;
 
     public LedgerReportingAuthoritativeSource(
         ILedgerJournalStore journalStore,
         IFundProfileTenancyRegistry tenancyRegistry,
         IFundStructureService fundStructure,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        ILedgerTaxLotDisposalHistory? taxLotDisposalHistory = null)
     {
         _journalStore = journalStore ?? throw new ArgumentNullException(nameof(journalStore));
         _tenancyRegistry = tenancyRegistry ?? throw new ArgumentNullException(nameof(tenancyRegistry));
         _fundStructure = fundStructure ?? throw new ArgumentNullException(nameof(fundStructure));
         _timeProvider = timeProvider ?? TimeProvider.System;
+
+        // Optional: a store without retained tax-lot history contributes no realized-gain rows, which
+        // is exactly the behavior the pack had before. Falling back to the journal store keeps the
+        // common case (one Postgres store implementing both) wired without extra registration.
+        _taxLotDisposalHistory = taxLotDisposalHistory ?? journalStore as ILedgerTaxLotDisposalHistory;
     }
 
     public ValueTask<ReportingAuthoritativeSourceCapture> CaptureAsync(
@@ -385,7 +392,113 @@ public sealed class LedgerReportingAuthoritativeSource : IReportingAuthoritative
             lockedPeriod,
             lineDimensions: selectedDimensions);
 
-        return LedgerReportPackBuilder.Build(ledger, reportRequest);
+        // The pack's tax-lot artifact has always accepted relief projections but never been given
+        // any, so it shipped as a header with no rows. Rebuilding them from retained disposal
+        // history against the same journals this checkpoint was taken over is what makes the
+        // realized-gain and wash-sale columns report real numbers.
+        var taxLotReliefProjections = await BuildTaxLotReliefProjectionsAsync(
+                book.LedgerBookId,
+                orderedHistory,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return LedgerReportPackBuilder.Build(
+            ledger,
+            reportRequest,
+            taxLotReliefProjections: taxLotReliefProjections);
+    }
+
+    /// <summary>
+    /// Rebuilds realized-gain relief projections for the disposals recorded against
+    /// <paramref name="journals"/>. A disposal whose retained economics cannot produce a well-formed
+    /// projection is omitted rather than failing the capture: an unreconstructable historical row
+    /// must not block a governed pack from being produced at all.
+    /// </summary>
+    private async Task<IReadOnlyList<LedgerTaxLotReliefProjection>> BuildTaxLotReliefProjectionsAsync(
+        Guid ledgerBookId,
+        IReadOnlyList<LedgerJournalEntryRecord> journals,
+        CancellationToken cancellationToken)
+    {
+        if (_taxLotDisposalHistory is null || journals.Count == 0)
+        {
+            return [];
+        }
+
+        IReadOnlyList<LedgerTaxLotDisposalHistoryRecord> disposals;
+        try
+        {
+            disposals = await _taxLotDisposalHistory
+                .GetTaxLotDisposalHistoryAsync(
+                    ledgerBookId,
+                    journals.Select(static record => record.Entry.JournalEntryId).ToArray(),
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (NotSupportedException)
+        {
+            return [];
+        }
+
+        if (disposals.Count == 0)
+        {
+            return [];
+        }
+
+        var journalsById = journals
+            .GroupBy(static record => record.Entry.JournalEntryId)
+            .ToDictionary(static group => group.Key, static group => group.First().Entry);
+
+        var projections = new List<LedgerTaxLotReliefProjection>(disposals.Count);
+        foreach (var disposal in disposals)
+        {
+            if (!journalsById.TryGetValue(disposal.JournalEntryId, out var entry))
+            {
+                continue;
+            }
+
+            var projection = LedgerTaxLotReliefHistoryProjector.Project(new LedgerTaxLotDisposalHistory(
+                disposal.MutationBatchId,
+                disposal.JournalEntryId,
+                disposal.Account,
+                entry.Metadata.EffectiveDate ?? DateOnly.FromDateTime(entry.Timestamp.UtcDateTime),
+                disposal.ReliefMethod,
+                disposal.Lots,
+                ResolveRecognizedGainOrLoss(entry),
+                disposal.WashSaleBasisIncreases,
+                disposal.MatchedReplacementQuantity));
+
+            if (projection is not null)
+            {
+                projections.Add(projection);
+            }
+        }
+
+        return projections;
+    }
+
+    /// <summary>
+    /// The gain or loss this journal actually booked, read from its realized gain/loss lines. Any
+    /// wash-sale deferral is excluded by construction (only the allowed portion was ever posted),
+    /// which is why the rebuild adds the retained deferral back to recover economic proceeds.
+    /// Accounts are matched by name so both the unscoped and per-financial-account variants count.
+    /// </summary>
+    private static decimal ResolveRecognizedGainOrLoss(JournalEntry entry)
+    {
+        var gain = 0m;
+        var loss = 0m;
+        foreach (var line in entry.Lines)
+        {
+            if (string.Equals(line.Account.Name, LedgerAccounts.RealizedGain.Name, StringComparison.Ordinal))
+            {
+                gain += line.Credit - line.Debit;
+            }
+            else if (string.Equals(line.Account.Name, LedgerAccounts.RealizedLoss.Name, StringComparison.Ordinal))
+            {
+                loss += line.Debit - line.Credit;
+            }
+        }
+
+        return gain - loss;
     }
 
     private async Task<LedgerBookRecord> ResolveBookAsync(

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -1296,6 +1296,7 @@ internal sealed class ServiceProviderReportingAuthoritativeSource :
             journalStore,
             tenancyRegistry,
             fundStructure,
-            _services.GetService<TimeProvider>());
+            _services.GetService<TimeProvider>(),
+            journalStore);
     }
 }

--- a/tests/Meridian.Tests/Ledger/LedgerIntegrationTests.cs
+++ b/tests/Meridian.Tests/Ledger/LedgerIntegrationTests.cs
@@ -1721,10 +1721,16 @@ public sealed class LedgerIntegrationTests
         var taxArtifact = pack.Artifacts.Single(artifact => artifact.Name == "tax-lot-realized-gains.csv");
         taxArtifact.Content.Should().Contain("SaleDate,AccountName,Symbol,FinancialAccountId,ReliefMethod,LotId");
         taxArtifact.Content.Should().Contain("RealizedGainOrLoss,DisallowedWashSaleLoss,RecognizedGainOrLoss");
-        // Non-wash-sale row still nets recognized == realized (100), with zero disallowed.
-        taxArtifact.Content.Should().Contain("2026-05-15,Assets:Investments:AAPL,AAPL,broker-1,Hifo,lot-high,2026-02-10,5,100,600,500,100,0,100");
-        // Wash-sale row: full 200 loss disallowed, recognized loss zero.
-        taxArtifact.Content.Should().Contain("2026-05-20,Assets:Investments:AAPL,AAPL,broker-1,Fifo,lot-wash,2026-01-05,10,100,800,1000,-200,200,0");
+        taxArtifact.Content.Should().Contain("TaxCharacter,HoldingPeriodExtendedByWashSale");
+        taxArtifact.Content.Should().Contain("ShortTermRecognizedGainOrLoss,LongTermRecognizedGainOrLoss");
+        // Non-wash-sale row still nets recognized == realized (100), with zero disallowed. Held
+        // 2026-02-10 to 2026-05-15 (94 days), so the recognized gain routes to the short-term column.
+        taxArtifact.Content.Should().Contain(
+            "2026-05-15,Assets:Investments:AAPL,AAPL,broker-1,Hifo,lot-high,2026-02-10,2026-02-10,94,ShortTerm,false,5,100,600,500,100,0,100,100,0");
+        // Wash-sale row: full 200 loss disallowed, recognized loss zero — so both character columns
+        // are zero even though the parcel itself is short-term.
+        taxArtifact.Content.Should().Contain(
+            "2026-05-20,Assets:Investments:AAPL,AAPL,broker-1,Fifo,lot-wash,2026-01-05,2026-01-05,135,ShortTerm,false,10,100,800,1000,-200,200,0,0,0");
         pack.Signature.Algorithm.Should().Be("SHA256");
         pack.Signature.PayloadChecksumSha256.Should().HaveLength(64);
         pack.Signature.SignedBy.Should().Be("controller");

--- a/tests/Meridian.Tests/Ledger/LedgerTaxCharacterTests.cs
+++ b/tests/Meridian.Tests/Ledger/LedgerTaxCharacterTests.cs
@@ -1,0 +1,194 @@
+using FluentAssertions;
+using Meridian.Ledger;
+using Xunit;
+
+namespace Meridian.Tests.Ledger;
+
+/// <summary>
+/// Holding-period character on relief projections. Classification follows IRC §1222/§1223: the
+/// holding period starts the day after acquisition and must exceed one year, so a lot held exactly
+/// one year is short-term. A prior wash sale moves the start earlier under §1223(3).
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class LedgerTaxCharacterTests
+{
+    private static readonly Guid SecurityId = Guid.Parse("aaaaaaaa-0000-0000-0000-000000000010");
+
+    private static LedgerAccount Account => LedgerAccounts.Securities("AAPL", "broker-1");
+
+    [Theory]
+    // Acquired 2025-01-01: one year later is 2026-01-01, which is NOT more than a year.
+    [InlineData("2025-01-01", "2026-01-01", false)]
+    [InlineData("2025-01-01", "2026-01-02", true)]
+    // Sold the day before the anniversary is unambiguously short-term.
+    [InlineData("2025-01-01", "2025-12-31", false)]
+    // A span containing 29 Feb must not be promoted early by a 365-day count: 2024-02-28 +1y is
+    // 2025-02-28, so 2025-02-28 is still short-term even though 366 days have elapsed.
+    [InlineData("2024-02-28", "2025-02-28", false)]
+    [InlineData("2024-02-28", "2025-03-01", true)]
+    public void Classify_AppliesMoreThanOneYearRule(string acquired, string sold, bool expectLongTerm)
+    {
+        var character = TaxCharacterRule.Classify(DateOnly.Parse(acquired), DateOnly.Parse(sold));
+
+        character.Should().Be(expectLongTerm ? TaxCharacter.LongTerm : TaxCharacter.ShortTerm);
+    }
+
+    [Fact]
+    public void Projection_ReportsShortTermCharacterAndHoldingPeriodDays()
+    {
+        var projection = LedgerTaxLotReliefProjector.Project(new LedgerTaxLotReliefInput(
+            Account,
+            new DateOnly(2026, 3, 1),
+            quantitySold: 100m,
+            salePrice: 150m,
+            LedgerTaxLotReliefMethod.Fifo,
+            [new LedgerTaxLot("lot-a", new DateOnly(2026, 1, 1), 100m, 100m, SecurityId)]));
+
+        var selection = projection.Selections.Single();
+        selection.TaxCharacter.Should().Be(TaxCharacter.ShortTerm);
+        selection.HoldingPeriodDays.Should().Be(59);
+        selection.HoldingPeriodExtendedByWashSale.Should().BeFalse();
+        projection.ShortTermRealizedGainOrLoss.Should().Be(5_000m);
+        projection.LongTermRealizedGainOrLoss.Should().Be(0m);
+    }
+
+    [Fact]
+    public void Projection_SplitsCharacterTotalsAcrossLotsAndTiesToRealizedTotal()
+    {
+        // One lot held well over a year and one bought last month, sold together.
+        var projection = LedgerTaxLotReliefProjector.Project(new LedgerTaxLotReliefInput(
+            Account,
+            new DateOnly(2026, 3, 1),
+            quantitySold: 200m,
+            salePrice: 150m,
+            LedgerTaxLotReliefMethod.Fifo,
+            [
+                new LedgerTaxLot("lot-old", new DateOnly(2024, 1, 1), 100m, 100m, SecurityId),
+                new LedgerTaxLot("lot-new", new DateOnly(2026, 2, 1), 100m, 140m, SecurityId),
+            ]));
+
+        projection.Selections.Should().HaveCount(2);
+        projection.Selections.Single(selection => selection.Lot.LotId == "lot-old")
+            .TaxCharacter.Should().Be(TaxCharacter.LongTerm);
+        projection.Selections.Single(selection => selection.Lot.LotId == "lot-new")
+            .TaxCharacter.Should().Be(TaxCharacter.ShortTerm);
+
+        projection.LongTermRealizedGainOrLoss.Should().Be(5_000m);  // 15,000 - 10,000
+        projection.ShortTermRealizedGainOrLoss.Should().Be(1_000m); // 15,000 - 14,000
+
+        // The split is a partition of the total, never an approximation of it.
+        (projection.ShortTermRealizedGainOrLoss + projection.LongTermRealizedGainOrLoss)
+            .Should().Be(projection.RealizedGainOrLoss);
+    }
+
+    [Fact]
+    public void Projection_ParcelProceedsSumExactlyToTotalProceeds()
+    {
+        // A price that does not divide evenly across three parcels forces a rounding residual; the
+        // parcels must still sum to the projection total so an export ties to the journal.
+        var projection = LedgerTaxLotReliefProjector.Project(new LedgerTaxLotReliefInput(
+            Account,
+            new DateOnly(2026, 3, 1),
+            quantitySold: 3m,
+            salePrice: 100m / 3m,
+            LedgerTaxLotReliefMethod.Fifo,
+            [
+                new LedgerTaxLot("lot-a", new DateOnly(2026, 1, 1), 1m, 10m, SecurityId),
+                new LedgerTaxLot("lot-b", new DateOnly(2026, 1, 2), 1m, 10m, SecurityId),
+                new LedgerTaxLot("lot-c", new DateOnly(2026, 1, 3), 1m, 10m, SecurityId),
+            ]));
+
+        projection.Selections.Sum(selection => selection.Proceeds).Should().Be(projection.Proceeds);
+        projection.Selections.Sum(selection => selection.RealizedGainOrLoss)
+            .Should().Be(projection.RealizedGainOrLoss);
+    }
+
+    [Fact]
+    public void WashSaleCarry_ExtendsHoldingPeriodOntoReplacementLot()
+    {
+        // A replacement bought a month ago would be short-term on its own, but it absorbed a wash
+        // sale whose shares were acquired in 2024 — §1223(3) carries that start onto it.
+        var carried = new LedgerTaxLot(
+            "lot-rep",
+            new DateOnly(2026, 2, 1),
+            100m,
+            100m,
+            SecurityId,
+            holdingPeriodStartDate: new DateOnly(2024, 1, 1));
+
+        var projection = LedgerTaxLotReliefProjector.Project(new LedgerTaxLotReliefInput(
+            Account,
+            new DateOnly(2026, 3, 1),
+            quantitySold: 100m,
+            salePrice: 150m,
+            LedgerTaxLotReliefMethod.Fifo,
+            [carried]));
+
+        var selection = projection.Selections.Single();
+        selection.TaxCharacter.Should().Be(TaxCharacter.LongTerm);
+        selection.HoldingPeriodExtendedByWashSale.Should().BeTrue();
+        projection.LongTermRealizedGainOrLoss.Should().Be(5_000m);
+    }
+
+    [Fact]
+    public void WashSaleBasisAdjustment_CapitalizesLossAndCarriesHoldingPeriod()
+    {
+        // Replaying a retained deferral onto the replacement lot is what finally recognizes the
+        // deferred loss: basis rises by the deferred amount and the holding period is inherited.
+        var deferral = new LedgerTaxLotBasisAdjustment(
+            LedgerTaxLotBasisAdjustmentKind.WashSale,
+            2_000m,
+            new DateOnly(2026, 1, 15),
+            SecurityId,
+            "lot-rep",
+            "wash-sale-deferral:test",
+            HoldingPeriodCarryDate: new DateOnly(2024, 1, 1));
+
+        var projection = LedgerTaxLotReliefProjector.Project(new LedgerTaxLotReliefInput(
+            Account,
+            new DateOnly(2026, 3, 1),
+            quantitySold: 100m,
+            salePrice: 150m,
+            LedgerTaxLotReliefMethod.Fifo,
+            // Acquired *after* the deferral's sale date — the symmetric §1091 window means a
+            // replacement is frequently forward of the sale, which the reference-data
+            // acquired-before-effective-date guard would otherwise reject.
+            [new LedgerTaxLot("lot-rep", new DateOnly(2026, 2, 1), 100m, 100m, SecurityId)],
+            basisAdjustments: [deferral]));
+
+        // Basis rose from 10,000 to 12,000, so the gain is 3,000 rather than 5,000.
+        projection.CostBasis.Should().Be(12_000m);
+        projection.RealizedGainOrLoss.Should().Be(3_000m);
+
+        var selection = projection.Selections.Single();
+        selection.TaxCharacter.Should().Be(TaxCharacter.LongTerm);
+        selection.HoldingPeriodExtendedByWashSale.Should().BeTrue();
+    }
+
+    [Fact]
+    public void WashSaleBasisAdjustment_RequiresAReplacementLot()
+    {
+        var act = () => new LedgerTaxLotBasisAdjustment(
+            LedgerTaxLotBasisAdjustmentKind.WashSale,
+            100m,
+            new DateOnly(2026, 1, 15),
+            SecurityId)
+            .EnsureValid();
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void LedgerTaxLot_RejectsHoldingPeriodStartLaterThanAcquisition()
+    {
+        var act = () => new LedgerTaxLot(
+            "lot-a",
+            new DateOnly(2026, 1, 1),
+            100m,
+            100m,
+            SecurityId,
+            holdingPeriodStartDate: new DateOnly(2026, 2, 1));
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/tests/Meridian.Tests/Ledger/LedgerTaxCharacterTests.cs
+++ b/tests/Meridian.Tests/Ledger/LedgerTaxCharacterTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using FluentAssertions;
 using Meridian.Ledger;
 using Xunit;
@@ -28,10 +29,13 @@ public sealed class LedgerTaxCharacterTests
     [InlineData("2024-02-28", "2025-03-01", true)]
     public void Classify_AppliesMoreThanOneYearRule(string acquired, string sold, bool expectLongTerm)
     {
-        var character = TaxCharacterRule.Classify(DateOnly.Parse(acquired), DateOnly.Parse(sold));
+        var character = TaxCharacterRule.Classify(ParseDate(acquired), ParseDate(sold));
 
         character.Should().Be(expectLongTerm ? TaxCharacter.LongTerm : TaxCharacter.ShortTerm);
     }
+
+    private static DateOnly ParseDate(string value)
+        => DateOnly.ParseExact(value, "yyyy-MM-dd", CultureInfo.InvariantCulture);
 
     [Fact]
     public void Projection_ReportsShortTermCharacterAndHoldingPeriodDays()

--- a/tests/Meridian.Tests/Ledger/LedgerWashSaleActivationTests.cs
+++ b/tests/Meridian.Tests/Ledger/LedgerWashSaleActivationTests.cs
@@ -1,0 +1,261 @@
+using FluentAssertions;
+using Meridian.Ledger;
+using Xunit;
+
+namespace Meridian.Tests.Ledger;
+
+/// <summary>
+/// The activation surface for the wash-sale engine: the dated policy that gates it, the scope that
+/// decides which accounts a replacement can come from, and the rebuild of relief projections from
+/// retained disposal history that lets a governed report pack carry real realized-gain rows.
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class LedgerWashSaleActivationTests
+{
+    private static readonly Guid SecurityId = Guid.Parse("aaaaaaaa-0000-0000-0000-000000000010");
+
+    private static LedgerAccount Account => LedgerAccounts.Securities("AAPL", "broker-1");
+
+    // -------------------------------------------------------------------------
+    // Policy gating
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Policy_DefaultsToLedgerBookScope()
+    {
+        // A repurchase in a sibling custody account is still a wash sale, so the default scope has
+        // to be the book rather than the single disposing account.
+        WashSalePolicy.UnitedStates.Scope.Should().Be(WashSaleReplacementScope.LedgerBook);
+        WashSalePolicy.UnitedStates.WindowDays.Should().Be(30);
+    }
+
+    [Fact]
+    public void Policy_WithoutEffectiveDate_AppliesToEverySale()
+    {
+        WashSalePolicy.UnitedStates.AppliesOn(new DateOnly(2020, 1, 1)).Should().BeTrue();
+        WashSalePolicy.Disabled.AppliesOn(new DateOnly(2026, 1, 1)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Policy_BeforeEffectiveDate_DoesNotApply()
+    {
+        var dated = WashSalePolicy.UnitedStates with { EffectiveDate = new DateOnly(2026, 1, 1) };
+
+        dated.AppliesOn(new DateOnly(2025, 12, 31)).Should().BeFalse();
+        dated.AppliesOn(new DateOnly(2026, 1, 1)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Projection_BeforePolicyEffectiveDate_RecognizesFullLoss()
+    {
+        // Enabling deferral must not restate periods that were already closed and reported.
+        var projection = LedgerTaxLotReliefProjector.Project(LossSaleInput(
+            WashSalePolicy.UnitedStates with { EffectiveDate = new DateOnly(2026, 6, 1) }));
+
+        projection.WashSale.Should().BeNull();
+        projection.RealizedGainOrLoss.Should().Be(-2_000m);
+        projection.RecognizedGainOrLoss.Should().Be(-2_000m);
+    }
+
+    [Fact]
+    public void Projection_OnOrAfterPolicyEffectiveDate_DefersLoss()
+    {
+        var projection = LedgerTaxLotReliefProjector.Project(LossSaleInput(
+            WashSalePolicy.UnitedStates with { EffectiveDate = new DateOnly(2026, 3, 1) }));
+
+        projection.WashSale.Should().NotBeNull();
+        projection.DisallowedWashSaleLoss.Should().Be(2_000m);
+        projection.RecognizedGainOrLoss.Should().Be(0m);
+    }
+
+    [Fact]
+    public void Policy_RejectsNegativeWindow()
+    {
+        var act = () => new WashSalePolicy(true, -1).EnsureValid();
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void BasisIncrease_CarriesTheAccountThatAbsorbedTheLoss()
+    {
+        // Under a book-wide scope the absorbing account is frequently not the one that sold, so the
+        // deferral has to name it or the trace back to the replacement lot is ambiguous.
+        var replacementAccount = LedgerAccounts.Securities("AAPL", "broker-2");
+        var projection = LedgerTaxLotReliefProjector.Project(new LedgerTaxLotReliefInput(
+            Account,
+            new DateOnly(2026, 3, 1),
+            quantitySold: 100m,
+            salePrice: 80m,
+            LedgerTaxLotReliefMethod.Fifo,
+            [new LedgerTaxLot("lot-a", new DateOnly(2026, 1, 1), 100m, 100m, SecurityId)],
+            washSalePolicy: WashSalePolicy.UnitedStates,
+            replacementAcquisitions:
+            [
+                new WashSaleReplacementAcquisition(
+                    "lot-rep",
+                    new DateOnly(2026, 3, 5),
+                    100m,
+                    SecurityId,
+                    replacementAccount),
+            ]));
+
+        var increase = projection.WashSale!.BasisIncreases.Single();
+        increase.ReplacementAccount.Should().Be(replacementAccount);
+        increase.HoldingPeriodCarryDate.Should().Be(new DateOnly(2026, 1, 1));
+    }
+
+    [Fact]
+    public void CarryDate_ChainsThroughAnAlreadyExtendedLot()
+    {
+        // Selling a lot that itself absorbed an earlier wash sale must pass the older holding-period
+        // start along, not reset it to that lot's own purchase date.
+        var projection = LedgerTaxLotReliefProjector.Project(new LedgerTaxLotReliefInput(
+            Account,
+            new DateOnly(2026, 3, 1),
+            quantitySold: 100m,
+            salePrice: 80m,
+            LedgerTaxLotReliefMethod.Fifo,
+            [
+                new LedgerTaxLot(
+                    "lot-a",
+                    new DateOnly(2026, 1, 1),
+                    100m,
+                    100m,
+                    SecurityId,
+                    holdingPeriodStartDate: new DateOnly(2023, 5, 4)),
+            ],
+            washSalePolicy: WashSalePolicy.UnitedStates,
+            replacementAcquisitions:
+            [
+                new WashSaleReplacementAcquisition("lot-rep", new DateOnly(2026, 3, 5), 100m, SecurityId),
+            ]));
+
+        projection.WashSale!.BasisIncreases.Single()
+            .HoldingPeriodCarryDate.Should().Be(new DateOnly(2023, 5, 4));
+    }
+
+    // -------------------------------------------------------------------------
+    // Rebuilding projections from retained disposal history
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void HistoryProjector_RecoversProceedsFromBookedGainAndBasis()
+    {
+        // Sale price is not retained; it is recovered as basis + recognized + deferred, which keeps
+        // rebuilt rows tied to the journal rather than to a separately-stored price.
+        var projection = LedgerTaxLotReliefHistoryProjector.Project(History(
+            recognizedGainOrLoss: -2_000m));
+
+        projection.Should().NotBeNull();
+        projection!.Proceeds.Should().Be(8_000m);
+        projection.CostBasis.Should().Be(10_000m);
+        projection.RealizedGainOrLoss.Should().Be(-2_000m);
+        projection.Selections.Single().TaxCharacter.Should().Be(TaxCharacter.LongTerm);
+    }
+
+    [Fact]
+    public void HistoryProjector_ReattachesTheDeferralThatWasActuallyBooked()
+    {
+        // A fully-deferred loss books no loss line, so recognized is zero; adding the retained
+        // deferral back is what recovers the true economic proceeds and loss.
+        var projection = LedgerTaxLotReliefHistoryProjector.Project(History(
+            recognizedGainOrLoss: 0m,
+            increases:
+            [
+                new WashSaleBasisIncrease("lot-rep", 2_000m, new DateOnly(2024, 1, 1)),
+            ],
+            matchedReplacementQuantity: 100m));
+
+        projection.Should().NotBeNull();
+        projection!.Proceeds.Should().Be(8_000m);
+        projection.RealizedGainOrLoss.Should().Be(-2_000m);
+        projection.DisallowedWashSaleLoss.Should().Be(2_000m);
+        projection.WashSale!.AllowedLoss.Should().Be(0m);
+        projection.WashSale.MatchedReplacementQuantity.Should().Be(100m);
+        projection.RecognizedGainOrLoss.Should().Be(0m);
+    }
+
+    [Fact]
+    public void HistoryProjector_ReturnsNullRatherThanThrowingOnUnreconstructableHistory()
+    {
+        // One bad historical row must not stop a governed pack from being produced.
+        LedgerTaxLotReliefHistoryProjector
+            .Project(History() with { Lots = Array.Empty<LedgerTaxLotDisposalHistoryLot>() })
+            .Should().BeNull();
+
+        // Recognized loss larger than the basis would imply negative proceeds.
+        LedgerTaxLotReliefHistoryProjector.Project(History(recognizedGainOrLoss: -20_000m))
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void HistoryProjector_SplitsRebuiltRowsByCharacter()
+    {
+        var projection = LedgerTaxLotReliefHistoryProjector.Project(new LedgerTaxLotDisposalHistory(
+            Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            Account,
+            new DateOnly(2026, 3, 1),
+            LedgerTaxLotReliefMethod.Fifo,
+            [
+                new LedgerTaxLotDisposalHistoryLot(
+                    "lot-old", new DateOnly(2024, 1, 1), new DateOnly(2024, 1, 1), 100m, 100m, 10_000m),
+                new LedgerTaxLotDisposalHistoryLot(
+                    "lot-new", new DateOnly(2026, 2, 1), new DateOnly(2026, 2, 1), 100m, 100m, 10_000m),
+            ],
+            RecognizedGainOrLoss: 4_000m,
+            WashSaleBasisIncreases: [],
+            MatchedReplacementQuantity: 0m));
+
+        projection.Should().NotBeNull();
+        projection!.Selections.Should().HaveCount(2);
+        projection.Selections.Single(selection => selection.Lot.LotId == "lot-old")
+            .TaxCharacter.Should().Be(TaxCharacter.LongTerm);
+        projection.Selections.Single(selection => selection.Lot.LotId == "lot-new")
+            .TaxCharacter.Should().Be(TaxCharacter.ShortTerm);
+        (projection.ShortTermRealizedGainOrLoss + projection.LongTermRealizedGainOrLoss)
+            .Should().Be(projection.RealizedGainOrLoss);
+    }
+
+    // -------------------------------------------------------------------------
+    // Fixtures
+    // -------------------------------------------------------------------------
+
+    private static LedgerTaxLotReliefInput LossSaleInput(WashSalePolicy policy) =>
+        new(
+            Account,
+            new DateOnly(2026, 3, 1),
+            quantitySold: 100m,
+            salePrice: 80m, // 100 @ cost 100 sold at 80 -> 2,000 loss
+            LedgerTaxLotReliefMethod.Fifo,
+            [new LedgerTaxLot("lot-a", new DateOnly(2026, 1, 1), 100m, 100m, SecurityId)],
+            washSalePolicy: policy,
+            replacementAcquisitions:
+            [
+                new WashSaleReplacementAcquisition("lot-rep", new DateOnly(2026, 3, 5), 100m, SecurityId),
+            ]);
+
+    private static LedgerTaxLotDisposalHistory History(
+        decimal recognizedGainOrLoss = -2_000m,
+        IReadOnlyList<WashSaleBasisIncrease>? increases = null,
+        decimal matchedReplacementQuantity = 0m) =>
+        new(
+            Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            Account,
+            new DateOnly(2026, 3, 1),
+            LedgerTaxLotReliefMethod.Fifo,
+            [
+                new LedgerTaxLotDisposalHistoryLot(
+                    "lot-a",
+                    new DateOnly(2024, 1, 1),
+                    new DateOnly(2024, 1, 1),
+                    100m,
+                    100m,
+                    10_000m),
+            ],
+            recognizedGainOrLoss,
+            increases ?? [],
+            matchedReplacementQuantity);
+}


### PR DESCRIPTION
## Summary

Two connected gaps in tax-lot accounting.

**The wash-sale engine never ran.** `LedgerTaxLotReliefProjector.ComputeWashSale` is complete and well tested, but it returns `null` on every production disposal: `ComputeWashSale` requires an enabled policy *and* a non-empty replacement set, and every production construction of `LedgerTaxLotReliefInput` supplied neither — taking the `WashSalePolicy.Disabled` constructor default. `replacementAcquisitions:` appeared only in tests.

This adds the missing seam (`IWashSaleReplacementResolver`), durable policy, and durable deferral retention, so the engine actually fires.

**Realized gains carried no short/long-term character.** `Meridian.Backtesting.Sdk` knew about holding periods; the ledger — the side that feeds a 1099-B or K-1 — did not. Relief selections now carry `TaxCharacter`, holding-period days, and whether a prior wash sale extended the period.

One correction to the original diagnosis, worth flagging for review: the report pack's `DisallowedWashSaleLoss` column was not "always 0.00" — the artifact had **no rows at all**. `LedgerReportingAuthoritativeSource` called `LedgerReportPackBuilder.Build(ledger, reportRequest)` and passed no projections, so `tax-lot-realized-gains.csv` shipped as a bare header. Also, of the two call sites named as needing the resolver, only one is a real relief projection — `PostgresLedgerJournalStore.ValidateAuthoritativeDisposalPolicyAsync` uses the projector as a lot-selection *validator* with `salePrice: 0m` and reads only `relief.Selections`, so computing a wash sale there would be meaningless (every zero-price sale looks like a loss) and is deliberately not wired.

### Domain

- `WashSalePolicy` gains a replacement **scope** and an **effective date**. Scope defaults to `LedgerBook` — a ledger book is the accounting boundary for one taxable entity, which is the closest available analogue to the §1091 rule that looks across all of a taxpayer's accounts rather than one custodian. The effective date exists because enabling deferral changes reported losses; the projector now gates on `AppliesOn(saleDate)` rather than `Enabled`, so already-closed periods are not restated.
- Selections carry `TaxCharacter`, `HoldingPeriodDays`, and `HoldingPeriodExtendedByWashSale`, plus per-parcel `Proceeds` and `RealizedGainOrLoss` allocated so rows sum **exactly** to the projection totals rather than being re-derived (and drifting a cent) per consumer.
- Classification follows IRC §1222/§1223 — *more than* one year, compared calendar-wise. This deliberately differs from `ClosedLot.IsLongTerm`'s `>= 365 days`, which promotes a leap-year-spanning lot a day early; that rule was not propagated into tax reporting.
- `LedgerTaxLot` carries an optional holding-period start so a replacement inherits the disallowed sale's holding period under §1223(3). The carry chains: selling a lot that already absorbed a wash sale passes the older start along instead of resetting it.
- New `LedgerTaxLotBasisAdjustmentKind.WashSale` lets a retained deferral be replayed onto the replacement lot when it is finally relieved. It matches on lot identity rather than the acquired-before-effective-date guard the reference-data kinds use, because the §1091 window is symmetric and a replacement is usually *forward* of the sale.

### Storage

- Wash-sale policy is persisted on the existing effective-dated `tax_lot_policies` row, so relief method and deferral policy resolve together.
- New `wash_sale_deferrals` table retains each deferral against the replacement lot that absorbed it. It is the **single source of truth** — increased basis and carried holding period are not denormalized onto `tax_lots`, so they cannot drift out of step with a correction.
- `PostgresLedgerJournalStore` implements the resolver over a new `(ledger_book_id, security_id, acquired_date, lot_id)` index. The existing `ix_tax_lots_asset_scope_open` cannot serve this lookup: it is partial on open quantity (a fully-disposed lot is still a valid replacement) and orders `book_position_id` ahead of `acquired_date`, which a book-wide scope does not constrain.

### Reporting

- `LedgerTaxLotReliefHistoryProjector` rebuilds projections from retained disposal history. Proceeds are recovered as `basis + recognized + deferred` rather than stored separately, keeping rebuilt rows tied to the journal. The retained wash-sale outcome is reattached, not recomputed, so the pack reports what was booked rather than a re-derivation against today's lot history.
- A disposal whose retained economics cannot produce a well-formed projection is omitted rather than throwing — one bad historical row must not block a governed pack.
- The CSV adds `HoldingPeriodStartDate`, `HoldingPeriodDays`, `TaxCharacter`, `HoldingPeriodExtendedByWashSale`, and `ShortTermRecognizedGainOrLoss` / `LongTermRecognizedGainOrLoss`. The existing `RealizedGainOrLoss,DisallowedWashSaleLoss,RecognizedGainOrLoss` header substring is preserved contiguously.

### Bug fixed along the way

`SecurityMasterCostBasisAdjustmentService.ProjectReliefAsync` rebuilt `LedgerTaxLotReliefInput` without `washSalePolicy` or `replacementAcquisitions`, so a caller that had resolved replacements lost them the moment it routed through Security Master enrichment and silently recognized a loss the policy meant to defer.

## Reason

The wash-sale work was already built and tested but structurally unreachable in production, and the governed report pack advertised a wash-sale column it could never populate. For a platform whose pitch is "prove the number," a confidently-formatted empty artifact is the expensive kind of gap.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

No .NET SDK is available in this environment, so nothing was compiled or run locally — validation is entirely via the hosted workflows, and the boxes above stay unchecked until those pass. Please treat the build result on this PR as the first real signal.

New unit tests cover the holding-period boundary (including a leap-year span a 365-day count would promote a day early), character totals partitioning the realized total exactly, parcel proceeds summing to the projection total, the dated policy gate in both directions, carry-date chaining through an already-extended lot, and history rebuild with and without a deferral.

Not covered by tests here: the Postgres resolver and disposal-history queries have no integration coverage in this change — they need a database fixture. The pure reconstruction logic they feed is tested directly.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01UTZH5MbMNJJ79KvMbPcg6T)_