### PR TITLE
Anchor cash-flow payment dates on the issue date

### DIFF
--- a/src/Meridian.Application/SecurityMaster/SecurityMasterCashFlowService.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityMasterCashFlowService.cs
@@ -250,32 +250,26 @@ public sealed class SecurityMasterCashFlowService : ISecurityMasterCashFlowServi
         }
 
         var periodMonths = Math.Max(1, 12 / ResolvePaymentFrequencyPerYear(terms.PaymentFrequency));
-        var dates = BuildPaymentDates(issueDate, maturity, periodMonths)
-            .Where(date => date >= asOfDate)
+        var periods = BuildPaymentPeriods(issueDate, maturity, periodMonths)
+            .Where(period => period.PaymentDate >= asOfDate)
             .ToArray();
-        if (dates.Length == 0)
+        if (periods.Length == 0)
         {
             return Empty();
         }
 
-        var entries = new List<StructuredCashFlowScheduleEntry>(dates.Length);
-        var accrualStart = issueDate;
+        var entries = new List<StructuredCashFlowScheduleEntry>(periods.Length);
         var sinkerPrincipal = sourceKind == StructuredCashFlowSourceKind.CalculatedSinker
-            ? RoundCash(outstanding / dates.Length)
+            ? RoundCash(outstanding / periods.Length)
             : 0m;
-        for (var i = 0; i < dates.Length; i++)
+        for (var i = 0; i < periods.Length; i++)
         {
-            var date = dates[i];
-            while (accrualStart.AddMonths(periodMonths) < date)
-            {
-                accrualStart = accrualStart.AddMonths(periodMonths);
-            }
-
+            var (accrualStart, date) = periods[i];
             var interest = annualRate > 0m && outstanding > 0m
                 ? RoundCash(outstanding * annualRate * DayCountConventions.Fraction(terms.DayCountConvention, accrualStart, date))
                 : 0m;
             var principal = 0m;
-            var isLast = i == dates.Length - 1;
+            var isLast = i == periods.Length - 1;
             if (sourceKind == StructuredCashFlowSourceKind.CalculatedBullet && isLast)
             {
                 principal = outstanding;
@@ -291,7 +285,6 @@ public sealed class SecurityMasterCashFlowService : ISecurityMasterCashFlowServi
                 RoundCash(principal),
                 interest,
                 principalBasis == 0m ? 0m : RoundCash(outstanding / principalBasis)));
-            accrualStart = date;
         }
 
         return new StructuredCashFlowProjectionDto(
@@ -350,35 +343,28 @@ public sealed class SecurityMasterCashFlowService : ISecurityMasterCashFlowServi
         var annualRate = ResolveLegAnnualRate(leg, scenario);
         var dayCount = leg.DayCountConvention ?? terms.DayCountConvention;
         var periodMonths = Math.Max(1, 12 / ResolvePaymentFrequencyPerYear(leg.PaymentFrequency ?? terms.PaymentFrequency));
-        var dates = BuildPaymentDates(issueDate, maturity, periodMonths)
-            .Where(date => date >= asOfDate)
+        var periods = BuildPaymentPeriods(issueDate, maturity, periodMonths)
+            .Where(period => period.PaymentDate >= asOfDate)
             .ToArray();
-        if (dates.Length == 0)
+        if (periods.Length == 0)
         {
             return [];
         }
 
-        var entries = new List<StructuredCashFlowScheduleEntry>(dates.Length);
-        var accrualStart = issueDate;
-        for (var i = 0; i < dates.Length; i++)
+        var entries = new List<StructuredCashFlowScheduleEntry>(periods.Length);
+        for (var i = 0; i < periods.Length; i++)
         {
-            var date = dates[i];
-            while (accrualStart.AddMonths(periodMonths) < date)
-            {
-                accrualStart = accrualStart.AddMonths(periodMonths);
-            }
-
+            var (accrualStart, date) = periods[i];
             var interest = annualRate > 0m
                 ? RoundCash(notional * annualRate * DayCountConventions.Fraction(dayCount, accrualStart, date))
                 : 0m;
-            var isLast = i == dates.Length - 1;
+            var isLast = i == periods.Length - 1;
             var principal = leg.ExchangesPrincipal && isLast ? RoundCash(notional) : 0m;
             entries.Add(new StructuredCashFlowScheduleEntry(
                 ToUtcDateTimeOffset(date),
                 principal,
                 interest,
                 leg.ExchangesPrincipal && isLast ? 0m : 1m));
-            accrualStart = date;
         }
 
         return entries;
@@ -434,18 +420,44 @@ public sealed class SecurityMasterCashFlowService : ISecurityMasterCashFlowServi
         _ => string.Empty
     };
 
-    private static IEnumerable<DateOnly> BuildPaymentDates(DateOnly issueDate, DateOnly maturity, int periodMonths)
+    /// <summary>
+    /// Yields each coupon period as an accrual start and its payment date, ending on maturity.
+    /// </summary>
+    /// <remarks>
+    /// Every payment date is anchored on the issue date rather than compounded from the previous
+    /// payment date. <see cref="DateOnly.AddMonths"/> clamps a month-end anchor into shorter months
+    /// (31 Jan plus three months is 30 Apr), and compounding that clamp walks the schedule earlier
+    /// every period. For a bond issued on the 31st that drift lands the final period one day before
+    /// maturity and emits a spurious one-day stub, so a one-year quarterly bond yields five payments
+    /// instead of four. Anchoring keeps each period on the issue day-of-month, clamping only where
+    /// the target month is shorter.
+    /// </remarks>
+    private static IEnumerable<(DateOnly AccrualStart, DateOnly PaymentDate)> BuildPaymentPeriods(
+        DateOnly issueDate,
+        DateOnly maturity,
+        int periodMonths)
     {
-        var date = issueDate;
-        while (date < maturity)
+        // A non-positive period would never advance the anchor and would spin forever. Both callers
+        // clamp with Math.Max(1, ...), so this guards the contract rather than a reachable path.
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(periodMonths);
+
+        if (issueDate >= maturity)
         {
-            date = date.AddMonths(periodMonths);
-            if (date > maturity)
+            yield break;
+        }
+
+        var accrualStart = issueDate;
+        for (var period = 1; ; period++)
+        {
+            var paymentDate = issueDate.AddMonths(periodMonths * period);
+            if (paymentDate >= maturity)
             {
-                date = maturity;
+                yield return (accrualStart, maturity);
+                yield break;
             }
 
-            yield return date;
+            yield return (accrualStart, paymentDate);
+            accrualStart = paymentDate;
         }
     }
 

--- a/tests/Meridian.Tests/Application/SecurityMasterCashFlowServiceTests.cs
+++ b/tests/Meridian.Tests/Application/SecurityMasterCashFlowServiceTests.cs
@@ -101,6 +101,67 @@ public sealed class SecurityMasterCashFlowServiceTests
     }
 
     [Fact]
+    public async Task GetProjectionAsync_MonthEndIssueDate_ShouldAnchorScheduleWithoutStubPeriod()
+    {
+        // Regression: payment dates used to compound AddMonths from the previous payment date.
+        // AddMonths clamps a month-end anchor into shorter months (31 Jan plus three months is
+        // 30 Apr), and compounding that clamp walked the schedule earlier every period until the
+        // final coupon landed one day before maturity and emitted a spurious one-day stub, so a
+        // one-year quarterly bond produced five payments instead of four.
+        //
+        // The issue date is pinned to the end of the current month so this exercises the clamping
+        // path on every calendar day rather than only when the suite happens to run on a month end.
+        var today = DateOnly.FromDateTime(DateTime.UtcNow.Date);
+        var issueDate = new DateOnly(today.Year, today.Month, DateTime.DaysInMonth(today.Year, today.Month));
+        var maturityDate = issueDate.AddMonths(12);
+        var securityId = Guid.Parse("44444444-dddd-dddd-dddd-444444444444");
+        var store = Substitute.For<ISecurityMasterCashFlowStore>();
+        store.GetSourceAsync(securityId, Arg.Any<CancellationToken>())
+            .Returns(new SecurityCashFlowSourceDto(
+                securityId,
+                StructuredCashFlowSourceKind.CalculatedBullet,
+                DateTimeOffset.UtcNow,
+                false,
+                null,
+                null));
+        var query = Substitute.For<SecurityMasterQueryContract>();
+        query.GetByIdAsync(securityId, Arg.Any<CancellationToken>())
+            .Returns(BuildSecurity(
+                securityId,
+                JsonSerializer.SerializeToElement(new
+                {
+                    issueDate,
+                    maturityDate,
+                    par = 100m,
+                    couponRate = 4m,
+                    paymentFrequency = "Quarterly",
+                    dayCountConvention = "30/360"
+                })));
+        var service = BuildService(store, query);
+
+        var projection = await service.GetProjectionAsync(securityId, StructuredCashFlowScenario.Base);
+
+        projection.Should().NotBeNull();
+        projection!.Schedule.Should().HaveCount(4);
+        projection.Schedule
+            .Select(static row => DateOnly.FromDateTime(row.PeriodDate.UtcDateTime.Date))
+            .Should().Equal(
+                issueDate.AddMonths(3),
+                issueDate.AddMonths(6),
+                issueDate.AddMonths(9),
+                maturityDate);
+        // Principal is repaid once, at maturity, with no trailing stub period.
+        projection.Schedule.Should().ContainSingle(static row => row.PrincipalAmount > 0m);
+        projection.Schedule.Last().PrincipalAmount.Should().Be(100m);
+        projection.Schedule.Last().Factor.Should().Be(0m);
+        // Every accrual period is a whole quarter, so no coupon collapses to a stub. A quarter of a
+        // 4% coupon on par 100 is ~1.00 (day-count fractions vary slightly with month length, so
+        // this is a floor rather than an equality); the one-day stub the old schedule produced
+        // accrued about 0.01.
+        projection.Schedule.Should().OnlyContain(static row => row.InterestAmount > 0.9m);
+    }
+
+    [Fact]
     public async Task GetProjectionAsync_StaleSource_ShouldFlagStalenessButStillReturnForDisplay()
     {
         var securityId = Guid.Parse("33333333-cccc-cccc-cccc-333333333333");


### PR DESCRIPTION
<!-- phase:PR9 -->

## Summary

Fixes a month-end drift bug in `SecurityMasterCashFlowService` that has had `main` red since 2026-07-29.

`BuildPaymentDates` compounded `AddMonths` from the *previous* payment date. `DateOnly.AddMonths` clamps a month-end anchor into shorter months (31 Jan + 3m = 30 Apr), and compounding that clamp walks the schedule earlier every period. For a bond issued on the 31st, the final period lands one day before maturity and emits a spurious one-day stub:

```
issue 2026-07-31, maturity 2027-07-31, quarterly
before: 2026-10-31, 2027-01-31, 2027-04-30, 2027-07-30, 2027-07-31   (5 payments)
after:  2026-10-31, 2027-01-31, 2027-04-30, 2027-07-31               (4 payments)
```

Anchoring each payment date on the issue date removes the drift. The generator now yields `(AccrualStart, PaymentDate)` pairs, which also deletes the duplicated catch-up `while` loop in both the fixed and floating schedule builders — that loop compounded the same clamp, so a security whose early coupons had already been filtered out could accrue its first retained coupon from a drifted start.

## Reason

`verify-dotnet` fails on `main` with two tests in `SecurityMasterCashFlowServiceTests`:

```
GetProjectionAsync_CalculatedSinker_ShouldAmortizePrincipalAcrossScheduleDates
GetProjectionAsync_SingleFloatingLeg_ProjectsFloatingRateNoteWithPrincipalExchange

Expected projection.Schedule to contain 4 item(s), but found 5
  first entry PeriodDate = <2026-10-31 +0h>
```

The tests seed their as-of date from `DateTime.UtcNow`, so this only reproduces on run dates that trigger clamping. Commit `2ed06af6` passed its 2026-07-28 nightly and has failed every nightly since 2026-07-29 — identical code, different day.

This is a real defect in the projection, not a test-data problem: a one-year quarterly bond should pay four coupons on any issue date. Split out of #2548, where it was blocking an unrelated docs-only change.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully — **not run; there is no .NET SDK in my environment** (`command -v dotnet` is empty), so I could not build or execute the suite locally
- [x] `bash scripts/ci.sh --lane verify-docs` exits 0
- [x] Relevant unit tests were added or updated — one regression test added
- [ ] Relevant integration tests were added or updated — n/a
- [ ] GitHub Actions `quality-gate` passed — pending on this PR

Since I could not run the tests, I modelled `DateOnly.AddMonths` clamping and both algorithms and swept the input space:

| Check | Old | New |
| --- | --- | --- |
| Reproduces the CI failure (`2026-07-31`, quarterly, 1y) | 5 payments, first `2026-10-31` — matches the CI log exactly | 4 payments |
| Month-end issue date, quarterly, 1y — all 12 months of 2026 | wrong count in **8 / 12** | wrong count in **0 / 12** |
| Every issue date in 2026 × monthly/quarterly/semiannual/annual | **49** wrong-count cases | **0** |
| `issue == maturity` | no periods | no periods (unchanged) |
| `issue > maturity` | no periods | no periods (unchanged) |
| period longer than tenor | single payment at maturity | single payment at maturity (unchanged) |

**CI is the real gate here** — please treat the above as reasoning, not as a substitute for a green `verify-dotnet`.

### On the regression test

The new test pins the issue date to the **end of the current month**, so it exercises the clamping path on every calendar day rather than only when the suite happens to run on a month end. It asserts the exact anchored date sequence, which is the invariant that broke.

One note on its interest assertion: I first wrote `InterestAmount == 1m` (a quarter of a 4% coupon on par 100) and it would itself have been wall-clock-fragile — under 30/360 US the Nov 30 → Feb 28 period is 88/360, giving 0.98. It now asserts a floor of `> 0.9`, which still discriminates: the one-day stub the old code produced accrued ~0.011. Verified across 72 month-ends spanning six years, including leap years.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

## Follow-up worth considering, not done here

`SecurityMasterCashFlowService` reads `DateTimeOffset.UtcNow` directly (line 211), so these tests cannot pin an as-of date without a clock seam. This fix makes them pass on every date, but they stay time-coupled. Injecting `TimeProvider` — the pattern `AutomatedJournalSchedulerHostedService` already uses — would make them fully deterministic. That is a wider refactor than a red-CI fix should carry, so I left it alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmjUgJo83aA3MMR5ZiGeHA)_