### PR TITLE
Sort roadmap diagram by wave number and in-wave sequence

### DIFF
--- a/build/scripts/docs/render-roadmap-diagrams.py
+++ b/build/scripts/docs/render-roadmap-diagrams.py
@@ -3,7 +3,45 @@
 
 from __future__ import annotations
 
+import re
+
 from common import build_arg_parser, load_data, repo_root, write_text_if_changed
+
+
+# Roadmap identifiers are `W<wave><suffix>-<AREA>-<NNN>`, e.g. W1-DATA-001, W5X-CONNECT-001,
+# W5X-STMT-ONBOARD-001 (two-token area), W9-ASSET-010, W10-MARK-001.
+_WAVE_PATTERN = re.compile(r"^W(\d+)([A-Z]*)$")
+
+# Sorts unparsable tokens deterministically last instead of letting them collide with wave 1.
+_UNPARSABLE = 1_000_000
+
+
+def diagram_sort_key(identifier: str) -> tuple[int, str, int, str, str]:
+    """Order roadmap identifiers by wave, then by sequence within the wave.
+
+    Sorting on the raw identifier string is lexicographic, which places `W10-` between `W1-` and
+    `W2-` and orders items within a wave alphabetically by area. Both are wrong: the first renders
+    a planned wave in the middle of delivered work, and the second discards the rank that the
+    numeric suffix encodes (see `DEC-PRIORITY-SLATE-001`, which states rank is carried in each W9
+    item's numeric suffix).
+
+    Waves sort numerically with their alphabetic suffix as a tiebreak, so `W5` precedes `W5X` and
+    `W9` precedes `W10`. Within a wave, items sort by their trailing sequence number first so a
+    rank-encoding wave renders in rank order, then by area for stability.
+    """
+    parts = identifier.split("-")
+    wave_token = parts[0] if parts else ""
+    wave_match = _WAVE_PATTERN.match(wave_token)
+    wave_number = int(wave_match.group(1)) if wave_match else _UNPARSABLE
+    wave_suffix = wave_match.group(2) if wave_match else wave_token
+
+    try:
+        sequence = int(parts[-1])
+    except (IndexError, ValueError):
+        sequence = _UNPARSABLE
+
+    area = "-".join(parts[1:-1])
+    return (wave_number, wave_suffix, sequence, area, identifier)
 
 
 def main() -> int:
@@ -13,7 +51,7 @@ def main() -> int:
     items = load_data(root / "docs" / "roadmap" / "data" / "roadmap-items.yml").get("items", [])
     lines = ["flowchart LR"]
     previous = None
-    for item in sorted(items, key=lambda entry: entry.get("id", "")):
+    for item in sorted(items, key=lambda entry: diagram_sort_key(entry.get("id", "") or "")):
         node = item.get("id", "").replace("-", "_")
         label = f"{item.get('id')}\\n{item.get('wave')} - {item.get('status')} / {item.get('health')}"
         lines.append(f'  {node}["{label}"]')

--- a/docs/architecture/diagrams/meridian-development-roadmap.mmd
+++ b/docs/architecture/diagrams/meridian-development-roadmap.mmd
@@ -34,23 +34,23 @@ flowchart LR
   W7_LIVE_001 --> W8_UX_CONSOL_001
   W8_WPF_PARITY_001["W8-WPF-PARITY-001\nW8 - in_progress / on_track"]
   W8_UX_CONSOL_001 --> W8_WPF_PARITY_001
-  W9_ALPACA_004["W9-ALPACA-004\nW9 - planned / green"]
-  W8_WPF_PARITY_001 --> W9_ALPACA_004
-  W9_ASSET_010["W9-ASSET-010\nW9 - done / green"]
-  W9_ALPACA_004 --> W9_ASSET_010
+  W9_TRUTH_001["W9-TRUTH-001\nW9 - planned / green"]
+  W8_WPF_PARITY_001 --> W9_TRUTH_001
   W9_DEMO_002["W9-DEMO-002\nW9 - planned / green"]
-  W9_ASSET_010 --> W9_DEMO_002
+  W9_TRUTH_001 --> W9_DEMO_002
+  W9_PAPER_003["W9-PAPER-003\nW9 - planned / green"]
+  W9_DEMO_002 --> W9_PAPER_003
+  W9_ALPACA_004["W9-ALPACA-004\nW9 - planned / green"]
+  W9_PAPER_003 --> W9_ALPACA_004
+  W9_REPORT_005["W9-REPORT-005\nW9 - planned / green"]
+  W9_ALPACA_004 --> W9_REPORT_005
+  W9_NAV_006["W9-NAV-006\nW9 - planned / green"]
+  W9_REPORT_005 --> W9_NAV_006
+  W9_SAFETY_007["W9-SAFETY-007\nW9 - planned / green"]
+  W9_NAV_006 --> W9_SAFETY_007
   W9_GOV_008["W9-GOV-008\nW9 - planned / green"]
-  W9_DEMO_002 --> W9_GOV_008
+  W9_SAFETY_007 --> W9_GOV_008
   W9_INGEST_009["W9-INGEST-009\nW9 - planned / green"]
   W9_GOV_008 --> W9_INGEST_009
-  W9_NAV_006["W9-NAV-006\nW9 - planned / green"]
-  W9_INGEST_009 --> W9_NAV_006
-  W9_PAPER_003["W9-PAPER-003\nW9 - planned / green"]
-  W9_NAV_006 --> W9_PAPER_003
-  W9_REPORT_005["W9-REPORT-005\nW9 - planned / green"]
-  W9_PAPER_003 --> W9_REPORT_005
-  W9_SAFETY_007["W9-SAFETY-007\nW9 - planned / green"]
-  W9_REPORT_005 --> W9_SAFETY_007
-  W9_TRUTH_001["W9-TRUTH-001\nW9 - planned / green"]
-  W9_SAFETY_007 --> W9_TRUTH_001
+  W9_ASSET_010["W9-ASSET-010\nW9 - done / green"]
+  W9_INGEST_009 --> W9_ASSET_010

--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -4920,6 +4920,7 @@ Meridian-main
 │   │   ├── IDepreciationScheduleCalculator.cs
 │   │   ├── ILedgerReportBinaryRenderer.cs
 │   │   ├── IReadOnlyLedger.cs
+│   │   ├── IWashSaleReplacementResolver.cs
 │   │   ├── JournalEntry.cs
 │   │   ├── JournalEntryMetadata.cs
 │   │   ├── JournalEvidenceReference.cs
@@ -4967,6 +4968,7 @@ Meridian-main
 │   │   ├── LedgerTaxLotBasisAdjuster.cs
 │   │   ├── LedgerTaxLotBasisAdjustment.cs
 │   │   ├── LedgerTaxLotBasisAdjustmentKind.cs
+│   │   ├── LedgerTaxLotReliefHistoryProjector.cs
 │   │   ├── LedgerTaxLotReliefInput.cs
 │   │   ├── LedgerTaxLotReliefMethod.cs
 │   │   ├── LedgerTaxLotReliefProjection.cs
@@ -5018,6 +5020,7 @@ Meridian-main
 │   │   ├── ShareClass.cs
 │   │   ├── ShareClassUnitRegisterProjector.cs
 │   │   ├── StalePricePolicy.cs
+│   │   ├── TaxCharacter.cs
 │   │   ├── WashSale.cs
 │   │   └── YearEndClose.cs
 │   ├── Meridian.LifecycleSupervisor
@@ -5398,7 +5401,8 @@ Meridian-main
 │   │   │   │   ├── V_ledger_024__tax_lot_average_cost_method.sql
 │   │   │   │   ├── V_ledger_025__global_posting_command_identity.sql
 │   │   │   │   ├── V_ledger_026__journal_leg_currency.sql
-│   │   │   │   └── V_ledger_027__atomic_tax_lot_posting.sql
+│   │   │   │   ├── V_ledger_027__atomic_tax_lot_posting.sql
+│   │   │   │   └── V_ledger_028__wash_sale_activation.sql
 │   │   │   ├── AccountingPostingCommandFingerprintJsonContext.cs
 │   │   │   ├── AccountingPostingCommandValidator.cs
 │   │   │   ├── AtomicTaxLotJournalFingerprint.cs
@@ -5417,7 +5421,10 @@ Meridian-main
 │   │   │   ├── PostgresLedgerJournalStore.AtomicTaxLots.cs
 │   │   │   ├── PostgresLedgerJournalStore.cs
 │   │   │   ├── PostgresLedgerJournalStore.Serialization.cs
-│   │   │   └── PostgresLedgerJournalStore.Validation.cs
+│   │   │   ├── PostgresLedgerJournalStore.TaxLotDisposalHistory.cs
+│   │   │   ├── PostgresLedgerJournalStore.Validation.cs
+│   │   │   ├── PostgresLedgerJournalStore.WashSale.cs
+│   │   │   └── WashSaleDeferralRecord.cs
 │   │   ├── Maintenance
 │   │   │   ├── ArchiveMaintenanceModels.cs
 │   │   │   ├── ArchiveMaintenanceScheduleManager.cs
@@ -8592,8 +8599,10 @@ Meridian-main
 │   │   │   ├── LedgerReportPackTestData.cs
 │   │   │   ├── LedgerReportRendererCompositionTests.cs
 │   │   │   ├── LedgerScheduledExportFormatTests.cs
+│   │   │   ├── LedgerTaxCharacterTests.cs
 │   │   │   ├── LedgerTaxLotBasisAdjusterTests.cs
 │   │   │   ├── LedgerTaxLotReliefWashSaleTests.cs
+│   │   │   ├── LedgerWashSaleActivationTests.cs
 │   │   │   ├── LotConsumptionTests.cs
 │   │   │   ├── NavPerUnitAndEqualizationTests.cs
 │   │   │   ├── PartnersCapitalAllocationBreakoutTests.cs

--- a/docs/status/coverage-report.md
+++ b/docs/status/coverage-report.md
@@ -5,7 +5,7 @@
 
 ## Overall Coverage
 
-**3791 / 8579** items documented (**44.2%**) &mdash; Grade: **D**
+**3795 / 8592** items documented (**44.2%**) &mdash; Grade: **D**
 
 ```text
 [=========-----------] 44.2%
@@ -15,7 +15,7 @@
 
 | Category | Documented | Total | Coverage | Grade |
 | ---------- | ----------- | ------- | ---------- | ------- |
-| Public Classes / Interfaces | 3665 | 8110 | 45.2% | D |
+| Public Classes / Interfaces | 3669 | 8123 | 45.2% | D |
 | API Endpoints | 112 | 316 | 35.4% | F |
 | Configuration Options | 3 | 142 | 2.1% | F |
 | Provider Implementations | 0 | 0 | 100.0% | A |
@@ -23,7 +23,7 @@
 
 ## Undocumented Items
 
-### Public Classes / Interfaces (4445 undocumented)
+### Public Classes / Interfaces (4454 undocumented)
 
 | Item | Location |
 | ------ | ---------- |
@@ -77,7 +77,7 @@
 | `ProviderIntegrationSetupValidationIssue` | `src/Meridian.Application/Integrations/ProviderIntegrationSetupValidation.cs:10` |
 | `ProviderIntegrationSetupValidationException` | `src/Meridian.Application/Integrations/ProviderIntegrationSetupValidation.cs:21` |
 | `DualPathPipelineStopStatus` | `src/Meridian.Application/Pipeline/DualPathEventPipeline.cs:16` |
-| ... and 4395 more | |
+| ... and 4404 more | |
 
 ### API Endpoints (204 undocumented)
 
@@ -193,7 +193,7 @@
 
 ## Recommendations
 
-1. **Public Classes / Interfaces**: 4445 undocumented types. Consider generating API docs with DocFX (`docfx docfx.json`) to cover the long tail of public types automatically.
+1. **Public Classes / Interfaces**: 4454 undocumented types. Consider generating API docs with DocFX (`docfx docfx.json`) to cover the long tail of public types automatically.
 2. **API Endpoints**: 204 endpoint(s) missing from `docs/reference/api-reference.md`. Run the endpoint audit and update the API reference table.
 3. **Configuration Options**: 139 config key(s) not found in `docs/generated/configuration-schema.md`. Re-run the configuration schema generator to synchronise.
 

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,11 +1,11 @@
 {
   "total_files": 637,
-  "total_lines": 114999,
+  "total_lines": 115250,
   "orphaned_count": 258,
   "no_heading_count": 148,
   "stale_count": 0,
   "todo_count": 218,
-  "average_lines": 180.5,
+  "average_lines": 180.9,
   "health_score": 79,
   "orphaned_files": [
     ".agents/skills/meridian-archive-organizer/SKILL.md",
@@ -509,7 +509,7 @@
     },
     {
       "path": ".agents/skills/meridian-brainstorm/CHANGELOG.md",
-      "line_count": 54,
+      "line_count": 122,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -517,7 +517,7 @@
     },
     {
       "path": ".agents/skills/meridian-brainstorm/references/competitive-landscape.md",
-      "line_count": 77,
+      "line_count": 118,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -525,7 +525,7 @@
     },
     {
       "path": ".agents/skills/meridian-brainstorm/references/idea-dimensions.md",
-      "line_count": 233,
+      "line_count": 330,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -533,7 +533,7 @@
     },
     {
       "path": ".agents/skills/meridian-brainstorm/SKILL.md",
-      "line_count": 273,
+      "line_count": 309,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -2573,7 +2573,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 9617,
+      "line_count": 9626,
       "has_heading": true,
       "todo_count": 8,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,8 +20,8 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 637 |
-| Total lines | 114,999 |
-| Average file size (lines) | 180.5 |
+| Total lines | 115,250 |
+| Average file size (lines) | 180.9 |
 | Orphaned files | 258 |
 | Files without headings | 148 |
 | Stale files (>90 days) | 0 |

--- a/tests/scripts/test_render_roadmap_diagrams.py
+++ b/tests/scripts/test_render_roadmap_diagrams.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 import tempfile
@@ -27,13 +28,28 @@ items:
 """
 
 
+def _item(identifier: str, wave: str) -> str:
+    return (
+        f"  - id: {identifier}\n"
+        f"    title: {identifier}\n"
+        f"    wave: {wave}\n"
+        "    status: planned\n"
+        "    health: green\n"
+    )
+
+
+def _registry(*entries: tuple[str, str]) -> str:
+    header = 'schema:\n  id: meridian.roadmap-items\n  version: "1.0.0"\nitems:\n'
+    return header + "".join(_item(identifier, wave) for identifier, wave in entries)
+
+
 class RenderRoadmapDiagramsTests(unittest.TestCase):
-    def test_renderer_labels_nodes_with_registry_wave(self) -> None:
+    def _render(self, registry: str) -> str:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             data_dir = root / "docs" / "roadmap" / "data"
             data_dir.mkdir(parents=True)
-            (data_dir / "roadmap-items.yml").write_text(ROADMAP_ITEMS, encoding="utf-8")
+            (data_dir / "roadmap-items.yml").write_text(registry, encoding="utf-8")
 
             result = subprocess.run(
                 [sys.executable, str(SCRIPT_PATH), "--root", str(root), "--summary"],
@@ -43,9 +59,63 @@ class RenderRoadmapDiagramsTests(unittest.TestCase):
             )
 
             self.assertEqual(0, result.returncode, result.stderr)
-            diagram = (root / "docs" / "architecture" / "diagrams" / "meridian-development-roadmap.mmd").read_text(encoding="utf-8")
-            self.assertIn('W6_BTSTUDIO_001["W6-BTSTUDIO-001\\nW6 - planned / green"]', diagram)
-            self.assertIn('W7_LIVE_001["W7-LIVE-001\\nW7 - planned / green"]', diagram)
+            return (
+                root / "docs" / "architecture" / "diagrams" / "meridian-development-roadmap.mmd"
+            ).read_text(encoding="utf-8")
+
+    @staticmethod
+    def _node_order(diagram: str) -> list[str]:
+        return re.findall(r"^  ([A-Z0-9_]+)\[", diagram, flags=re.MULTILINE)
+
+    def test_renderer_labels_nodes_with_registry_wave(self) -> None:
+        diagram = self._render(ROADMAP_ITEMS)
+        self.assertIn('W6_BTSTUDIO_001["W6-BTSTUDIO-001\\nW6 - planned / green"]', diagram)
+        self.assertIn('W7_LIVE_001["W7-LIVE-001\\nW7 - planned / green"]', diagram)
+
+    def test_double_digit_wave_sorts_after_single_digit_waves(self) -> None:
+        # Lexicographic ordering placed "W10-" between "W1-" and "W2-", rendering a planned wave
+        # in the middle of delivered work and drawing an edge from it into an earlier wave.
+        diagram = self._render(
+            _registry(
+                ("W10-MARK-001", "W10"),
+                ("W2-TRD-001", "W2"),
+                ("W1-DATA-001", "W1"),
+                ("W9-TRUTH-001", "W9"),
+            )
+        )
+        self.assertEqual(
+            ["W1_DATA_001", "W2_TRD_001", "W9_TRUTH_001", "W10_MARK_001"],
+            self._node_order(diagram),
+        )
+
+    def test_items_order_by_sequence_within_a_wave_not_by_area(self) -> None:
+        # DEC-PRIORITY-SLATE-001 records that rank is carried in each W9 item's numeric suffix, so
+        # ordering alphabetically by area discards it.
+        diagram = self._render(
+            _registry(
+                ("W9-ASSET-010", "W9"),
+                ("W9-DEMO-002", "W9"),
+                ("W9-TRUTH-001", "W9"),
+                ("W9-ALPACA-004", "W9"),
+            )
+        )
+        self.assertEqual(
+            ["W9_TRUTH_001", "W9_DEMO_002", "W9_ALPACA_004", "W9_ASSET_010"],
+            self._node_order(diagram),
+        )
+
+    def test_lettered_wave_suffix_sorts_after_its_base_wave(self) -> None:
+        diagram = self._render(
+            _registry(
+                ("W5X-CONNECT-001", "W5X"),
+                ("W6-BTSTUDIO-001", "W6"),
+                ("W5-ACCT-001", "W5"),
+            )
+        )
+        self.assertEqual(
+            ["W5_ACCT_001", "W5X_CONNECT_001", "W6_BTSTUDIO_001"],
+            self._node_order(diagram),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- phase:PR6 -->

## Summary

`render-roadmap-diagrams.py` sorted items by raw identifier string, which is lexicographic. Two defects followed.

**The reported one:** `W10-` sorts between `W1-` and `W2-`, because comparison is character by character. Since the renderer chains every item into one flowchart, a planned wave lands in the middle of delivered work and draws an edge from itself back into an earlier, already-closed wave.

**A pre-existing one nobody had noticed:** items inside a wave sorted alphabetically by *area*, discarding the rank their numeric suffix carries. `DEC-PRIORITY-SLATE-001` states rank is encoded in each W9 item's numeric suffix — but the committed diagram on `main` renders W9 as:

```
ALPACA, ASSET, DEMO, GOV, INGEST, NAV, PAPER, REPORT, SAFETY, TRUTH
```

That is alphabetical, not rank. It was already wrong before any W10 row existed.

Identifiers now sort by wave number → the wave's alphabetic suffix (so `W5` precedes `W5X`) → trailing sequence number (so a rank-encoding wave renders in rank order) → area, for stability. Unparsable tokens sort last deterministically instead of colliding with wave 1.

Regenerated on `main`'s registry, W9 comes out in its adopted rank:

```
TRUTH, DEMO, PAPER, ALPACA, REPORT, NAV, SAFETY, GOV, INGEST, ASSET
```

and the wave sequence is W1 → W2 → W3 → W4 → W5 → W5X → W6 → W7 → W8 → W9. **Node labels are unchanged** — this is ordering only.

## Reason

Raised in review on #2548, where adding eleven `W10` rows made the lexicographic bug visible. Split onto its own branch because the fix changes how *every* wave renders, which does not belong in a PR whose scope is registry data and whose safety review claims no unrelated changes.

## Known limitation, stated deliberately

The diagram still cannot render the W10 slate in its adopted rank. W10 identifiers **intentionally** do not encode rank the way W9's do — `DEC-PRIORITY-SLATE-001` reserved that convention for W9, and W10 carries rank in its slate document instead. Recovering it in the diagram would require an explicit ordering field on the registry schema, which is out of scope for a rendering fix. W10 will render deterministically (by sequence, then area), just not in slate order.

If rank-in-diagram matters for W10, the follow-up is an optional `sequence` property on `roadmap-items.v1.schema.json` with a minor schema version bump — happy to do that separately.

## Testing performed

- [x] `bash scripts/ci.sh --lane verify-docs` — exit 0
- [x] `bash scripts/ci.sh --lane verify-workflows` — exit 0
- [x] Relevant unit tests were added or updated — three new ordering regressions
- [ ] Relevant integration tests were added or updated — n/a
- [ ] `bash scripts/ci.sh` full quality-gate — not run locally; no compiled source is touched
- [ ] GitHub Actions `quality-gate` passed — pending on this PR

`python3 build/scripts/ci/run-script-tests.py` → **418 tests, 0 failures, 0 errors**.

New tests in `tests/scripts/test_render_roadmap_diagrams.py`, each pinning one rule:

| Test | Pins |
| --- | --- |
| `test_double_digit_wave_sorts_after_single_digit_waves` | W1 → W2 → W9 → **W10**, the reported bug |
| `test_items_order_by_sequence_within_a_wave_not_by_area` | W9 renders TRUTH(001) → DEMO(002) → ALPACA(004) → ASSET(010), not alphabetically |
| `test_lettered_wave_suffix_sorts_after_its_base_wave` | W5 → W5X → W6 |

The pre-existing label test is unchanged and still passes, which is the guard that this is ordering-only.

**Phase marker:** this PR is `phase:PR6`. It first went out as `PR1` (carried over from the registry-data PR this was split from) and `scope-gate` correctly rejected it — `PR1` covers `docs/**` only, while this touches `build/**` and `tests/**`. `PR6` is the narrowest phase that covers all three, confirmed locally with `tools/roadmap/enforce_phase_scope.py`.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

Touches `build/scripts/docs/render-roadmap-diagrams.py`, its test, and the regenerated `.mmd`. No workflow, CODEOWNERS, `AGENTS.md`, or `scripts/ci.sh` changes.