### PR TITLE
Realign the brainstorm skill with the current product charter

### DIFF
--- a/.agents/skills/meridian-brainstorm/CHANGELOG.md
+++ b/.agents/skills/meridian-brainstorm/CHANGELOG.md
@@ -1,5 +1,73 @@
 # meridian-brainstorm — Changelog
 
+## v2.0.0 (2026-07-28)
+
+Realignment to the current product charter. The skill had drifted to a v1.3.0 snapshot (2026-03-19)
+that framed Meridian as a market-data collection platform for hobbyist quants, academics, and
+institutional trading desks. That framing no longer matches the repository or the canonical design
+document.
+
+### Changed
+
+- **Product framing rewritten** — Meridian is now described as a self-hosted financial operations
+  platform selling *proven numbers* to fund administrators, private fund managers/fund CFOs, RIAs,
+  family offices, and hybrid institutional teams. Fund management is documented as a first-class
+  specialization, not the root model. The canonical operator spine
+  (`Import → Validate → Reconcile → Investigate → Approve → Report`) replaces the four-pillar
+  (ADR-016) framing as the organizing idea
+- **Project statistics replaced** — v1.3.0 claimed 868 source files, 261 test files, 22 main
+  projects, and 33 CI/CD workflows. Now sourced from the design charter §5.2 measurement table
+  (2026-07-28): 41 source projects, ~242,000 lines of C# across 2,902 files, 12,736 lines of F#,
+  ~295,000 lines of TypeScript/TSX, 845 `/api/...` routes, 22 provider adapter families,
+  6 statement connector formats, 142 ledger classes, ~12,900 xUnit facts/theories
+- **Wave posture added** — closed baselines (W1-W5, W5X FREX/FINOPS/CONNECT, W7, W9-ASSET-010),
+  active rows (`W5X-EVIDENCE-001`, `W5X-STMT-ONBOARD-001`, `W8-WPF-PARITY-001`,
+  `W8-UX-CONSOL-001`), and the ranked W9 slate, with the roadmap registry named as the only live
+  status source
+- **WPF lane corrected** — was described as a "retained compatibility surface" with WPF product/UI
+  scope closed; it is an active co-equal operator UI lane whose current focus is web-UI parity
+  (`W8-WPF-PARITY-001`)
+- **Personas replaced** — Hobbyist Quant Developer / Academic / Institutional gave way to grouped
+  codes over the canonical 24-role Persona Matrix (design charter §4.2): OPS, ACCT, INV, GOV, EXEC,
+  STAKE, ADMIN. The Financial Operations Professional is named as the primary operator, and the
+  summary-table audience key changed from `H/Q/I` accordingly
+- **User Experience Lens rewritten** as the Operator Experience Lens — evidence-one-click-away,
+  self-explaining blocked states, and the two co-equal UI lanes replace "Meridian is a desktop
+  application people monitor for hours"
+- **Mode table updated** — added **Activation** (wire dormant capability), **Evidence &
+  Governance**, and **Adoption / Onboarding**; renamed Persona-Focused to Role-Focused; retargeted
+  Competitive and UX triggers to the current product surface. Growth mode's community/evangelism
+  framing was folded into Adoption
+- **Idea requirements expanded** — every idea now states its evidence and governance impact
+  (what proof it creates, what it blocks when absent, what approval it requires)
+- **Session ledger corrected** — `brainstorm-history.jsonl` is tracked in the repository, not
+  gitignored; the documented entry shape now matches the real records
+- **`references/idea-dimensions.md` rebuilt** — the anchor table is reorganized into seven verified
+  sections (import/providers, reconciliation, ledger/close, fund economics, evidence, reporting,
+  execution/research, platform seams) with all paths checked against the tree on 2026-07-28;
+  `GracefulShutdownService` repointed to `src/Meridian.Platform/Runtime/`; `UiApiRoutes` recorded at
+  `src/Meridian.Contracts/Api/`. The ten market-data-era dimension categories were replaced with
+  eleven current-domain categories, and an **Activation Targets** section was added from the
+  charter's activation register
+- **`references/competitive-landscape.md` rebuilt** — Bloomberg/Databento/Polygon/QuestDB
+  positioning was the whole file; it is now scoped to the Trading/Data lane, with close-and-controls
+  managers (BlackLine, Trintech), fund administration suites (Carta, FundStudio), asset servicing
+  (SS&C Advent Geneva, eFront, Addepar), and ledger APIs (Modern Treasury) as the primary
+  categories. The differentiation matrix and moat list follow design charter §1.4
+
+### Added
+
+- **Non-Negotiable Guardrails section** — seven root workspaces, no mobile lane, truth discipline,
+  governed autonomy, Meridian owns ledger truth, deferred expansion boundaries, claim rules, and
+  activation-before-expansion. Ideas that violate these are documented as wrong ideas
+- **Handoffs section** — routes to `meridian-blueprint`, `meridian-roadmap-strategist`,
+  `meridian-simulated-user-panel`, and `meridian-repo-navigation`, matching the Codex lane
+- **Durable-artifact step** in the completion workflow — brainstorms that produce documents write to
+  `docs/product/<topic>-brainstorm-<yyyy-mm>.md` as a dated working design input, never a status
+  source
+
+---
+
 ## v1.3.0 (2026-03-19)
 
 ### Changed

--- a/.agents/skills/meridian-brainstorm/SKILL.md
+++ b/.agents/skills/meridian-brainstorm/SKILL.md
@@ -1,30 +1,30 @@
 ---
 name: meridian-brainstorm
 description: >
-  Brainstorming, ideation, and creative feature exploration skill for the Meridian project.
-  Use this skill whenever the user wants to generate new ideas, features, or improvements for Meridian,
+  Brainstorming, ideation, and creative feature exploration for the Meridian project.
+  Use whenever the user wants new ideas, features, or improvements for Meridian,
   or when they ask "what could we add", "how could we improve", "what would be valuable", "what features should we build",
-  or any variant of creative/generative thinking about the project. Also trigger when the user describes a pain point,
-  a user persona (hobbyist, academic, institutional), or a domain problem (latency, data quality, accessibility,
-  backtesting, compliance) and wants ideas for solving it. Also trigger for architecture or refactoring brainstorms,
-  user growth and adoption strategy discussions, or technical debt and code quality improvement ideation.
-  Trigger even if the user just says "brainstorm" or "give me ideas" in the context of this project. This skill
-  produces detailed idea writeups with implementation sketches, audience fit analysis, effort ratings, and concrete
-  next steps.
+  or any variant of generative thinking about the project. Also trigger when the user describes a pain point,
+  an operator role (financial operations, fund accountant, reconciliation analyst, controller, portfolio manager,
+  compliance officer, auditor), or a domain problem (import trust, reconciliation breaks, close readiness, NAV support,
+  evidence retention, approvals, governed reporting, execution safety). Also trigger for architecture or refactoring
+  brainstorms, activation ideas for built-but-unwired capability, adoption and onboarding strategy, or technical debt
+  ideation. Trigger even if the user just says "brainstorm" or "give me ideas" here. Produces idea writeups with
+  implementation sketches, audience fit, and effort ratings.
 license: See repository LICENSE
 compatibility: >
   Portable Agent Skill package for Agent Skills-compatible hosts. Reads markdown references on demand
   and may append to a local brainstorming history ledger when the host permits filesystem writes.
 metadata:
   owner: meridian-ai
-  version: "1.1"
+  version: "2.0"
   spec: open-agent-skills-v1
 ---
 # Meridian — Brainstorming & Ideation Skill
 
-Generate high-value, implementable ideas for the Meridian platform. Every idea should feel like a natural extension of the program — something that makes the existing experience richer, clearer, and more capable, not a bolt-on afterthought.
+Generate high-value, implementable ideas for the Meridian platform. Every idea should feel like a natural extension of the program — something that makes the existing operator experience richer, clearer, and more provable, not a bolt-on afterthought.
 
-> **Shared project context:** [`../_shared/project-context.md`](../_shared/project-context.md) — authoritative stats, provider list, key abstraction file paths, storage design, ADR table. Read this before generating ideas that reference specific classes, interfaces, or provider names.
+> **Shared project context:** [`../_shared/project-context.md`](../_shared/project-context.md) — authoritative platform framing, solution map, key abstraction file paths, and review guardrails. Read this before generating ideas that reference specific classes, interfaces, or surfaces.
 
 ---
 
@@ -32,25 +32,30 @@ Generate high-value, implementable ideas for the Meridian platform. Every idea s
 
 Every brainstorming task follows this 4-step workflow:
 
-### 1 — GATHER CONTEXT (MCP)
-- Fetch the GitHub issue, discussion, or feature request that prompted the brainstorm
-- Read `../_shared/project-context.md` for authoritative project stats and abstraction paths
+### 1 — GATHER CONTEXT
+
+- Read `../_shared/project-context.md` for the authoritative platform framing and abstraction paths
+- Check current product direction in `docs/product/meridian-design-document.md` (the canonical charter) and live status in `docs/roadmap/generated/ROADMAP_SUMMARY.md` — never assert status from memory
+- Fetch the GitHub issue, discussion, or feature request that prompted the brainstorm, when there is one
 - Review [`references/competitive-landscape.md`](references/competitive-landscape.md) for competitive signals relevant to the request
 
-### 2 — ANALYZE & PLAN (Agents)
-- Detect the brainstorm mode (Open Exploration, Problem-Focused, Persona-Focused, etc.) using the mode table
-- Check the `brainstorm-history.jsonl` ledger to avoid repeating previously covered themes
-- Plan the idea set: quantity targets, audience personas, and effort tiers to cover
+### 2 — ANALYZE & PLAN
 
-### 3 — EXECUTE (Skills + Manual)
+- Detect the brainstorm mode (Open Exploration, Problem-Focused, Activation, etc.) using the mode table
+- Check the `brainstorm-history.jsonl` ledger to avoid repeating previously covered themes
+- Plan the idea set: quantity targets, operator roles, and effort tiers to cover
+
+### 3 — EXECUTE
+
 - Emit the mode declaration and summary table before writing any ideas
-- Write each idea as a natural narrative with anchor, user moment, implementation shape, and tradeoffs
+- Write each idea as a natural narrative with anchor, operator moment, implementation shape, and tradeoffs
 - Synthesize: call out the highest-leverage idea, platform bets, and sequencing recommendation
 
-### 4 — COMPLETE (MCP)
+### 4 — COMPLETE
+
 - Append a new entry to `brainstorm-history.jsonl` recording today's session themes
-- If the session produced actionable proposals, create GitHub issues for the top 1-3 ideas
-- Create a PR or discussion thread via GitHub to share the brainstorm output with stakeholders
+- When the session produces a durable artifact, write it to `docs/product/<topic>-brainstorm-<yyyy-mm>.md` and register it as a dated working design input, not a status source
+- If the session produced actionable proposals, create GitHub issues for the top 1-3 ideas or open a discussion thread to share the output
 
 ---
 
@@ -58,76 +63,88 @@ Every brainstorming task follows this 4-step workflow:
 
 The best ideas for Meridian aren't isolated features. They're extensions that **amplify what already exists**. Before generating any idea, ask:
 
-1. **What does Meridian already do well nearby?** Find the existing capability this idea extends, deepens, or connects to. An idea with no anchor to current functionality is probably the wrong idea.
-2. **What would a user actually see and feel?** Every idea must have a concrete UI or interaction moment. If you can't describe what the user clicks, reads, or watches — the idea isn't finished yet.
-3. **Does this make the whole program more coherent?** The best features make users think "of course this is here." They reduce the number of tools a user needs open, surfacing the right information at the right time within Meridian itself.
-4. **Is the information presented clearly?** Data-dense applications live or die on information hierarchy. Every idea that touches the UI should consider: what's the most important thing on screen? What's secondary? What can be progressive-disclosed or hidden until needed?
+1. **What does Meridian already do well nearby?** Find the existing capability this idea extends, deepens, wires up, or connects to. An idea with no anchor to current functionality is probably the wrong idea.
+2. **What would an operator actually see and do?** Every idea must have a concrete UI or interaction moment. If you can't describe what the operator clicks, reads, approves, or resolves — the idea isn't finished yet.
+3. **Does this make a number more provable?** Meridian sells proven numbers: every figure carries a reconstructable chain from source evidence through normalization, validation, reconciliation, ledger impact, approval, report usage, and delivery. Ideas that shorten, strengthen, or expose that chain outrank ideas that only add surface.
+4. **Is the information presented clearly?** Evidence-dense applications live or die on information hierarchy. Every idea that touches the UI should consider: what's the most important thing on screen? What's secondary? What can be progressive-disclosed until needed?
 
 ---
 
 ## Project Context
 
 **What Meridian is:**
-A provider-agnostic .NET 10 platform for evidence-backed investment operations: trusted data, research, paper validation, execution, books, reconciliation, approvals, and governed reporting. The browser workstation under `src/Meridian.Ui/dashboard/` and the reactivated WPF desktop workstation under `src/Meridian.Wpf/` are two active co-equal operator UI lanes over shared contracts.
+A modular, configurable, self-hosted .NET 10 financial operations platform for fund administrators, private fund managers and fund CFOs, registered investment advisors, family offices, and hybrid institutional teams. Fund management is a first-class *specialization*, not the platform root model — core contracts use customer-neutral concepts (organization, entity, portfolio, account, book, period, transaction, evidence, approval, journal, report, audit trail). Trading, research, backtesting, and paper validation are lanes on the same governed evidence spine, not a separate product.
 
-**Tech stack:** .NET 10, C# infrastructure, F# domain models, browser workstation UI, WPF desktop shell, Docker, Prometheus/Grafana, OpenTelemetry, Bounded Channels, WAL storage, JSONL + Parquet, GitHub Actions CI/CD.
+**The operating question every surface must answer:** *Can Meridian prove, book, reconcile, approve, and report this number?*
 
-**Four-pillar architecture (ADR-016):**
-- **Data Collection** — streaming ingestion, historical backfill, storage, data quality monitoring
-- **Backtesting** — historical tick replay, fill simulation, portfolio metrics, Ledger-based P&L
-- **Execution** — live/simulated order routing, `IOrderGateway`, `PaperTradingGateway`, broker adapters, pre-trade risk (`Meridian.Risk`)
-- **Strategies** — strategy lifecycle management, run archive, paper→live promotion workflow
+**The canonical operator spine:** `Import → Validate → Reconcile → Investigate → Approve → Report`
 
-**Current capabilities:**
+**Tech stack:** .NET 10, C# infrastructure, F# deterministic calculation kernels, React/TypeScript browser workstation, WPF desktop workstation, Docker, Prometheus/Grafana, OpenTelemetry, Bounded Channels, WAL storage, JSONL + Parquet, Postgres-backed stores, GitHub Actions CI/CD.
 
-- Real-time streaming: trades, quotes, L2 order book depth from 5 providers
-- Historical backfill: 11 providers with auto-fallback chain
-- Multi-provider failover via `FailoverAwareMarketDataClient`
-- Backtesting engine with tick-by-tick replay, fill models, and double-entry `Ledger` P&L
-- Paper trading gateway (`PaperTradingGateway`) for risk-free strategy validation
-- Strategy lifecycle: register, run, pause, promote paper→live
-- Pre-trade risk validation via `CompositeRiskValidator` / `IRiskRule`
-- Browser workstation: operator workflows, live status, data browser, and API-backed work queues
-- Retained WPF compatibility surface: shared contracts, regressions, and approved maintenance workflows
-- MCP server layer (`Meridian.Mcp` / `Meridian.McpServer`) exposing tools + prompts for AI agents
-- Deployment: Docker Compose, systemd, Kubernetes
-- Observability: OpenTelemetry tracing, Prometheus metrics, Grafana dashboards
-- CI/CD: 33 GitHub Actions workflows for build, test, and automated documentation
+**Scale of the foundation** (measured 2026-07-28; authoritative table in `docs/product/meridian-design-document.md` §5.2):
 
-**What's coming:** StockSharp 90+ provider activation, Python-accessible layer, Arrow Flight / DuckDB integration, assembly-level SIMD hot-path optimizations, browser-first operator UX improvements, and live broker adapters beyond paper trading.
+- 41 source projects under `src/` (52 projects in `Meridian.sln` including tests and benchmarks)
+- ~242,000 lines of C# (2,902 files); 12,736 lines of F# across four calculation projects
+- ~295,000 lines of TypeScript/TSX in the browser workstation (720 files, 165 screen modules)
+- 497 C# files and 147 XAML views in the WPF desktop workstation
+- 845 distinct `/api/...` routes; 22 provider adapter families; 6 statement connector formats
+- 142 classes in `src/Meridian.Ledger/`; ~12,900 xUnit facts/theories across 12 .NET test projects
 
-**Current count (authoritative: `../_shared/project-context.md`):** 868 source files (856 C# + 12 F#), 261 test files, 22 main projects, 33 CI/CD workflows.
+**Wave posture** (live status is always the roadmap registry, never this file):
+
+- **Closed baselines:** provider trust gate (W1), paper trading cockpit and promotion evidence (W2), research-to-paper continuity (W3), ledger reconciliation and governed report packs (W4), accounting records and multi-asset coverage (W5), shared Financial Record Explorers, Financial Operations control center, statement connector library, bounded live-readiness governance, asset accounting event spine
+- **Active:** Evidence Vault productization (`W5X-EVIDENCE-001`), statement reconciliation onboarding wedge (`W5X-STMT-ONBOARD-001`), WPF web-UI parity (`W8-WPF-PARITY-001`), browser screen consolidation (`W8-UX-CONSOL-001`)
+- **Planned:** Operational Evidence Graph surface (`W5X-OEG-001`), Backtesting Studio (`W6-BTSTUDIO-001`), and the ranked W9 slate — truth/fail-closed (`W9-TRUTH-001`), seeded demo (`W9-DEMO-002`), paper realism (`W9-PAPER-003`), broker fill streaming (`W9-ALPACA-004`), client-grade exports (`W9-REPORT-005`), unitized NAV economics (`W9-NAV-006`), execution safety rules (`W9-SAFETY-007`), route authorization and hash-chained audit (`W9-GOV-008`), institutional ingestion (`W9-INGEST-009`)
+
+**Two co-equal operator UI lanes over one shared seam:** the browser workstation in `src/Meridian.Ui/dashboard/` (built assets in `src/Meridian.Ui/wwwroot/workstation/`) and the WPF desktop workstation in `src/Meridian.Wpf/`. Both consume `src/Meridian.Ui.Services/`, `src/Meridian.Ui.Shared/`, and `src/Meridian.Contracts/`. Presentation can differ; business state cannot.
 
 ---
 
-## Audience Personas
+## Non-Negotiable Guardrails
 
-### 🎯 Hobbyist Quant Developer
+Ideas that violate these are wrong ideas, however attractive. Check every idea against this list before writing it up.
 
-Software developer or data scientist learning quant finance. Frustrated by setup complexity and the gap between "collecting data" and "doing something with it." Wants quick wins, low cost, and integration with tools they already know (Jupyter, pandas). Low risk tolerance — prefers paper trading and sandboxed environments.
-
-### 🎓 Academic / Researcher
-
-Quantitative finance PhD, financial economist, or ML researcher. Cares deeply about data reproducibility, provenance, and quality validation. Institutional data is prohibitively expensive. Needs citation-ready data, audit trails, and bulk export to research infrastructure (HDF5, Arrow, DuckDB).
-
-### 🏦 Institutional / Professional
-
-Prop trading firm, hedge fund ops, or quant analyst at an asset manager. Pain points are vendor lock-in, latency SLAs, compliance, and disaster recovery. Values reliability, throughput, and support. Low tolerance for infrastructure failures.
+- **Seven root workspaces only:** `Trading`, `Portfolio`, `Accounting`, `Reporting`, `Strategy`, `Data`, `Settings`. `Research`, `Data Operations`, and `Governance` are compatibility aliases, not new roots. Never propose an eighth root workspace.
+- **No mobile lane:** no native iOS/Android, MAUI, React Native, Flutter, or mobile-first workflows. Responsive browser behavior is allowed only to keep the browser workstation usable.
+- **Truth discipline:** simulated, sample, or fixture-derived values carry loud labels; unsupported persistence fails closed; missing or stale evidence renders as `review-required` or `blocked`, never as plausible-looking data. Never propose a feature that makes unwired capability look finished.
+- **Governed autonomy:** AI may extract, match, summarize, detect discrepancies, and draft. It must never bypass operator approval, retained evidence, ledger controls, period locks, segregation of duties, report release checks, or payment controls.
+- **Meridian owns ledger truth:** external accounting systems contribute read-only evidence unless an approved publishing workflow exports Meridian-owned entries.
+- **Deferred expansion boundaries** (`docs/product/deferred-expansion-boundaries.md`): live treasury payment execution, enterprise risk, forecasting engines, capital-structure modeling, broad client portal, and no-code workflow design each require a roadmap row defining evidence, approval, and audit gates first. You may brainstorm *toward* the acceptance boundary; do not propose shipping past it.
+- **Claim rules:** brainstorm output is an idea, never a status claim. Never describe planned or dormant capability as shipped.
+- **Activation before expansion:** the codebase is more capable than the running product. When a dormant capability exists in source, wiring it is a stronger idea than building a new one beside it.
 
 ---
 
-## The User Experience Lens
+## Audience Roles
 
-**Apply this lens to every idea.** Meridian is a desktop application people monitor for hours. The quality of the experience — how information is organized, how status is communicated, how configuration feels, how errors surface — determines whether someone keeps using it or switches to a script.
+Meridian's canonical Persona Matrix lives in `docs/product/meridian-design-document.md` §4.2 (24 roles). For brainstorm triage, use these grouped codes in the summary table:
 
-**Principles for UI-touching ideas:**
+| Code | Roles | What they need from an idea |
+| --- | --- | --- |
+| **OPS** | Financial Operations Professional (primary operator), Reconciliation Analyst, Data Operations Analyst, Operations Manager, Treasury Operations Specialist | Fewer manual touches, clearer break resolution, trustworthy imports, visible queue state |
+| **ACCT** | Investment Accountant, Fund Accountant, Reporting Analyst, Controller | Correct postings, NAV support, defensible close, period-lock discipline, package accuracy |
+| **INV** | Portfolio Manager, Investment Analyst, Quantitative Researcher, Trader | Position and valuation truth, research-to-paper continuity, execution feedback, drill-down proof |
+| **GOV** | Compliance Officer, Risk Manager, Auditor | Scoped access, retained evidence, audit reconstruction, control enforcement |
+| **EXEC** | CFO, CIO | Decision-grade summaries, exception visibility, blocked-output clarity |
+| **STAKE** | Fund Investor / LP, RIA Client, Family Beneficiary, Trustee, Board / IC Member | Governed delivery, verifiable statements, entitlement-scoped read access |
+| **ADMIN** | System / Security / Integration Administrator | Platform health, connection setup, permission scoping, upgrade safety |
 
-- **Information hierarchy matters.** A streaming data app can easily become a wall of numbers. Every screen should have a clear primary focus, secondary details accessible on hover or drill-down, and a calm default state that doesn't demand attention when things are healthy.
-- **Status at a glance.** The user should be able to look at Meridian for 2 seconds and know: is everything OK? Is anything degraded? Is a backfill running? Use color, density, and spatial position to communicate state — not just text.
-- **Progressive disclosure.** Show the essential view first. Let users expand into detail when they want it. A symbol's health score is the top layer; the per-provider tick rate breakdown is the drill-down.
-- **Contextual actions.** When showing data, show what the user can _do_ with it right there. Viewing a gap in historical data? Offer a one-click backfill. Seeing an anomalous tick? Offer to flag or exclude it.
-- **Consistency across views.** Symbols, providers, time ranges, and status indicators should look and behave the same way everywhere in the app. Build a shared visual vocabulary.
-- **Respect the active medium.** Browser-workstation ideas should feel native to a browser operator surface, while any explicitly approved WPF maintenance should preserve dense desktop affordances without reopening WPF product/UI scope.
+The **Financial Operations Professional is the primary operator**. When an idea has no OPS, ACCT, or GOV benefit, say so explicitly and justify why it still earns build time.
+
+---
+
+## The Operator Experience Lens
+
+**Apply this lens to every idea.** Meridian is an application operators live in for a working day. How information is organized, how state is communicated, how evidence surfaces, and how blockers explain themselves determines whether someone trusts it or falls back to a spreadsheet.
+
+- **Information hierarchy matters.** An evidence-dense app easily becomes a wall of rows. Every screen should have a clear primary focus, secondary details on hover or drill-down, and a calm default state when nothing needs attention.
+- **State at a glance.** An operator should look for 2 seconds and know: what is blocked, what is waiting on me, what is stale. Use color, density, and position to communicate state — not just text.
+- **Evidence is one click away, never the main event.** Proof should be reachable from any number (drill from a report line to its journal, its source record, its approval) without dominating the working surface.
+- **Progressive disclosure.** Show the essential view first; expand into detail on demand. The reconciliation queue's break count is the top layer; the per-row matching detail is the drill-down.
+- **Contextual actions.** When showing state, show what the operator can *do* about it. Viewing an unmatched statement row? Offer match, split, and escalate right there.
+- **Blocked states must explain themselves.** "Blocked" is only useful with the reason, the owner, and the next action attached.
+- **Consistency across views.** Entities, accounts, periods, evidence chips, and status indicators should look and behave the same everywhere. Build on the shared design system, not per-screen variants.
+- **Respect both lanes.** Browser-workstation ideas should feel native to a browser operator surface; WPF ideas should preserve dense desktop affordances while consuming the same shared contracts. Neither lane may fork product state.
 
 ---
 
@@ -139,21 +156,23 @@ Before generating any ideas, output a one-line mode declaration at the top of yo
 
 > **Mode detected:** [Mode Name] — *[one sentence explaining why]*
 
-Use the table below to identify the mode. If the request is ambiguous between two modes, state both and explain which one you're optimizing for.
+Use the table below. If the request is ambiguous between two modes, state both and explain which one you're optimizing for.
 
 | Mode | Trigger phrases | Approach |
 | ------ | --------- | ---------- |
-| **Open Exploration** | "What could we build?" / "What's valuable?" / "Give me ideas" | Generate across all dimensions, all personas. Favor ideas that connect multiple existing capabilities. |
-| **Problem-Focused** | "How do we solve X?" / "What's the best way to fix Y?" | 3-5 deep ideas targeting the specific pain. Show how each integrates with existing features. |
-| **Persona-Focused** | "What do hobbyist quants want?" / "Ideas for academics" / "Institutional use cases" | 5-8 ideas optimized for that audience. Describe the user journey, not just the feature. |
-| **Domain-Focused** | "Ideas for latency / storage / UX / data quality" | Technical depth in that domain. Every idea still needs a UI or interaction touchpoint. |
-| **Competitive** | "What are others doing?" / "How do we compare to Databento?" | Scan `references/competitive-landscape.md`. Identify gaps; only propose ideas that fit Meridian's architecture naturally. |
-| **Quick Wins** | "What's easy to ship?" / "Low-hanging fruit?" | Effort ≤ Medium, impact ≥ High. Emphasize ideas that improve the existing experience, not new surface area. |
-| **Architecture / Refactoring** | "How should we restructure X?" / "Refactoring ideas" / "What should we improve architecturally?" | Code structure, MVVM compliance, separation of concerns, testability. Anchor to real patterns (`BindableBase`, `EventPipeline`, `IStorageSink`). Include before/after and migration risk. |
-| **User Growth / Adoption** | "How do we get more users?" / "Growth ideas" / "Onboarding friction" | Onboarding, evangelism, community. Map to personas. Span awareness → activation → retention. |
-| **Technical Debt / Code Quality** | "What tech debt should we address?" / "Audit ideas" / "Code quality improvements" | Test coverage, static analysis, CI/CD hardening, dead code. Quantify the cost of inaction. |
-| **UX / Information Design** | "How should we display X?" / "The UI feels cluttered" / "Dashboard design" | Focus on information architecture, visual hierarchy, interaction flow, clarity. Every idea is UI-first. |
-| **Skill Improvement** | "How can the skills be improved?" / "Improve the brainstorm skill" / "Better code reviews" | Apply the brainstorm process reflexively to the skills themselves: eval coverage, output quality, reference freshness, DX. |
+| **Open Exploration** | "What could we build?" / "What's valuable?" / "Give me ideas" | Generate across domains and roles. Favor ideas that connect existing capabilities into one proven path. |
+| **Problem-Focused** | "How do we solve X?" / "What's the best way to fix Y?" | 3-5 deep ideas targeting the specific pain. Show how each integrates with existing surfaces. |
+| **Activation** | "What's built but not wired?" / "What can we turn on?" / "Cheapest high-value win" | Find dormant capability in source, propose the wiring path, and name what it replaces on the live path. Read the activation register in charter §2.1. |
+| **Role-Focused** | "What do fund accountants need?" / "Ideas for controllers" / "Auditor use cases" | 5-8 ideas optimized for that role. Describe the working session, not just the feature. |
+| **Domain-Focused** | "Ideas for reconciliation / close / evidence / providers / reporting" | Technical depth in that domain. Every idea still needs an operator touchpoint. |
+| **Competitive** | "What are others doing?" / "How do we compare to BlackLine?" | Scan `references/competitive-landscape.md`. Identify gaps; only propose ideas that fit Meridian's architecture naturally. |
+| **Quick Wins** | "What's easy to ship?" / "Low-hanging fruit?" | Effort ≤ Medium, impact ≥ High. Emphasize ideas that improve the existing path, not new surface area. |
+| **Architecture / Refactoring** | "How should we restructure X?" / "Refactoring ideas" | Code structure, seam integrity, shared-contract compliance, testability. Anchor to real patterns (`EventPipeline`, `IStorageSink`, `BindableBase`, endpoint/read-model seams). Include before/after and migration risk. |
+| **Evidence & Governance** | "How do we prove X?" / "Audit readiness ideas" / "Approval workflow gaps" | Evidence packets, provenance, approval separation, retention, audit reconstruction. Every idea names what it blocks when absent. |
+| **Adoption / Onboarding** | "How do we reduce time-to-value?" / "Onboarding friction" / "Shadow-mode adoption" | Time to First Proof, seeded demo, import wedge, shadow-mode parallel books. Map to roles and to the wedge in charter §22. |
+| **Technical Debt / Code Quality** | "What tech debt should we address?" / "Code quality improvements" | Test effectiveness, static analysis, CI hardening, dead code, duplicated seams. Quantify the cost of inaction. |
+| **UX / Information Design** | "How should we display X?" / "The screen feels cluttered" / "Workspace design" | Information architecture, visual hierarchy, interaction flow, clarity. Every idea is UI-first and maps to one of the seven roots. |
+| **Skill Improvement** | "How can the skills be improved?" / "Improve the brainstorm skill" | Apply the brainstorm process reflexively to the skills themselves: eval coverage, output quality, reference freshness, DX. |
 
 ### Step 1: Emit the Summary Table
 
@@ -164,7 +183,7 @@ Use the table below to identify the mode. If the request is ambiguous between tw
 
 | # | Idea | Effort | Audience | Impact | Depends On |
 |---|------|--------|----------|--------|------------|
-| 1 | [Short name] | S/M/L/XL | H=Hobbyist, Q=Academic, I=Institutional | High/Med/Low | [prereq or —] |
+| 1 | [Short name] | S/M/L/XL | OPS/ACCT/INV/GOV/EXEC/STAKE/ADMIN | High/Med/Low | [prereq or —] |
 | 2 | ... | | | | |
 ```
 
@@ -176,27 +195,30 @@ Write each idea as a **natural narrative**, not a form to fill out. The reader s
 
 **What every idea must include** (woven into prose, not as labeled fields):
 
-- **The anchor:** What existing Meridian capability does this extend or complement? Reference real file paths from `../_shared/project-context.md` where helpful (e.g., "extends `IStorageSink` at `src/Meridian.Storage/Interfaces/IStorageSink.cs`").
-- **The user moment:** What does the user see, click, or experience? Be specific — describe a screen, a notification, an interaction, not just a backend change.
-- **The implementation shape:** Key technical approach — interfaces, patterns, data flow. Enough that a developer could start scoping.
+- **The anchor:** What existing Meridian capability does this extend, wire, or complement? Reference real file paths (e.g., "extends `StatementMatchingEngine` at `src/Meridian.FinancialOperations/Reconciliation/StatementMatchingEngine.cs`"). Use the anchor table in `references/idea-dimensions.md`.
+- **The operator moment:** What does the operator see, click, resolve, or approve? Name the workspace it lands in and the screen it changes.
+- **The implementation shape:** Key technical approach — contracts, seams, data flow, persistence. Enough that a developer could start scoping.
+- **The evidence and governance impact:** What proof does this create, retain, or expose? What does it block when absent? What approval does it require?
 - **The tradeoffs:** What's hard? What could go wrong? What does this cost in complexity?
 - **Effort and audience:** Who benefits most? How big is this?
 
 **What to include when relevant** (not every idea needs all of these):
 
 - A rough UI sketch described in words (layout, what's prominent, what's secondary)
-- How this feature connects to other features in the app
+- How this feature connects to other features and workspaces
 - Before/after comparison for architecture ideas
-- Funnel stage and success metrics for growth ideas
+- Which roadmap row it belongs to, or that it needs a new one
 - Debt cost and payoff timeline for tech debt ideas
 
 **Quantity guidelines:**
 
-- Open Exploration: 8-12 ideas across 3+ categories
-- Problem/Persona/Domain focused: 4-6 deep ideas
+- Open Exploration: 8-12 ideas across 3+ domains
+- Problem / Role / Domain focused: 4-6 deep ideas
+- Activation: 4-6 ideas, each naming the dormant capability and the live path it replaces
 - Quick Wins: 6-8 ideas
 - Architecture/Refactoring: 4-6 ideas
-- User Growth/Adoption: 5-8 ideas
+- Evidence & Governance: 4-6 ideas
+- Adoption / Onboarding: 5-8 ideas
 - Technical Debt/Code Quality: 4-6 ideas
 - UX/Information Design: 4-6 ideas
 
@@ -204,15 +226,17 @@ Write each idea as a **natural narrative**, not a form to fill out. The reader s
 
 After the ideas, step back and write a synthesis that:
 
-- Identifies the highest-leverage idea (best impact/effort ratio, most complementary to existing features)
+- Identifies the highest-leverage idea (best impact/effort ratio, most complementary to existing capability)
 - Calls out "platform bets" — ideas that unlock multiple others
-- Flags cross-cutting themes (e.g., "three of these ideas all need a shared symbol health model")
+- Flags cross-cutting themes (e.g., "three of these ideas all need the evidence graph projection")
 - Suggests sequencing: what to build first, what it enables next
-- **Competitive signals (always include):** 2-3 sentences from `references/competitive-landscape.md` on how competitors handle this space and which pattern is most adaptable to Meridian's architecture
+- Names roadmap fit: which existing row absorbs each idea, and which would need a new row
+- **Competitive signals (always include):** 2-3 sentences from `references/competitive-landscape.md` on how adjacent products handle this space and which pattern is most adaptable to Meridian's architecture
+- For Activation mode: what the wiring replaces, and how the predecessor gets retired
 - For Architecture mode: migration ordering and risk dependencies
-- For Growth mode: which funnel stage to invest in first
+- For Adoption mode: which stage of Time to First Proof to invest in
 - For Tech Debt mode: quick wins first, then structural changes
-- For UX mode: which screens or views to redesign first based on user frequency and pain
+- For UX mode: which screens to redesign first based on operator frequency and pain
 
 ---
 
@@ -220,54 +244,66 @@ After the ideas, step back and write a synthesis that:
 
 **Write ideas like you're pitching them to a product-minded developer**, not filling in a form. Each idea should read as a short, compelling argument — "here's what's painful today, here's what we'd build, here's what it looks like, here's why it's worth it."
 
-- **Be specific, not generic.** "Add a Python SDK" is weak. "Add a `marketdata` Python package with an async iterator over the live WebSocket feed, pandas DataFrame output, and a `snap()` convenience method for the last N ticks" is strong.
-- **Always describe the user experience.** Even backend optimizations have a user-facing moment: "The backfill that used to take 45 minutes now finishes in 8. The browser progress strip reflects this - the user sees symbols resolving in rapid succession."
-- **Show how features connect.** "This data quality scorecard feeds into the existing dashboard's symbol list — the health score appears as a colored dot next to each symbol. Clicking it expands to the detailed breakdown."
+- **Be specific, not generic.** "Improve reconciliation" is weak. "Promote `StatementMatchingEngine`'s sided matching onto the live statement path so a bank row and a ledger row match as a pair, with a confidence score and a one-click split/escalate action in the Accounting reconciliation queue" is strong.
+- **Always describe the operator experience.** Even backend work has a user-facing moment: "The close that used to need a spreadsheet tie-out now shows a readiness score with the three blocking items named, each linking to the record that caused it."
+- **Show how features connect.** "This evidence chip appears next to every report line; clicking it opens the same proof drawer the reconciliation queue uses."
 - **Acknowledge tradeoffs honestly.** Hidden complexity is the enemy. Name it.
-- **Anchor to the codebase.** Reference real abstractions: `IMarketDataClient`, `IHistoricalDataProvider`, `EventPipeline`, `IStorageSink`, `BindableBase`, the Options pattern. Include file paths from `../_shared/project-context.md` when it clarifies the implementation.
-- **For architecture ideas:** Show concrete code-level changes, not just diagrams. Reference actual class names and namespaces.
-- **For growth ideas:** Be honest about what requires sustained investment vs. one-time effort.
-- **For tech debt ideas:** Quantify the cost: "This makes onboarding a new contributor take 2 days instead of 2 hours" beats "this is messy."
-- **For UX ideas:** Describe the screen. What's at the top? What's the primary action? What information is visible by default vs. on drill-down? How does this view connect to other views in the app?
+- **Anchor to the codebase.** Reference real abstractions: `EventPipeline`, `IStorageSink`, `IOrderGateway`, `IRiskRule`, `AccountingCloseManagementService`, `EvidenceGraphService`, `LedgerReportPackBuilder`, `WorkstationEndpoints`, the Options pattern, source-generated JSON.
+- **For architecture ideas:** show concrete code-level changes, not just diagrams. Reference actual class names and namespaces.
+- **For adoption ideas:** be honest about what requires sustained investment vs. one-time effort.
+- **For tech debt ideas:** quantify the cost. "Two services own overlapping close state, so a fix has to land twice" beats "this is messy."
+- **For UX ideas:** describe the screen. What's at the top? What's the primary action? What's visible by default vs. on drill-down? How does this view connect to the rest of the workspace?
 
 ---
 
 ## Idea Continuity (Session History)
 
-To avoid repeating ideas across sessions, a lightweight ledger can be maintained at `.Codex/skills/meridian-brainstorm/brainstorm-history.jsonl` (gitignored by default). Each line is a JSON object:
+A ledger of past sessions is maintained at `.agents/skills/meridian-brainstorm/brainstorm-history.jsonl` and tracked in the repository. Each line is a JSON object:
 
 ```json
-{"session_date": "2026-03-16", "mode": "Open Exploration", "themes": ["Python SDK", "data quality scorecard", "tiered storage"], "ideas_count": 10}
+{"session_date": "2026-07-14", "mode": "Problem-Focused / UX", "themes": ["Excel onboarding workbook generator", "multi-sheet XLSX staged review"], "ideas_count": 5, "document_updated": "docs/product/excel-onboarding-workbook-brainstorm-2026-07.md", "notes": "code findings and sequencing"}
 ```
 
-If this file exists, open each brainstorm session with:
+Read it before generating, and open each brainstorm session with:
 > **Previous sessions covered:** [summary of themes from history]. **Unexplored areas:** [gaps].
 
-This prevents the same ideas from appearing session after session and surfaces genuinely new territory.
+Append a new line at the end of the session. This prevents the same ideas from appearing session after session and surfaces genuinely new territory.
 
 ---
 
 ## Idea Generation Reference
 
-When brainstorming, read [`references/idea-dimensions.md`](references/idea-dimensions.md) for the full seeded concept bank organized by category. The file includes a **codebase anchor table** mapping concept names to file paths for precise implementation references.
+When brainstorming, read [`references/idea-dimensions.md`](references/idea-dimensions.md) for the full seeded concept bank organized by domain. The file opens with a **codebase anchor table** mapping concept names to verified file paths.
 
 **Quick-access dimensions:**
 
-- **Data access:** streaming API, bulk export, query API, Python SDK, gRPC, Arrow Flight, DuckDB integration
-- **Data quality:** gap detection, anomaly flagging, cross-provider reconciliation, tick quality scoring, options chain validation
-- **Performance:** kernel bypass, lock-free queues, SIMD processing, GC tuning, backpressure metrics
-- **Storage:** Parquet/Arrow, time-series DB, tiered cold storage, deduplication, schema evolution, retention policies
-- **Integrations:** Jupyter, pandas, QuantConnect, Backtrader, Grafana, dbt, OpenBB, Dagster/Airflow
-- **UX:** setup wizard, symbol browser, live visualizer, order book heatmap, config validation, theme system, diagnostics panel
-- **Reliability:** multi-provider failover, health scoring, alerting, chaos testing, rolling restart
-- **Architecture:** MVVM compliance, DI container, hot/cold path separation, interface segregation, pipeline modularization
-- **Growth:** quickstart experience, content series, README optimization, integration showcases, contributor onboarding
-- **Code quality:** mutation testing, static analysis gates, dead code elimination, test isolation, error handling patterns
+- **Import & data trust:** connector coverage, mapping profiles, drift detection, preview/confidence, replay, certified import runs
+- **Reconciliation & breaks:** sided matching, tolerance policy, casework, SLA, aging, bulk resolution, root-cause clustering
+- **Ledger & accounting:** journals, period lock, close readiness, capital accounts, tax lots, multi-currency, NAV economics
+- **Evidence & provenance:** evidence packets, manifests, document extraction, object links, evidence graph, number-level lineage
+- **Reporting & delivery:** report packs, report-writer grids, client-grade rendering, provenance drill-through, publication and restatement
+- **Portfolio & valuation:** positions, marks, security master, corporate actions, multi-asset coverage, cash ladder
+- **Execution & risk:** order gateways, paper realism, fill and cost models, pre-trade rules, kill-switch and safety controls
+- **Research & strategy:** strategy lifecycle, backtesting runtime, run comparison, promotion evidence, QuantScript
+- **Workstation UX:** the seven roots, screen consolidation, command palette, trust strip, proof drawers, operator focus and queues
+- **Governance & tenancy:** scoped authorization, approval separation, audit chain, retention, access review
+- **Platform quality:** durability, performance, observability, test effectiveness, CI hardening, activation coverage
+
+---
+
+## Handoffs
+
+- Hand off to `meridian-blueprint` when the user selects one idea for implementation design.
+- Hand off to `meridian-roadmap-strategist` when ideas need sequencing into roadmap waves or a new registry row.
+- Hand off to `meridian-simulated-user-panel` when ideas need persona critique before selection.
+- Hand off to `meridian-repo-navigation` when grounding an idea needs subsystem routing first.
 
 ---
 
 ## Reference Files
 
-- [`references/idea-dimensions.md`](references/idea-dimensions.md) — Seeded idea bank organized by category, including codebase anchor table
-- [`references/competitive-landscape.md`](references/competitive-landscape.md) — What Bloomberg, Databento, Polygon, Refinitiv, and open-source tools offer (read for competitive signals in every synthesis section)
-- `../_shared/project-context.md` — Authoritative project stats, abstraction file paths, provider inventory
+- [`references/idea-dimensions.md`](references/idea-dimensions.md) — Seeded idea bank organized by domain, including the verified codebase anchor table
+- [`references/competitive-landscape.md`](references/competitive-landscape.md) — How close managers, fund-administration suites, asset-servicing platforms, ledger APIs, and market-data vendors compare (read for competitive signals in every synthesis section)
+- `../_shared/project-context.md` — Authoritative platform framing, solution map, abstraction file paths, review guardrails
+- `docs/product/meridian-design-document.md` — Canonical product charter: value proposition, doctrines, persona matrix, implementation baseline, wedge
+- `docs/roadmap/generated/ROADMAP_SUMMARY.md` — Live roadmap status; the only source for what is done, active, or planned

--- a/.agents/skills/meridian-brainstorm/references/competitive-landscape.md
+++ b/.agents/skills/meridian-brainstorm/references/competitive-landscape.md
@@ -1,77 +1,118 @@
 # Competitive Landscape — Meridian Brainstorm Reference
 
-Understanding the market helps identify where Meridian can differentiate vs. where it needs feature parity.
+Understanding the market helps identify where Meridian can differentiate vs. where it needs parity. The category set below follows the differentiation analysis in `docs/product/meridian-design-document.md` §1.4 and the market-entry wedge in §22.
+
+**The gap Meridian sells against:** the market has tools for every fragment and no product for the whole proof. Portfolio systems *show* numbers but cannot prove them. Accounting systems *record* numbers but do not carry the operational evidence behind them. Close-management tools *track tasks* around numbers but own neither the data nor the ledger. Fund administrators *certify* numbers as a service, at service-provider speed and cost.
 
 ---
 
-## Paid Commercial Providers
+## Close and Controls Managers
 
-### Bloomberg Terminal / Bloomberg B-PIPE
+**BlackLine, Trintech**
 
-- Gold standard for institutional data; real-time + historical across all asset classes
-- Costs $20K-$24K/user/year
-- Meridian opportunity: target long tail who cannot justify this cost — hobbyists, small funds, academic labs
-- Features worth borrowing: data lineage tagging, real-time anomaly flagging
-
-### Databento
-
-- Modern developer-first market data API; pay-per-use; MBO + MBP data; DBN binary format
-- Pricing: ~$0.10-$1.00/symbol-day historical; real-time from $150/month
-- Meridian advantage: cloud-only with no self-hosted option; Meridian wins on on-premise, no per-tick fees for self-collected data
-- Features worth borrowing: DBN format, databento-python ergonomics, MBO data model
-
-### Polygon.io
-
-- REST + WebSocket for US equities, options, forex, crypto; free tier available
-- Meridian advantage: Polygon does not enable structured local storage; Meridian local-first means no ongoing per-query cost
-- Features worth borrowing: aggregates/OHLCV API design, options chain endpoint
+- Own the close checklist, task assignment, sign-off, and account-reconciliation certification workflow
+- Sit *beside* the ERP/GL: they track and certify work about numbers they do not own
+- Strong at: reviewer workflow, control evidence attachment, close status reporting, SOX-style certification
+- Meridian's angle: it owns the data, the reconciliation, and the ledger, so the close checklist is derived from real record state rather than manually asserted. A task marked complete in Meridian is backed by a reconciled, approved record — not a checkbox.
+- Worth borrowing: certification rigor, reviewer/preparer separation UX, close calendar ergonomics, materiality-driven task scoping
 
 ---
 
-## Open Source / Community Tools
+## Fund Administration and Private-Capital Suites
 
-### QuestDB
+**Carta, FundStudio, Investran-class platforms**
 
-- Open-source time-series SQL database; ILP ingest; nanosecond timestamp support
-- Natural Meridian storage backend replacing JSONL for query-heavy use cases
-- Integration: Meridian to QuestDB sink (ILP over TCP) alongside JSONL
+- Capital accounts, commitments, closings, allocations, waterfalls, carry, fees, investor statements, notices
+- Typically strong on fund economics, weaker on operational evidence chains and general-purpose accounting
+- Meridian's angle: the same capital-account and waterfall math (`src/Meridian.Ledger/`) sits on a customer-neutral core — organization, entity, portfolio, account, book, period — so fund workflows are a specialization rather than the root model, and non-fund customers use the same spine
+- Worth borrowing: LP statement quality, capital-call and distribution notice workflows, equalization handling, investor-facing clarity
+- Not worth borrowing: fund-shaped root data models that make non-fund customers second-class
 
-### QuantConnect LEAN / Backtrader / Zipline
+---
 
-- Open-source backtesting frameworks with their own data ingestion pipelines
-- None have a good live-data collection layer — Meridian can be "the collector that feeds your backtesting framework"
-- LEAN bridge is highest-value (large QuantConnect community)
+## Asset-Servicing and Portfolio Accounting Platforms
 
-### OpenBB Terminal
+**SS&C Advent Geneva, eFront, Addepar-class platforms**
 
-- Open-source Bloomberg Terminal alternative; Python-based; no persistent storage
-- Meridian could be an OpenBB data provider backend, giving OpenBB users high-quality local storage
+- Multi-book portfolio accounting, valuation, performance, and consolidated reporting at institutional scale
+- Expensive, implementation-heavy, often service-wrapped; customization typically flows through the vendor
+- Meridian's angle: self-hosted, contract-pack extensible, and evidence-first — the proof chain is a product object, not an export
+- Worth borrowing: multi-book rigor, valuation methodology discipline, consolidation and elimination modeling, report library depth
+- Not worth borrowing: implementation models that require vendor services for routine configuration
+
+---
+
+## Ledger and Payment APIs
+
+**Modern Treasury and similar ledger/payment infrastructure**
+
+- Developer-first double-entry ledger APIs, bank connectivity, and payment orchestration
+- Excellent primitives, but the customer builds the operator product on top
+- Meridian's angle: Meridian ships the operator product — queues, close cockpit, approvals, evidence, reporting — with the ledger as internal truth rather than an API surface to be assembled
+- Worth borrowing: ledger API ergonomics, idempotency discipline, bank-format handling (BAI2/CAMT.053 — already in source at `src/Meridian.FinancialOperations/Reconciliation/Connectors/`)
+- Boundary reminder: live payment execution remains a deferred lane (`docs/product/deferred-expansion-boundaries.md`); brainstorm toward the acceptance boundary, not past it
+
+---
+
+## Market Data and Trading Infrastructure
+
+Relevant to the Trading, Strategy, and Data lanes, which remain part of the same governed spine.
+
+- **Bloomberg Terminal / B-PIPE** — institutional gold standard, $20K+/user/year; strong lineage and monitoring expectations worth borrowing
+- **Databento** — developer-first market data, cloud-only, strong data-product packaging and client ergonomics
+- **Polygon.io** — simple REST/WebSocket access with a free tier; no local storage or workflow story
+- **QuantConnect LEAN / Backtrader / Zipline** — backtesting ecosystems with their own ingestion; none carry an accounting or evidence lane
+- Meridian's angle: decision-to-delivery continuity — research, backtest, paper validation, promotion governance, execution records, reconciliation, ledger, close, and delivery on one evidence model. Close tools have no trading lane; trading platforms have no close.
 
 ---
 
 ## Differentiation Matrix
 
-| Capability          | Bloomberg | Databento | Polygon | Meridian now | Meridian potential |
-|---------------------|-----------|-----------|---------|---------|---------------|
-| Self-hosted         | No        | No        | No      | Yes     | Yes           |
-| Multi-provider      | Yes       | No        | No      | Yes (5) | Yes (90+)     |
-| Free tier           | No        | No        | Yes     | Yes     | Yes           |
-| Sub-ms latency      | Yes       | Yes       | No      | Yes     | Yes           |
-| Python SDK          | Yes       | Yes       | Yes     | No      | Planned       |
-| L2 order book       | Yes       | Yes       | Yes     | Yes(IB) | Yes           |
-| Data provenance     | Yes       | Partial   | No      | No      | Opportunity   |
-| Backtesting engine  | No        | No        | No      | Yes     | Yes (full)    |
-| Paper trading       | No        | No        | No      | Yes     | Yes           |
-| Strategy execution  | No        | No        | No      | Yes     | Yes (live)    |
-| Pre-trade risk      | Yes       | No        | No      | Yes     | Yes           |
-| Community sharing   | No        | No        | No      | No      | Opportunity   |
-| Academic citation   | No        | No        | No      | No      | Opportunity   |
-| MCP / AI tooling    | No        | No        | No      | Yes     | Yes           |
+Columns are category representatives, not exhaustive vendor claims. "Meridian now" reflects accepted roadmap evidence; "potential" reflects charter direction, not shipped capability.
 
-Meridian defensible moats:
+| Capability | Close managers | Fund admin suites | Asset servicing | Ledger APIs | Meridian now | Meridian potential |
+|---|---|---|---|---|---|---|
+| Self-hosted | No | No | No | No | Yes | Yes |
+| Owns the data *and* the ledger | No | Partial | Yes | Partial | Yes | Yes |
+| Evidence chain as a product object | Partial | No | Partial | No | Yes (packets, manifests) | Number Passport on every figure |
+| Reconciliation engine | Certification only | Partial | Yes | No | Yes | Sided matching on the live path |
+| Close cockpit | Yes | Partial | Partial | No | Yes | Readiness scoring with named blockers |
+| Governed report packs with lineage | No | Partial | Yes | No | Yes | Client-grade rendering |
+| Fund economics (NAV, waterfall, carry) | No | Yes | Yes | No | Supported foundation | Wired economics path |
+| Trading / research lane | No | No | Partial | No | Yes | Backtesting Studio evidence loop |
+| Fail-closed truth discipline | No | No | No | No | Yes | Datum-level labeling |
+| Contract-pack extensibility | No | No | Vendor-led | Partial | Partial | Certified asset packs |
+| AI/MCP tooling surface | No | No | No | No | Yes | Governed-autonomy assistants |
+| Cheap stakeholder verification seats | No | Partial | No | No | Partial | Free/low-cost reviewer roles |
 
-1. Self-hosted, no per-query cloud fees
-2. Multi-provider failover and reconciliation (no competitor does this affordably)
-3. Full platform: data collection → backtesting → execution → strategy lifecycle in one codebase
-4. Hackable open architecture — plugins, custom sinks, C# + F# extensibility
-5. MCP server layer — AI-native tooling surface (unique in this space)
+---
+
+## Meridian's Defensible Moats
+
+1. **Proof as the product.** Provenance, evidence retention, reconciliation state, approvals, and report-line lineage are first-class, user-visible objects — not exports or logs.
+2. **Truthful by construction.** Loud labeling of simulated data, fail-closed persistence, and `review-required` / `blocked` states instead of plausible-looking numbers. Honesty is expensive for competitors to retrofit.
+3. **Decision-to-delivery continuity.** One governed evidence model spanning research through delivery; the codebase already carries both ends.
+4. **Whole-balance-sheet modeling.** Assets, liabilities, commitments, guarantees, collateral, and contingent exposures as equal citizens via contract packs.
+5. **Lower-risk adoption.** Shadow-mode onboarding proves value before a customer migrates official books.
+6. **Trust as distribution.** Every governed delivery is a verification event; cheap reviewer seats spread the proof network.
+7. **Self-hosted and hackable.** No per-query cloud fees, extensible in C# and F#, with an MCP surface for AI-native tooling.
+
+---
+
+## Good Borrowing Targets
+
+- Certification and reviewer-workflow rigor from close managers
+- LP statement and capital-activity notice quality from fund administration suites
+- Multi-book and consolidation discipline from asset-servicing platforms
+- Idempotency and bank-format handling from ledger APIs
+- Data lineage and anomaly surfacing from institutional market-data vendors
+- Client ergonomics and packaging polish from developer-first data products
+
+## Bad Borrowing Targets
+
+- Cloud-only assumptions that break self-hosted operation
+- Vendor-service-dependent configuration models
+- Fund-shaped root data models that demote non-fund customers
+- Checklist-only close tracking that asserts completion without record backing
+- Any surface that presents unwired capability as finished
+- Features that ignore Meridian's seven-root navigation, evidence discipline, or the co-equal browser and desktop lanes

--- a/.agents/skills/meridian-brainstorm/references/idea-dimensions.md
+++ b/.agents/skills/meridian-brainstorm/references/idea-dimensions.md
@@ -1,233 +1,330 @@
 # Idea Dimensions — Meridian Brainstorm Reference
 
-Seeded concept bank organized by category. Use these as inspiration prompts, not final ideas — the goal is to develop them into full Idea Cards grounded in the Meridian codebase.
+Seeded concept bank organized by domain. Use these as inspiration prompts, not final ideas — the goal is to develop them into full idea writeups grounded in the Meridian codebase.
 
-> **See also:** [`../../_shared/project-context.md`](../../_shared/project-context.md) for authoritative project stats, ADR table, and key abstraction file paths.
+> **See also:** [`../../_shared/project-context.md`](../../_shared/project-context.md) for the authoritative platform framing, solution map, and review guardrails, and `docs/product/meridian-design-document.md` for the canonical product charter.
+>
+> **Claim discipline:** the presence of a type in this table means the code exists, not that the capability is wired into the live operator path. Several entries below are explicitly dormant (see *Activation Targets*). Never describe a dormant capability as shipped.
 
 ---
 
 ## 🗺️ Codebase Anchor Table
 
-Use these when referencing specific abstractions in ideas. File paths are relative to the repository root.
+Use these when referencing specific abstractions in ideas. File paths are relative to the repository root and were verified 2026-07-28.
+
+### Import, providers, and data trust
 
 | Concept | Interface / Class | File Path |
 |---------|-------------------|-----------|
 | Streaming provider contract | `IMarketDataClient` | `src/Meridian.ProviderSdk/IMarketDataClient.cs` |
 | Historical provider contract | `IHistoricalDataProvider` | `src/Meridian.Infrastructure/Adapters/Core/IHistoricalDataProvider.cs` |
-| Storage sink contract | `IStorageSink` | `src/Meridian.Storage/Interfaces/IStorageSink.cs` |
-| Event pipeline coordinator | `EventPipeline` | `src/Meridian.Application/Pipeline/EventPipeline.cs` |
-| Write-ahead log | `WriteAheadLog` | `src/Meridian.Storage/Archival/WriteAheadLog.cs` |
-| Crash-safe file writes | `AtomicFileWriter` | `src/Meridian.Storage/Archival/AtomicFileWriter.cs` |
-| JSONL sink | `JsonlStorageSink` | `src/Meridian.Storage/Sinks/JsonlStorageSink.cs` |
-| Parquet sink | `ParquetStorageSink` | `src/Meridian.Storage/Sinks/ParquetStorageSink.cs` |
-| MVVM base class | `BindableBase` | `src/Meridian.Wpf/ViewModels/BindableBase.cs` |
-| ICommand implementation | `RelayCommand` | `src/Meridian.Wpf/ViewModels/` |
-| JSON source-gen context | `MarketDataJsonContext` | `src/Meridian.Core/Serialization/MarketDataJsonContext.cs` |
-| Multi-provider historical routing | `CompositeHistoricalDataProvider` | `src/Meridian.Infrastructure/Adapters/Core/` |
-| Backfill orchestration | `HistoricalBackfillService` | `src/Meridian.Application/Backfill/HistoricalBackfillService.cs` |
-| Gap detection | `GapBackfillService` | `src/Meridian.Application/Backfill/GapBackfillService.cs` |
-| Data quality orchestrator | `DataQualityMonitoringService` | `src/Meridian.Application/Monitoring/DataQuality/` |
-| Data completeness scoring | `CompletenessScoreCalculator` | `src/Meridian.Application/Monitoring/DataQuality/` |
-| Prometheus metrics | `PrometheusMetrics` | `src/Meridian.Application/Monitoring/PrometheusMetrics.cs` |
-| Storage catalog | `StorageCatalogService` | `src/Meridian.Storage/Services/StorageCatalogService.cs` |
-| Tiered storage migration | `TierMigrationService` | `src/Meridian.Storage/Services/TierMigrationService.cs` |
-| Parquet conversion | `ParquetConversionService` | `src/Meridian.Storage/Services/ParquetConversionService.cs` |
-| F# validation pipeline | `ValidationPipeline` | `src/Meridian.FSharp/Validation/ValidationPipeline.fs` |
-| F# quote validator | `QuoteValidator` | `src/Meridian.FSharp/Validation/QuoteValidator.fs` |
-| F# trade validator | `TradeValidator` | `src/Meridian.FSharp/Validation/TradeValidator.fs` |
 | Provider SDK attribute | `DataSourceAttribute` | `src/Meridian.ProviderSdk/DataSourceAttribute.cs` |
 | Provider SDK discovery | `DataSourceRegistry` | `src/Meridian.ProviderSdk/DataSourceRegistry.cs` |
-| Graceful shutdown | `GracefulShutdownService` | `src/Meridian.Application/Services/GracefulShutdownService.cs` |
-| Storage sink discovery | `StorageSinkRegistry` | `src/Meridian.Storage/StorageSinkRegistry.cs` |
-| Subscription orchestration | `SubscriptionOrchestrator` | `src/Meridian.Application/Subscriptions/SubscriptionOrchestrator.cs` |
 | Failover provider | `FailoverAwareMarketDataClient` | `src/Meridian.Infrastructure/Adapters/Failover/` |
-| Alpaca streaming | `AlpacaMarketDataClient` | `src/Meridian.Infrastructure/Adapters/Alpaca/` |
-| IB streaming | `IBMarketDataClient` | `src/Meridian.Infrastructure/Adapters/InteractiveBrokers/` |
-| WPF Dashboard page | `DashboardPage` | `src/Meridian.Wpf/Views/DashboardPage.xaml(.cs)` |
-| WPF Dashboard ViewModel | `DashboardViewModel` | `src/Meridian.Wpf/ViewModels/DashboardViewModel.cs` |
-| Configuration pipeline | `ConfigurationPipeline` | `src/Meridian.Application/Config/ConfigurationPipeline.cs` |
-| Hot-path batch serializer | `HotPathBatchSerializer` | `src/Meridian.Application/Pipeline/HotPathBatchSerializer.cs` |
-| Portable data packaging | `PortableDataPackager` | `src/Meridian.Storage/Packaging/PortableDataPackager.cs` |
-| Order gateway (broker-agnostic) | `IOrderGateway` | `src/Meridian.Execution/Interfaces/IOrderGateway.cs` |
+| Backfill orchestration | `HistoricalBackfillService` | `src/Meridian.Application/Backfill/HistoricalBackfillService.cs` |
+| Gap detection | `GapBackfillService` | `src/Meridian.Application/Backfill/GapBackfillService.cs` |
+| F# validation pipeline | `ValidationPipeline` | `src/Meridian.FSharp/Validation/ValidationPipeline.fs` |
+| Statement connector (BAI2) | `Bai2StatementConnector` | `src/Meridian.FinancialOperations/Reconciliation/Connectors/Bai2/Bai2StatementConnector.cs` |
+| Statement connector (CAMT.053) | `Camt053StatementConnector` | `src/Meridian.FinancialOperations/Reconciliation/Connectors/Camt/Camt053StatementConnector.cs` |
+| Statement ingestion scheduling | `DefaultReconciliationIngestionScheduler` | `src/Meridian.FinancialOperations/Reconciliation/DefaultReconciliationIngestionScheduler.cs` |
+| Import-to-evidence bridge | `StatementImportEvidenceBridge` | `src/Meridian.Ui.Shared/Evidence/StatementImportEvidenceBridge.cs` |
+
+### Reconciliation and breaks
+
+| Concept | Interface / Class | File Path |
+|---------|-------------------|-----------|
+| Sided statement matching | `StatementMatchingEngine` | `src/Meridian.FinancialOperations/Reconciliation/StatementMatchingEngine.cs` |
+| Reconciliation matching engine | `ReconciliationMatchingEngine` | `src/Meridian.FinancialOperations/Reconciliation/ReconciliationMatchingEngine.cs` |
+| Match kernel | `ReconciliationMatchKernel` | `src/Meridian.FinancialOperations/Reconciliation/ReconciliationMatchKernel.cs` |
+| Tolerance policy | `MatchingTolerances` | `src/Meridian.FinancialOperations/Reconciliation/MatchingTolerances.cs` |
+| Normalization | `ReconciliationNormalizationService` | `src/Meridian.FinancialOperations/Reconciliation/ReconciliationNormalizationService.cs` |
+| Run orchestration | `ReconciliationRunService` | `src/Meridian.Strategies/Services/ReconciliationRunService.cs` |
+| Break queue persistence | `FileReconciliationBreakQueueRepository` | `src/Meridian.Strategies/Services/FileReconciliationBreakQueueRepository.cs` |
+| Casework workflow | `ReconciliationCaseWorkflowService` | `src/Meridian.Strategies/Services/ReconciliationCaseWorkflowService.cs` |
+| SLA calculation | `ReconciliationSlaCalculator` | `src/Meridian.Strategies/Services/ReconciliationSlaCalculator.cs` |
+| Reconciliation governance | `ReconciliationGovernanceService` | `src/Meridian.Strategies/Services/ReconciliationGovernanceService.cs` |
+| Position reconciliation | `PositionReconciliationService` | `src/Meridian.Execution/Services/PositionReconciliationService.cs` |
+
+### Ledger, accounting, and close
+
+| Concept | Interface / Class | File Path |
+|---------|-------------------|-----------|
+| Journal entry | `JournalEntry` | `src/Meridian.Ledger/JournalEntry.cs` |
+| Journal evidence link | `JournalEvidenceReference` | `src/Meridian.Ledger/JournalEvidenceReference.cs` |
+| Automated journal draft | `AutomatedJournalDraft` | `src/Meridian.Ledger/AutomatedJournalDraft.cs` |
+| Journal reversal | `LedgerJournalReversal` | `src/Meridian.Ledger/LedgerJournalReversal.cs` |
+| Multi-currency translation | `LedgerCurrencyTranslation` | `src/Meridian.Ledger/LedgerCurrencyTranslation.cs` |
+| Tax-lot policy | `LedgerAccountTaxLotPolicy` | `src/Meridian.Ledger/LedgerAccountTaxLotPolicy.cs` |
+| Period reopen evidence | `PeriodReopenEvidence` | `src/Meridian.Ledger/PeriodReopenEvidence.cs` |
+| Period lock reader | `ILedgerPeriodLockReader` | `src/Meridian.Application/SecurityMaster/ILedgerPeriodLockReader.cs` |
+| Close management | `AccountingCloseManagementService` | `src/Meridian.FinancialOperations/AccountingClose/AccountingCloseManagementService.cs` |
+| Close posting workbench | `AccountingClosePostingWorkbench` | `src/Meridian.FinancialOperations/AccountingClose/AccountingClosePostingWorkbench.cs` |
+| Accounting report package | `AccountingReportPackageService` | `src/Meridian.FinancialOperations/AccountingClose/AccountingReportPackageService.cs` |
+| Approval policy matrix | `OperationsApprovalPolicyMatrixService` | `src/Meridian.FinancialOperations/OperationsContinuity/OperationsApprovalPolicyMatrixService.cs` |
+| Asset accounting event spine | `AssetAccountingEventSpineService` | `src/Meridian.FinancialOperations/Ledger/AssetAccountingEventSpineService.cs` |
+| Capital account workbench | `CapitalAccountWorkbenchService` | `src/Meridian.Ui.Shared/Services/CapitalAccountWorkbenchService.cs` |
+| Capital-account subledger | `PrivateCapitalCapitalAccountSubledgerBuilder` | `src/Meridian.FinancialOperations/PrivateCapital/PrivateCapitalCapitalAccountSubledgerBuilder.cs` |
+
+### Fund economics (dormant — see Activation Targets)
+
+| Concept | Interface / Class | File Path |
+|---------|-------------------|-----------|
+| Unitized NAV | `NavPerUnitCalculator` | `src/Meridian.Ledger/NavPerUnitCalculator.cs` |
+| European waterfall | `EuropeanDistributionWaterfall` | `src/Meridian.Ledger/EuropeanDistributionWaterfall.cs` |
+| Preferred return | `PreferredReturnCalculator` | `src/Meridian.Ledger/PreferredReturnCalculator.cs` |
+| Carry clawback | `CarriedInterestClawbackCalculator` | `src/Meridian.Ledger/CarriedInterestClawbackCalculator.cs` |
+| Equalization | `EqualizationCalculator` | `src/Meridian.Ledger/EqualizationCalculator.cs` |
+| Capital call planning | `CapitalCallPlanBuilder` | `src/Meridian.Ledger/CapitalCallPlanBuilder.cs` |
+
+### Evidence and provenance
+
+| Concept | Interface / Class | File Path |
+|---------|-------------------|-----------|
+| Evidence graph | `EvidenceGraphService` | `src/Meridian.Ui.Shared/Evidence/EvidenceGraphService.cs` |
+| Proof chain builder | `EvidenceProofChainBuilder` | `src/Meridian.Ui.Shared/Evidence/EvidenceProofChainBuilder.cs` |
+| Evidence packet validation | `EvidencePacketValidationService` | `src/Meridian.Ui.Shared/Evidence/EvidencePacketValidationService.cs` |
+| Evidence artifact store | `FileEvidenceArtifactStore` | `src/Meridian.Ui.Shared/Evidence/FileEvidenceArtifactStore.cs` |
+| Document field extraction | `EvidenceDocumentExtraction` | `src/Meridian.Ui.Shared/Evidence/EvidenceDocumentExtraction.cs` |
+| Evidence templates | `EvidenceTemplateRegistry` | `src/Meridian.Ui.Shared/Evidence/EvidenceTemplateRegistry.cs` |
+| Amount-level provenance | `LedgerAmountProvenanceService` | `src/Meridian.Ui.Shared/Services/LedgerAmountProvenanceService.cs` |
+| Hash-chained audit | `AuditChainService` | `src/Meridian.Storage/Services/AuditChainService.cs` |
+
+### Reporting and delivery
+
+| Concept | Interface / Class | File Path |
+|---------|-------------------|-----------|
+| Report generation | `ReportGenerationService` | `src/Meridian.Reporting/ReportGenerationService.cs` |
+| Report-writer grids | `ReportWriterGridEngine` | `src/Meridian.Reporting/ReportWriterGridEngine.cs` |
+| Reporting governance | `ReportingGovernanceService` | `src/Meridian.Reporting/ReportingGovernanceService.cs` |
+| Snapshot diff | `ReportSnapshotDiffEngine` | `src/Meridian.Reporting/ReportSnapshotDiffEngine.cs` |
+| Certified snapshot | `CertifiedReportingSnapshotBuilder` | `src/Meridian.Reporting/CertifiedReportingSnapshotBuilder.cs` |
+| NAV attribution | `NavAttributionService` | `src/Meridian.Reporting/NavAttributionService.cs` |
+| Partners-capital projection | `PartnersCapitalProjection` | `src/Meridian.Reporting/PartnersCapitalProjection.cs` |
+| Report pack builder | `LedgerReportPackBuilder` | `src/Meridian.Ledger/LedgerReportPackBuilder.cs` |
+| Report pack signature | `LedgerReportPackSignature` | `src/Meridian.Ledger/LedgerReportPackSignature.cs` |
+| Report pack delivery | `ReportPackDeliveryService` | `src/Meridian.Ui.Shared/Services/ReportPackDeliveryService.cs` |
+| Client-grade rendering | `ClientGradeReportRenderer` | `src/Meridian.Documents/ClientGradeReportRenderer.cs` |
+| Financial document rendering | `FinancialReportDocumentRenderer` | `src/Meridian.Documents/FinancialReportDocumentRenderer.cs` |
+
+### Execution, risk, and research
+
+| Concept | Interface / Class | File Path |
+|---------|-------------------|-----------|
+| Order gateway | `IOrderGateway` | `src/Meridian.Execution/Interfaces/IOrderGateway.cs` |
 | Broker adapter SDK contract | `IExecutionGateway` | `src/Meridian.Execution.Sdk/IExecutionGateway.cs` |
 | Live strategy context | `IExecutionContext` | `src/Meridian.Execution/Interfaces/IExecutionContext.cs` |
 | Paper trading gateway | `PaperTradingGateway` | `src/Meridian.Execution/Adapters/PaperTradingGateway.cs` |
+| Broker fill gateway | `AlpacaBrokerageGateway` | `src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaBrokerageGateway.cs` |
 | Order lifecycle tracking | `OrderManagementSystem` | `src/Meridian.Execution/OrderManagementSystem.cs` |
 | Pre-trade risk validation | `CompositeRiskValidator` | `src/Meridian.Risk/CompositeRiskValidator.cs` |
 | Risk rule contract | `IRiskRule` | `src/Meridian.Risk/IRiskRule.cs` |
 | Strategy lifecycle contract | `IStrategyLifecycle` | `src/Meridian.Strategies/Interfaces/IStrategyLifecycle.cs` |
+| Strategy run read model | `StrategyRunReadService` | `src/Meridian.Strategies/Services/StrategyRunReadService.cs` |
 | Strategy run archive | `StrategyRunStore` | `src/Meridian.Strategies/Storage/StrategyRunStore.cs` |
-| Live strategy contract | `ILiveStrategy` | `src/Meridian.Strategies/Interfaces/ILiveStrategy.cs` |
-| P&L ledger (double-entry) | `Ledger` | `src/Meridian.Ledger/Ledger.cs` |
-| Ledger read-only view | `IReadOnlyLedger` | `src/Meridian.Ledger/IReadOnlyLedger.cs` |
 | Backtest strategy contract | `IBacktestStrategy` | `src/Meridian.Backtesting.Sdk/IBacktestStrategy.cs` |
-| Backtest context | `IBacktestContext` | `src/Meridian.Backtesting.Sdk/IBacktestContext.cs` |
-| Backtest engine | `BacktestEngine` | `src/Meridian.Backtesting/Engine/` |
+| Market-impact fill model | `MarketImpactFillModel` | `src/Meridian.Backtesting/FillModels/MarketImpactFillModel.cs` |
+| Order-book fill model | `OrderBookFillModel` | `src/Meridian.Backtesting/FillModels/OrderBookFillModel.cs` |
+| P&L ledger | `Ledger` | `src/Meridian.Ledger/Ledger.cs` |
+
+### Platform, storage, and workstation seams
+
+| Concept | Interface / Class | File Path |
+|---------|-------------------|-----------|
+| Event pipeline coordinator | `EventPipeline` | `src/Meridian.Application/Pipeline/EventPipeline.cs` |
+| Storage sink contract | `IStorageSink` | `src/Meridian.Storage/Interfaces/IStorageSink.cs` |
+| Write-ahead log | `WriteAheadLog` | `src/Meridian.Storage/Archival/WriteAheadLog.cs` |
+| Crash-safe file writes | `AtomicFileWriter` | `src/Meridian.Storage/Archival/AtomicFileWriter.cs` |
+| JSON source-gen context | `MarketDataJsonContext` | `src/Meridian.Core/Serialization/MarketDataJsonContext.cs` |
+| Storage catalog | `StorageCatalogService` | `src/Meridian.Storage/Services/StorageCatalogService.cs` |
+| Graceful shutdown | `GracefulShutdownService` | `src/Meridian.Platform/Runtime/GracefulShutdownService.cs` |
+| Shared route constants | `UiApiRoutes` | `src/Meridian.Contracts/Api/UiApiRoutes.cs` |
+| Shared workstation surface | `WorkstationEndpoints` | `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` |
+| Browser accounting workspace | `accounting-screen.tsx` | `src/Meridian.Ui/dashboard/src/screens/accounting-screen.tsx` |
+| Browser trust strip | `app-shell.trust-strip.ts` | `src/Meridian.Ui/dashboard/src/app-shell.trust-strip.ts` |
+| Browser evidence timeline | `app-shell.evidence-timeline.ts` | `src/Meridian.Ui/dashboard/src/app-shell.evidence-timeline.ts` |
+| Browser provenance badge | `app-shell.data-provenance-badge.ts` | `src/Meridian.Ui/dashboard/src/app-shell.data-provenance-badge.ts` |
+| Browser command palette | `app-shell.command-palette.ts` | `src/Meridian.Ui/dashboard/src/app-shell.command-palette.ts` |
+| MVVM base class | `BindableBase` | `src/Meridian.Wpf/ViewModels/BindableBase.cs` |
+| Desktop shell orchestration | `MainPageViewModel` | `src/Meridian.Wpf/ViewModels/MainPageViewModel.cs` |
 
 ---
 
-## 🔌 Data Access & APIs
+## ⚡ Activation Targets
 
-- **Python SDK** — async iterator over live feed, pandas DataFrame output, `snap()` for last N ticks, `history()` for bulk pull. Wraps the WebSocket/REST HTTP layer already exposed by Meridian.
-- **gRPC streaming endpoint** — low-latency alternative to WebSocket for intra-datacenter consumers (e.g., C++ strategy engine consuming from Meridian)
-- **Arrow Flight endpoint** — columnar bulk data transfer without REST overhead; natural fit for academic batch pulls
-- **GraphQL query API** — flexible ad-hoc querying over stored JSONL data; explorers can filter/aggregate without file access
-- **Tick replay API** — serve historical ticks at configurable speed multiplier (1x, 10x, 100x market time); valuable for backtesting engines that need realistic feed simulation
-- **Snapshot API** — point-in-time orderbook snapshot endpoint; `GET /api/snapshot/{symbol}?at=2024-01-15T14:30:00Z`
-- **WebSocket multiplex protocol** — single connection, multiple symbol subscriptions, backpressure signaling; reduces connection overhead for subscribers with large universes
-- **R language bindings** — `reticulate`-free native R package via `.NET Interop` or a thin REST wrapper; academic quant finance community is heavily R-based
-- **DuckDB virtual table** — register Meridian's JSONL/Parquet store as a DuckDB external table; enables SQL queries without data movement
-- **Event-driven webhooks** — push notifications on configurable triggers (new gap detected, anomaly flagged, backfill complete); enables serverless downstream workflows
-- **OpenAPI spec auto-generation** — auto-generate OpenAPI 3.1 spec from Meridian's REST controllers; enables code-gen for any language client
+The charter's headline finding (`docs/product/meridian-design-document.md` §2.1) is that the codebase is more capable than the running product. These capabilities exist in source with tests but are not the wired operator path. Activation ideas — connecting, labeling, and proving them — are the highest-return lane available, and an activated capability must *replace* its weaker predecessor rather than sit beside it.
 
----
+- **Sided statement-vs-ledger matching** (`StatementMatchingEngine`) — the live path still uses a weaker per-row check
+- **Institutional bank formats** (`Bai2StatementConnector`, `Camt053StatementConnector`) — in source, registry acceptance planned
+- **Client-grade PDF/XLSX rendering** (`ClientGradeReportRenderer`, `FinancialReportDocumentRenderer`) — production path still emits text-grade artifacts
+- **Unitized NAV and fund economics** (`NavPerUnitCalculator`, `EuropeanDistributionWaterfall`, `PreferredReturnCalculator`, `CarriedInterestClawbackCalculator`, `EqualizationCalculator`) — not yet the wired economics path
+- **Broker fill streaming** (`AlpacaBrokerageGateway`) — live fill loop into order and ledger state incomplete
+- **Realistic fill and cost models** (`MarketImpactFillModel`, `OrderBookFillModel`) — implemented for backtests; paper trading must adopt them
+- **Kill-switch, cancel-all, notional and collar controls** — partial foundation; safety surfaces must be wired or visibly demoted
+- **Hash-chained audit for the accounting ledger and route-level authorization** — `AuditChainService` covers storage; the journal chain and blanket route coverage do not exist
+- **Operational Evidence Graph as a shared product surface** — explorer, proof-drawer, and manifest primitives exist; the product surface is planned
 
-## 📊 Data Quality & Validation
-
-- **Cross-provider reconciliation** — when multiple providers are connected, flag ticks where IB and Alpaca disagree by >N bps on the same timestamp; generate quality score per symbol
-- **Anomaly detection pipeline** — pluggable anomaly detectors (Z-score, IQR, price spike) that tag suspicious ticks in the JSONL stream without dropping them
-- **Data completeness scorecard** — per-symbol dashboard showing: expected ticks per session vs. received, gap count, last gap timestamp, interpolation rate
-- **Halts and corporate actions awareness** — ingest halt/resume events and tag data around trading halts; avoid surfacing garbage ticks during circuit breakers
-- **Latency attribution** — instrument the full path from provider → storage; report per-provider median/p99 latency in the dashboard; identify if a provider is lagging
-- **Synthetic data injection** — for testing: inject synthetic tick sequences that stress-test downstream consumers (flash crash simulation, gap, stale quote)
-- **Tick sequence validation** — detect out-of-order timestamps, duplicate sequence numbers, and backwards price jumps that indicate feed issues rather than market events
-- **Provider SLA scoring** — track uptime, reconnect frequency, message throughput, and data freshness per provider over rolling windows; generate a weekly provider health report
-- **Options chain consistency checks** — validate put-call parity relationships, strike price monotonicity, and expiration date coherence in options data feeds
-- **Bid-ask spread anomaly detector** — flag inverted markets, abnormally wide spreads, and locked markets as data quality events distinct from normal market microstructure
+A strong activation idea names the dormant type, the live path it replaces, the operator-visible difference, and how the predecessor gets retired.
 
 ---
 
-## ⚡ Performance & Latency
+## 📥 Import, Providers & Data Trust
 
-- **Kernel-bypass receive path** — optional DPDK or io_uring path for the IB/FIX socket; bypasses OS TCP stack for sub-100μs receive latency on Linux
-- **SIMD tick normalizer** — vectorized price/size parsing using `System.Runtime.Intrinsics`; batch-process raw FIX/ITCH bytes 16 at a time
-- **Zero-allocation tick path** — object pooling for `MarketEvent` structs, avoiding GC pressure on the hot path; use `ArrayPool<T>` for intermediate buffers
-- **CPU affinity pinning** — pin the receive thread and the storage flush thread to isolated cores; reduce scheduling jitter
-- **Lock-free ring buffer** — replace `BoundedChannel` on the critical path with a Disruptor-style ring buffer (LMAX pattern) for guaranteed sub-microsecond handoff
-- **Nanosecond timestamps** — upgrade from `DateTime` to `long` nanoseconds since epoch on all hot-path structs; use `Stopwatch.GetTimestamp()` with hardware frequency
-- **Batched WAL writes** — group WAL entries into 4KB aligned blocks for sequential disk write optimization; measure with `fio` before/after
-- **GC-tuned server mode** — configure `ServerGC` with region-based collection and `GCLatencyMode.SustainedLowLatency`; document the GC tuning profile as a runbook
-- **Hot-path profiling harness** — built-in `BenchmarkDotNet` suite that profiles the tick-receive-to-storage path end-to-end; run as part of CI to detect regressions
-- **Memory-mapped file writes** — use `MemoryMappedFile` for WAL/JSONL output on the hot path; avoids kernel buffer copies for sequential append workloads
-- **Pipeline backpressure metrics** — expose `BoundedChannel` fill level, drop count, and consumer lag as Prometheus gauges; alert before pipeline saturation
-
----
-
-## 🗄️ Storage & Data Formats
-
-- **Parquet/Arrow output** — convert JSONL daily files to Parquet at session close; columnar layout makes pandas/DuckDB queries 10-100x faster
-- **QuestDB integration** — optional sink to QuestDB time-series database; enables SQL queries over streaming data with nanosecond timestamps
-- **InfluxDB/TimescaleDB sink** — standard TSDB integration for users with existing monitoring infrastructure
-- **Tiered cold storage** — auto-migrate data older than N days to S3/Backblaze with Zstd compression; local disk holds only hot tier
-- **Deduplication store** — persistent bloom filter + hash store for exactly-once storage guarantees across restarts; currently in-memory only
-- **Incremental Parquet compaction** — merge small daily Parquet files into monthly partitions; improves query performance on multi-month backtests
-- **Schema evolution** — forward/backward-compatible schema registry for JSONL/Parquet format changes; version tag every file header
-- **HDF5 export** — one-click export to HDF5 format for academic users coming from WRDS/TAQ ecosystems; preserves hierarchical symbol/date structure
-- **Delta Lake / Iceberg table format** — store market data as a lakehouse table with ACID transactions, time travel, and schema enforcement; enables both streaming ingest and batch analytics
-- **Configurable retention policies** — per-symbol or per-asset-class retention rules (e.g., keep L2 data for 30 days, L1 for 1 year, daily OHLCV forever); enforced automatically with compaction
+- **Mapping profile library** — reusable, versioned column/field mappings per counterparty with drift detection when a file's shape changes mid-relationship
+- **Import run certification UX** — one screen where an import run is certified, rejected with repair instructions, or replayed; blocked downstream outputs named explicitly
+- **Connector confidence scoring** — per-connector parse confidence and drift signals surfaced before commit, not after
+- **Provider capability matrix** — what each of the 22 adapter families actually supplies (asset classes, fields, history depth, refresh cadence) as a browsable operator surface
+- **Credential and connection health** — expiry warnings, scope verification, and last-successful-pull per connection in `Settings`
+- **Raw payload preservation and replay** — every import replayable from retained source bytes with a diff against what was originally committed
+- **Email/SFTP intake lane** — scheduled pickup with the same preview → confidence → commit rails as manual upload
+- **Cross-source disagreement surfacing** — when two sources disagree on a position or price, show both with lineage rather than silently preferring one
+- **Excel round-trip maintenance** — export a domain to a workbook, edit offline, re-upload, diff, amend under approval
+- **Fixture and simulated-data labeling** — datum-level provenance badges so no synthetic value ever reads as operational truth
 
 ---
 
-## 🔗 Integrations & Ecosystem
+## 🔀 Reconciliation & Break Resolution
 
-- **Jupyter kernel extension** — `%marketdata` magic command that connects to a running Meridian instance and streams ticks into a DataFrame in real time
-- **pandas accessor** — `df.marketdata.resample_ohlcv('1min')` style API built on top of Meridian's historical export format
-- **QuantConnect LEAN bridge** — Meridian as a custom data source for LEAN backtesting engine; map `IMarketDataClient` to LEAN's `IDataQueueHandler` interface
-- **Backtrader data feed** — Python class wrapping Meridian's REST/WebSocket endpoint as a `bt.DataBase` subclass
-- **Zipline ingestion bundle** — export Meridian data as a Zipline ingest bundle for Zipline-Reloaded backtesting
-- **dbt integration** — Meridian as a dbt source, enabling SQL-based data transformations and quality tests on stored market data
-- **Grafana data source plugin** — native Grafana plugin (Go) that queries Meridian's `/api` endpoints; enables blending market data with infrastructure metrics on one board
-- **TradingView webhook receiver** — ingest TradingView alerts as structured events alongside market data; correlate signal firing with tick data
-- **Slack/Discord bot** — alert bot that posts to a channel when: data gap detected, provider disconnected, anomalous tick received, backfill completed
-- **OpenBB integration** — serve as a data backend for OpenBB Terminal; Meridian provides the persistent collection layer that OpenBB lacks
-- **NinjaTrader / MetaTrader bridge** — expose Meridian data via the NinjaTrader Connection Adapter or MetaTrader EA interface; captures the retail algo trading audience
-- **Dagster / Airflow operator** — custom operator for orchestrating Meridian backfill jobs, Parquet compaction, and data quality checks inside existing data pipelines
+- **Sided matching on the live path** — pair-level matching with confidence scoring, replacing per-row checks
+- **Tolerance policy workbench** — per-account, per-currency, per-transaction-type tolerances with a preview of how many breaks a change would create or clear
+- **Break root-cause clustering** — group breaks by inferred cause (timing, FX, fee, missing security, duplicate) so one fix clears many
+- **Bulk resolution with retained justification** — resolve a cluster in one action while retaining per-row evidence
+- **Aging and SLA pressure view** — breaks by age band and owner, with escalation state visible before the SLA is missed
+- **Match explanation** — for any matched pair, show which rule matched, at what tolerance, and what the alternatives were
+- **Unmatch and re-match audit** — reversing a match is an auditable event with before/after state
+- **Intercompany and cross-entity elimination** — reconcile between related entities, not just against external statements
+- **Cash vs. position break separation** — different queues, different owners, different resolution rails
+- **Recurring break suppression with expiry** — known differences suppressed under a dated, reviewable policy rather than silently ignored
 
 ---
 
-## 🌐 Community & Sharing
+## 📒 Ledger, Accounting & Close
 
-- **Public data snapshots** — opt-in feature to publish anonymized daily OHLCV snapshots to a shared S3 bucket; community-maintained free data layer
-- **Provider plugin SDK** — documented interface + CLI scaffolding tool for third parties to build new `IMarketDataClient` implementations; npm-style plugin registry
-- **Strategy template library** — curated set of Jupyter notebooks demonstrating: loading Meridian data → feature engineering → backtest → performance report
-- **Discord/forum integration** — built-in "share session" feature that posts a summary of today's collection run (symbols, tick count, anomalies) to a community feed
-- **Contribution leaderboard** — gamified: users who contribute provider plugins or data quality validators earn recognition on a public leaderboard
-- **Data marketplace** — users who collect rare data (options chains, crypto perps, international equities) can make it discoverable to others with access controls
-
----
-
-## 🖥️ UX / Developer Experience
-
-- **Interactive setup wizard** — terminal TUI (Spectre.Console) that walks through provider selection, API key entry, symbol configuration, and validates connectivity before first run
-- **Symbol universe browser** — searchable browser-workstation UI for browsing available symbols per provider; click-to-subscribe without editing JSON config
-- **Data quality report (PDF export)** — one-click PDF report of collection quality for a date range; useful for academic data provenance documentation
-- **Live tick visualizer** — real-time candlestick chart in the browser workstation for any subscribed symbol; no external charting tool needed
-- **Order book heatmap** — animated L2 order book depth visualization in the browser workstation; visually identify spoofing, iceberg orders
-- **Config diff viewer** — when appsettings.json changes, show a visual diff of what changed and what the system will do differently
-- **Backfill progress UX** — rich progress bars for historical backfill jobs: symbol × date range × provider, with ETA, pause/resume, and error summary
-- **CLI REPL** — `meridian> subscribe AAPL` style interactive shell for power users; tab-completion for symbols and commands
-- **WPF theme system** — light/dark mode toggle plus a theme engine for the desktop app; reduces eye strain during long monitoring sessions and demonstrates UI polish
-- **In-app diagnostics panel** — embedded panel showing pipeline throughput, channel fill levels, GC pause times, and provider connection state; replaces the need to open Grafana for quick checks
-- **Config schema validation with friendly errors** — validate `appsettings.json` on startup against a JSON Schema; surface human-readable error messages in the WPF app instead of cryptic exceptions
+- **Close readiness score** — one number per book/period, decomposed into the blocking items with links to the records causing them
+- **Blocked-close report** — when a period cannot close, produce the artifact that explains why to a controller
+- **Journal template library** — parameterized templates for recurring entries with approval requirements attached
+- **Automated journal draft review** — drafts proposed by the system, approved by a human, with the evidence that produced them visible in the same view
+- **Period lock enforcement surfacing** — show what a lock prevents and who can grant a governed reopen, before the operator tries
+- **Multi-currency exposure view** — translation impact by book and period with the FX rates and their source retained
+- **Tax-lot method comparison** — show disposal outcomes under alternative lot policies before committing a method
+- **Capital account statement generation** — per-investor activity, contributions, distributions, and closing balances from the subledger
+- **Trial balance drill-through** — from any trial balance line to the journals, and from a journal to its evidence
+- **Late-activity handling** — post-close adjustments routed through explicit reopen or next-period accrual with retained rationale
 
 ---
 
-## 🔐 Reliability & Production Readiness
+## 🧾 Evidence, Provenance & Governance
 
-- **Multi-provider active-active** — subscribe to the same symbol on two providers simultaneously; merge streams, use cross-provider reconciliation to detect and correct bad ticks
-- **Intelligent failover** — when primary provider disconnects, automatically switch to secondary; track gap introduced by failover; backfill from secondary on reconnect
-- **Health scoring per symbol** — composite score (0-100) for each symbol based on: tick rate vs. expected, anomaly rate, gap frequency; surface in dashboard as RAG status
-- **Alerting engine** — configurable rules: `if health_score(AAPL) < 80 for 5min → notify`; delivery via email, webhook, Slack
-- **Chaos mode** — optional fault injection (random disconnect, tick drop, latency spike) for testing downstream resilience; controlled via CLI flag
-- **Rolling restart support** — drain in-flight events before shutdown; resume without data loss; important for Kubernetes rolling deployments
-- **Multi-region replication** — async replication of JSONL/Parquet files to a secondary region; DR for institutional users
+- **Number Passport surface** — for any amount, expose basis, dates, positions, journals, source records, extracted fields, transformations, valuation method, reconciliation state, approval history, and freshness (charter §22)
+- **Proof drawer everywhere** — the same drill-down component reachable from report lines, ledger rows, portfolio marks, and dashboard metrics
+- **Evidence completeness meter** — per packet, what is present, stale, or missing, and what output it blocks
+- **Immutable manifest freeze** — freeze the evidence set attached to a delivered package so later changes cannot rewrite history
+- **Document extraction review lane** — extracted fields shown next to the source document region with accept/correct actions
+- **Scoped access review packet** — periodic certification of who holds what scope, with revocation flowing to an audit event
+- **Journal-level hash chaining** — extend the storage audit chain into the accounting ledger
+- **Segregation-of-duties enforcement** — preparer ≠ approver enforced structurally, with attempted-violation events retained
+- **Auditor read-only workspace** — entitlement-scoped access that lets an external reviewer drill from a package line to support without operator mediation
+- **Legal hold and retention policy** — hold state that blocks purge and is visible wherever affected records appear
 
 ---
 
-## 📚 Academic & Research
+## 📤 Reporting & Delivery
 
-- **Data provenance ledger** — every stored file gets a hash, timestamp, provider version, and collection parameter snapshot; immutable append-only log satisfies academic reproducibility requirements
-- **Citation generator** — one-click: "Generate BibTeX citation for this dataset" that produces a citable reference with DOI-style identifier
-- **Dataset versioning** — snapshot the full symbol universe configuration at each session; enables exact replay of what was collected on a given date
-- **Tick quality metadata** — alongside each tick file, store: source exchange, feed type (CTA/SIP vs direct), latency bucket, anomaly flags; enables downstream filtering
-- **Research pack export** — bundle a date range of data for multiple symbols into a single reproducible ZIP with README, schema documentation, and provenance ledger
-- **Regulatory data retention mode** — WORM (Write Once Read Many) storage policy; files are checksummed and cannot be modified; audit log of all access
+- **Client-grade rendering activation** — replace text-grade production artifacts with the existing PDF/XLSX renderers
+- **Report-line lineage** — every line traceable to its inputs, with the trace surviving into the delivered artifact
+- **Package diff and restatement** — show what changed between two versions of a package and why an amendment was issued
+- **Delivery evidence** — who received what, when, under which entitlement, with acknowledgement state
+- **Report-writer authoring UX** — durable drafts, live preview, multi-filter support, formula workbench, keyboard-first token composition
+- **Saved views and template catalog** — governed, shareable report definitions with versioning
+- **Scheduled package runs** — recurring generation with pre-release consistency gates and hold-on-failure
+- **Board and IC pack composition** — assemble multiple certified outputs into one governed binder
+- **Stakeholder verification view** — read-only drill-through attached to a delivered package (not a broad portal — see deferred boundaries)
+- **Export evidence retention** — every export recorded with parameters, snapshot identity, and requester
+
+---
+
+## 📈 Portfolio, Valuation & Reference Data
+
+- **Security master passport** — one identity view per instrument with provider mappings, conflicts, and trust summary
+- **Stale mark detection** — flag positions whose valuation inputs have aged past policy, with the age and source visible
+- **Corporate action evidence** — factor and action records joined to the positions and journals they affected
+- **Multi-asset coverage gaps** — which asset classes lack required terms, evidence, or accounting classification
+- **Cash ladder and liquidity view** — scenario-aware, per-currency projections aggregated from per-security runs
+- **Valuation methodology disclosure** — show which method produced a mark and what its inputs were
+- **Position-to-custodian tie-out** — daily agreement state per account with break linkage
+- **Household and entity rollup** — consolidated views across entities with elimination visibility
+- **Private and structured asset terms capture** — declared required terms with evidence and close/reporting handoff
+- **Commitment and unfunded tracking** — commitments, drawdowns, and remaining unfunded with capital-call linkage
+
+---
+
+## 🎯 Execution, Risk & Research
+
+- **Paper realism** — limit/stop semantics and trading costs in paper sessions before their statistics feed promotion decisions
+- **Broker fill loop** — streamed fills flowing into order state and ledger postings with reconciliation against the broker's own record
+- **Kill-switch and cancel-all** — a wired safety control with confirmation, scope, and retained event
+- **Pre-trade guardrails** — fat-finger, notional, and price-collar rules with clear operator-facing rejection reasons
+- **Promotion evidence gate** — paper-to-live promotion showing the full required evidence set and any manual override
+- **Run comparison** — diff two strategy runs across parameters, fills, costs, and outcomes
+- **Backtesting Studio evidence loop** — link a backtest run to the data snapshot, code version, and resulting decisions
+- **QuantScript ergonomics** — authoring, validation, and charting improvements for research users
+- **Execution-to-ledger continuity** — trades landing as postings with lot creation and disposal in one governed transaction
+- **Risk breach acknowledgement** — breaches with owner, acknowledgement, and acceptance records rather than transient alerts
+
+---
+
+## 🖥️ Workstation UX & Information Design
+
+- **Screen consolidation behind the seven roots** — fewer, deeper screens; retired routes remain redirects
+- **Operator focus and task modes** — surface what is waiting on this operator, in this scope, right now
+- **Trust strip and provenance badges** — persistent, honest state about data freshness and simulation at the top of every workspace
+- **Command palette coverage** — every meaningful navigation and action reachable by keyboard
+- **Queue-first workspace design** — start from what needs resolving, not from a static dashboard
+- **Empty states with a next action** — a fresh install shows a concrete path, never a wall of zeros
+- **Linked context across workspaces** — carrying entity, period, and account scope as the operator moves between roots
+- **Blocked-state explanations** — reason, owner, and next action attached to every blocked indicator
+- **Density and progressive disclosure** — summary rows expand to detail without a page change
+- **WPF web-parity closure** — bring desktop screens that shipped browser-first onto the shared contracts (`W8-WPF-PARITY-001`)
+- **Shared design-system compliance** — new surfaces compose existing components rather than forking per-screen variants
+
+---
+
+## 🚀 Adoption, Onboarding & Time to First Proof
+
+- **One-command seeded demo** — a truthful, populated, durable demonstration workspace from a fresh install
+- **Shadow-mode onboarding** — read-only parallel views, opening-balance reconciliations, and close-readiness scores before a customer migrates official books
+- **Statement reconciliation wedge** — browser-first import → commit → retained proof as the first slice a new customer runs
+- **Excel onboarding workbook** — download → fill → upload → review → governed commit for security master, entities, chart of accounts, opening balances
+- **Get-connected hub** — provider setup tied to the imported instrument universe with a coverage handshake
+- **Guided first close** — a checklist that walks a new operator through the canonical spine once, end to end
+- **Time to First Proof instrumentation** — measure and expose how long a fresh install takes to produce its first verified number
+- **Activation coverage surface** — show which shipped capability is reachable in the running product, keeping unwired capability visible as debt
 
 ---
 
 ## 🏗️ Architecture & Refactoring
 
-- **ViewModel extraction audit** — systematically identify code-behind logic in WPF Pages/Windows that should live in ViewModels; produce a migration checklist per view with effort estimates
-- **DI container for WPF shell** — introduce `Microsoft.Extensions.DependencyInjection` into the WPF application host; eliminate manual service wiring and enable constructor injection across all ViewModels
-- **Hot-path / cold-path separation** — physically separate the real-time tick pipeline (hot) from config management, backfill orchestration, and UI (cold) into distinct assemblies; enables independent deployment and testing
-- **Interface segregation pass** — audit `IMarketDataClient` and `IStorageSink` for ISP violations; split fat interfaces into focused contracts (e.g., `ITickReceiver`, `IOrderBookReceiver`, `IHistoricalFetcher`)
-- **Event pipeline modularization** — refactor `EventPipeline` into composable middleware stages (receive → normalize → validate → route → store); each stage independently testable and replaceable
-- **Configuration as strongly-typed objects** — replace raw `IConfiguration` indexing with Options pattern (`IOptions<ProviderSettings>`, `IOptions<StorageSettings>`) everywhere; compile-time safety + validation via `IValidateOptions<T>`
-- **Shared kernel extraction** — extract domain primitives (Symbol, Timestamp, Price, Quantity, MarketEvent) into a standalone `Meridian.Domain` assembly with zero infrastructure dependencies; consumed by all layers
-- **Plugin architecture for sinks** — replace hardcoded storage sink registration with a MEF/plugin-style discovery system; third parties drop a DLL into a `/plugins` folder and it's auto-registered as an `IStorageSink`
+- **Shared-seam compliance audit** — find product state that a workstation lane computes locally instead of consuming from `Meridian.Ui.Services` / `Meridian.Ui.Shared` / `Meridian.Contracts`
+- **Endpoint surface consolidation** — 845 routes across 137 endpoint files; identify overlapping read models and duplicate contracts
+- **Partial-class sprawl review** — services split across many partials (close management, evidence stores, break repositories) and whether the split still reflects real seams
+- **Read-model boundary clarity** — which projections are books of record vs. derived views, and enforcing that distinction in code
+- **Durable-store abstraction** — consistent file/Postgres store selection with fail-closed behavior when the durable option is unavailable
+- **Contract-pack extensibility** — schema, lifecycle, valuation, accounting, validation, and reporting hooks for new asset types without core-ledger surgery
+- **Domain module registration** — consistent `DesignModule` and DI registration patterns across the newer projects
+- **F# kernel boundaries** — which deterministic calculations belong in the F# projects vs. C# services
+- **Options pattern and hot reload** — `IOptionsMonitor<T>` coverage for runtime-mutable configuration
+- **Hot/cold path separation** — keep the market-data hot path isolated from the evidence and accounting workloads
 
 ---
 
-## 📈 User Growth & Adoption
+## 🧹 Technical Debt, Quality & Operations
 
-- **"Zero to first tick" quickstart** — a single `docker compose up` command that starts Meridian with Alpaca's free tier, subscribes to SPY, and shows live ticks in the browser workstation within 60 seconds; optimize ruthlessly for time-to-value
-- **YouTube / blog content series** — "Building a Quant Data Pipeline" tutorial series showing Meridian as the backbone; each episode adds a capability (backfill, Jupyter, backtest); drives organic search traffic
-- **GitHub README overhaul** — hero GIF showing live ticks flowing, architecture diagram, one-click deploy badges, and "Why Meridian?" comparison table vs. alternatives; first 30 seconds of the README determine star/bounce
-- **Integration showcase gallery** — web page with working code snippets for each integration (Jupyter, LEAN, pandas, Grafana); copy-paste ready; each snippet links to a deeper tutorial
-- **Conference talk / meetup circuit** — target QuantConnect community meetups, .NET Conf, and local quant finance groups; live demo of Meridian collecting options data in real-time
-- **Freemium cloud-hosted tier** — a managed Meridian instance with limited symbol count (5 symbols, delayed data); removes all setup friction; converts to self-hosted when users hit limits
-- **First-run analytics** — anonymous telemetry (opt-in) tracking: setup completion rate, first successful tick received, first query executed; identify and fix the biggest drop-off points
-- **Contributor onboarding guide** — a `CONTRIBUTING.md` with architecture walkthrough, "good first issue" labels, and a mentorship channel; converts users into contributors
-
----
-
-## 🧹 Technical Debt & Code Quality
-
-- **Mutation testing baseline** — run Stryker.NET against the test suite to measure real test effectiveness beyond line coverage; identify tests that pass regardless of code changes
-- **Architecture decision records (ADRs)** — establish a `docs/adr/` directory; document every significant technical decision (why WPF over UWP, why BoundedChannel over Disruptor, why JSONL first); reduces re-litigation
-- **Static analysis gate in CI** — add Roslyn analyzers + `.editorconfig` enforcement to the GitHub Actions pipeline; fail the build on MVVM violations (e.g., code-behind referencing services directly)
-- **Dead code elimination sweep** — run a coverage + reference analysis to identify unreachable code paths, unused interfaces, and orphaned files left over from the UWP migration; reduce cognitive load
-- **Test isolation audit** — identify integration tests that depend on external state (file system, network, time); refactor to use `ITimeProvider`, in-memory file systems, and test doubles; reduce flaky test rate
-- **Dependency freshness dashboard** — automated PR (via Dependabot or similar) for NuGet package updates; track how far behind each dependency is; flag security-relevant updates
-- **XML doc coverage requirement** — enforce `<summary>` documentation on all public APIs via a Roslyn analyzer; auto-generate API reference docs from XML comments in CI
-- **Consistent error handling patterns** — audit and standardize exception handling across the codebase; replace bare `catch (Exception)` blocks with typed exceptions, Result types, or structured logging; establish a project-wide error taxonomy
+- **Mutation testing baseline** — measure real test effectiveness beyond the ~12,900 fact/theory count
+- **Static analysis gates** — Roslyn analyzers and `.editorconfig` enforcement wired into the quality gate
+- **Dead and duplicated seam elimination** — overlapping services that both own a slice of close, evidence, or reconciliation state
+- **Test isolation audit** — tests depending on wall-clock time, the file system, or network state
+- **Fixture-vs-production separation** — development seeding surfaces unreachable in production profiles by construction, not by comment
+- **Durability call-site review** — every persistence path routed through WAL or `AtomicFileWriter`
+- **Structured logging consistency** — no interpolation inside log calls; correlation IDs across the operator spine
+- **Observability for the operator spine** — traces and metrics that follow import → reconcile → post → approve → report
+- **Documentation-to-code alignment** — generated indexes, module READMEs, and skill packages kept current with the source registry
+- **CI feedback speed** — targeted test selection for touched subsystems instead of broad suite runs

--- a/.claude/agents/meridian-brainstorm.md
+++ b/.claude/agents/meridian-brainstorm.md
@@ -17,6 +17,13 @@ or solutions to a stated pain point, persona need, or domain problem.
 
 ## Workflow
 
-1. Gather project context and the brainstorming history ledger to avoid repeats.
-2. Generate mode-tagged ideas with anchors, user moments, and implementation shapes.
-3. Synthesize the highest-leverage picks with sequencing recommendations.
+1. Gather project context, current roadmap status, and the brainstorming history ledger to avoid repeats.
+2. Generate mode-tagged ideas with anchors, operator moments, implementation shapes, and evidence impact.
+3. Synthesize the highest-leverage picks with roadmap fit and sequencing recommendations.
+
+## Guardrails
+
+Keep ideas inside the seven root workspaces (Trading, Portfolio, Accounting, Reporting, Strategy,
+Data, Settings), respect the no-mobile lane and the deferred expansion boundaries, favor activating
+built-but-unwired capability over new surface, and never present planned or dormant capability as
+shipped. Live status comes from `docs/roadmap/generated/ROADMAP_SUMMARY.md`, never from memory.

--- a/.claude/skills/meridian-brainstorm/CHANGELOG.md
+++ b/.claude/skills/meridian-brainstorm/CHANGELOG.md
@@ -1,5 +1,73 @@
 # meridian-brainstorm — Changelog
 
+## v2.0.0 (2026-07-28)
+
+Realignment to the current product charter. The skill had drifted to a v1.3.0 snapshot (2026-03-19)
+that framed Meridian as a market-data collection platform for hobbyist quants, academics, and
+institutional trading desks. That framing no longer matches the repository or the canonical design
+document.
+
+### Changed
+
+- **Product framing rewritten** — Meridian is now described as a self-hosted financial operations
+  platform selling *proven numbers* to fund administrators, private fund managers/fund CFOs, RIAs,
+  family offices, and hybrid institutional teams. Fund management is documented as a first-class
+  specialization, not the root model. The canonical operator spine
+  (`Import → Validate → Reconcile → Investigate → Approve → Report`) replaces the four-pillar
+  (ADR-016) framing as the organizing idea
+- **Project statistics replaced** — v1.3.0 claimed 868 source files, 261 test files, 22 main
+  projects, and 33 CI/CD workflows. Now sourced from the design charter §5.2 measurement table
+  (2026-07-28): 41 source projects, ~242,000 lines of C# across 2,902 files, 12,736 lines of F#,
+  ~295,000 lines of TypeScript/TSX, 845 `/api/...` routes, 22 provider adapter families,
+  6 statement connector formats, 142 ledger classes, ~12,900 xUnit facts/theories
+- **Wave posture added** — closed baselines (W1-W5, W5X FREX/FINOPS/CONNECT, W7, W9-ASSET-010),
+  active rows (`W5X-EVIDENCE-001`, `W5X-STMT-ONBOARD-001`, `W8-WPF-PARITY-001`,
+  `W8-UX-CONSOL-001`), and the ranked W9 slate, with the roadmap registry named as the only live
+  status source
+- **WPF lane corrected** — was described as a "retained compatibility surface" with WPF product/UI
+  scope closed; it is an active co-equal operator UI lane whose current focus is web-UI parity
+  (`W8-WPF-PARITY-001`)
+- **Personas replaced** — Hobbyist Quant Developer / Academic / Institutional gave way to grouped
+  codes over the canonical 24-role Persona Matrix (design charter §4.2): OPS, ACCT, INV, GOV, EXEC,
+  STAKE, ADMIN. The Financial Operations Professional is named as the primary operator, and the
+  summary-table audience key changed from `H/Q/I` accordingly
+- **User Experience Lens rewritten** as the Operator Experience Lens — evidence-one-click-away,
+  self-explaining blocked states, and the two co-equal UI lanes replace "Meridian is a desktop
+  application people monitor for hours"
+- **Mode table updated** — added **Activation** (wire dormant capability), **Evidence &
+  Governance**, and **Adoption / Onboarding**; renamed Persona-Focused to Role-Focused; retargeted
+  Competitive and UX triggers to the current product surface. Growth mode's community/evangelism
+  framing was folded into Adoption
+- **Idea requirements expanded** — every idea now states its evidence and governance impact
+  (what proof it creates, what it blocks when absent, what approval it requires)
+- **Session ledger corrected** — `brainstorm-history.jsonl` is tracked in the repository, not
+  gitignored; the documented entry shape now matches the real records
+- **`references/idea-dimensions.md` rebuilt** — the anchor table is reorganized into seven verified
+  sections (import/providers, reconciliation, ledger/close, fund economics, evidence, reporting,
+  execution/research, platform seams) with all paths checked against the tree on 2026-07-28;
+  `GracefulShutdownService` repointed to `src/Meridian.Platform/Runtime/`; `UiApiRoutes` recorded at
+  `src/Meridian.Contracts/Api/`. The ten market-data-era dimension categories were replaced with
+  eleven current-domain categories, and an **Activation Targets** section was added from the
+  charter's activation register
+- **`references/competitive-landscape.md` rebuilt** — Bloomberg/Databento/Polygon/QuestDB
+  positioning was the whole file; it is now scoped to the Trading/Data lane, with close-and-controls
+  managers (BlackLine, Trintech), fund administration suites (Carta, FundStudio), asset servicing
+  (SS&C Advent Geneva, eFront, Addepar), and ledger APIs (Modern Treasury) as the primary
+  categories. The differentiation matrix and moat list follow design charter §1.4
+
+### Added
+
+- **Non-Negotiable Guardrails section** — seven root workspaces, no mobile lane, truth discipline,
+  governed autonomy, Meridian owns ledger truth, deferred expansion boundaries, claim rules, and
+  activation-before-expansion. Ideas that violate these are documented as wrong ideas
+- **Handoffs section** — routes to `meridian-blueprint`, `meridian-roadmap-strategist`,
+  `meridian-simulated-user-panel`, and `meridian-repo-navigation`, matching the Codex lane
+- **Durable-artifact step** in the completion workflow — brainstorms that produce documents write to
+  `docs/product/<topic>-brainstorm-<yyyy-mm>.md` as a dated working design input, never a status
+  source
+
+---
+
 ## v1.3.0 (2026-03-19)
 
 ### Changed

--- a/.claude/skills/meridian-brainstorm/SKILL.md
+++ b/.claude/skills/meridian-brainstorm/SKILL.md
@@ -1,30 +1,30 @@
 ---
 name: meridian-brainstorm
 description: >
-  Brainstorming, ideation, and creative feature exploration skill for the Meridian project.
-  Use this skill whenever the user wants to generate new ideas, features, or improvements for Meridian,
+  Brainstorming, ideation, and creative feature exploration for the Meridian project.
+  Use whenever the user wants new ideas, features, or improvements for Meridian,
   or when they ask "what could we add", "how could we improve", "what would be valuable", "what features should we build",
-  or any variant of creative/generative thinking about the project. Also trigger when the user describes a pain point,
-  a user persona (hobbyist, academic, institutional), or a domain problem (latency, data quality, accessibility,
-  backtesting, compliance) and wants ideas for solving it. Also trigger for architecture or refactoring brainstorms,
-  user growth and adoption strategy discussions, or technical debt and code quality improvement ideation.
-  Trigger even if the user just says "brainstorm" or "give me ideas" in the context of this project. This skill
-  produces detailed idea writeups with implementation sketches, audience fit analysis, effort ratings, and concrete
-  next steps.
+  or any variant of generative thinking about the project. Also trigger when the user describes a pain point,
+  an operator role (financial operations, fund accountant, reconciliation analyst, controller, portfolio manager,
+  compliance officer, auditor), or a domain problem (import trust, reconciliation breaks, close readiness, NAV support,
+  evidence retention, approvals, governed reporting, execution safety). Also trigger for architecture or refactoring
+  brainstorms, activation ideas for built-but-unwired capability, adoption and onboarding strategy, or technical debt
+  ideation. Trigger even if the user just says "brainstorm" or "give me ideas" here. Produces idea writeups with
+  implementation sketches, audience fit, and effort ratings.
 license: See repository LICENSE
 compatibility: >
   Portable Agent Skill package for Agent Skills-compatible hosts. Reads markdown references on demand
   and may append to a local brainstorming history ledger when the host permits filesystem writes.
 metadata:
   owner: meridian-ai
-  version: "1.1"
+  version: "2.0"
   spec: open-agent-skills-v1
 ---
 # Meridian — Brainstorming & Ideation Skill
 
-Generate high-value, implementable ideas for the Meridian platform. Every idea should feel like a natural extension of the program — something that makes the existing experience richer, clearer, and more capable, not a bolt-on afterthought.
+Generate high-value, implementable ideas for the Meridian platform. Every idea should feel like a natural extension of the program — something that makes the existing operator experience richer, clearer, and more provable, not a bolt-on afterthought.
 
-> **Shared project context:** [`../_shared/project-context.md`](../_shared/project-context.md) — authoritative stats, provider list, key abstraction file paths, storage design, ADR table. Read this before generating ideas that reference specific classes, interfaces, or provider names.
+> **Shared project context:** [`../_shared/project-context.md`](../_shared/project-context.md) — authoritative platform framing, solution map, key abstraction file paths, and review guardrails. Read this before generating ideas that reference specific classes, interfaces, or surfaces.
 
 ---
 
@@ -32,25 +32,30 @@ Generate high-value, implementable ideas for the Meridian platform. Every idea s
 
 Every brainstorming task follows this 4-step workflow:
 
-### 1 — GATHER CONTEXT (MCP)
-- Fetch the GitHub issue, discussion, or feature request that prompted the brainstorm
-- Read `../_shared/project-context.md` for authoritative project stats and abstraction paths
+### 1 — GATHER CONTEXT
+
+- Read `../_shared/project-context.md` for the authoritative platform framing and abstraction paths
+- Check current product direction in `docs/product/meridian-design-document.md` (the canonical charter) and live status in `docs/roadmap/generated/ROADMAP_SUMMARY.md` — never assert status from memory
+- Fetch the GitHub issue, discussion, or feature request that prompted the brainstorm, when there is one
 - Review [`references/competitive-landscape.md`](references/competitive-landscape.md) for competitive signals relevant to the request
 
-### 2 — ANALYZE & PLAN (Agents)
-- Detect the brainstorm mode (Open Exploration, Problem-Focused, Persona-Focused, etc.) using the mode table
-- Check the `brainstorm-history.jsonl` ledger to avoid repeating previously covered themes
-- Plan the idea set: quantity targets, audience personas, and effort tiers to cover
+### 2 — ANALYZE & PLAN
 
-### 3 — EXECUTE (Skills + Manual)
+- Detect the brainstorm mode (Open Exploration, Problem-Focused, Activation, etc.) using the mode table
+- Check the `brainstorm-history.jsonl` ledger to avoid repeating previously covered themes
+- Plan the idea set: quantity targets, operator roles, and effort tiers to cover
+
+### 3 — EXECUTE
+
 - Emit the mode declaration and summary table before writing any ideas
-- Write each idea as a natural narrative with anchor, user moment, implementation shape, and tradeoffs
+- Write each idea as a natural narrative with anchor, operator moment, implementation shape, and tradeoffs
 - Synthesize: call out the highest-leverage idea, platform bets, and sequencing recommendation
 
-### 4 — COMPLETE (MCP)
+### 4 — COMPLETE
+
 - Append a new entry to `brainstorm-history.jsonl` recording today's session themes
-- If the session produced actionable proposals, create GitHub issues for the top 1-3 ideas
-- Create a PR or discussion thread via GitHub to share the brainstorm output with stakeholders
+- When the session produces a durable artifact, write it to `docs/product/<topic>-brainstorm-<yyyy-mm>.md` and register it as a dated working design input, not a status source
+- If the session produced actionable proposals, create GitHub issues for the top 1-3 ideas or open a discussion thread to share the output
 
 ---
 
@@ -58,76 +63,88 @@ Every brainstorming task follows this 4-step workflow:
 
 The best ideas for Meridian aren't isolated features. They're extensions that **amplify what already exists**. Before generating any idea, ask:
 
-1. **What does Meridian already do well nearby?** Find the existing capability this idea extends, deepens, or connects to. An idea with no anchor to current functionality is probably the wrong idea.
-2. **What would a user actually see and feel?** Every idea must have a concrete UI or interaction moment. If you can't describe what the user clicks, reads, or watches — the idea isn't finished yet.
-3. **Does this make the whole program more coherent?** The best features make users think "of course this is here." They reduce the number of tools a user needs open, surfacing the right information at the right time within Meridian itself.
-4. **Is the information presented clearly?** Data-dense applications live or die on information hierarchy. Every idea that touches the UI should consider: what's the most important thing on screen? What's secondary? What can be progressive-disclosed or hidden until needed?
+1. **What does Meridian already do well nearby?** Find the existing capability this idea extends, deepens, wires up, or connects to. An idea with no anchor to current functionality is probably the wrong idea.
+2. **What would an operator actually see and do?** Every idea must have a concrete UI or interaction moment. If you can't describe what the operator clicks, reads, approves, or resolves — the idea isn't finished yet.
+3. **Does this make a number more provable?** Meridian sells proven numbers: every figure carries a reconstructable chain from source evidence through normalization, validation, reconciliation, ledger impact, approval, report usage, and delivery. Ideas that shorten, strengthen, or expose that chain outrank ideas that only add surface.
+4. **Is the information presented clearly?** Evidence-dense applications live or die on information hierarchy. Every idea that touches the UI should consider: what's the most important thing on screen? What's secondary? What can be progressive-disclosed until needed?
 
 ---
 
 ## Project Context
 
 **What Meridian is:**
-A provider-agnostic .NET 10 platform for evidence-backed investment operations: trusted data, research, paper validation, execution, books, reconciliation, approvals, and governed reporting. The browser workstation under `src/Meridian.Ui/dashboard/` and the reactivated WPF desktop workstation under `src/Meridian.Wpf/` are two active co-equal operator UI lanes over shared contracts.
+A modular, configurable, self-hosted .NET 10 financial operations platform for fund administrators, private fund managers and fund CFOs, registered investment advisors, family offices, and hybrid institutional teams. Fund management is a first-class *specialization*, not the platform root model — core contracts use customer-neutral concepts (organization, entity, portfolio, account, book, period, transaction, evidence, approval, journal, report, audit trail). Trading, research, backtesting, and paper validation are lanes on the same governed evidence spine, not a separate product.
 
-**Tech stack:** .NET 10, C# infrastructure, F# domain models, browser workstation UI, WPF desktop shell, Docker, Prometheus/Grafana, OpenTelemetry, Bounded Channels, WAL storage, JSONL + Parquet, GitHub Actions CI/CD.
+**The operating question every surface must answer:** *Can Meridian prove, book, reconcile, approve, and report this number?*
 
-**Four-pillar architecture (ADR-016):**
-- **Data Collection** — streaming ingestion, historical backfill, storage, data quality monitoring
-- **Backtesting** — historical tick replay, fill simulation, portfolio metrics, Ledger-based P&L
-- **Execution** — live/simulated order routing, `IOrderGateway`, `PaperTradingGateway`, broker adapters, pre-trade risk (`Meridian.Risk`)
-- **Strategies** — strategy lifecycle management, run archive, paper→live promotion workflow
+**The canonical operator spine:** `Import → Validate → Reconcile → Investigate → Approve → Report`
 
-**Current capabilities:**
+**Tech stack:** .NET 10, C# infrastructure, F# deterministic calculation kernels, React/TypeScript browser workstation, WPF desktop workstation, Docker, Prometheus/Grafana, OpenTelemetry, Bounded Channels, WAL storage, JSONL + Parquet, Postgres-backed stores, GitHub Actions CI/CD.
 
-- Real-time streaming: trades, quotes, L2 order book depth from 5 providers
-- Historical backfill: 11 providers with auto-fallback chain
-- Multi-provider failover via `FailoverAwareMarketDataClient`
-- Backtesting engine with tick-by-tick replay, fill models, and double-entry `Ledger` P&L
-- Paper trading gateway (`PaperTradingGateway`) for risk-free strategy validation
-- Strategy lifecycle: register, run, pause, promote paper→live
-- Pre-trade risk validation via `CompositeRiskValidator` / `IRiskRule`
-- Browser workstation: operator workflows, live status, data browser, and API-backed work queues
-- Retained WPF compatibility surface: shared contracts, regressions, and approved maintenance workflows
-- MCP server layer (`Meridian.Mcp` / `Meridian.McpServer`) exposing tools + prompts for AI agents
-- Deployment: Docker Compose, systemd, Kubernetes
-- Observability: OpenTelemetry tracing, Prometheus metrics, Grafana dashboards
-- CI/CD: 33 GitHub Actions workflows for build, test, and automated documentation
+**Scale of the foundation** (measured 2026-07-28; authoritative table in `docs/product/meridian-design-document.md` §5.2):
 
-**What's coming:** StockSharp 90+ provider activation, Python-accessible layer, Arrow Flight / DuckDB integration, assembly-level SIMD hot-path optimizations, browser-first operator UX improvements, and live broker adapters beyond paper trading.
+- 41 source projects under `src/` (52 projects in `Meridian.sln` including tests and benchmarks)
+- ~242,000 lines of C# (2,902 files); 12,736 lines of F# across four calculation projects
+- ~295,000 lines of TypeScript/TSX in the browser workstation (720 files, 165 screen modules)
+- 497 C# files and 147 XAML views in the WPF desktop workstation
+- 845 distinct `/api/...` routes; 22 provider adapter families; 6 statement connector formats
+- 142 classes in `src/Meridian.Ledger/`; ~12,900 xUnit facts/theories across 12 .NET test projects
 
-**Current count (authoritative: `../_shared/project-context.md`):** 868 source files (856 C# + 12 F#), 261 test files, 22 main projects, 33 CI/CD workflows.
+**Wave posture** (live status is always the roadmap registry, never this file):
+
+- **Closed baselines:** provider trust gate (W1), paper trading cockpit and promotion evidence (W2), research-to-paper continuity (W3), ledger reconciliation and governed report packs (W4), accounting records and multi-asset coverage (W5), shared Financial Record Explorers, Financial Operations control center, statement connector library, bounded live-readiness governance, asset accounting event spine
+- **Active:** Evidence Vault productization (`W5X-EVIDENCE-001`), statement reconciliation onboarding wedge (`W5X-STMT-ONBOARD-001`), WPF web-UI parity (`W8-WPF-PARITY-001`), browser screen consolidation (`W8-UX-CONSOL-001`)
+- **Planned:** Operational Evidence Graph surface (`W5X-OEG-001`), Backtesting Studio (`W6-BTSTUDIO-001`), and the ranked W9 slate — truth/fail-closed (`W9-TRUTH-001`), seeded demo (`W9-DEMO-002`), paper realism (`W9-PAPER-003`), broker fill streaming (`W9-ALPACA-004`), client-grade exports (`W9-REPORT-005`), unitized NAV economics (`W9-NAV-006`), execution safety rules (`W9-SAFETY-007`), route authorization and hash-chained audit (`W9-GOV-008`), institutional ingestion (`W9-INGEST-009`)
+
+**Two co-equal operator UI lanes over one shared seam:** the browser workstation in `src/Meridian.Ui/dashboard/` (built assets in `src/Meridian.Ui/wwwroot/workstation/`) and the WPF desktop workstation in `src/Meridian.Wpf/`. Both consume `src/Meridian.Ui.Services/`, `src/Meridian.Ui.Shared/`, and `src/Meridian.Contracts/`. Presentation can differ; business state cannot.
 
 ---
 
-## Audience Personas
+## Non-Negotiable Guardrails
 
-### 🎯 Hobbyist Quant Developer
+Ideas that violate these are wrong ideas, however attractive. Check every idea against this list before writing it up.
 
-Software developer or data scientist learning quant finance. Frustrated by setup complexity and the gap between "collecting data" and "doing something with it." Wants quick wins, low cost, and integration with tools they already know (Jupyter, pandas). Low risk tolerance — prefers paper trading and sandboxed environments.
-
-### 🎓 Academic / Researcher
-
-Quantitative finance PhD, financial economist, or ML researcher. Cares deeply about data reproducibility, provenance, and quality validation. Institutional data is prohibitively expensive. Needs citation-ready data, audit trails, and bulk export to research infrastructure (HDF5, Arrow, DuckDB).
-
-### 🏦 Institutional / Professional
-
-Prop trading firm, hedge fund ops, or quant analyst at an asset manager. Pain points are vendor lock-in, latency SLAs, compliance, and disaster recovery. Values reliability, throughput, and support. Low tolerance for infrastructure failures.
+- **Seven root workspaces only:** `Trading`, `Portfolio`, `Accounting`, `Reporting`, `Strategy`, `Data`, `Settings`. `Research`, `Data Operations`, and `Governance` are compatibility aliases, not new roots. Never propose an eighth root workspace.
+- **No mobile lane:** no native iOS/Android, MAUI, React Native, Flutter, or mobile-first workflows. Responsive browser behavior is allowed only to keep the browser workstation usable.
+- **Truth discipline:** simulated, sample, or fixture-derived values carry loud labels; unsupported persistence fails closed; missing or stale evidence renders as `review-required` or `blocked`, never as plausible-looking data. Never propose a feature that makes unwired capability look finished.
+- **Governed autonomy:** AI may extract, match, summarize, detect discrepancies, and draft. It must never bypass operator approval, retained evidence, ledger controls, period locks, segregation of duties, report release checks, or payment controls.
+- **Meridian owns ledger truth:** external accounting systems contribute read-only evidence unless an approved publishing workflow exports Meridian-owned entries.
+- **Deferred expansion boundaries** (`docs/product/deferred-expansion-boundaries.md`): live treasury payment execution, enterprise risk, forecasting engines, capital-structure modeling, broad client portal, and no-code workflow design each require a roadmap row defining evidence, approval, and audit gates first. You may brainstorm *toward* the acceptance boundary; do not propose shipping past it.
+- **Claim rules:** brainstorm output is an idea, never a status claim. Never describe planned or dormant capability as shipped.
+- **Activation before expansion:** the codebase is more capable than the running product. When a dormant capability exists in source, wiring it is a stronger idea than building a new one beside it.
 
 ---
 
-## The User Experience Lens
+## Audience Roles
 
-**Apply this lens to every idea.** Meridian is a desktop application people monitor for hours. The quality of the experience — how information is organized, how status is communicated, how configuration feels, how errors surface — determines whether someone keeps using it or switches to a script.
+Meridian's canonical Persona Matrix lives in `docs/product/meridian-design-document.md` §4.2 (24 roles). For brainstorm triage, use these grouped codes in the summary table:
 
-**Principles for UI-touching ideas:**
+| Code | Roles | What they need from an idea |
+| --- | --- | --- |
+| **OPS** | Financial Operations Professional (primary operator), Reconciliation Analyst, Data Operations Analyst, Operations Manager, Treasury Operations Specialist | Fewer manual touches, clearer break resolution, trustworthy imports, visible queue state |
+| **ACCT** | Investment Accountant, Fund Accountant, Reporting Analyst, Controller | Correct postings, NAV support, defensible close, period-lock discipline, package accuracy |
+| **INV** | Portfolio Manager, Investment Analyst, Quantitative Researcher, Trader | Position and valuation truth, research-to-paper continuity, execution feedback, drill-down proof |
+| **GOV** | Compliance Officer, Risk Manager, Auditor | Scoped access, retained evidence, audit reconstruction, control enforcement |
+| **EXEC** | CFO, CIO | Decision-grade summaries, exception visibility, blocked-output clarity |
+| **STAKE** | Fund Investor / LP, RIA Client, Family Beneficiary, Trustee, Board / IC Member | Governed delivery, verifiable statements, entitlement-scoped read access |
+| **ADMIN** | System / Security / Integration Administrator | Platform health, connection setup, permission scoping, upgrade safety |
 
-- **Information hierarchy matters.** A streaming data app can easily become a wall of numbers. Every screen should have a clear primary focus, secondary details accessible on hover or drill-down, and a calm default state that doesn't demand attention when things are healthy.
-- **Status at a glance.** The user should be able to look at Meridian for 2 seconds and know: is everything OK? Is anything degraded? Is a backfill running? Use color, density, and spatial position to communicate state — not just text.
-- **Progressive disclosure.** Show the essential view first. Let users expand into detail when they want it. A symbol's health score is the top layer; the per-provider tick rate breakdown is the drill-down.
-- **Contextual actions.** When showing data, show what the user can _do_ with it right there. Viewing a gap in historical data? Offer a one-click backfill. Seeing an anomalous tick? Offer to flag or exclude it.
-- **Consistency across views.** Symbols, providers, time ranges, and status indicators should look and behave the same way everywhere in the app. Build a shared visual vocabulary.
-- **Respect the active medium.** Browser-workstation ideas should feel native to a browser operator surface, while any explicitly approved WPF maintenance should preserve dense desktop affordances without reopening WPF product/UI scope.
+The **Financial Operations Professional is the primary operator**. When an idea has no OPS, ACCT, or GOV benefit, say so explicitly and justify why it still earns build time.
+
+---
+
+## The Operator Experience Lens
+
+**Apply this lens to every idea.** Meridian is an application operators live in for a working day. How information is organized, how state is communicated, how evidence surfaces, and how blockers explain themselves determines whether someone trusts it or falls back to a spreadsheet.
+
+- **Information hierarchy matters.** An evidence-dense app easily becomes a wall of rows. Every screen should have a clear primary focus, secondary details on hover or drill-down, and a calm default state when nothing needs attention.
+- **State at a glance.** An operator should look for 2 seconds and know: what is blocked, what is waiting on me, what is stale. Use color, density, and position to communicate state — not just text.
+- **Evidence is one click away, never the main event.** Proof should be reachable from any number (drill from a report line to its journal, its source record, its approval) without dominating the working surface.
+- **Progressive disclosure.** Show the essential view first; expand into detail on demand. The reconciliation queue's break count is the top layer; the per-row matching detail is the drill-down.
+- **Contextual actions.** When showing state, show what the operator can *do* about it. Viewing an unmatched statement row? Offer match, split, and escalate right there.
+- **Blocked states must explain themselves.** "Blocked" is only useful with the reason, the owner, and the next action attached.
+- **Consistency across views.** Entities, accounts, periods, evidence chips, and status indicators should look and behave the same everywhere. Build on the shared design system, not per-screen variants.
+- **Respect both lanes.** Browser-workstation ideas should feel native to a browser operator surface; WPF ideas should preserve dense desktop affordances while consuming the same shared contracts. Neither lane may fork product state.
 
 ---
 
@@ -139,21 +156,23 @@ Before generating any ideas, output a one-line mode declaration at the top of yo
 
 > **Mode detected:** [Mode Name] — *[one sentence explaining why]*
 
-Use the table below to identify the mode. If the request is ambiguous between two modes, state both and explain which one you're optimizing for.
+Use the table below. If the request is ambiguous between two modes, state both and explain which one you're optimizing for.
 
 | Mode | Trigger phrases | Approach |
 | ------ | --------- | ---------- |
-| **Open Exploration** | "What could we build?" / "What's valuable?" / "Give me ideas" | Generate across all dimensions, all personas. Favor ideas that connect multiple existing capabilities. |
-| **Problem-Focused** | "How do we solve X?" / "What's the best way to fix Y?" | 3-5 deep ideas targeting the specific pain. Show how each integrates with existing features. |
-| **Persona-Focused** | "What do hobbyist quants want?" / "Ideas for academics" / "Institutional use cases" | 5-8 ideas optimized for that audience. Describe the user journey, not just the feature. |
-| **Domain-Focused** | "Ideas for latency / storage / UX / data quality" | Technical depth in that domain. Every idea still needs a UI or interaction touchpoint. |
-| **Competitive** | "What are others doing?" / "How do we compare to Databento?" | Scan `references/competitive-landscape.md`. Identify gaps; only propose ideas that fit Meridian's architecture naturally. |
-| **Quick Wins** | "What's easy to ship?" / "Low-hanging fruit?" | Effort ≤ Medium, impact ≥ High. Emphasize ideas that improve the existing experience, not new surface area. |
-| **Architecture / Refactoring** | "How should we restructure X?" / "Refactoring ideas" / "What should we improve architecturally?" | Code structure, MVVM compliance, separation of concerns, testability. Anchor to real patterns (`BindableBase`, `EventPipeline`, `IStorageSink`). Include before/after and migration risk. |
-| **User Growth / Adoption** | "How do we get more users?" / "Growth ideas" / "Onboarding friction" | Onboarding, evangelism, community. Map to personas. Span awareness → activation → retention. |
-| **Technical Debt / Code Quality** | "What tech debt should we address?" / "Audit ideas" / "Code quality improvements" | Test coverage, static analysis, CI/CD hardening, dead code. Quantify the cost of inaction. |
-| **UX / Information Design** | "How should we display X?" / "The UI feels cluttered" / "Dashboard design" | Focus on information architecture, visual hierarchy, interaction flow, clarity. Every idea is UI-first. |
-| **Skill Improvement** | "How can the skills be improved?" / "Improve the brainstorm skill" / "Better code reviews" | Apply the brainstorm process reflexively to the skills themselves: eval coverage, output quality, reference freshness, DX. |
+| **Open Exploration** | "What could we build?" / "What's valuable?" / "Give me ideas" | Generate across domains and roles. Favor ideas that connect existing capabilities into one proven path. |
+| **Problem-Focused** | "How do we solve X?" / "What's the best way to fix Y?" | 3-5 deep ideas targeting the specific pain. Show how each integrates with existing surfaces. |
+| **Activation** | "What's built but not wired?" / "What can we turn on?" / "Cheapest high-value win" | Find dormant capability in source, propose the wiring path, and name what it replaces on the live path. Read the activation register in charter §2.1. |
+| **Role-Focused** | "What do fund accountants need?" / "Ideas for controllers" / "Auditor use cases" | 5-8 ideas optimized for that role. Describe the working session, not just the feature. |
+| **Domain-Focused** | "Ideas for reconciliation / close / evidence / providers / reporting" | Technical depth in that domain. Every idea still needs an operator touchpoint. |
+| **Competitive** | "What are others doing?" / "How do we compare to BlackLine?" | Scan `references/competitive-landscape.md`. Identify gaps; only propose ideas that fit Meridian's architecture naturally. |
+| **Quick Wins** | "What's easy to ship?" / "Low-hanging fruit?" | Effort ≤ Medium, impact ≥ High. Emphasize ideas that improve the existing path, not new surface area. |
+| **Architecture / Refactoring** | "How should we restructure X?" / "Refactoring ideas" | Code structure, seam integrity, shared-contract compliance, testability. Anchor to real patterns (`EventPipeline`, `IStorageSink`, `BindableBase`, endpoint/read-model seams). Include before/after and migration risk. |
+| **Evidence & Governance** | "How do we prove X?" / "Audit readiness ideas" / "Approval workflow gaps" | Evidence packets, provenance, approval separation, retention, audit reconstruction. Every idea names what it blocks when absent. |
+| **Adoption / Onboarding** | "How do we reduce time-to-value?" / "Onboarding friction" / "Shadow-mode adoption" | Time to First Proof, seeded demo, import wedge, shadow-mode parallel books. Map to roles and to the wedge in charter §22. |
+| **Technical Debt / Code Quality** | "What tech debt should we address?" / "Code quality improvements" | Test effectiveness, static analysis, CI hardening, dead code, duplicated seams. Quantify the cost of inaction. |
+| **UX / Information Design** | "How should we display X?" / "The screen feels cluttered" / "Workspace design" | Information architecture, visual hierarchy, interaction flow, clarity. Every idea is UI-first and maps to one of the seven roots. |
+| **Skill Improvement** | "How can the skills be improved?" / "Improve the brainstorm skill" | Apply the brainstorm process reflexively to the skills themselves: eval coverage, output quality, reference freshness, DX. |
 
 ### Step 1: Emit the Summary Table
 
@@ -164,7 +183,7 @@ Use the table below to identify the mode. If the request is ambiguous between tw
 
 | # | Idea | Effort | Audience | Impact | Depends On |
 |---|------|--------|----------|--------|------------|
-| 1 | [Short name] | S/M/L/XL | H=Hobbyist, Q=Academic, I=Institutional | High/Med/Low | [prereq or —] |
+| 1 | [Short name] | S/M/L/XL | OPS/ACCT/INV/GOV/EXEC/STAKE/ADMIN | High/Med/Low | [prereq or —] |
 | 2 | ... | | | | |
 ```
 
@@ -176,27 +195,30 @@ Write each idea as a **natural narrative**, not a form to fill out. The reader s
 
 **What every idea must include** (woven into prose, not as labeled fields):
 
-- **The anchor:** What existing Meridian capability does this extend or complement? Reference real file paths from `../_shared/project-context.md` where helpful (e.g., "extends `IStorageSink` at `src/Meridian.Storage/Interfaces/IStorageSink.cs`").
-- **The user moment:** What does the user see, click, or experience? Be specific — describe a screen, a notification, an interaction, not just a backend change.
-- **The implementation shape:** Key technical approach — interfaces, patterns, data flow. Enough that a developer could start scoping.
+- **The anchor:** What existing Meridian capability does this extend, wire, or complement? Reference real file paths (e.g., "extends `StatementMatchingEngine` at `src/Meridian.FinancialOperations/Reconciliation/StatementMatchingEngine.cs`"). Use the anchor table in `references/idea-dimensions.md`.
+- **The operator moment:** What does the operator see, click, resolve, or approve? Name the workspace it lands in and the screen it changes.
+- **The implementation shape:** Key technical approach — contracts, seams, data flow, persistence. Enough that a developer could start scoping.
+- **The evidence and governance impact:** What proof does this create, retain, or expose? What does it block when absent? What approval does it require?
 - **The tradeoffs:** What's hard? What could go wrong? What does this cost in complexity?
 - **Effort and audience:** Who benefits most? How big is this?
 
 **What to include when relevant** (not every idea needs all of these):
 
 - A rough UI sketch described in words (layout, what's prominent, what's secondary)
-- How this feature connects to other features in the app
+- How this feature connects to other features and workspaces
 - Before/after comparison for architecture ideas
-- Funnel stage and success metrics for growth ideas
+- Which roadmap row it belongs to, or that it needs a new one
 - Debt cost and payoff timeline for tech debt ideas
 
 **Quantity guidelines:**
 
-- Open Exploration: 8-12 ideas across 3+ categories
-- Problem/Persona/Domain focused: 4-6 deep ideas
+- Open Exploration: 8-12 ideas across 3+ domains
+- Problem / Role / Domain focused: 4-6 deep ideas
+- Activation: 4-6 ideas, each naming the dormant capability and the live path it replaces
 - Quick Wins: 6-8 ideas
 - Architecture/Refactoring: 4-6 ideas
-- User Growth/Adoption: 5-8 ideas
+- Evidence & Governance: 4-6 ideas
+- Adoption / Onboarding: 5-8 ideas
 - Technical Debt/Code Quality: 4-6 ideas
 - UX/Information Design: 4-6 ideas
 
@@ -204,15 +226,17 @@ Write each idea as a **natural narrative**, not a form to fill out. The reader s
 
 After the ideas, step back and write a synthesis that:
 
-- Identifies the highest-leverage idea (best impact/effort ratio, most complementary to existing features)
+- Identifies the highest-leverage idea (best impact/effort ratio, most complementary to existing capability)
 - Calls out "platform bets" — ideas that unlock multiple others
-- Flags cross-cutting themes (e.g., "three of these ideas all need a shared symbol health model")
+- Flags cross-cutting themes (e.g., "three of these ideas all need the evidence graph projection")
 - Suggests sequencing: what to build first, what it enables next
-- **Competitive signals (always include):** 2-3 sentences from `references/competitive-landscape.md` on how competitors handle this space and which pattern is most adaptable to Meridian's architecture
+- Names roadmap fit: which existing row absorbs each idea, and which would need a new row
+- **Competitive signals (always include):** 2-3 sentences from `references/competitive-landscape.md` on how adjacent products handle this space and which pattern is most adaptable to Meridian's architecture
+- For Activation mode: what the wiring replaces, and how the predecessor gets retired
 - For Architecture mode: migration ordering and risk dependencies
-- For Growth mode: which funnel stage to invest in first
+- For Adoption mode: which stage of Time to First Proof to invest in
 - For Tech Debt mode: quick wins first, then structural changes
-- For UX mode: which screens or views to redesign first based on user frequency and pain
+- For UX mode: which screens to redesign first based on operator frequency and pain
 
 ---
 
@@ -220,54 +244,66 @@ After the ideas, step back and write a synthesis that:
 
 **Write ideas like you're pitching them to a product-minded developer**, not filling in a form. Each idea should read as a short, compelling argument — "here's what's painful today, here's what we'd build, here's what it looks like, here's why it's worth it."
 
-- **Be specific, not generic.** "Add a Python SDK" is weak. "Add a `marketdata` Python package with an async iterator over the live WebSocket feed, pandas DataFrame output, and a `snap()` convenience method for the last N ticks" is strong.
-- **Always describe the user experience.** Even backend optimizations have a user-facing moment: "The backfill that used to take 45 minutes now finishes in 8. The browser progress strip reflects this - the user sees symbols resolving in rapid succession."
-- **Show how features connect.** "This data quality scorecard feeds into the existing dashboard's symbol list — the health score appears as a colored dot next to each symbol. Clicking it expands to the detailed breakdown."
+- **Be specific, not generic.** "Improve reconciliation" is weak. "Promote `StatementMatchingEngine`'s sided matching onto the live statement path so a bank row and a ledger row match as a pair, with a confidence score and a one-click split/escalate action in the Accounting reconciliation queue" is strong.
+- **Always describe the operator experience.** Even backend work has a user-facing moment: "The close that used to need a spreadsheet tie-out now shows a readiness score with the three blocking items named, each linking to the record that caused it."
+- **Show how features connect.** "This evidence chip appears next to every report line; clicking it opens the same proof drawer the reconciliation queue uses."
 - **Acknowledge tradeoffs honestly.** Hidden complexity is the enemy. Name it.
-- **Anchor to the codebase.** Reference real abstractions: `IMarketDataClient`, `IHistoricalDataProvider`, `EventPipeline`, `IStorageSink`, `BindableBase`, the Options pattern. Include file paths from `../_shared/project-context.md` when it clarifies the implementation.
-- **For architecture ideas:** Show concrete code-level changes, not just diagrams. Reference actual class names and namespaces.
-- **For growth ideas:** Be honest about what requires sustained investment vs. one-time effort.
-- **For tech debt ideas:** Quantify the cost: "This makes onboarding a new contributor take 2 days instead of 2 hours" beats "this is messy."
-- **For UX ideas:** Describe the screen. What's at the top? What's the primary action? What information is visible by default vs. on drill-down? How does this view connect to other views in the app?
+- **Anchor to the codebase.** Reference real abstractions: `EventPipeline`, `IStorageSink`, `IOrderGateway`, `IRiskRule`, `AccountingCloseManagementService`, `EvidenceGraphService`, `LedgerReportPackBuilder`, `WorkstationEndpoints`, the Options pattern, source-generated JSON.
+- **For architecture ideas:** show concrete code-level changes, not just diagrams. Reference actual class names and namespaces.
+- **For adoption ideas:** be honest about what requires sustained investment vs. one-time effort.
+- **For tech debt ideas:** quantify the cost. "Two services own overlapping close state, so a fix has to land twice" beats "this is messy."
+- **For UX ideas:** describe the screen. What's at the top? What's the primary action? What's visible by default vs. on drill-down? How does this view connect to the rest of the workspace?
 
 ---
 
 ## Idea Continuity (Session History)
 
-To avoid repeating ideas across sessions, a lightweight ledger can be maintained at `.claude/skills/meridian-brainstorm/brainstorm-history.jsonl` (gitignored by default). Each line is a JSON object:
+A ledger of past sessions is maintained at `.claude/skills/meridian-brainstorm/brainstorm-history.jsonl` and tracked in the repository. Each line is a JSON object:
 
 ```json
-{"session_date": "2026-03-16", "mode": "Open Exploration", "themes": ["Python SDK", "data quality scorecard", "tiered storage"], "ideas_count": 10}
+{"session_date": "2026-07-14", "mode": "Problem-Focused / UX", "themes": ["Excel onboarding workbook generator", "multi-sheet XLSX staged review"], "ideas_count": 5, "document_updated": "docs/product/excel-onboarding-workbook-brainstorm-2026-07.md", "notes": "code findings and sequencing"}
 ```
 
-If this file exists, open each brainstorm session with:
+Read it before generating, and open each brainstorm session with:
 > **Previous sessions covered:** [summary of themes from history]. **Unexplored areas:** [gaps].
 
-This prevents the same ideas from appearing session after session and surfaces genuinely new territory.
+Append a new line at the end of the session. This prevents the same ideas from appearing session after session and surfaces genuinely new territory.
 
 ---
 
 ## Idea Generation Reference
 
-When brainstorming, read [`references/idea-dimensions.md`](references/idea-dimensions.md) for the full seeded concept bank organized by category. The file includes a **codebase anchor table** mapping concept names to file paths for precise implementation references.
+When brainstorming, read [`references/idea-dimensions.md`](references/idea-dimensions.md) for the full seeded concept bank organized by domain. The file opens with a **codebase anchor table** mapping concept names to verified file paths.
 
 **Quick-access dimensions:**
 
-- **Data access:** streaming API, bulk export, query API, Python SDK, gRPC, Arrow Flight, DuckDB integration
-- **Data quality:** gap detection, anomaly flagging, cross-provider reconciliation, tick quality scoring, options chain validation
-- **Performance:** kernel bypass, lock-free queues, SIMD processing, GC tuning, backpressure metrics
-- **Storage:** Parquet/Arrow, time-series DB, tiered cold storage, deduplication, schema evolution, retention policies
-- **Integrations:** Jupyter, pandas, QuantConnect, Backtrader, Grafana, dbt, OpenBB, Dagster/Airflow
-- **UX:** setup wizard, symbol browser, live visualizer, order book heatmap, config validation, theme system, diagnostics panel
-- **Reliability:** multi-provider failover, health scoring, alerting, chaos testing, rolling restart
-- **Architecture:** MVVM compliance, DI container, hot/cold path separation, interface segregation, pipeline modularization
-- **Growth:** quickstart experience, content series, README optimization, integration showcases, contributor onboarding
-- **Code quality:** mutation testing, static analysis gates, dead code elimination, test isolation, error handling patterns
+- **Import & data trust:** connector coverage, mapping profiles, drift detection, preview/confidence, replay, certified import runs
+- **Reconciliation & breaks:** sided matching, tolerance policy, casework, SLA, aging, bulk resolution, root-cause clustering
+- **Ledger & accounting:** journals, period lock, close readiness, capital accounts, tax lots, multi-currency, NAV economics
+- **Evidence & provenance:** evidence packets, manifests, document extraction, object links, evidence graph, number-level lineage
+- **Reporting & delivery:** report packs, report-writer grids, client-grade rendering, provenance drill-through, publication and restatement
+- **Portfolio & valuation:** positions, marks, security master, corporate actions, multi-asset coverage, cash ladder
+- **Execution & risk:** order gateways, paper realism, fill and cost models, pre-trade rules, kill-switch and safety controls
+- **Research & strategy:** strategy lifecycle, backtesting runtime, run comparison, promotion evidence, QuantScript
+- **Workstation UX:** the seven roots, screen consolidation, command palette, trust strip, proof drawers, operator focus and queues
+- **Governance & tenancy:** scoped authorization, approval separation, audit chain, retention, access review
+- **Platform quality:** durability, performance, observability, test effectiveness, CI hardening, activation coverage
+
+---
+
+## Handoffs
+
+- Hand off to `meridian-blueprint` when the user selects one idea for implementation design.
+- Hand off to `meridian-roadmap-strategist` when ideas need sequencing into roadmap waves or a new registry row.
+- Hand off to `meridian-simulated-user-panel` when ideas need persona critique before selection.
+- Hand off to `meridian-repo-navigation` when grounding an idea needs subsystem routing first.
 
 ---
 
 ## Reference Files
 
-- [`references/idea-dimensions.md`](references/idea-dimensions.md) — Seeded idea bank organized by category, including codebase anchor table
-- [`references/competitive-landscape.md`](references/competitive-landscape.md) — What Bloomberg, Databento, Polygon, Refinitiv, and open-source tools offer (read for competitive signals in every synthesis section)
-- `../_shared/project-context.md` — Authoritative project stats, abstraction file paths, provider inventory
+- [`references/idea-dimensions.md`](references/idea-dimensions.md) — Seeded idea bank organized by domain, including the verified codebase anchor table
+- [`references/competitive-landscape.md`](references/competitive-landscape.md) — How close managers, fund-administration suites, asset-servicing platforms, ledger APIs, and market-data vendors compare (read for competitive signals in every synthesis section)
+- `../_shared/project-context.md` — Authoritative platform framing, solution map, abstraction file paths, review guardrails
+- `docs/product/meridian-design-document.md` — Canonical product charter: value proposition, doctrines, persona matrix, implementation baseline, wedge
+- `docs/roadmap/generated/ROADMAP_SUMMARY.md` — Live roadmap status; the only source for what is done, active, or planned

--- a/.claude/skills/meridian-brainstorm/references/competitive-landscape.md
+++ b/.claude/skills/meridian-brainstorm/references/competitive-landscape.md
@@ -1,77 +1,118 @@
 # Competitive Landscape — Meridian Brainstorm Reference
 
-Understanding the market helps identify where Meridian can differentiate vs. where it needs feature parity.
+Understanding the market helps identify where Meridian can differentiate vs. where it needs parity. The category set below follows the differentiation analysis in `docs/product/meridian-design-document.md` §1.4 and the market-entry wedge in §22.
+
+**The gap Meridian sells against:** the market has tools for every fragment and no product for the whole proof. Portfolio systems *show* numbers but cannot prove them. Accounting systems *record* numbers but do not carry the operational evidence behind them. Close-management tools *track tasks* around numbers but own neither the data nor the ledger. Fund administrators *certify* numbers as a service, at service-provider speed and cost.
 
 ---
 
-## Paid Commercial Providers
+## Close and Controls Managers
 
-### Bloomberg Terminal / Bloomberg B-PIPE
+**BlackLine, Trintech**
 
-- Gold standard for institutional data; real-time + historical across all asset classes
-- Costs $20K-$24K/user/year
-- Meridian opportunity: target long tail who cannot justify this cost — hobbyists, small funds, academic labs
-- Features worth borrowing: data lineage tagging, real-time anomaly flagging
-
-### Databento
-
-- Modern developer-first market data API; pay-per-use; MBO + MBP data; DBN binary format
-- Pricing: ~$0.10-$1.00/symbol-day historical; real-time from $150/month
-- Meridian advantage: cloud-only with no self-hosted option; Meridian wins on on-premise, no per-tick fees for self-collected data
-- Features worth borrowing: DBN format, databento-python ergonomics, MBO data model
-
-### Polygon.io
-
-- REST + WebSocket for US equities, options, forex, crypto; free tier available
-- Meridian advantage: Polygon does not enable structured local storage; Meridian local-first means no ongoing per-query cost
-- Features worth borrowing: aggregates/OHLCV API design, options chain endpoint
+- Own the close checklist, task assignment, sign-off, and account-reconciliation certification workflow
+- Sit *beside* the ERP/GL: they track and certify work about numbers they do not own
+- Strong at: reviewer workflow, control evidence attachment, close status reporting, SOX-style certification
+- Meridian's angle: it owns the data, the reconciliation, and the ledger, so the close checklist is derived from real record state rather than manually asserted. A task marked complete in Meridian is backed by a reconciled, approved record — not a checkbox.
+- Worth borrowing: certification rigor, reviewer/preparer separation UX, close calendar ergonomics, materiality-driven task scoping
 
 ---
 
-## Open Source / Community Tools
+## Fund Administration and Private-Capital Suites
 
-### QuestDB
+**Carta, FundStudio, Investran-class platforms**
 
-- Open-source time-series SQL database; ILP ingest; nanosecond timestamp support
-- Natural Meridian storage backend replacing JSONL for query-heavy use cases
-- Integration: Meridian to QuestDB sink (ILP over TCP) alongside JSONL
+- Capital accounts, commitments, closings, allocations, waterfalls, carry, fees, investor statements, notices
+- Typically strong on fund economics, weaker on operational evidence chains and general-purpose accounting
+- Meridian's angle: the same capital-account and waterfall math (`src/Meridian.Ledger/`) sits on a customer-neutral core — organization, entity, portfolio, account, book, period — so fund workflows are a specialization rather than the root model, and non-fund customers use the same spine
+- Worth borrowing: LP statement quality, capital-call and distribution notice workflows, equalization handling, investor-facing clarity
+- Not worth borrowing: fund-shaped root data models that make non-fund customers second-class
 
-### QuantConnect LEAN / Backtrader / Zipline
+---
 
-- Open-source backtesting frameworks with their own data ingestion pipelines
-- None have a good live-data collection layer — Meridian can be "the collector that feeds your backtesting framework"
-- LEAN bridge is highest-value (large QuantConnect community)
+## Asset-Servicing and Portfolio Accounting Platforms
 
-### OpenBB Terminal
+**SS&C Advent Geneva, eFront, Addepar-class platforms**
 
-- Open-source Bloomberg Terminal alternative; Python-based; no persistent storage
-- Meridian could be an OpenBB data provider backend, giving OpenBB users high-quality local storage
+- Multi-book portfolio accounting, valuation, performance, and consolidated reporting at institutional scale
+- Expensive, implementation-heavy, often service-wrapped; customization typically flows through the vendor
+- Meridian's angle: self-hosted, contract-pack extensible, and evidence-first — the proof chain is a product object, not an export
+- Worth borrowing: multi-book rigor, valuation methodology discipline, consolidation and elimination modeling, report library depth
+- Not worth borrowing: implementation models that require vendor services for routine configuration
+
+---
+
+## Ledger and Payment APIs
+
+**Modern Treasury and similar ledger/payment infrastructure**
+
+- Developer-first double-entry ledger APIs, bank connectivity, and payment orchestration
+- Excellent primitives, but the customer builds the operator product on top
+- Meridian's angle: Meridian ships the operator product — queues, close cockpit, approvals, evidence, reporting — with the ledger as internal truth rather than an API surface to be assembled
+- Worth borrowing: ledger API ergonomics, idempotency discipline, bank-format handling (BAI2/CAMT.053 — already in source at `src/Meridian.FinancialOperations/Reconciliation/Connectors/`)
+- Boundary reminder: live payment execution remains a deferred lane (`docs/product/deferred-expansion-boundaries.md`); brainstorm toward the acceptance boundary, not past it
+
+---
+
+## Market Data and Trading Infrastructure
+
+Relevant to the Trading, Strategy, and Data lanes, which remain part of the same governed spine.
+
+- **Bloomberg Terminal / B-PIPE** — institutional gold standard, $20K+/user/year; strong lineage and monitoring expectations worth borrowing
+- **Databento** — developer-first market data, cloud-only, strong data-product packaging and client ergonomics
+- **Polygon.io** — simple REST/WebSocket access with a free tier; no local storage or workflow story
+- **QuantConnect LEAN / Backtrader / Zipline** — backtesting ecosystems with their own ingestion; none carry an accounting or evidence lane
+- Meridian's angle: decision-to-delivery continuity — research, backtest, paper validation, promotion governance, execution records, reconciliation, ledger, close, and delivery on one evidence model. Close tools have no trading lane; trading platforms have no close.
 
 ---
 
 ## Differentiation Matrix
 
-| Capability          | Bloomberg | Databento | Polygon | Meridian now | Meridian potential |
-|---------------------|-----------|-----------|---------|---------|---------------|
-| Self-hosted         | No        | No        | No      | Yes     | Yes           |
-| Multi-provider      | Yes       | No        | No      | Yes (5) | Yes (90+)     |
-| Free tier           | No        | No        | Yes     | Yes     | Yes           |
-| Sub-ms latency      | Yes       | Yes       | No      | Yes     | Yes           |
-| Python SDK          | Yes       | Yes       | Yes     | No      | Planned       |
-| L2 order book       | Yes       | Yes       | Yes     | Yes(IB) | Yes           |
-| Data provenance     | Yes       | Partial   | No      | No      | Opportunity   |
-| Backtesting engine  | No        | No        | No      | Yes     | Yes (full)    |
-| Paper trading       | No        | No        | No      | Yes     | Yes           |
-| Strategy execution  | No        | No        | No      | Yes     | Yes (live)    |
-| Pre-trade risk      | Yes       | No        | No      | Yes     | Yes           |
-| Community sharing   | No        | No        | No      | No      | Opportunity   |
-| Academic citation   | No        | No        | No      | No      | Opportunity   |
-| MCP / AI tooling    | No        | No        | No      | Yes     | Yes           |
+Columns are category representatives, not exhaustive vendor claims. "Meridian now" reflects accepted roadmap evidence; "potential" reflects charter direction, not shipped capability.
 
-Meridian defensible moats:
+| Capability | Close managers | Fund admin suites | Asset servicing | Ledger APIs | Meridian now | Meridian potential |
+|---|---|---|---|---|---|---|
+| Self-hosted | No | No | No | No | Yes | Yes |
+| Owns the data *and* the ledger | No | Partial | Yes | Partial | Yes | Yes |
+| Evidence chain as a product object | Partial | No | Partial | No | Yes (packets, manifests) | Number Passport on every figure |
+| Reconciliation engine | Certification only | Partial | Yes | No | Yes | Sided matching on the live path |
+| Close cockpit | Yes | Partial | Partial | No | Yes | Readiness scoring with named blockers |
+| Governed report packs with lineage | No | Partial | Yes | No | Yes | Client-grade rendering |
+| Fund economics (NAV, waterfall, carry) | No | Yes | Yes | No | Supported foundation | Wired economics path |
+| Trading / research lane | No | No | Partial | No | Yes | Backtesting Studio evidence loop |
+| Fail-closed truth discipline | No | No | No | No | Yes | Datum-level labeling |
+| Contract-pack extensibility | No | No | Vendor-led | Partial | Partial | Certified asset packs |
+| AI/MCP tooling surface | No | No | No | No | Yes | Governed-autonomy assistants |
+| Cheap stakeholder verification seats | No | Partial | No | No | Partial | Free/low-cost reviewer roles |
 
-1. Self-hosted, no per-query cloud fees
-2. Multi-provider failover and reconciliation (no competitor does this affordably)
-3. Full platform: data collection → backtesting → execution → strategy lifecycle in one codebase
-4. Hackable open architecture — plugins, custom sinks, C# + F# extensibility
-5. MCP server layer — AI-native tooling surface (unique in this space)
+---
+
+## Meridian's Defensible Moats
+
+1. **Proof as the product.** Provenance, evidence retention, reconciliation state, approvals, and report-line lineage are first-class, user-visible objects — not exports or logs.
+2. **Truthful by construction.** Loud labeling of simulated data, fail-closed persistence, and `review-required` / `blocked` states instead of plausible-looking numbers. Honesty is expensive for competitors to retrofit.
+3. **Decision-to-delivery continuity.** One governed evidence model spanning research through delivery; the codebase already carries both ends.
+4. **Whole-balance-sheet modeling.** Assets, liabilities, commitments, guarantees, collateral, and contingent exposures as equal citizens via contract packs.
+5. **Lower-risk adoption.** Shadow-mode onboarding proves value before a customer migrates official books.
+6. **Trust as distribution.** Every governed delivery is a verification event; cheap reviewer seats spread the proof network.
+7. **Self-hosted and hackable.** No per-query cloud fees, extensible in C# and F#, with an MCP surface for AI-native tooling.
+
+---
+
+## Good Borrowing Targets
+
+- Certification and reviewer-workflow rigor from close managers
+- LP statement and capital-activity notice quality from fund administration suites
+- Multi-book and consolidation discipline from asset-servicing platforms
+- Idempotency and bank-format handling from ledger APIs
+- Data lineage and anomaly surfacing from institutional market-data vendors
+- Client ergonomics and packaging polish from developer-first data products
+
+## Bad Borrowing Targets
+
+- Cloud-only assumptions that break self-hosted operation
+- Vendor-service-dependent configuration models
+- Fund-shaped root data models that demote non-fund customers
+- Checklist-only close tracking that asserts completion without record backing
+- Any surface that presents unwired capability as finished
+- Features that ignore Meridian's seven-root navigation, evidence discipline, or the co-equal browser and desktop lanes

--- a/.claude/skills/meridian-brainstorm/references/idea-dimensions.md
+++ b/.claude/skills/meridian-brainstorm/references/idea-dimensions.md
@@ -1,233 +1,330 @@
 # Idea Dimensions — Meridian Brainstorm Reference
 
-Seeded concept bank organized by category. Use these as inspiration prompts, not final ideas — the goal is to develop them into full Idea Cards grounded in the Meridian codebase.
+Seeded concept bank organized by domain. Use these as inspiration prompts, not final ideas — the goal is to develop them into full idea writeups grounded in the Meridian codebase.
 
-> **See also:** [`../../_shared/project-context.md`](../../_shared/project-context.md) for authoritative project stats, ADR table, and key abstraction file paths.
+> **See also:** [`../../_shared/project-context.md`](../../_shared/project-context.md) for the authoritative platform framing, solution map, and review guardrails, and `docs/product/meridian-design-document.md` for the canonical product charter.
+>
+> **Claim discipline:** the presence of a type in this table means the code exists, not that the capability is wired into the live operator path. Several entries below are explicitly dormant (see *Activation Targets*). Never describe a dormant capability as shipped.
 
 ---
 
 ## 🗺️ Codebase Anchor Table
 
-Use these when referencing specific abstractions in ideas. File paths are relative to the repository root.
+Use these when referencing specific abstractions in ideas. File paths are relative to the repository root and were verified 2026-07-28.
+
+### Import, providers, and data trust
 
 | Concept | Interface / Class | File Path |
 |---------|-------------------|-----------|
 | Streaming provider contract | `IMarketDataClient` | `src/Meridian.ProviderSdk/IMarketDataClient.cs` |
 | Historical provider contract | `IHistoricalDataProvider` | `src/Meridian.Infrastructure/Adapters/Core/IHistoricalDataProvider.cs` |
-| Storage sink contract | `IStorageSink` | `src/Meridian.Storage/Interfaces/IStorageSink.cs` |
-| Event pipeline coordinator | `EventPipeline` | `src/Meridian.Application/Pipeline/EventPipeline.cs` |
-| Write-ahead log | `WriteAheadLog` | `src/Meridian.Storage/Archival/WriteAheadLog.cs` |
-| Crash-safe file writes | `AtomicFileWriter` | `src/Meridian.Storage/Archival/AtomicFileWriter.cs` |
-| JSONL sink | `JsonlStorageSink` | `src/Meridian.Storage/Sinks/JsonlStorageSink.cs` |
-| Parquet sink | `ParquetStorageSink` | `src/Meridian.Storage/Sinks/ParquetStorageSink.cs` |
-| MVVM base class | `BindableBase` | `src/Meridian.Wpf/ViewModels/BindableBase.cs` |
-| ICommand implementation | `RelayCommand` | `src/Meridian.Wpf/ViewModels/` |
-| JSON source-gen context | `MarketDataJsonContext` | `src/Meridian.Core/Serialization/MarketDataJsonContext.cs` |
-| Multi-provider historical routing | `CompositeHistoricalDataProvider` | `src/Meridian.Infrastructure/Adapters/Core/` |
-| Backfill orchestration | `HistoricalBackfillService` | `src/Meridian.Application/Backfill/HistoricalBackfillService.cs` |
-| Gap detection | `GapBackfillService` | `src/Meridian.Application/Backfill/GapBackfillService.cs` |
-| Data quality orchestrator | `DataQualityMonitoringService` | `src/Meridian.Application/Monitoring/DataQuality/` |
-| Data completeness scoring | `CompletenessScoreCalculator` | `src/Meridian.Application/Monitoring/DataQuality/` |
-| Prometheus metrics | `PrometheusMetrics` | `src/Meridian.Application/Monitoring/PrometheusMetrics.cs` |
-| Storage catalog | `StorageCatalogService` | `src/Meridian.Storage/Services/StorageCatalogService.cs` |
-| Tiered storage migration | `TierMigrationService` | `src/Meridian.Storage/Services/TierMigrationService.cs` |
-| Parquet conversion | `ParquetConversionService` | `src/Meridian.Storage/Services/ParquetConversionService.cs` |
-| F# validation pipeline | `ValidationPipeline` | `src/Meridian.FSharp/Validation/ValidationPipeline.fs` |
-| F# quote validator | `QuoteValidator` | `src/Meridian.FSharp/Validation/QuoteValidator.fs` |
-| F# trade validator | `TradeValidator` | `src/Meridian.FSharp/Validation/TradeValidator.fs` |
 | Provider SDK attribute | `DataSourceAttribute` | `src/Meridian.ProviderSdk/DataSourceAttribute.cs` |
 | Provider SDK discovery | `DataSourceRegistry` | `src/Meridian.ProviderSdk/DataSourceRegistry.cs` |
-| Graceful shutdown | `GracefulShutdownService` | `src/Meridian.Application/Services/GracefulShutdownService.cs` |
-| Storage sink discovery | `StorageSinkRegistry` | `src/Meridian.Storage/StorageSinkRegistry.cs` |
-| Subscription orchestration | `SubscriptionOrchestrator` | `src/Meridian.Application/Subscriptions/SubscriptionOrchestrator.cs` |
 | Failover provider | `FailoverAwareMarketDataClient` | `src/Meridian.Infrastructure/Adapters/Failover/` |
-| Alpaca streaming | `AlpacaMarketDataClient` | `src/Meridian.Infrastructure/Adapters/Alpaca/` |
-| IB streaming | `IBMarketDataClient` | `src/Meridian.Infrastructure/Adapters/InteractiveBrokers/` |
-| WPF Dashboard page | `DashboardPage` | `src/Meridian.Wpf/Views/DashboardPage.xaml(.cs)` |
-| WPF Dashboard ViewModel | `DashboardViewModel` | `src/Meridian.Wpf/ViewModels/DashboardViewModel.cs` |
-| Configuration pipeline | `ConfigurationPipeline` | `src/Meridian.Application/Config/ConfigurationPipeline.cs` |
-| Hot-path batch serializer | `HotPathBatchSerializer` | `src/Meridian.Application/Pipeline/HotPathBatchSerializer.cs` |
-| Portable data packaging | `PortableDataPackager` | `src/Meridian.Storage/Packaging/PortableDataPackager.cs` |
-| Order gateway (broker-agnostic) | `IOrderGateway` | `src/Meridian.Execution/Interfaces/IOrderGateway.cs` |
+| Backfill orchestration | `HistoricalBackfillService` | `src/Meridian.Application/Backfill/HistoricalBackfillService.cs` |
+| Gap detection | `GapBackfillService` | `src/Meridian.Application/Backfill/GapBackfillService.cs` |
+| F# validation pipeline | `ValidationPipeline` | `src/Meridian.FSharp/Validation/ValidationPipeline.fs` |
+| Statement connector (BAI2) | `Bai2StatementConnector` | `src/Meridian.FinancialOperations/Reconciliation/Connectors/Bai2/Bai2StatementConnector.cs` |
+| Statement connector (CAMT.053) | `Camt053StatementConnector` | `src/Meridian.FinancialOperations/Reconciliation/Connectors/Camt/Camt053StatementConnector.cs` |
+| Statement ingestion scheduling | `DefaultReconciliationIngestionScheduler` | `src/Meridian.FinancialOperations/Reconciliation/DefaultReconciliationIngestionScheduler.cs` |
+| Import-to-evidence bridge | `StatementImportEvidenceBridge` | `src/Meridian.Ui.Shared/Evidence/StatementImportEvidenceBridge.cs` |
+
+### Reconciliation and breaks
+
+| Concept | Interface / Class | File Path |
+|---------|-------------------|-----------|
+| Sided statement matching | `StatementMatchingEngine` | `src/Meridian.FinancialOperations/Reconciliation/StatementMatchingEngine.cs` |
+| Reconciliation matching engine | `ReconciliationMatchingEngine` | `src/Meridian.FinancialOperations/Reconciliation/ReconciliationMatchingEngine.cs` |
+| Match kernel | `ReconciliationMatchKernel` | `src/Meridian.FinancialOperations/Reconciliation/ReconciliationMatchKernel.cs` |
+| Tolerance policy | `MatchingTolerances` | `src/Meridian.FinancialOperations/Reconciliation/MatchingTolerances.cs` |
+| Normalization | `ReconciliationNormalizationService` | `src/Meridian.FinancialOperations/Reconciliation/ReconciliationNormalizationService.cs` |
+| Run orchestration | `ReconciliationRunService` | `src/Meridian.Strategies/Services/ReconciliationRunService.cs` |
+| Break queue persistence | `FileReconciliationBreakQueueRepository` | `src/Meridian.Strategies/Services/FileReconciliationBreakQueueRepository.cs` |
+| Casework workflow | `ReconciliationCaseWorkflowService` | `src/Meridian.Strategies/Services/ReconciliationCaseWorkflowService.cs` |
+| SLA calculation | `ReconciliationSlaCalculator` | `src/Meridian.Strategies/Services/ReconciliationSlaCalculator.cs` |
+| Reconciliation governance | `ReconciliationGovernanceService` | `src/Meridian.Strategies/Services/ReconciliationGovernanceService.cs` |
+| Position reconciliation | `PositionReconciliationService` | `src/Meridian.Execution/Services/PositionReconciliationService.cs` |
+
+### Ledger, accounting, and close
+
+| Concept | Interface / Class | File Path |
+|---------|-------------------|-----------|
+| Journal entry | `JournalEntry` | `src/Meridian.Ledger/JournalEntry.cs` |
+| Journal evidence link | `JournalEvidenceReference` | `src/Meridian.Ledger/JournalEvidenceReference.cs` |
+| Automated journal draft | `AutomatedJournalDraft` | `src/Meridian.Ledger/AutomatedJournalDraft.cs` |
+| Journal reversal | `LedgerJournalReversal` | `src/Meridian.Ledger/LedgerJournalReversal.cs` |
+| Multi-currency translation | `LedgerCurrencyTranslation` | `src/Meridian.Ledger/LedgerCurrencyTranslation.cs` |
+| Tax-lot policy | `LedgerAccountTaxLotPolicy` | `src/Meridian.Ledger/LedgerAccountTaxLotPolicy.cs` |
+| Period reopen evidence | `PeriodReopenEvidence` | `src/Meridian.Ledger/PeriodReopenEvidence.cs` |
+| Period lock reader | `ILedgerPeriodLockReader` | `src/Meridian.Application/SecurityMaster/ILedgerPeriodLockReader.cs` |
+| Close management | `AccountingCloseManagementService` | `src/Meridian.FinancialOperations/AccountingClose/AccountingCloseManagementService.cs` |
+| Close posting workbench | `AccountingClosePostingWorkbench` | `src/Meridian.FinancialOperations/AccountingClose/AccountingClosePostingWorkbench.cs` |
+| Accounting report package | `AccountingReportPackageService` | `src/Meridian.FinancialOperations/AccountingClose/AccountingReportPackageService.cs` |
+| Approval policy matrix | `OperationsApprovalPolicyMatrixService` | `src/Meridian.FinancialOperations/OperationsContinuity/OperationsApprovalPolicyMatrixService.cs` |
+| Asset accounting event spine | `AssetAccountingEventSpineService` | `src/Meridian.FinancialOperations/Ledger/AssetAccountingEventSpineService.cs` |
+| Capital account workbench | `CapitalAccountWorkbenchService` | `src/Meridian.Ui.Shared/Services/CapitalAccountWorkbenchService.cs` |
+| Capital-account subledger | `PrivateCapitalCapitalAccountSubledgerBuilder` | `src/Meridian.FinancialOperations/PrivateCapital/PrivateCapitalCapitalAccountSubledgerBuilder.cs` |
+
+### Fund economics (dormant — see Activation Targets)
+
+| Concept | Interface / Class | File Path |
+|---------|-------------------|-----------|
+| Unitized NAV | `NavPerUnitCalculator` | `src/Meridian.Ledger/NavPerUnitCalculator.cs` |
+| European waterfall | `EuropeanDistributionWaterfall` | `src/Meridian.Ledger/EuropeanDistributionWaterfall.cs` |
+| Preferred return | `PreferredReturnCalculator` | `src/Meridian.Ledger/PreferredReturnCalculator.cs` |
+| Carry clawback | `CarriedInterestClawbackCalculator` | `src/Meridian.Ledger/CarriedInterestClawbackCalculator.cs` |
+| Equalization | `EqualizationCalculator` | `src/Meridian.Ledger/EqualizationCalculator.cs` |
+| Capital call planning | `CapitalCallPlanBuilder` | `src/Meridian.Ledger/CapitalCallPlanBuilder.cs` |
+
+### Evidence and provenance
+
+| Concept | Interface / Class | File Path |
+|---------|-------------------|-----------|
+| Evidence graph | `EvidenceGraphService` | `src/Meridian.Ui.Shared/Evidence/EvidenceGraphService.cs` |
+| Proof chain builder | `EvidenceProofChainBuilder` | `src/Meridian.Ui.Shared/Evidence/EvidenceProofChainBuilder.cs` |
+| Evidence packet validation | `EvidencePacketValidationService` | `src/Meridian.Ui.Shared/Evidence/EvidencePacketValidationService.cs` |
+| Evidence artifact store | `FileEvidenceArtifactStore` | `src/Meridian.Ui.Shared/Evidence/FileEvidenceArtifactStore.cs` |
+| Document field extraction | `EvidenceDocumentExtraction` | `src/Meridian.Ui.Shared/Evidence/EvidenceDocumentExtraction.cs` |
+| Evidence templates | `EvidenceTemplateRegistry` | `src/Meridian.Ui.Shared/Evidence/EvidenceTemplateRegistry.cs` |
+| Amount-level provenance | `LedgerAmountProvenanceService` | `src/Meridian.Ui.Shared/Services/LedgerAmountProvenanceService.cs` |
+| Hash-chained audit | `AuditChainService` | `src/Meridian.Storage/Services/AuditChainService.cs` |
+
+### Reporting and delivery
+
+| Concept | Interface / Class | File Path |
+|---------|-------------------|-----------|
+| Report generation | `ReportGenerationService` | `src/Meridian.Reporting/ReportGenerationService.cs` |
+| Report-writer grids | `ReportWriterGridEngine` | `src/Meridian.Reporting/ReportWriterGridEngine.cs` |
+| Reporting governance | `ReportingGovernanceService` | `src/Meridian.Reporting/ReportingGovernanceService.cs` |
+| Snapshot diff | `ReportSnapshotDiffEngine` | `src/Meridian.Reporting/ReportSnapshotDiffEngine.cs` |
+| Certified snapshot | `CertifiedReportingSnapshotBuilder` | `src/Meridian.Reporting/CertifiedReportingSnapshotBuilder.cs` |
+| NAV attribution | `NavAttributionService` | `src/Meridian.Reporting/NavAttributionService.cs` |
+| Partners-capital projection | `PartnersCapitalProjection` | `src/Meridian.Reporting/PartnersCapitalProjection.cs` |
+| Report pack builder | `LedgerReportPackBuilder` | `src/Meridian.Ledger/LedgerReportPackBuilder.cs` |
+| Report pack signature | `LedgerReportPackSignature` | `src/Meridian.Ledger/LedgerReportPackSignature.cs` |
+| Report pack delivery | `ReportPackDeliveryService` | `src/Meridian.Ui.Shared/Services/ReportPackDeliveryService.cs` |
+| Client-grade rendering | `ClientGradeReportRenderer` | `src/Meridian.Documents/ClientGradeReportRenderer.cs` |
+| Financial document rendering | `FinancialReportDocumentRenderer` | `src/Meridian.Documents/FinancialReportDocumentRenderer.cs` |
+
+### Execution, risk, and research
+
+| Concept | Interface / Class | File Path |
+|---------|-------------------|-----------|
+| Order gateway | `IOrderGateway` | `src/Meridian.Execution/Interfaces/IOrderGateway.cs` |
 | Broker adapter SDK contract | `IExecutionGateway` | `src/Meridian.Execution.Sdk/IExecutionGateway.cs` |
 | Live strategy context | `IExecutionContext` | `src/Meridian.Execution/Interfaces/IExecutionContext.cs` |
 | Paper trading gateway | `PaperTradingGateway` | `src/Meridian.Execution/Adapters/PaperTradingGateway.cs` |
+| Broker fill gateway | `AlpacaBrokerageGateway` | `src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaBrokerageGateway.cs` |
 | Order lifecycle tracking | `OrderManagementSystem` | `src/Meridian.Execution/OrderManagementSystem.cs` |
 | Pre-trade risk validation | `CompositeRiskValidator` | `src/Meridian.Risk/CompositeRiskValidator.cs` |
 | Risk rule contract | `IRiskRule` | `src/Meridian.Risk/IRiskRule.cs` |
 | Strategy lifecycle contract | `IStrategyLifecycle` | `src/Meridian.Strategies/Interfaces/IStrategyLifecycle.cs` |
+| Strategy run read model | `StrategyRunReadService` | `src/Meridian.Strategies/Services/StrategyRunReadService.cs` |
 | Strategy run archive | `StrategyRunStore` | `src/Meridian.Strategies/Storage/StrategyRunStore.cs` |
-| Live strategy contract | `ILiveStrategy` | `src/Meridian.Strategies/Interfaces/ILiveStrategy.cs` |
-| P&L ledger (double-entry) | `Ledger` | `src/Meridian.Ledger/Ledger.cs` |
-| Ledger read-only view | `IReadOnlyLedger` | `src/Meridian.Ledger/IReadOnlyLedger.cs` |
 | Backtest strategy contract | `IBacktestStrategy` | `src/Meridian.Backtesting.Sdk/IBacktestStrategy.cs` |
-| Backtest context | `IBacktestContext` | `src/Meridian.Backtesting.Sdk/IBacktestContext.cs` |
-| Backtest engine | `BacktestEngine` | `src/Meridian.Backtesting/Engine/` |
+| Market-impact fill model | `MarketImpactFillModel` | `src/Meridian.Backtesting/FillModels/MarketImpactFillModel.cs` |
+| Order-book fill model | `OrderBookFillModel` | `src/Meridian.Backtesting/FillModels/OrderBookFillModel.cs` |
+| P&L ledger | `Ledger` | `src/Meridian.Ledger/Ledger.cs` |
+
+### Platform, storage, and workstation seams
+
+| Concept | Interface / Class | File Path |
+|---------|-------------------|-----------|
+| Event pipeline coordinator | `EventPipeline` | `src/Meridian.Application/Pipeline/EventPipeline.cs` |
+| Storage sink contract | `IStorageSink` | `src/Meridian.Storage/Interfaces/IStorageSink.cs` |
+| Write-ahead log | `WriteAheadLog` | `src/Meridian.Storage/Archival/WriteAheadLog.cs` |
+| Crash-safe file writes | `AtomicFileWriter` | `src/Meridian.Storage/Archival/AtomicFileWriter.cs` |
+| JSON source-gen context | `MarketDataJsonContext` | `src/Meridian.Core/Serialization/MarketDataJsonContext.cs` |
+| Storage catalog | `StorageCatalogService` | `src/Meridian.Storage/Services/StorageCatalogService.cs` |
+| Graceful shutdown | `GracefulShutdownService` | `src/Meridian.Platform/Runtime/GracefulShutdownService.cs` |
+| Shared route constants | `UiApiRoutes` | `src/Meridian.Contracts/Api/UiApiRoutes.cs` |
+| Shared workstation surface | `WorkstationEndpoints` | `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` |
+| Browser accounting workspace | `accounting-screen.tsx` | `src/Meridian.Ui/dashboard/src/screens/accounting-screen.tsx` |
+| Browser trust strip | `app-shell.trust-strip.ts` | `src/Meridian.Ui/dashboard/src/app-shell.trust-strip.ts` |
+| Browser evidence timeline | `app-shell.evidence-timeline.ts` | `src/Meridian.Ui/dashboard/src/app-shell.evidence-timeline.ts` |
+| Browser provenance badge | `app-shell.data-provenance-badge.ts` | `src/Meridian.Ui/dashboard/src/app-shell.data-provenance-badge.ts` |
+| Browser command palette | `app-shell.command-palette.ts` | `src/Meridian.Ui/dashboard/src/app-shell.command-palette.ts` |
+| MVVM base class | `BindableBase` | `src/Meridian.Wpf/ViewModels/BindableBase.cs` |
+| Desktop shell orchestration | `MainPageViewModel` | `src/Meridian.Wpf/ViewModels/MainPageViewModel.cs` |
 
 ---
 
-## 🔌 Data Access & APIs
+## ⚡ Activation Targets
 
-- **Python SDK** — async iterator over live feed, pandas DataFrame output, `snap()` for last N ticks, `history()` for bulk pull. Wraps the WebSocket/REST HTTP layer already exposed by Meridian.
-- **gRPC streaming endpoint** — low-latency alternative to WebSocket for intra-datacenter consumers (e.g., C++ strategy engine consuming from Meridian)
-- **Arrow Flight endpoint** — columnar bulk data transfer without REST overhead; natural fit for academic batch pulls
-- **GraphQL query API** — flexible ad-hoc querying over stored JSONL data; explorers can filter/aggregate without file access
-- **Tick replay API** — serve historical ticks at configurable speed multiplier (1x, 10x, 100x market time); valuable for backtesting engines that need realistic feed simulation
-- **Snapshot API** — point-in-time orderbook snapshot endpoint; `GET /api/snapshot/{symbol}?at=2024-01-15T14:30:00Z`
-- **WebSocket multiplex protocol** — single connection, multiple symbol subscriptions, backpressure signaling; reduces connection overhead for subscribers with large universes
-- **R language bindings** — `reticulate`-free native R package via `.NET Interop` or a thin REST wrapper; academic quant finance community is heavily R-based
-- **DuckDB virtual table** — register Meridian's JSONL/Parquet store as a DuckDB external table; enables SQL queries without data movement
-- **Event-driven webhooks** — push notifications on configurable triggers (new gap detected, anomaly flagged, backfill complete); enables serverless downstream workflows
-- **OpenAPI spec auto-generation** — auto-generate OpenAPI 3.1 spec from Meridian's REST controllers; enables code-gen for any language client
+The charter's headline finding (`docs/product/meridian-design-document.md` §2.1) is that the codebase is more capable than the running product. These capabilities exist in source with tests but are not the wired operator path. Activation ideas — connecting, labeling, and proving them — are the highest-return lane available, and an activated capability must *replace* its weaker predecessor rather than sit beside it.
 
----
+- **Sided statement-vs-ledger matching** (`StatementMatchingEngine`) — the live path still uses a weaker per-row check
+- **Institutional bank formats** (`Bai2StatementConnector`, `Camt053StatementConnector`) — in source, registry acceptance planned
+- **Client-grade PDF/XLSX rendering** (`ClientGradeReportRenderer`, `FinancialReportDocumentRenderer`) — production path still emits text-grade artifacts
+- **Unitized NAV and fund economics** (`NavPerUnitCalculator`, `EuropeanDistributionWaterfall`, `PreferredReturnCalculator`, `CarriedInterestClawbackCalculator`, `EqualizationCalculator`) — not yet the wired economics path
+- **Broker fill streaming** (`AlpacaBrokerageGateway`) — live fill loop into order and ledger state incomplete
+- **Realistic fill and cost models** (`MarketImpactFillModel`, `OrderBookFillModel`) — implemented for backtests; paper trading must adopt them
+- **Kill-switch, cancel-all, notional and collar controls** — partial foundation; safety surfaces must be wired or visibly demoted
+- **Hash-chained audit for the accounting ledger and route-level authorization** — `AuditChainService` covers storage; the journal chain and blanket route coverage do not exist
+- **Operational Evidence Graph as a shared product surface** — explorer, proof-drawer, and manifest primitives exist; the product surface is planned
 
-## 📊 Data Quality & Validation
-
-- **Cross-provider reconciliation** — when multiple providers are connected, flag ticks where IB and Alpaca disagree by >N bps on the same timestamp; generate quality score per symbol
-- **Anomaly detection pipeline** — pluggable anomaly detectors (Z-score, IQR, price spike) that tag suspicious ticks in the JSONL stream without dropping them
-- **Data completeness scorecard** — per-symbol dashboard showing: expected ticks per session vs. received, gap count, last gap timestamp, interpolation rate
-- **Halts and corporate actions awareness** — ingest halt/resume events and tag data around trading halts; avoid surfacing garbage ticks during circuit breakers
-- **Latency attribution** — instrument the full path from provider → storage; report per-provider median/p99 latency in the dashboard; identify if a provider is lagging
-- **Synthetic data injection** — for testing: inject synthetic tick sequences that stress-test downstream consumers (flash crash simulation, gap, stale quote)
-- **Tick sequence validation** — detect out-of-order timestamps, duplicate sequence numbers, and backwards price jumps that indicate feed issues rather than market events
-- **Provider SLA scoring** — track uptime, reconnect frequency, message throughput, and data freshness per provider over rolling windows; generate a weekly provider health report
-- **Options chain consistency checks** — validate put-call parity relationships, strike price monotonicity, and expiration date coherence in options data feeds
-- **Bid-ask spread anomaly detector** — flag inverted markets, abnormally wide spreads, and locked markets as data quality events distinct from normal market microstructure
+A strong activation idea names the dormant type, the live path it replaces, the operator-visible difference, and how the predecessor gets retired.
 
 ---
 
-## ⚡ Performance & Latency
+## 📥 Import, Providers & Data Trust
 
-- **Kernel-bypass receive path** — optional DPDK or io_uring path for the IB/FIX socket; bypasses OS TCP stack for sub-100μs receive latency on Linux
-- **SIMD tick normalizer** — vectorized price/size parsing using `System.Runtime.Intrinsics`; batch-process raw FIX/ITCH bytes 16 at a time
-- **Zero-allocation tick path** — object pooling for `MarketEvent` structs, avoiding GC pressure on the hot path; use `ArrayPool<T>` for intermediate buffers
-- **CPU affinity pinning** — pin the receive thread and the storage flush thread to isolated cores; reduce scheduling jitter
-- **Lock-free ring buffer** — replace `BoundedChannel` on the critical path with a Disruptor-style ring buffer (LMAX pattern) for guaranteed sub-microsecond handoff
-- **Nanosecond timestamps** — upgrade from `DateTime` to `long` nanoseconds since epoch on all hot-path structs; use `Stopwatch.GetTimestamp()` with hardware frequency
-- **Batched WAL writes** — group WAL entries into 4KB aligned blocks for sequential disk write optimization; measure with `fio` before/after
-- **GC-tuned server mode** — configure `ServerGC` with region-based collection and `GCLatencyMode.SustainedLowLatency`; document the GC tuning profile as a runbook
-- **Hot-path profiling harness** — built-in `BenchmarkDotNet` suite that profiles the tick-receive-to-storage path end-to-end; run as part of CI to detect regressions
-- **Memory-mapped file writes** — use `MemoryMappedFile` for WAL/JSONL output on the hot path; avoids kernel buffer copies for sequential append workloads
-- **Pipeline backpressure metrics** — expose `BoundedChannel` fill level, drop count, and consumer lag as Prometheus gauges; alert before pipeline saturation
-
----
-
-## 🗄️ Storage & Data Formats
-
-- **Parquet/Arrow output** — convert JSONL daily files to Parquet at session close; columnar layout makes pandas/DuckDB queries 10-100x faster
-- **QuestDB integration** — optional sink to QuestDB time-series database; enables SQL queries over streaming data with nanosecond timestamps
-- **InfluxDB/TimescaleDB sink** — standard TSDB integration for users with existing monitoring infrastructure
-- **Tiered cold storage** — auto-migrate data older than N days to S3/Backblaze with Zstd compression; local disk holds only hot tier
-- **Deduplication store** — persistent bloom filter + hash store for exactly-once storage guarantees across restarts; currently in-memory only
-- **Incremental Parquet compaction** — merge small daily Parquet files into monthly partitions; improves query performance on multi-month backtests
-- **Schema evolution** — forward/backward-compatible schema registry for JSONL/Parquet format changes; version tag every file header
-- **HDF5 export** — one-click export to HDF5 format for academic users coming from WRDS/TAQ ecosystems; preserves hierarchical symbol/date structure
-- **Delta Lake / Iceberg table format** — store market data as a lakehouse table with ACID transactions, time travel, and schema enforcement; enables both streaming ingest and batch analytics
-- **Configurable retention policies** — per-symbol or per-asset-class retention rules (e.g., keep L2 data for 30 days, L1 for 1 year, daily OHLCV forever); enforced automatically with compaction
+- **Mapping profile library** — reusable, versioned column/field mappings per counterparty with drift detection when a file's shape changes mid-relationship
+- **Import run certification UX** — one screen where an import run is certified, rejected with repair instructions, or replayed; blocked downstream outputs named explicitly
+- **Connector confidence scoring** — per-connector parse confidence and drift signals surfaced before commit, not after
+- **Provider capability matrix** — what each of the 22 adapter families actually supplies (asset classes, fields, history depth, refresh cadence) as a browsable operator surface
+- **Credential and connection health** — expiry warnings, scope verification, and last-successful-pull per connection in `Settings`
+- **Raw payload preservation and replay** — every import replayable from retained source bytes with a diff against what was originally committed
+- **Email/SFTP intake lane** — scheduled pickup with the same preview → confidence → commit rails as manual upload
+- **Cross-source disagreement surfacing** — when two sources disagree on a position or price, show both with lineage rather than silently preferring one
+- **Excel round-trip maintenance** — export a domain to a workbook, edit offline, re-upload, diff, amend under approval
+- **Fixture and simulated-data labeling** — datum-level provenance badges so no synthetic value ever reads as operational truth
 
 ---
 
-## 🔗 Integrations & Ecosystem
+## 🔀 Reconciliation & Break Resolution
 
-- **Jupyter kernel extension** — `%marketdata` magic command that connects to a running Meridian instance and streams ticks into a DataFrame in real time
-- **pandas accessor** — `df.marketdata.resample_ohlcv('1min')` style API built on top of Meridian's historical export format
-- **QuantConnect LEAN bridge** — Meridian as a custom data source for LEAN backtesting engine; map `IMarketDataClient` to LEAN's `IDataQueueHandler` interface
-- **Backtrader data feed** — Python class wrapping Meridian's REST/WebSocket endpoint as a `bt.DataBase` subclass
-- **Zipline ingestion bundle** — export Meridian data as a Zipline ingest bundle for Zipline-Reloaded backtesting
-- **dbt integration** — Meridian as a dbt source, enabling SQL-based data transformations and quality tests on stored market data
-- **Grafana data source plugin** — native Grafana plugin (Go) that queries Meridian's `/api` endpoints; enables blending market data with infrastructure metrics on one board
-- **TradingView webhook receiver** — ingest TradingView alerts as structured events alongside market data; correlate signal firing with tick data
-- **Slack/Discord bot** — alert bot that posts to a channel when: data gap detected, provider disconnected, anomalous tick received, backfill completed
-- **OpenBB integration** — serve as a data backend for OpenBB Terminal; Meridian provides the persistent collection layer that OpenBB lacks
-- **NinjaTrader / MetaTrader bridge** — expose Meridian data via the NinjaTrader Connection Adapter or MetaTrader EA interface; captures the retail algo trading audience
-- **Dagster / Airflow operator** — custom operator for orchestrating Meridian backfill jobs, Parquet compaction, and data quality checks inside existing data pipelines
+- **Sided matching on the live path** — pair-level matching with confidence scoring, replacing per-row checks
+- **Tolerance policy workbench** — per-account, per-currency, per-transaction-type tolerances with a preview of how many breaks a change would create or clear
+- **Break root-cause clustering** — group breaks by inferred cause (timing, FX, fee, missing security, duplicate) so one fix clears many
+- **Bulk resolution with retained justification** — resolve a cluster in one action while retaining per-row evidence
+- **Aging and SLA pressure view** — breaks by age band and owner, with escalation state visible before the SLA is missed
+- **Match explanation** — for any matched pair, show which rule matched, at what tolerance, and what the alternatives were
+- **Unmatch and re-match audit** — reversing a match is an auditable event with before/after state
+- **Intercompany and cross-entity elimination** — reconcile between related entities, not just against external statements
+- **Cash vs. position break separation** — different queues, different owners, different resolution rails
+- **Recurring break suppression with expiry** — known differences suppressed under a dated, reviewable policy rather than silently ignored
 
 ---
 
-## 🌐 Community & Sharing
+## 📒 Ledger, Accounting & Close
 
-- **Public data snapshots** — opt-in feature to publish anonymized daily OHLCV snapshots to a shared S3 bucket; community-maintained free data layer
-- **Provider plugin SDK** — documented interface + CLI scaffolding tool for third parties to build new `IMarketDataClient` implementations; npm-style plugin registry
-- **Strategy template library** — curated set of Jupyter notebooks demonstrating: loading Meridian data → feature engineering → backtest → performance report
-- **Discord/forum integration** — built-in "share session" feature that posts a summary of today's collection run (symbols, tick count, anomalies) to a community feed
-- **Contribution leaderboard** — gamified: users who contribute provider plugins or data quality validators earn recognition on a public leaderboard
-- **Data marketplace** — users who collect rare data (options chains, crypto perps, international equities) can make it discoverable to others with access controls
-
----
-
-## 🖥️ UX / Developer Experience
-
-- **Interactive setup wizard** — terminal TUI (Spectre.Console) that walks through provider selection, API key entry, symbol configuration, and validates connectivity before first run
-- **Symbol universe browser** — searchable browser-workstation UI for browsing available symbols per provider; click-to-subscribe without editing JSON config
-- **Data quality report (PDF export)** — one-click PDF report of collection quality for a date range; useful for academic data provenance documentation
-- **Live tick visualizer** — real-time candlestick chart in the browser workstation for any subscribed symbol; no external charting tool needed
-- **Order book heatmap** — animated L2 order book depth visualization in the browser workstation; visually identify spoofing, iceberg orders
-- **Config diff viewer** — when appsettings.json changes, show a visual diff of what changed and what the system will do differently
-- **Backfill progress UX** — rich progress bars for historical backfill jobs: symbol × date range × provider, with ETA, pause/resume, and error summary
-- **CLI REPL** — `meridian> subscribe AAPL` style interactive shell for power users; tab-completion for symbols and commands
-- **WPF theme system** — light/dark mode toggle plus a theme engine for the desktop app; reduces eye strain during long monitoring sessions and demonstrates UI polish
-- **In-app diagnostics panel** — embedded panel showing pipeline throughput, channel fill levels, GC pause times, and provider connection state; replaces the need to open Grafana for quick checks
-- **Config schema validation with friendly errors** — validate `appsettings.json` on startup against a JSON Schema; surface human-readable error messages in the WPF app instead of cryptic exceptions
+- **Close readiness score** — one number per book/period, decomposed into the blocking items with links to the records causing them
+- **Blocked-close report** — when a period cannot close, produce the artifact that explains why to a controller
+- **Journal template library** — parameterized templates for recurring entries with approval requirements attached
+- **Automated journal draft review** — drafts proposed by the system, approved by a human, with the evidence that produced them visible in the same view
+- **Period lock enforcement surfacing** — show what a lock prevents and who can grant a governed reopen, before the operator tries
+- **Multi-currency exposure view** — translation impact by book and period with the FX rates and their source retained
+- **Tax-lot method comparison** — show disposal outcomes under alternative lot policies before committing a method
+- **Capital account statement generation** — per-investor activity, contributions, distributions, and closing balances from the subledger
+- **Trial balance drill-through** — from any trial balance line to the journals, and from a journal to its evidence
+- **Late-activity handling** — post-close adjustments routed through explicit reopen or next-period accrual with retained rationale
 
 ---
 
-## 🔐 Reliability & Production Readiness
+## 🧾 Evidence, Provenance & Governance
 
-- **Multi-provider active-active** — subscribe to the same symbol on two providers simultaneously; merge streams, use cross-provider reconciliation to detect and correct bad ticks
-- **Intelligent failover** — when primary provider disconnects, automatically switch to secondary; track gap introduced by failover; backfill from secondary on reconnect
-- **Health scoring per symbol** — composite score (0-100) for each symbol based on: tick rate vs. expected, anomaly rate, gap frequency; surface in dashboard as RAG status
-- **Alerting engine** — configurable rules: `if health_score(AAPL) < 80 for 5min → notify`; delivery via email, webhook, Slack
-- **Chaos mode** — optional fault injection (random disconnect, tick drop, latency spike) for testing downstream resilience; controlled via CLI flag
-- **Rolling restart support** — drain in-flight events before shutdown; resume without data loss; important for Kubernetes rolling deployments
-- **Multi-region replication** — async replication of JSONL/Parquet files to a secondary region; DR for institutional users
+- **Number Passport surface** — for any amount, expose basis, dates, positions, journals, source records, extracted fields, transformations, valuation method, reconciliation state, approval history, and freshness (charter §22)
+- **Proof drawer everywhere** — the same drill-down component reachable from report lines, ledger rows, portfolio marks, and dashboard metrics
+- **Evidence completeness meter** — per packet, what is present, stale, or missing, and what output it blocks
+- **Immutable manifest freeze** — freeze the evidence set attached to a delivered package so later changes cannot rewrite history
+- **Document extraction review lane** — extracted fields shown next to the source document region with accept/correct actions
+- **Scoped access review packet** — periodic certification of who holds what scope, with revocation flowing to an audit event
+- **Journal-level hash chaining** — extend the storage audit chain into the accounting ledger
+- **Segregation-of-duties enforcement** — preparer ≠ approver enforced structurally, with attempted-violation events retained
+- **Auditor read-only workspace** — entitlement-scoped access that lets an external reviewer drill from a package line to support without operator mediation
+- **Legal hold and retention policy** — hold state that blocks purge and is visible wherever affected records appear
 
 ---
 
-## 📚 Academic & Research
+## 📤 Reporting & Delivery
 
-- **Data provenance ledger** — every stored file gets a hash, timestamp, provider version, and collection parameter snapshot; immutable append-only log satisfies academic reproducibility requirements
-- **Citation generator** — one-click: "Generate BibTeX citation for this dataset" that produces a citable reference with DOI-style identifier
-- **Dataset versioning** — snapshot the full symbol universe configuration at each session; enables exact replay of what was collected on a given date
-- **Tick quality metadata** — alongside each tick file, store: source exchange, feed type (CTA/SIP vs direct), latency bucket, anomaly flags; enables downstream filtering
-- **Research pack export** — bundle a date range of data for multiple symbols into a single reproducible ZIP with README, schema documentation, and provenance ledger
-- **Regulatory data retention mode** — WORM (Write Once Read Many) storage policy; files are checksummed and cannot be modified; audit log of all access
+- **Client-grade rendering activation** — replace text-grade production artifacts with the existing PDF/XLSX renderers
+- **Report-line lineage** — every line traceable to its inputs, with the trace surviving into the delivered artifact
+- **Package diff and restatement** — show what changed between two versions of a package and why an amendment was issued
+- **Delivery evidence** — who received what, when, under which entitlement, with acknowledgement state
+- **Report-writer authoring UX** — durable drafts, live preview, multi-filter support, formula workbench, keyboard-first token composition
+- **Saved views and template catalog** — governed, shareable report definitions with versioning
+- **Scheduled package runs** — recurring generation with pre-release consistency gates and hold-on-failure
+- **Board and IC pack composition** — assemble multiple certified outputs into one governed binder
+- **Stakeholder verification view** — read-only drill-through attached to a delivered package (not a broad portal — see deferred boundaries)
+- **Export evidence retention** — every export recorded with parameters, snapshot identity, and requester
+
+---
+
+## 📈 Portfolio, Valuation & Reference Data
+
+- **Security master passport** — one identity view per instrument with provider mappings, conflicts, and trust summary
+- **Stale mark detection** — flag positions whose valuation inputs have aged past policy, with the age and source visible
+- **Corporate action evidence** — factor and action records joined to the positions and journals they affected
+- **Multi-asset coverage gaps** — which asset classes lack required terms, evidence, or accounting classification
+- **Cash ladder and liquidity view** — scenario-aware, per-currency projections aggregated from per-security runs
+- **Valuation methodology disclosure** — show which method produced a mark and what its inputs were
+- **Position-to-custodian tie-out** — daily agreement state per account with break linkage
+- **Household and entity rollup** — consolidated views across entities with elimination visibility
+- **Private and structured asset terms capture** — declared required terms with evidence and close/reporting handoff
+- **Commitment and unfunded tracking** — commitments, drawdowns, and remaining unfunded with capital-call linkage
+
+---
+
+## 🎯 Execution, Risk & Research
+
+- **Paper realism** — limit/stop semantics and trading costs in paper sessions before their statistics feed promotion decisions
+- **Broker fill loop** — streamed fills flowing into order state and ledger postings with reconciliation against the broker's own record
+- **Kill-switch and cancel-all** — a wired safety control with confirmation, scope, and retained event
+- **Pre-trade guardrails** — fat-finger, notional, and price-collar rules with clear operator-facing rejection reasons
+- **Promotion evidence gate** — paper-to-live promotion showing the full required evidence set and any manual override
+- **Run comparison** — diff two strategy runs across parameters, fills, costs, and outcomes
+- **Backtesting Studio evidence loop** — link a backtest run to the data snapshot, code version, and resulting decisions
+- **QuantScript ergonomics** — authoring, validation, and charting improvements for research users
+- **Execution-to-ledger continuity** — trades landing as postings with lot creation and disposal in one governed transaction
+- **Risk breach acknowledgement** — breaches with owner, acknowledgement, and acceptance records rather than transient alerts
+
+---
+
+## 🖥️ Workstation UX & Information Design
+
+- **Screen consolidation behind the seven roots** — fewer, deeper screens; retired routes remain redirects
+- **Operator focus and task modes** — surface what is waiting on this operator, in this scope, right now
+- **Trust strip and provenance badges** — persistent, honest state about data freshness and simulation at the top of every workspace
+- **Command palette coverage** — every meaningful navigation and action reachable by keyboard
+- **Queue-first workspace design** — start from what needs resolving, not from a static dashboard
+- **Empty states with a next action** — a fresh install shows a concrete path, never a wall of zeros
+- **Linked context across workspaces** — carrying entity, period, and account scope as the operator moves between roots
+- **Blocked-state explanations** — reason, owner, and next action attached to every blocked indicator
+- **Density and progressive disclosure** — summary rows expand to detail without a page change
+- **WPF web-parity closure** — bring desktop screens that shipped browser-first onto the shared contracts (`W8-WPF-PARITY-001`)
+- **Shared design-system compliance** — new surfaces compose existing components rather than forking per-screen variants
+
+---
+
+## 🚀 Adoption, Onboarding & Time to First Proof
+
+- **One-command seeded demo** — a truthful, populated, durable demonstration workspace from a fresh install
+- **Shadow-mode onboarding** — read-only parallel views, opening-balance reconciliations, and close-readiness scores before a customer migrates official books
+- **Statement reconciliation wedge** — browser-first import → commit → retained proof as the first slice a new customer runs
+- **Excel onboarding workbook** — download → fill → upload → review → governed commit for security master, entities, chart of accounts, opening balances
+- **Get-connected hub** — provider setup tied to the imported instrument universe with a coverage handshake
+- **Guided first close** — a checklist that walks a new operator through the canonical spine once, end to end
+- **Time to First Proof instrumentation** — measure and expose how long a fresh install takes to produce its first verified number
+- **Activation coverage surface** — show which shipped capability is reachable in the running product, keeping unwired capability visible as debt
 
 ---
 
 ## 🏗️ Architecture & Refactoring
 
-- **ViewModel extraction audit** — systematically identify code-behind logic in WPF Pages/Windows that should live in ViewModels; produce a migration checklist per view with effort estimates
-- **DI container for WPF shell** — introduce `Microsoft.Extensions.DependencyInjection` into the WPF application host; eliminate manual service wiring and enable constructor injection across all ViewModels
-- **Hot-path / cold-path separation** — physically separate the real-time tick pipeline (hot) from config management, backfill orchestration, and UI (cold) into distinct assemblies; enables independent deployment and testing
-- **Interface segregation pass** — audit `IMarketDataClient` and `IStorageSink` for ISP violations; split fat interfaces into focused contracts (e.g., `ITickReceiver`, `IOrderBookReceiver`, `IHistoricalFetcher`)
-- **Event pipeline modularization** — refactor `EventPipeline` into composable middleware stages (receive → normalize → validate → route → store); each stage independently testable and replaceable
-- **Configuration as strongly-typed objects** — replace raw `IConfiguration` indexing with Options pattern (`IOptions<ProviderSettings>`, `IOptions<StorageSettings>`) everywhere; compile-time safety + validation via `IValidateOptions<T>`
-- **Shared kernel extraction** — extract domain primitives (Symbol, Timestamp, Price, Quantity, MarketEvent) into a standalone `Meridian.Domain` assembly with zero infrastructure dependencies; consumed by all layers
-- **Plugin architecture for sinks** — replace hardcoded storage sink registration with a MEF/plugin-style discovery system; third parties drop a DLL into a `/plugins` folder and it's auto-registered as an `IStorageSink`
+- **Shared-seam compliance audit** — find product state that a workstation lane computes locally instead of consuming from `Meridian.Ui.Services` / `Meridian.Ui.Shared` / `Meridian.Contracts`
+- **Endpoint surface consolidation** — 845 routes across 137 endpoint files; identify overlapping read models and duplicate contracts
+- **Partial-class sprawl review** — services split across many partials (close management, evidence stores, break repositories) and whether the split still reflects real seams
+- **Read-model boundary clarity** — which projections are books of record vs. derived views, and enforcing that distinction in code
+- **Durable-store abstraction** — consistent file/Postgres store selection with fail-closed behavior when the durable option is unavailable
+- **Contract-pack extensibility** — schema, lifecycle, valuation, accounting, validation, and reporting hooks for new asset types without core-ledger surgery
+- **Domain module registration** — consistent `DesignModule` and DI registration patterns across the newer projects
+- **F# kernel boundaries** — which deterministic calculations belong in the F# projects vs. C# services
+- **Options pattern and hot reload** — `IOptionsMonitor<T>` coverage for runtime-mutable configuration
+- **Hot/cold path separation** — keep the market-data hot path isolated from the evidence and accounting workloads
 
 ---
 
-## 📈 User Growth & Adoption
+## 🧹 Technical Debt, Quality & Operations
 
-- **"Zero to first tick" quickstart** — a single `docker compose up` command that starts Meridian with Alpaca's free tier, subscribes to SPY, and shows live ticks in the browser workstation within 60 seconds; optimize ruthlessly for time-to-value
-- **YouTube / blog content series** — "Building a Quant Data Pipeline" tutorial series showing Meridian as the backbone; each episode adds a capability (backfill, Jupyter, backtest); drives organic search traffic
-- **GitHub README overhaul** — hero GIF showing live ticks flowing, architecture diagram, one-click deploy badges, and "Why Meridian?" comparison table vs. alternatives; first 30 seconds of the README determine star/bounce
-- **Integration showcase gallery** — web page with working code snippets for each integration (Jupyter, LEAN, pandas, Grafana); copy-paste ready; each snippet links to a deeper tutorial
-- **Conference talk / meetup circuit** — target QuantConnect community meetups, .NET Conf, and local quant finance groups; live demo of Meridian collecting options data in real-time
-- **Freemium cloud-hosted tier** — a managed Meridian instance with limited symbol count (5 symbols, delayed data); removes all setup friction; converts to self-hosted when users hit limits
-- **First-run analytics** — anonymous telemetry (opt-in) tracking: setup completion rate, first successful tick received, first query executed; identify and fix the biggest drop-off points
-- **Contributor onboarding guide** — a `CONTRIBUTING.md` with architecture walkthrough, "good first issue" labels, and a mentorship channel; converts users into contributors
-
----
-
-## 🧹 Technical Debt & Code Quality
-
-- **Mutation testing baseline** — run Stryker.NET against the test suite to measure real test effectiveness beyond line coverage; identify tests that pass regardless of code changes
-- **Architecture decision records (ADRs)** — establish a `docs/adr/` directory; document every significant technical decision (why WPF over UWP, why BoundedChannel over Disruptor, why JSONL first); reduces re-litigation
-- **Static analysis gate in CI** — add Roslyn analyzers + `.editorconfig` enforcement to the GitHub Actions pipeline; fail the build on MVVM violations (e.g., code-behind referencing services directly)
-- **Dead code elimination sweep** — run a coverage + reference analysis to identify unreachable code paths, unused interfaces, and orphaned files left over from the UWP migration; reduce cognitive load
-- **Test isolation audit** — identify integration tests that depend on external state (file system, network, time); refactor to use `ITimeProvider`, in-memory file systems, and test doubles; reduce flaky test rate
-- **Dependency freshness dashboard** — automated PR (via Dependabot or similar) for NuGet package updates; track how far behind each dependency is; flag security-relevant updates
-- **XML doc coverage requirement** — enforce `<summary>` documentation on all public APIs via a Roslyn analyzer; auto-generate API reference docs from XML comments in CI
-- **Consistent error handling patterns** — audit and standardize exception handling across the codebase; replace bare `catch (Exception)` blocks with typed exceptions, Result types, or structured logging; establish a project-wide error taxonomy
+- **Mutation testing baseline** — measure real test effectiveness beyond the ~12,900 fact/theory count
+- **Static analysis gates** — Roslyn analyzers and `.editorconfig` enforcement wired into the quality gate
+- **Dead and duplicated seam elimination** — overlapping services that both own a slice of close, evidence, or reconciliation state
+- **Test isolation audit** — tests depending on wall-clock time, the file system, or network state
+- **Fixture-vs-production separation** — development seeding surfaces unreachable in production profiles by construction, not by comment
+- **Durability call-site review** — every persistence path routed through WAL or `AtomicFileWriter`
+- **Structured logging consistency** — no interpolation inside log calls; correlation IDs across the operator spine
+- **Observability for the operator spine** — traces and metrics that follow import → reconcile → post → approve → report
+- **Documentation-to-code alignment** — generated indexes, module READMEs, and skill packages kept current with the source registry
+- **CI feedback speed** — targeted test selection for touched subsystems instead of broad suite runs

--- a/.codex/agents/meridian-brainstorm.toml
+++ b/.codex/agents/meridian-brainstorm.toml
@@ -3,7 +3,7 @@ description = "Brainstorming specialist for Meridian product, UX, architecture, 
 developer_instructions = """
 # Meridian — Meridian Brainstorm Agent
 
-Use this agent for ideation only. Ground ideas in Meridian's W1-W5 operational record baseline and current product scope; do not turn brainstorms into implementation without a follow-on blueprint or roadmap lane.
+Use this agent for ideation only. Ground ideas in current source, the roadmap registry, and the canonical design charter; do not turn brainstorms into implementation without a follow-on blueprint or roadmap lane. Favor activating built-but-unwired capability over new surface, keep ideas inside the seven root workspaces and the deferred expansion boundaries, and never present planned or dormant capability as shipped.
 
 > Skill equivalent: [`.codex/skills/meridian-brainstorm/SKILL.md`](../skills/meridian-brainstorm/SKILL.md)
 > Shared project context: [`.codex/skills/_shared/project-context.md`](../skills/_shared/project-context.md)

--- a/.codex/skills/meridian-brainstorm/SKILL.md
+++ b/.codex/skills/meridian-brainstorm/SKILL.md
@@ -18,9 +18,10 @@ improvements, architecture directions, or persona-informed opportunity generatio
 
 Trigger examples:
 
-- "Brainstorm improvements to provider credential management."
+- "Brainstorm improvements to the reconciliation break queue."
 - "What should we build next in the browser workstation?"
 - "Give me quick wins for operator trust."
+- "What's already built that we could just wire up?"
 
 ## Do Not Use When
 
@@ -35,11 +36,11 @@ Non-trigger examples:
 
 ## Workflow
 
-1. Detect the mode: open exploration, problem-focused, persona-focused, quick wins, architecture, UX, growth, or technical debt.
+1. Detect the mode: open exploration, problem-focused, activation, role-focused, quick wins, architecture, evidence and governance, adoption, UX, or technical debt.
 2. State the detected mode in the skill selection receipt.
-3. Start the brainstorm body with a compact summary table so the user can triage quickly.
-4. Write ideas as short narratives that connect user value, Meridian anchor points, likely implementation shape, and tradeoffs.
-5. End with synthesis: highest-leverage idea, enabling bets, and suggested sequencing.
+3. Start the brainstorm body with a compact summary table so the user can triage quickly. Use grouped audience codes: OPS, ACCT, INV, GOV, EXEC, STAKE, ADMIN (roles in `docs/product/meridian-design-document.md` §4.2).
+4. Write ideas as short narratives that connect operator value, Meridian anchor points, likely implementation shape, evidence and governance impact, and tradeoffs.
+5. End with synthesis: highest-leverage idea, enabling bets, roadmap fit, and suggested sequencing.
 
 ## Handoffs
 
@@ -50,8 +51,9 @@ Non-trigger examples:
 ## Validation
 
 - Ground ideas in current repo capabilities and known product direction before proposing new surfaces.
+- Take live status only from `docs/roadmap/generated/ROADMAP_SUMMARY.md` and `docs/roadmap/data/*.yml`; take product framing from `docs/product/meridian-design-document.md`. Never assert wave or capability status from memory.
 - Search or read relevant docs only as far as needed to avoid stale or generic suggestions.
-- Do not claim delivery status or implementation completeness from brainstorming output.
+- Do not claim delivery status or implementation completeness from brainstorming output; a capability that exists in source is not therefore on the live operator path.
 
 ## Automation Scripts
 
@@ -66,9 +68,10 @@ Non-trigger examples:
 
 Every strong idea should include:
 
-- The anchor: what existing Meridian capability or abstraction it extends
-- The user moment: what the user sees, clicks, compares, or monitors
+- The anchor: what existing Meridian capability or abstraction it extends or wires up
+- The operator moment: what the operator sees, clicks, resolves, or approves, and in which workspace
 - The implementation shape: enough detail to scope follow-up work
+- The evidence and governance impact: what proof it creates or exposes, what it blocks when absent, what approval it requires
 - Honest tradeoffs: complexity, migration cost, or prerequisites
 - Audience and effort: who benefits and roughly how big the work is
 
@@ -93,12 +96,34 @@ Every strong idea should include:
 
 ## Meridian-Specific Guidance
 
-- Favor ideas that connect multiple existing pillars: collection, backtesting, execution, strategies, ledger, and UI.
-- For UI-facing ideas, start from the active browser workstation in `src/Meridian.Ui/dashboard/`; describe screen hierarchy and operator flow, not just backend plumbing.
-- For workstation-related ideas, map them to the current visible operator workspaces: Trading, Portfolio, Accounting, Reporting, Strategy, Data, or Settings.
-- For refactoring ideas, reference real seams such as `BindableBase`, `EventPipeline`, `IStorageSink`, provider contracts, or orchestration services.
-- For competitive questions, focus on patterns Meridian can adapt naturally rather than cargo-culting product surfaces.
-- Exclude mobile app ideas unless the user or roadmap explicitly asks to reopen mobile product development.
+- Meridian sells proven numbers: every figure carries a reconstructable chain from source evidence
+  through validation, reconciliation, ledger impact, approval, report usage, and delivery. Favor
+  ideas that shorten, strengthen, or expose that chain along the operator spine
+  (`Import → Validate → Reconcile → Investigate → Approve → Report`).
+- Favor activation over expansion. The codebase is more capable than the running product; wiring a
+  dormant capability and retiring its weaker predecessor beats building new surface beside it. See
+  the activation register in `docs/product/meridian-design-document.md` §2.1.
+- For UI-facing ideas, start from the browser workstation in `src/Meridian.Ui/dashboard/` or the
+  co-equal WPF desktop workstation in `src/Meridian.Wpf/`; both consume the shared
+  `Meridian.Ui.Services` / `Meridian.Ui.Shared` / `Meridian.Contracts` seam and neither may fork
+  product state. Describe screen hierarchy and operator flow, not just backend plumbing.
+- For workstation-related ideas, map them to the seven visible operator workspaces: Trading,
+  Portfolio, Accounting, Reporting, Strategy, Data, or Settings. Never propose an eighth root.
+- For refactoring ideas, reference real seams such as `EventPipeline`, `IStorageSink`,
+  `BindableBase`, `WorkstationEndpoints`, provider contracts, or orchestration services.
+- For competitive questions, focus on patterns Meridian can adapt naturally rather than
+  cargo-culting product surfaces. Read `references/competitive-landscape.md` first.
+- Respect truth discipline: simulated data stays loudly labeled, unsupported persistence fails
+  closed, and missing evidence renders as `review-required` or `blocked`. Never propose a feature
+  that makes unwired capability look finished.
+- Respect governed autonomy: AI may extract, match, summarize, detect, and draft, but never bypass
+  operator approval, retained evidence, ledger controls, period locks, segregation of duties,
+  report release checks, or payment controls.
+- Respect the deferred expansion boundaries in `docs/product/deferred-expansion-boundaries.md`
+  (live treasury payments, enterprise risk, forecasting engines, capital-structure modeling, broad
+  client portal, no-code workflow design). Brainstorm toward the acceptance boundary, not past it.
+- Exclude mobile app ideas unless the user or roadmap explicitly asks to reopen mobile product
+  development.
 
 ## Avoid
 

--- a/.codex/skills/meridian-brainstorm/references/competitive-landscape.md
+++ b/.codex/skills/meridian-brainstorm/references/competitive-landscape.md
@@ -1,32 +1,52 @@
 # Meridian Competitive Landscape
 
-Use this file when brainstorming against competitors or positioning Meridian's strengths.
+Use this file when brainstorming against competitors or positioning Meridian's strengths. Categories
+follow `docs/product/meridian-design-document.md` §1.4.
+
+**The gap Meridian sells against:** portfolio systems *show* numbers but cannot prove them,
+accounting systems *record* numbers without the operational evidence behind them, close-management
+tools *track tasks* around numbers they do not own, and fund administrators *certify* numbers as a
+service. Meridian sells the number with its proof attached.
 
 ## Useful Comparisons
 
-- Bloomberg and B-PIPE: broad institutional coverage, expensive, strong lineage and monitoring expectations
-- Databento: developer-first API ergonomics, cloud-centric, strong data product packaging
-- Polygon: simple REST and WebSocket access, weaker local-first workflow story
-- LEAN / Backtrader / Zipline: backtesting-first ecosystems without Meridian's collection-first architecture
-- OpenBB: strong data-consumer ergonomics and community mindshare, less durable local storage focus
+- Close and controls managers (BlackLine, Trintech): strong certification, reviewer workflow, and
+  close-calendar ergonomics, but they sit beside the ledger and certify work about data they do not own
+- Fund administration suites (Carta, FundStudio, Investran-class): strong fund economics and LP
+  statement quality, weaker general-purpose accounting and evidence chains; often fund-shaped at the root
+- Asset servicing and portfolio accounting (SS&C Advent Geneva, eFront, Addepar-class): multi-book
+  rigor, valuation discipline, deep report libraries; expensive and vendor-service dependent
+- Ledger and payment APIs (Modern Treasury and similar): excellent double-entry and bank-format
+  primitives, but the customer builds the operator product on top
+- Market data and trading infrastructure (Bloomberg, Databento, Polygon; LEAN/Backtrader/Zipline):
+  relevant to the Trading, Strategy, and Data lanes; none carry an accounting, close, or evidence lane
 
 ## Meridian Strengths
 
-- Self-hosted and local-first
-- Multi-provider ingestion with failover
-- End-to-end platform from data collection to backtesting to paper/live workflow
-- WPF desktop plus web surfaces
-- AI/MCP integration points
+- Self-hosted and local-first, with no per-query cloud fees
+- Owns the data, the reconciliation, and the ledger — so close state is derived, not asserted
+- Evidence chain as a first-class product object: packets, manifests, provenance, approval history
+- Truthful by construction: loud simulation labels, fail-closed persistence, `review-required` and
+  `blocked` instead of plausible-looking numbers
+- Decision-to-delivery continuity on one governed spine, from research through delivery
+- Two co-equal operator lanes (browser and WPF desktop) over shared contracts
+- AI/MCP integration points under governed-autonomy boundaries
 
 ## Good Borrowing Targets
 
-- Data provenance and anomaly surfacing
-- Better Python-facing ergonomics
-- Run comparison and research workflow polish
-- Cleaner packaging/export experiences
+- Certification rigor and preparer/approver separation UX from close managers
+- LP statement, capital-call, and distribution-notice quality from fund administration suites
+- Multi-book, consolidation, and elimination discipline from asset servicing platforms
+- Idempotency and bank-format handling (BAI2, CAMT.053) from ledger APIs
+- Data lineage and anomaly surfacing from institutional market-data vendors
+- Packaging and client ergonomics polish from developer-first data products
 
 ## Bad Borrowing Targets
 
-- Cloud-only assumptions
-- Vendor-locked storage formats with no local ownership
-- Features that ignore Meridian's operator workflow, local-first strengths, or active desktop operator surface
+- Cloud-only assumptions with no local ownership
+- Vendor-service-dependent configuration models
+- Fund-shaped root data models that demote non-fund customers
+- Checklist-only close tracking that asserts completion without record backing
+- Any surface that presents unwired capability as finished
+- Features that ignore Meridian's seven-root navigation, evidence discipline, operator workflow, or
+  the co-equal browser and desktop lanes

--- a/.github/agents/brainstorm-agent.md
+++ b/.github/agents/brainstorm-agent.md
@@ -18,25 +18,63 @@ primary responsibility is to generate detailed, implementable ideas for the plat
 implementation sketches, audience fit analysis, effort ratings, and concrete next steps.
 
 **Trigger on:** "what could we add", "how could we improve", "what would be valuable", "what features
-should we build", "brainstorm", "give me ideas", or when the user describes a pain point, a user
-persona (hobbyist, academic, institutional), or a domain problem (latency, data quality, backtesting,
-compliance) and wants ideas for solving it. Also trigger for architecture/refactoring brainstorms,
-user growth strategy, or technical debt ideation.
+should we build", "brainstorm", "give me ideas", or when the user describes a pain point, an operator
+role (financial operations, fund accountant, reconciliation analyst, controller, portfolio manager,
+compliance officer, auditor), or a domain problem (import trust, reconciliation breaks, close
+readiness, NAV support, evidence retention, approvals, governed reporting, execution safety) and
+wants ideas for solving it. Also trigger for architecture/refactoring brainstorms, activation ideas
+for built-but-unwired capability, adoption/onboarding strategy, or technical debt ideation.
 
 ---
 
 ## Context: What This Project Is
 
-Meridian is a .NET 10 fund-management and trading-platform codebase in active delivery. It already
-spans provider ingestion and backfill, tiered storage, replay, backtesting, execution and risk
-seams, shared run, portfolio, and ledger models, QuantScript, MCP, an active browser workstation,
-and retained WPF compatibility. The current delivery focus is turning that breadth into one
-cohesive operator product across Trading, Portfolio, Accounting, Reporting, Strategy, Data, and
-Settings.
+Meridian is a self-hosted .NET 10 financial operations platform for fund administrators, private
+fund managers and fund CFOs, registered investment advisors, family offices, and hybrid
+institutional teams. Fund management is a first-class *specialization*, not the root model — core
+contracts use customer-neutral concepts (organization, entity, portfolio, account, book, period,
+transaction, evidence, approval, journal, report, audit trail).
 
-**Use current repo docs as authoritative context:** rely on `README.md`, `docs/roadmap/data/*.yml`,
+**Meridian sells proven numbers.** Every figure carries a reconstructable chain — source evidence,
+normalization, validation, reconciliation, ledger impact, approval, report usage, delivery. The
+operating question every surface must answer: *can Meridian prove, book, reconcile, approve, and
+report this number?*
+
+**The canonical operator spine:** `Import → Validate → Reconcile → Investigate → Approve → Report`
+
+The codebase spans provider ingestion and backfill, statement connectors, reconciliation and
+casework, the ledger and accounting close, evidence packets and provenance, governed report packs
+and delivery, portfolio and reference data, execution and pre-trade risk, strategy lifecycle and
+backtesting, QuantScript, MCP, and two co-equal operator UI lanes: the browser workstation
+(`src/Meridian.Ui/dashboard/`) and the WPF desktop workstation (`src/Meridian.Wpf/`), both over the
+shared `Meridian.Ui.Services` / `Meridian.Ui.Shared` / `Meridian.Contracts` seam.
+
+**Use current repo docs as authoritative context:** rely on `README.md`,
+`docs/product/meridian-design-document.md` (canonical charter), `docs/roadmap/data/*.yml`,
 `docs/roadmap/generated/ROADMAP_SUMMARY.md`, and `.claude/skills/_shared/project-context.md`
-instead of fixed file-count snapshots or migrated status stubs.
+instead of fixed file-count snapshots or migrated status stubs. Never assert wave or capability
+status from memory.
+
+---
+
+## Non-Negotiable Guardrails
+
+- **Seven root workspaces only:** Trading, Portfolio, Accounting, Reporting, Strategy, Data,
+  Settings. `Research`, `Data Operations`, and `Governance` are compatibility aliases. Never
+  propose an eighth root.
+- **No mobile lane:** no native iOS/Android, MAUI, React Native, Flutter, or mobile-first
+  workflows. Responsive browser behavior is allowed only to keep the browser workstation usable.
+- **Truth discipline:** simulated data carries loud labels, unsupported persistence fails closed,
+  and missing or stale evidence renders as `review-required` or `blocked`. Never propose a feature
+  that makes unwired capability look finished.
+- **Governed autonomy:** AI may extract, match, summarize, detect discrepancies, and draft — never
+  bypass operator approval, retained evidence, ledger controls, period locks, segregation of
+  duties, report release checks, or payment controls.
+- **Deferred expansion boundaries** (`docs/product/deferred-expansion-boundaries.md`): live
+  treasury payment execution, enterprise risk, forecasting engines, capital-structure modeling,
+  broad client portal, and no-code workflow design each need a roadmap row defining evidence,
+  approval, and audit gates first.
+- **Claim rules:** brainstorm output is an idea, never a status claim.
 
 ---
 
@@ -44,35 +82,38 @@ instead of fixed file-count snapshots or migrated status stubs.
 
 The best ideas for Meridian **amplify what already exists**. Before generating any idea, ask:
 
-1. **What does Meridian already do well nearby?** Find the existing capability this idea extends or
-   connects to. An idea with no anchor to current functionality is probably the wrong idea.
-2. **What would a user actually see and feel?** Every idea must have a concrete UI or interaction
-   moment. If you can't describe what the user clicks, reads, or watches — the idea isn't finished.
-3. **Does this make the whole program more coherent?** The best features make users think "of
-   course this is here."
+1. **What does Meridian already do well nearby?** Find the existing capability this idea extends,
+   wires up, or connects to. An idea with no anchor to current functionality is probably wrong.
+2. **What would an operator actually see and do?** Every idea must have a concrete UI or
+   interaction moment — what they click, resolve, or approve.
+3. **Does this make a number more provable?** Ideas that shorten, strengthen, or expose the proof
+   chain outrank ideas that only add surface.
 4. **Is the information presented clearly?** Every idea that touches the UI should consider
-   information hierarchy: what's the most important thing on screen? What's secondary?
+   information hierarchy: what's primary on screen, what's secondary, what's progressive-disclosed?
+
+**Activation over expansion:** the codebase is more capable than the running product. When a
+dormant capability exists in source, wiring it — and retiring its weaker predecessor — beats
+building a new one beside it.
 
 ---
 
-## Audience Personas
+## Audience Roles
 
-### 🎯 Hobbyist Quant Developer
+The canonical Persona Matrix (24 roles) lives in `docs/product/meridian-design-document.md` §4.2.
+For triage, use these grouped codes:
 
-Software developer or data scientist learning quant finance. Frustrated by setup complexity and the
-gap between "collecting data" and "doing something with it." Wants quick wins, low cost, and
-integration with tools they already know (Jupyter, pandas). Low risk tolerance.
+| Code | Roles |
+|------|-------|
+| **OPS** | Financial Operations Professional (primary operator), Reconciliation Analyst, Data Operations Analyst, Operations Manager, Treasury Operations Specialist |
+| **ACCT** | Investment Accountant, Fund Accountant, Reporting Analyst, Controller |
+| **INV** | Portfolio Manager, Investment Analyst, Quantitative Researcher, Trader |
+| **GOV** | Compliance Officer, Risk Manager, Auditor |
+| **EXEC** | CFO, CIO |
+| **STAKE** | Fund Investor / LP, RIA Client, Family Beneficiary, Trustee, Board / IC Member |
+| **ADMIN** | System / Security / Integration Administrator |
 
-### 🎓 Academic / Researcher
-
-Quantitative finance PhD, financial economist, or ML researcher. Cares deeply about data
-reproducibility, provenance, and quality validation. Needs citation-ready data, audit trails, and
-bulk export to research infrastructure (HDF5, Arrow, DuckDB).
-
-### 🏦 Institutional / Professional
-
-Prop trading firm, hedge fund ops, or quant analyst at an asset manager. Values reliability,
-throughput, compliance, and support. Low tolerance for infrastructure failures.
+The **Financial Operations Professional is the primary operator**. When an idea has no OPS, ACCT,
+or GOV benefit, say so explicitly and justify why it still earns build time.
 
 ---
 
@@ -84,17 +125,19 @@ Before generating any ideas, output a one-line mode declaration:
 
 | Mode | Trigger Phrases | Approach |
 |------|----------------|----------|
-| **Open Exploration** | "What could we build?" / "Give me ideas" | Generate across all dimensions, all personas |
+| **Open Exploration** | "What could we build?" / "Give me ideas" | Generate across domains and roles |
 | **Problem-Focused** | "How do we solve X?" / "Fix Y" | 3–5 deep ideas targeting the specific pain |
-| **Persona-Focused** | "Ideas for academics" / "Institutional use cases" | 5–8 ideas optimized for that audience |
-| **Domain-Focused** | "Ideas for latency / storage / UX / data quality" | Technical depth in that domain |
-| **Competitive** | "What are others doing?" / "Compare to Databento?" | Identify gaps; only propose ideas that fit Meridian's architecture |
+| **Activation** | "What's built but not wired?" / "Cheapest high-value win" | Name the dormant capability, the wiring path, and what it replaces |
+| **Role-Focused** | "Ideas for controllers" / "Auditor use cases" | 5–8 ideas optimized for that role's working session |
+| **Domain-Focused** | "Ideas for reconciliation / close / evidence / reporting" | Technical depth with an operator touchpoint |
+| **Competitive** | "How do we compare to BlackLine?" | Identify gaps; only propose ideas that fit Meridian's architecture |
 | **Quick Wins** | "What's easy to ship?" / "Low-hanging fruit?" | Effort ≤ Medium, impact ≥ High |
-| **Architecture / Refactoring** | "How should we restructure X?" | Code structure, MVVM, testability |
-| **User Growth / Adoption** | "How do we get more users?" / "Growth ideas" | Onboarding, community, retention |
-| **Technical Debt / Code Quality** | "What tech debt?" / "Code quality improvements" | Test coverage, static analysis, CI/CD |
-| **UX / Information Design** | "How should we display X?" / "Dashboard design" | Information architecture, visual hierarchy |
-| **Skill Improvement** | "Improve the brainstorm skill" | Apply process reflexively to the skills themselves |
+| **Architecture / Refactoring** | "How should we restructure X?" | Seam integrity, shared-contract compliance, testability |
+| **Evidence & Governance** | "How do we prove X?" / "Audit readiness" | Evidence packets, provenance, approval separation, retention |
+| **Adoption / Onboarding** | "How do we reduce time-to-value?" | Time to First Proof, seeded demo, import wedge, shadow mode |
+| **Technical Debt / Code Quality** | "What tech debt?" | Test effectiveness, static analysis, CI hardening, duplicated seams |
+| **UX / Information Design** | "The screen feels cluttered" | Information architecture, hierarchy, interaction flow |
+| **Skill Improvement** | "Improve the brainstorm skill" | Apply the process reflexively to the skills themselves |
 
 ---
 
@@ -109,7 +152,7 @@ Before generating any ideas, output a one-line mode declaration:
 
 | # | Idea | Effort | Audience | Impact | Depends On |
 |---|------|--------|----------|--------|------------|
-| 1 | [Short name] | S/M/L/XL | H=Hobbyist, Q=Academic, I=Institutional | High/Med/Low | [prereq or —] |
+| 1 | [Short name] | S/M/L/XL | OPS/ACCT/INV/GOV/EXEC/STAKE/ADMIN | High/Med/Low | [prereq or —] |
 ```
 
 **Effort key:** S = days, M = 1–2 weeks, L = 1+ month, XL = quarter+
@@ -118,20 +161,26 @@ Before generating any ideas, output a one-line mode declaration:
 
 Write each idea as a **natural narrative** — a short, compelling argument. Every idea must include:
 
-- **The anchor:** What existing Meridian capability does this extend? Reference real types/files
-  (e.g., "extends `IStorageSink` at `src/Meridian.Storage/Interfaces/IStorageSink.cs`").
-- **The user moment:** What does the user see, click, or experience? Describe the interaction.
-- **The implementation shape:** Key technical approach — interfaces, patterns, data flow.
-- **The tradeoffs:** What's hard? What could go wrong? What does this cost in complexity?
-- **Effort and audience:** Who benefits most? How big is this?
+- **The anchor:** what existing Meridian capability this extends or wires up. Reference real
+  types/files (e.g., "promotes `StatementMatchingEngine` at
+  `src/Meridian.FinancialOperations/Reconciliation/StatementMatchingEngine.cs` onto the live path").
+- **The operator moment:** what the operator sees, clicks, resolves, or approves, and in which
+  workspace.
+- **The implementation shape:** contracts, seams, data flow, persistence.
+- **The evidence and governance impact:** what proof it creates or exposes, what it blocks when
+  absent, what approval it requires.
+- **The tradeoffs:** what's hard, what could go wrong, what it costs in complexity.
+- **Effort and audience:** who benefits most and how big this is.
 
 **Quantity guidelines:**
 
-- Open Exploration: 8–12 ideas across 3+ categories
-- Problem/Persona/Domain focused: 4–6 deep ideas
+- Open Exploration: 8–12 ideas across 3+ domains
+- Problem / Role / Domain focused: 4–6 deep ideas
+- Activation: 4–6 ideas
 - Quick Wins: 6–8 ideas
 - Architecture/Refactoring: 4–6 ideas
-- User Growth/Adoption: 5–8 ideas
+- Evidence & Governance: 4–6 ideas
+- Adoption / Onboarding: 5–8 ideas
 - Technical Debt/Code Quality: 4–6 ideas
 - UX/Information Design: 4–6 ideas
 
@@ -141,53 +190,56 @@ After the ideas, write a synthesis that:
 
 - Identifies the **highest-leverage idea** (best impact/effort ratio)
 - Calls out **platform bets** — ideas that unlock multiple others
-- Flags **cross-cutting themes** (e.g., "three of these ideas all need a shared symbol health model")
+- Flags **cross-cutting themes** (e.g., "three of these need the evidence graph projection")
 - Suggests **sequencing**: what to build first, what it enables next
-- Includes **competitive signals**: how do Bloomberg, Databento, Polygon, and open-source tools
-  handle this space? Which pattern is most adaptable to Meridian's architecture?
+- Names **roadmap fit**: which existing row absorbs each idea, which needs a new one
+- Includes **competitive signals**: how close managers, fund administration suites, asset-servicing
+  platforms, and ledger APIs handle this space, and which pattern adapts to Meridian's architecture
 
 ---
 
 ## Output Quality Standards
 
-- **Be specific, not generic.** "Add a Python SDK" is weak. "Add a `marketdata` Python package
-  with an async iterator over the live WebSocket feed, pandas DataFrame output, and a `snap()`
-  convenience method for the last N ticks" is strong.
-- **Always describe the user experience.** Even backend optimizations have a user-facing moment.
-- **Show how features connect** to other existing features in the app.
+- **Be specific, not generic.** "Improve reconciliation" is weak. "Promote sided matching onto the
+  live statement path so a bank row and a ledger row match as a pair, with confidence scoring and a
+  one-click split/escalate action in the Accounting reconciliation queue" is strong.
+- **Always describe the operator experience.** Even backend work has a user-facing moment.
+- **Show how features connect** to other surfaces and workspaces.
 - **Acknowledge tradeoffs honestly.** Hidden complexity is the enemy. Name it.
-- **Anchor to the codebase.** Reference real abstractions: `IMarketDataClient`,
-  `IHistoricalDataProvider`, `EventPipeline`, `IStorageSink`, `BindableBase`.
-- **Respect the WPF medium.** Ideas should feel native to a desktop application — data grids,
-  split panes, keyboard shortcuts, system tray integration.
+- **Anchor to the codebase.** Reference real abstractions: `EventPipeline`, `IStorageSink`,
+  `IOrderGateway`, `IRiskRule`, `AccountingCloseManagementService`, `EvidenceGraphService`,
+  `LedgerReportPackBuilder`, `WorkstationEndpoints`.
+- **Respect both UI lanes.** Browser ideas should feel native to a browser operator surface; WPF
+  ideas should preserve dense desktop affordances. Neither lane may fork product state.
 
 ---
 
 ## Idea Dimensions (Quick Reference)
 
-When brainstorming, consider ideas across these dimensions:
-
-- **Data access:** streaming API, bulk export, query API, Python SDK, gRPC, Arrow Flight, DuckDB
-- **Data quality:** gap detection, anomaly flagging, cross-provider reconciliation, tick scoring
-- **Performance:** kernel bypass, lock-free queues, SIMD, GC tuning, backpressure metrics
-- **Storage:** Parquet/Arrow, tiered cold storage, deduplication, schema evolution, retention policies
-- **Integrations:** Jupyter, pandas, QuantConnect, Backtrader, Grafana, dbt, OpenBB
-- **UX:** setup wizard, symbol browser, live visualizer, order book heatmap, config validation
-- **Reliability:** multi-provider failover, health scoring, alerting, chaos testing
-- **Architecture:** MVVM compliance, hot/cold path separation, interface segregation
-- **Growth:** quickstart experience, content series, contributor onboarding
-- **Code quality:** mutation testing, static analysis gates, dead code elimination
+- **Import & data trust:** connector coverage, mapping profiles, drift detection, preview/confidence, replay, certified import runs
+- **Reconciliation & breaks:** sided matching, tolerance policy, casework, SLA, aging, bulk resolution, root-cause clustering
+- **Ledger & accounting:** journals, period lock, close readiness, capital accounts, tax lots, multi-currency, NAV economics
+- **Evidence & provenance:** evidence packets, manifests, document extraction, object links, evidence graph, number-level lineage
+- **Reporting & delivery:** report packs, report-writer grids, client-grade rendering, provenance drill-through, publication and restatement
+- **Portfolio & valuation:** positions, marks, security master, corporate actions, multi-asset coverage, cash ladder
+- **Execution & risk:** order gateways, paper realism, fill and cost models, pre-trade rules, kill-switch and safety controls
+- **Research & strategy:** strategy lifecycle, backtesting runtime, run comparison, promotion evidence, QuantScript
+- **Workstation UX:** the seven roots, screen consolidation, command palette, trust strip, proof drawers, operator focus and queues
+- **Governance & tenancy:** scoped authorization, approval separation, audit chain, retention, access review
+- **Platform quality:** durability, performance, observability, test effectiveness, CI hardening, activation coverage
 
 ---
 
 ## Related Resources
 
 - **Master AI index:** [`docs/ai/README.md`](../../docs/ai/README.md)
+- **Canonical product charter:** [`docs/product/meridian-design-document.md`](../../docs/product/meridian-design-document.md)
+- **Live roadmap status:** [`docs/roadmap/generated/ROADMAP_SUMMARY.md`](../../docs/roadmap/generated/ROADMAP_SUMMARY.md)
+- **Deferred boundaries:** [`docs/product/deferred-expansion-boundaries.md`](../../docs/product/deferred-expansion-boundaries.md)
 - **Claude skill equivalent:** documented in the AI documentation index
 - **Root context:** [`CLAUDE.md`](../../CLAUDE.md)
 - **Error prevention:** [`docs/ai/ai-known-errors.md`](../../docs/ai/ai-known-errors.md)
-- **Project context:** [`docs/ai/copilot/instructions.md`](../../docs/ai/copilot/instructions.md)
 
 ---
 
-*Last Updated: 2026-03-17*
+*Last Updated: 2026-07-28*


### PR DESCRIPTION
## Summary

Updates the `meridian-brainstorm` skill package (and its mirrored agent entrypoints) to match the current state of the project. No product code changes — this is AI-guidance content only.

The skill had drifted to a v1.3.0 snapshot from 2026-03-19 that framed Meridian as a market-data collection platform for hobbyist quants, academics, and institutional trading desks. Every substantive section is now grounded in `docs/product/meridian-design-document.md`, the roadmap registry, and paths verified against the tree.

**Framing and facts**

- Reframed as a self-hosted financial operations platform selling *proven numbers*, organized around the `Import → Validate → Reconcile → Investigate → Approve → Report` operator spine. Fund management is documented as a first-class specialization, not the root model.
- Replaced the stale statistics (868 source files, 261 test files, 22 projects, 33 workflows) with the design charter §5.2 measurement table: 41 source projects, ~242k lines of C# across 2,902 files, 12,736 lines of F#, ~295k lines of TS/TSX, 845 API routes, 22 provider adapter families, 6 statement connectors, ~12,900 xUnit facts/theories.
- Added current wave posture (closed baselines, active rows, the ranked W9 slate) with the roadmap registry named as the only live status source.
- Corrected the WPF lane: it was described as a "retained compatibility surface" with product/UI scope closed; it is an active co-equal operator UI lane focused on web-UI parity (`W8-WPF-PARITY-001`).

**Guidance**

- Replaced the Hobbyist / Academic / Institutional personas with grouped codes (OPS, ACCT, INV, GOV, EXEC, STAKE, ADMIN) over the canonical 24-role Persona Matrix; the triage table audience key changed from `H/Q/I` to match.
- Added a non-negotiable guardrails section: seven root workspaces, no mobile lane, truth discipline, governed autonomy, Meridian owns ledger truth, deferred expansion boundaries, claim rules, activation before expansion.
- Added Activation, Evidence & Governance, and Adoption modes; renamed Persona-Focused to Role-Focused; every idea now must state its evidence and governance impact.
- Added a handoffs section routing to `meridian-blueprint`, `meridian-roadmap-strategist`, `meridian-simulated-user-panel`, and `meridian-repo-navigation`.
- Corrected the session-ledger note: `brainstorm-history.jsonl` is tracked in the repository, not gitignored.

**References**

- `references/idea-dimensions.md`: anchor table rebuilt into seven sections with every path verified (`GracefulShutdownService` repointed to `src/Meridian.Platform/Runtime/`, `UiApiRoutes` to `src/Meridian.Contracts/Api/`); ten market-data-era categories replaced with eleven current-domain ones; added an **Activation Targets** section from the charter's activation register.
- `references/competitive-landscape.md`: rebuilt around close/controls managers, fund administration suites, asset-servicing platforms, and ledger APIs. Market-data vendors are retained but scoped to the Trading and Data lanes.

**Mirrors and entrypoints**

`.agents/skills/meridian-brainstorm/` (full mirror, history path adjusted for the lane), `.codex/skills/meridian-brainstorm/`, `.claude/agents/meridian-brainstorm.md`, `.codex/agents/meridian-brainstorm.toml`, and `.github/agents/brainstorm-agent.md`.

## Reason

The skill's project context, statistics, personas, competitive framing, and idea bank no longer described the repository. An assistant loading it would generate ideas for the wrong product — market-data features for hobbyist quants — and would have asserted a WPF scope posture that was reversed months ago.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [ ] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Validation run for these files (markdown-only change, no compiled code touched):

- `python3 build/scripts/docs/validate-skill-packages.py` → `Validated 13 skill packages in .claude/skills/`
- `python3 build/scripts/docs/check-ai-inventory.py --summary` → `pass; 322 item(s), 0 finding(s)`
- `python3 .codex/skills/meridian-brainstorm/scripts/run_evals.py --all --summary` → `summary 1/1 passed`

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01EfkRaazudSiQALV7Yw3QqD)_