### PR TITLE
Share one ordering across generated roadmap views and let a wave declare explicit rank

### DIFF
--- a/build/scripts/docs/common.py
+++ b/build/scripts/docs/common.py
@@ -231,6 +231,64 @@ def front_matter(markdown: str) -> dict[str, str]:
     return result
 
 
+# Roadmap identifiers are `W<wave><suffix>-<AREA>-<NNN>`, e.g. W1-DATA-001, W5X-CONNECT-001,
+# W5X-STMT-ONBOARD-001 (two-token area), W9-ASSET-010, W10-MARK-001.
+_WAVE_PATTERN = re.compile(r"^W(\d+)([A-Z]*)$")
+
+# Sorts unparsable tokens deterministically last instead of letting them collide with wave 1.
+_UNPARSABLE_SEQUENCE = 1_000_000
+
+
+def roadmap_item_sort_key(item: dict) -> tuple[int, str, int, str, str]:
+    """Order roadmap items by wave, then by rank within the wave.
+
+    Every generated roadmap view shares this ordering so the diagram, the summary, and the register
+    cannot disagree about delivery sequence.
+
+    Sorting on the raw identifier string is lexicographic, which places `W10-` between `W1-` and
+    `W2-` and orders items within a wave alphabetically by area. Both are wrong: the first renders a
+    planned wave in the middle of delivered work, and the second discards the rank that the numeric
+    suffix encodes (see `DEC-PRIORITY-SLATE-001`, which states rank is carried in each W9 item's
+    numeric suffix).
+
+    Waves sort numerically with their alphabetic suffix as a tiebreak, so `W5` precedes `W5X` and
+    `W9` precedes `W10`.
+
+    Within a wave, an explicit `sequence` wins when the item declares a usable one. Otherwise rank
+    falls back to the identifier's trailing number, which is only meaningful for waves that encode
+    rank there. A wave that numbers per area instead - every row `-001` - has no recoverable rank
+    without the explicit field. Area and identifier remain as stability tiebreaks.
+    """
+    identifier = item.get("id", "") or ""
+    parts = identifier.split("-")
+    wave_token = parts[0] if parts else ""
+    wave_match = _WAVE_PATTERN.match(wave_token)
+    wave_number = int(wave_match.group(1)) if wave_match else _UNPARSABLE_SEQUENCE
+    wave_suffix = wave_match.group(2) if wave_match else wave_token
+
+    declared = item.get("sequence")
+    if is_usable_sequence(declared):
+        sequence = declared
+    else:
+        try:
+            sequence = int(parts[-1])
+        except (IndexError, ValueError):
+            sequence = _UNPARSABLE_SEQUENCE
+
+    area = "-".join(parts[1:-1])
+    return (wave_number, wave_suffix, sequence, area, identifier)
+
+
+def is_usable_sequence(value: Any) -> bool:
+    """Whether a declared `sequence` is a rank the renderers may sort on.
+
+    `bool` is an `int` subclass in Python, so `sequence: true` would otherwise sort as rank 1. The
+    schema also bounds the field at 1; a nonpositive value is rejected here rather than silently
+    ordering ahead of every legitimate rank. Validation reports these; the renderers fall back.
+    """
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 1
+
+
 def markdown_table(headers: Sequence[str], rows: Iterable[Sequence[Any]]) -> str:
     output = [
         "| " + " | ".join(headers) + " |",

--- a/build/scripts/docs/common.py
+++ b/build/scripts/docs/common.py
@@ -299,14 +299,25 @@ def markdown_table(headers: Sequence[str], rows: Iterable[Sequence[Any]]) -> str
     return "\n".join(output)
 
 
-def generated_header(generator: str, schema_versions: Sequence[str], inputs: Sequence[str]) -> str:
+def generated_header(
+    generator: str,
+    schema_versions: Sequence[str],
+    inputs: Sequence[str],
+    generator_version: str = "1.0.0",
+) -> str:
+    """Emit the standard generated-doc header.
+
+    `generator_version` is per-generator: a generator that changes its output semantics bumps its
+    own version so an audit can tell which ordering or shape contract produced a committed artifact,
+    without disturbing every other generated doc.
+    """
     schema_lines = "\n".join(f"  - {item}" for item in schema_versions)
     input_lines = "\n".join(f"  - {normalize_path(item)}" for item in inputs)
     return (
         "<!--\n"
         "generated: true\n"
         f"generator: {normalize_path(generator)}\n"
-        "generator_version: 1.0.0\n"
+        f"generator_version: {generator_version}\n"
         f"render_contract: {GENERATOR_CONTRACT}\n"
         "schema_versions:\n"
         f"{schema_lines}\n"
@@ -317,13 +328,20 @@ def generated_header(generator: str, schema_versions: Sequence[str], inputs: Seq
     )
 
 
-def write_manifest(path: Path, generator: str, inputs: Sequence[Path], outputs: Sequence[Path], root: Path) -> bool:
+def write_manifest(
+    path: Path,
+    generator: str,
+    inputs: Sequence[Path],
+    outputs: Sequence[Path],
+    root: Path,
+    generator_version: str = "1.0.0",
+) -> bool:
     def sort_key(item: Path) -> str:
         return repo_path(item, root)
 
     payload = {
         "schema": {"id": "meridian.generated-manifest", "version": "1.0.0"},
-        "generator": {"name": normalize_path(generator), "version": "1.0.0"},
+        "generator": {"name": normalize_path(generator), "version": generator_version},
         "inputs": [{"path": repo_path(item, root), "sha256": sha256_manifest_file(item)} for item in sorted(inputs, key=sort_key)],
         "outputs": [{"path": repo_path(item, root), "sha256": sha256_manifest_file(item)} for item in sorted(outputs, key=sort_key) if item.exists()],
     }

--- a/build/scripts/docs/render-roadmap-diagrams.py
+++ b/build/scripts/docs/render-roadmap-diagrams.py
@@ -3,55 +3,13 @@
 
 from __future__ import annotations
 
-import re
-
-from common import build_arg_parser, load_data, repo_root, write_text_if_changed
-
-
-# Roadmap identifiers are `W<wave><suffix>-<AREA>-<NNN>`, e.g. W1-DATA-001, W5X-CONNECT-001,
-# W5X-STMT-ONBOARD-001 (two-token area), W9-ASSET-010, W10-MARK-001.
-_WAVE_PATTERN = re.compile(r"^W(\d+)([A-Z]*)$")
-
-# Sorts unparsable tokens deterministically last instead of letting them collide with wave 1.
-_UNPARSABLE = 1_000_000
-
-
-def diagram_sort_key(item: dict) -> tuple[int, str, int, str, str]:
-    """Order roadmap items by wave, then by rank within the wave.
-
-    Sorting on the raw identifier string is lexicographic, which places `W10-` between `W1-` and
-    `W2-` and orders items within a wave alphabetically by area. Both are wrong: the first renders
-    a planned wave in the middle of delivered work, and the second discards the rank that the
-    numeric suffix encodes (see `DEC-PRIORITY-SLATE-001`, which states rank is carried in each W9
-    item's numeric suffix).
-
-    Waves sort numerically with their alphabetic suffix as a tiebreak, so `W5` precedes `W5X` and
-    `W9` precedes `W10`.
-
-    Within a wave, an explicit `sequence` wins when the item declares one. Otherwise rank falls back
-    to the identifier's trailing number, which is only meaningful for waves that encode rank there.
-    A wave that numbers per area instead — every row `-001` — has no recoverable rank without the
-    explicit field, and would otherwise fall through to an alphabetical area sort that contradicts
-    its adopted order. Area and identifier remain as stability tiebreaks.
-    """
-    identifier = item.get("id", "") or ""
-    parts = identifier.split("-")
-    wave_token = parts[0] if parts else ""
-    wave_match = _WAVE_PATTERN.match(wave_token)
-    wave_number = int(wave_match.group(1)) if wave_match else _UNPARSABLE
-    wave_suffix = wave_match.group(2) if wave_match else wave_token
-
-    declared = item.get("sequence")
-    if isinstance(declared, int) and not isinstance(declared, bool):
-        sequence = declared
-    else:
-        try:
-            sequence = int(parts[-1])
-        except (IndexError, ValueError):
-            sequence = _UNPARSABLE
-
-    area = "-".join(parts[1:-1])
-    return (wave_number, wave_suffix, sequence, area, identifier)
+from common import (
+    build_arg_parser,
+    load_data,
+    repo_root,
+    roadmap_item_sort_key,
+    write_text_if_changed,
+)
 
 
 def main() -> int:
@@ -61,7 +19,7 @@ def main() -> int:
     items = load_data(root / "docs" / "roadmap" / "data" / "roadmap-items.yml").get("items", [])
     lines = ["flowchart LR"]
     previous = None
-    for item in sorted(items, key=diagram_sort_key):
+    for item in sorted(items, key=roadmap_item_sort_key):
         node = item.get("id", "").replace("-", "_")
         label = f"{item.get('id')}\\n{item.get('wave')} - {item.get('status')} / {item.get('health')}"
         lines.append(f'  {node}["{label}"]')

--- a/build/scripts/docs/render-roadmap-diagrams.py
+++ b/build/scripts/docs/render-roadmap-diagrams.py
@@ -16,8 +16,8 @@ _WAVE_PATTERN = re.compile(r"^W(\d+)([A-Z]*)$")
 _UNPARSABLE = 1_000_000
 
 
-def diagram_sort_key(identifier: str) -> tuple[int, str, int, str, str]:
-    """Order roadmap identifiers by wave, then by sequence within the wave.
+def diagram_sort_key(item: dict) -> tuple[int, str, int, str, str]:
+    """Order roadmap items by wave, then by rank within the wave.
 
     Sorting on the raw identifier string is lexicographic, which places `W10-` between `W1-` and
     `W2-` and orders items within a wave alphabetically by area. Both are wrong: the first renders
@@ -26,19 +26,29 @@ def diagram_sort_key(identifier: str) -> tuple[int, str, int, str, str]:
     item's numeric suffix).
 
     Waves sort numerically with their alphabetic suffix as a tiebreak, so `W5` precedes `W5X` and
-    `W9` precedes `W10`. Within a wave, items sort by their trailing sequence number first so a
-    rank-encoding wave renders in rank order, then by area for stability.
+    `W9` precedes `W10`.
+
+    Within a wave, an explicit `sequence` wins when the item declares one. Otherwise rank falls back
+    to the identifier's trailing number, which is only meaningful for waves that encode rank there.
+    A wave that numbers per area instead — every row `-001` — has no recoverable rank without the
+    explicit field, and would otherwise fall through to an alphabetical area sort that contradicts
+    its adopted order. Area and identifier remain as stability tiebreaks.
     """
+    identifier = item.get("id", "") or ""
     parts = identifier.split("-")
     wave_token = parts[0] if parts else ""
     wave_match = _WAVE_PATTERN.match(wave_token)
     wave_number = int(wave_match.group(1)) if wave_match else _UNPARSABLE
     wave_suffix = wave_match.group(2) if wave_match else wave_token
 
-    try:
-        sequence = int(parts[-1])
-    except (IndexError, ValueError):
-        sequence = _UNPARSABLE
+    declared = item.get("sequence")
+    if isinstance(declared, int) and not isinstance(declared, bool):
+        sequence = declared
+    else:
+        try:
+            sequence = int(parts[-1])
+        except (IndexError, ValueError):
+            sequence = _UNPARSABLE
 
     area = "-".join(parts[1:-1])
     return (wave_number, wave_suffix, sequence, area, identifier)
@@ -51,7 +61,7 @@ def main() -> int:
     items = load_data(root / "docs" / "roadmap" / "data" / "roadmap-items.yml").get("items", [])
     lines = ["flowchart LR"]
     previous = None
-    for item in sorted(items, key=lambda entry: diagram_sort_key(entry.get("id", "") or "")):
+    for item in sorted(items, key=diagram_sort_key):
         node = item.get("id", "").replace("-", "_")
         label = f"{item.get('id')}\\n{item.get('wave')} - {item.get('status')} / {item.get('health')}"
         lines.append(f'  {node}["{label}"]')

--- a/build/scripts/docs/render-roadmap-docs.py
+++ b/build/scripts/docs/render-roadmap-docs.py
@@ -12,6 +12,7 @@ from common import (
     markdown_table,
     repo_path,
     repo_root,
+    roadmap_item_sort_key,
     write_manifest,
     write_text_if_changed,
 )
@@ -26,7 +27,7 @@ def load_roadmap(root: Path) -> tuple[dict, dict, list[Path]]:
 
 
 def render_summary(root: Path, program: dict, roadmap: dict, inputs: list[Path]) -> str:
-    items = sorted(roadmap.get("items", []), key=lambda item: item.get("id", ""))
+    items = sorted(roadmap.get("items", []), key=roadmap_item_sort_key)
     schema_versions = [
         f"{program.get('schema', {}).get('id')}@{program.get('schema', {}).get('version')}",
         f"{roadmap.get('schema', {}).get('id')}@{roadmap.get('schema', {}).get('version')}",
@@ -52,7 +53,7 @@ def render_summary(root: Path, program: dict, roadmap: dict, inputs: list[Path])
 
 
 def render_register(root: Path, program: dict, roadmap: dict, inputs: list[Path]) -> str:
-    items = sorted(roadmap.get("items", []), key=lambda item: item.get("id", ""))
+    items = sorted(roadmap.get("items", []), key=roadmap_item_sort_key)
     schema_versions = [f"{roadmap.get('schema', {}).get('id')}@{roadmap.get('schema', {}).get('version')}"]
     parts = [
         generated_header("build/scripts/docs/render-roadmap-docs.py", schema_versions, [repo_path(path, root) for path in inputs]),

--- a/build/scripts/docs/render-roadmap-docs.py
+++ b/build/scripts/docs/render-roadmap-docs.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
+# Renderer major version. `docs/roadmap/schema-versioning.md` classifies a change in generated
+# output semantics as major-or-renderer-major; 2.0.0 marks the switch from lexical identifier
+# order to shared wave-then-rank order, so an audit can tell which contract produced an artifact.
+ROADMAP_RENDERER_VERSION = "2.0.0"
+
 from common import (
     build_arg_parser,
     generated_header,
@@ -44,7 +49,7 @@ def render_summary(root: Path, program: dict, roadmap: dict, inputs: list[Path])
         for item in items
     ]
     return (
-        generated_header("build/scripts/docs/render-roadmap-docs.py", schema_versions, [repo_path(path, root) for path in inputs])
+        generated_header("build/scripts/docs/render-roadmap-docs.py", schema_versions, [repo_path(path, root) for path in inputs], ROADMAP_RENDERER_VERSION)
         + "\n# Roadmap Summary\n\n"
         + f"Snapshot date: {program.get('program', {}).get('snapshot_date', '-')}\n\n"
         + markdown_table(["ID", "Title", "Status", "Health", "Priority", "Owner lane"], rows)
@@ -56,7 +61,7 @@ def render_register(root: Path, program: dict, roadmap: dict, inputs: list[Path]
     items = sorted(roadmap.get("items", []), key=roadmap_item_sort_key)
     schema_versions = [f"{roadmap.get('schema', {}).get('id')}@{roadmap.get('schema', {}).get('version')}"]
     parts = [
-        generated_header("build/scripts/docs/render-roadmap-docs.py", schema_versions, [repo_path(path, root) for path in inputs]),
+        generated_header("build/scripts/docs/render-roadmap-docs.py", schema_versions, [repo_path(path, root) for path in inputs], ROADMAP_RENDERER_VERSION),
         "\n# Roadmap Register\n",
         f"\nSnapshot date: {program.get('program', {}).get('snapshot_date', '-')}\n",
     ]
@@ -104,7 +109,7 @@ def main() -> int:
         write_text_if_changed(outputs[1], render_register(root, program, roadmap, inputs)),
         write_text_if_changed(outputs[2], render_summary(root, program, roadmap, inputs)),
     ]
-    manifest_changed = write_manifest(output_dir / "MANIFEST.json", "build/scripts/docs/render-roadmap-docs.py", inputs, outputs, root)
+    manifest_changed = write_manifest(output_dir / "MANIFEST.json", "build/scripts/docs/render-roadmap-docs.py", inputs, outputs, root, ROADMAP_RENDERER_VERSION)
     if args.summary:
         print(f"roadmap docs rendered: {sum(1 for item in changed if item) + int(manifest_changed)} file(s) changed")
     return 0

--- a/build/scripts/docs/validate-roadmap-registry.py
+++ b/build/scripts/docs/validate-roadmap-registry.py
@@ -5,7 +5,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from common import Finding, build_arg_parser, emit_findings, load_data, repo_path, repo_root
+from common import (
+    Finding,
+    build_arg_parser,
+    emit_findings,
+    is_usable_sequence,
+    load_data,
+    repo_path,
+    repo_root,
+)
 
 STATUSES = {"planned", "in_progress", "ready_for_acceptance", "accepted", "done"}
 HEALTH = {"green", "yellow", "red", "on_track", "watch", "at_risk", "blocked"}
@@ -122,6 +130,16 @@ def validate(root: Path) -> list[Finding]:
                 findings.append(Finding("error", repo_path(roadmap_path), f"{item_id} is {item.get('status')} without evidence"))
             if not item.get("exit_criteria"):
                 findings.append(Finding("error", repo_path(roadmap_path), f"{item_id} must declare exit criteria"))
+            # The JSON Schema bounds `sequence` at integer >= 1, but nothing loads it, so an
+            # out-of-range or wrong-typed value would otherwise reach the renderers. They fall back
+            # to the identifier suffix rather than fail, which would silently order a generated view
+            # against its adopted rank. Reject it here, where the documented CI lane runs.
+            if "sequence" in item and not is_usable_sequence(item.get("sequence")):
+                findings.append(Finding(
+                    "error",
+                    repo_path(roadmap_path),
+                    f"{item_id} has invalid sequence {item.get('sequence')!r}; expected an integer >= 1",
+                ))
 
     return findings
 

--- a/build/scripts/docs/validate-roadmap-registry.py
+++ b/build/scripts/docs/validate-roadmap-registry.py
@@ -134,6 +134,17 @@ def validate(root: Path) -> list[Finding]:
             # out-of-range or wrong-typed value would otherwise reach the renderers. They fall back
             # to the identifier suffix rather than fail, which would silently order a generated view
             # against its adopted rank. Reject it here, where the documented CI lane runs.
+            # Generated views sort on the wave parsed from the identifier but label with the
+            # declared `wave`. A disagreement would place an item among one wave's work while
+            # presenting it as another's, so the two must agree.
+            declared_wave = str(item.get("wave", ""))
+            identifier_wave = str(item.get("id", "")).split("-")[0]
+            if declared_wave and identifier_wave and declared_wave != identifier_wave:
+                findings.append(Finding(
+                    "error",
+                    repo_path(roadmap_path),
+                    f"{item_id} declares wave {declared_wave} but its identifier belongs to {identifier_wave}",
+                ))
             if "sequence" in item and not is_usable_sequence(item.get("sequence")):
                 findings.append(Finding(
                     "error",

--- a/docs/roadmap/data/roadmap-items.yml
+++ b/docs/roadmap/data/roadmap-items.yml
@@ -1,7 +1,7 @@
 schema:
   id: meridian.roadmap-items
-  version: "1.0.0"
-  minimum_renderer_version: "1.0.0"
+  version: "1.1.0"
+  minimum_renderer_version: "2.0.0"
 
 registry:
   id: roadmap-items

--- a/docs/roadmap/generated/MANIFEST.json
+++ b/docs/roadmap/generated/MANIFEST.json
@@ -32,15 +32,15 @@
   "outputs": [
     {
       "path": "docs/roadmap/generated/ROADMAP_SUMMARY.md",
-      "sha256": "dccb26838a6025400f251ccfe7fa1f4d20032e7cce46d6a8563973ee438bbcb8"
+      "sha256": "09b7afc05741a8a6f4bbc866cf3d759e86a0a66b63e1338c934f663418dcfdcc"
     },
     {
       "path": "docs/roadmap/generated/roadmap-register.md",
-      "sha256": "85db1224ed6fb92fe89fecd41eb3b69eeb9f49ccc6935f465ba0fe8963e2728c"
+      "sha256": "0c0f17181c69f61ad3ab9fbff6c4b9f68fd9a4abf37040e4c2a04a7b1250a40b"
     },
     {
       "path": "docs/status/ROADMAP_SUMMARY.md",
-      "sha256": "dccb26838a6025400f251ccfe7fa1f4d20032e7cce46d6a8563973ee438bbcb8"
+      "sha256": "09b7afc05741a8a6f4bbc866cf3d759e86a0a66b63e1338c934f663418dcfdcc"
     }
   ],
   "schema": {

--- a/docs/roadmap/generated/MANIFEST.json
+++ b/docs/roadmap/generated/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "generator": {
     "name": "build/scripts/docs/render-roadmap-docs.py",
-    "version": "1.0.0"
+    "version": "2.0.0"
   },
   "inputs": [
     {
@@ -22,7 +22,7 @@
     },
     {
       "path": "docs/roadmap/data/roadmap-items.yml",
-      "sha256": "b9ad0616b7fc060c1d2966115a533ec4ad75f7e126ad0bde5d9a2735f4eefd95"
+      "sha256": "1212ad7ef5a4d827aeb1eb0f8dfc6cecfa3b8dd31b14af97efaea2bf38b328c0"
     },
     {
       "path": "docs/roadmap/data/stage-gates.yml",
@@ -32,15 +32,15 @@
   "outputs": [
     {
       "path": "docs/roadmap/generated/ROADMAP_SUMMARY.md",
-      "sha256": "09b7afc05741a8a6f4bbc866cf3d759e86a0a66b63e1338c934f663418dcfdcc"
+      "sha256": "1ee6c32864af0495d9157550e985e797f42c7443c2cd3c4693adcec14d6ecfe8"
     },
     {
       "path": "docs/roadmap/generated/roadmap-register.md",
-      "sha256": "0c0f17181c69f61ad3ab9fbff6c4b9f68fd9a4abf37040e4c2a04a7b1250a40b"
+      "sha256": "8db06116e6160f869500f0deb51cb237e5d66923a73a1d5a2486f5d0a3cc01a3"
     },
     {
       "path": "docs/status/ROADMAP_SUMMARY.md",
-      "sha256": "09b7afc05741a8a6f4bbc866cf3d759e86a0a66b63e1338c934f663418dcfdcc"
+      "sha256": "1ee6c32864af0495d9157550e985e797f42c7443c2cd3c4693adcec14d6ecfe8"
     }
   ],
   "schema": {

--- a/docs/roadmap/generated/ROADMAP_SUMMARY.md
+++ b/docs/roadmap/generated/ROADMAP_SUMMARY.md
@@ -1,11 +1,11 @@
 <!--
 generated: true
 generator: build/scripts/docs/render-roadmap-docs.py
-generator_version: 1.0.0
+generator_version: 2.0.0
 render_contract: meridian.generated-docs.v1
 schema_versions:
   - meridian.program-state@1.0.0
-  - meridian.roadmap-items@1.0.0
+  - meridian.roadmap-items@1.1.0
 inputs:
   - docs/roadmap/data/decision-log.yml
   - docs/roadmap/data/document-index.yml

--- a/docs/roadmap/generated/ROADMAP_SUMMARY.md
+++ b/docs/roadmap/generated/ROADMAP_SUMMARY.md
@@ -40,13 +40,13 @@ Snapshot date: 2026-07-28
 | W7-LIVE-001 | Live-readiness governance | done | green | medium | Accounting and Ledger |
 | W8-UX-CONSOL-001 | Browser workstation screen consolidation | in_progress | on_track | medium | Workstation Shell and UX |
 | W8-WPF-PARITY-001 | WPF desktop workstation reactivation and web-UI parity | in_progress | on_track | high | Desktop Workstation |
-| W9-ALPACA-004 | Alpaca fill streaming into order and ledger state | planned | green | high | Execution and Fund Accounts |
-| W9-ASSET-010 | Asset Accounting Event Spine and atomic lot posting | done | green | critical | Accounting and Ledger |
+| W9-TRUTH-001 | Loud fail-closed handling of simulated data and in-memory persistence | planned | green | critical | Data Confidence and Validation |
 | W9-DEMO-002 | One-command seeded demo with durable storage | planned | green | critical | Workstation Shell and UX |
+| W9-PAPER-003 | Paper-trading realism with limit/stop matching and costs | planned | green | critical | Execution and Fund Accounts |
+| W9-ALPACA-004 | Alpaca fill streaming into order and ledger state | planned | green | high | Execution and Fund Accounts |
+| W9-REPORT-005 | Client-grade PDF/XLSX exports and partners-capital statement | planned | green | high | Accounting and Ledger |
+| W9-NAV-006 | Unitized NAV and real fee, waterfall, and capital-call economics | planned | green | high | Accounting and Ledger |
+| W9-SAFETY-007 | Kill-switch cancel-all and fat-finger, notional, and collar rules | planned | green | high | Execution and Fund Accounts |
 | W9-GOV-008 | Route-level authorization, fail-closed tenancy, and hash-chained accounting audit | planned | green | high | Platform Security and Governance |
 | W9-INGEST-009 | Institutional file ingestion (camt.053/BAI2) and sided reconciliation matcher | planned | green | high | Accounting and Ledger |
-| W9-NAV-006 | Unitized NAV and real fee, waterfall, and capital-call economics | planned | green | high | Accounting and Ledger |
-| W9-PAPER-003 | Paper-trading realism with limit/stop matching and costs | planned | green | critical | Execution and Fund Accounts |
-| W9-REPORT-005 | Client-grade PDF/XLSX exports and partners-capital statement | planned | green | high | Accounting and Ledger |
-| W9-SAFETY-007 | Kill-switch cancel-all and fat-finger, notional, and collar rules | planned | green | high | Execution and Fund Accounts |
-| W9-TRUTH-001 | Loud fail-closed handling of simulated data and in-memory persistence | planned | green | critical | Data Confidence and Validation |
+| W9-ASSET-010 | Asset Accounting Event Spine and atomic lot posting | done | green | critical | Accounting and Ledger |

--- a/docs/roadmap/generated/roadmap-register.md
+++ b/docs/roadmap/generated/roadmap-register.md
@@ -550,64 +550,36 @@ Reactivated 2026-07-06. The WPF desktop workstation returns to the active produc
 - `SRC-UI-DASHBOARD`
 - `SRC-CONTRACTS`
 
-## W9-ALPACA-004 - Alpaca fill streaming into order and ledger state
+## W9-TRUTH-001 - Loud fail-closed handling of simulated data and in-memory persistence
 | Field | Value |
 | --- | --- |
 | Wave | W9 |
 | Status | planned |
 | Health | green |
-| Priority | high |
-| Owner lane | Execution and Fund Accounts |
+| Priority | critical |
+| Owner lane | Data Confidence and Validation |
 | Evidence posture | planned_evidence |
 | Last reviewed | 2026-07-21 |
 
 ### Current Summary
 
-Rank 4 of the 2026-07 first-order improvement slate. Alpaca is the only turnkey live venue and its order feedback loop is broken; trade-update and fill events must stream back into order lifecycle state, positions, and the durable trade-fill posting path instead of relying on polling or manual refresh.
+Rank 1 of the 2026-07 first-order improvement slate. Fake-looking-real output is fatal for a prove-the-number product, so every simulated, sample, or synthetic surface must be loudly labeled and every in-memory or placeholder persistence selection must fail closed in supported production profiles, extending the PRD-000/PRD-005/PRD-007/PRD-012 posture in the production-readiness tracker.
 
 ### Exit Criteria
 
-- Alpaca trade-update and fill events stream into the execution gateway and drive order lifecycle state, including partial fills, cancels, and rejects, without polling.
-- Streamed fills flow into the existing durable trade-fill posting and ledger handoff path.
-- Reconnect recovery backfills fills missed during a disconnect, with tests covering duplicate and out-of-order delivery.
+- Every simulated, sample, or synthetic data surface renders a persistent operator-visible simulation label in both the browser and WPF workstations.
+- Supported production profiles refuse startup when an in-memory, null, no-op, or placeholder persistence implementation is selected for a durable role, with startup rejection tests per prohibited binding.
+- Non-production adapters carry an explicit non-production marker and registration guards keep them out of production composition with focused test coverage.
+- No figure derived from simulated or seeded data can enter ledger, reconciliation, report-pack, or promotion evidence without a blocking simulation provenance mark.
 
 ### Source Modules
 
-- `SRC-EXECUTION`
-- `SRC-INFRASTRUCTURE`
+- `SRC-HOST`
 - `SRC-APP`
-
-## W9-ASSET-010 - Asset Accounting Event Spine and atomic lot posting
-| Field | Value |
-| --- | --- |
-| Wave | W9 |
-| Status | done |
-| Health | green |
-| Priority | critical |
-| Owner lane | Accounting and Ledger |
-| Evidence posture | complete |
-| Last reviewed | 2026-07-28 |
-
-### Current Summary
-
-Completed 2026-07-28. One evidence-backed Asset Accounting Event Spine covers acquisition, capitalization, valuation, income, corporate action, impairment, depreciation/amortization, and disposal, resolving Security Master identity, versioned book position, ledger book, period, accounting basis, promoted rule pack, projection lineage, and complete typed retained evidence before candidate drafting. Expected, Projected, Drafted, Approved, Posted, Reconciled, and Reported remain distinct lifecycle states; only a retained immutable journal establishes Posted impact. Acquisition lot creation and versioned selected-lot disposal share one idempotent serializable journal-plus-lot transaction, and readiness and UI projections fail closed when retained evidence identity, hash, source, review, effective-date, version, or scope is incomplete. Focused contract, spine, storage, endpoint, shared-read-model, and readiness suites are green ahead of the authoritative GitHub Actions quality gate.
-
-### Exit Criteria
-
-- All eight canonical asset accounting event kinds resolve Security Master identity, authoritative book position and version, ledger book, period and version, accounting basis, promoted rule pack, projection lineage, and complete retained evidence before candidate drafting.
-- Lifecycle contracts and shared read models never collapse Expected or Projected into a candidate, Approved into Posted, or Reported into Published; journal impact is absent unless an immutable journal id, ledger book, period, balanced amounts, currency, and Posted status are retained.
-- Acquisition creates its lot with the journal, and disposal consumes explicitly selected lot ids and expected versions with retained selection evidence, relief policy, before/after snapshots, correction lineage, and replay-safe fingerprints in one database transaction.
-- Production-readiness flags, service or endpoint availability, navigation links, legacy full tokens, and synthesized obligations cannot substitute for complete typed retained evidence.
-- Focused contract, spine, storage, endpoint, shared-read-model, and readiness tests pass before the full repository CI and GitHub Actions authority gates.
-
-### Source Modules
-
-- `SRC-CONTRACTS`
-- `SRC-DESIGN-INSTRUMENTS`
-- `SRC-DESIGN-FINANCIAL-OPERATIONS`
-- `SRC-LEDGER`
 - `SRC-STORAGE`
 - `SRC-UI-SHARED`
+- `SRC-UI-DASHBOARD`
+- `SRC-WPF`
 
 ## W9-DEMO-002 - One-command seeded demo with durable storage
 | Field | Value |
@@ -637,6 +609,148 @@ Rank 2 of the 2026-07 first-order improvement slate. The first evaluation hour c
 - `SRC-APP`
 - `SRC-STORAGE`
 - `SRC-UI-DASHBOARD`
+
+## W9-PAPER-003 - Paper-trading realism with limit/stop matching and costs
+| Field | Value |
+| --- | --- |
+| Wave | W9 |
+| Status | planned |
+| Health | green |
+| Priority | critical |
+| Owner lane | Execution and Fund Accounts |
+| Evidence posture | planned_evidence |
+| Last reviewed | 2026-07-21 |
+
+### Current Summary
+
+Rank 3 of the 2026-07 first-order improvement slate. The promotion gate currently launders overfit strategies because paper fills ignore limit/stop semantics and trading costs and can print placeholder prices; paper evidence must stop overstating live viability before it feeds promotion review.
+
+### Exit Criteria
+
+- Paper matching honors order-type semantics - limit orders fill only at or better than the limit price, stops trigger per a documented trade/quote policy, and market orders fill from observed market data, never at placeholder prices such as one dollar.
+- Commission, fee, slippage, and spread cost models apply to every paper fill and are visible in paper-session economics.
+- A regression suite proves no paper fill can occur at a price outside the observed market-data envelope for the bar or tick in effect.
+- Promotion evidence records the matching and cost model version used by the paper session it cites.
+
+### Source Modules
+
+- `SRC-EXECUTION`
+- `SRC-APP`
+- `SRC-STRATEGIES`
+- `SRC-CONTRACTS`
+
+## W9-ALPACA-004 - Alpaca fill streaming into order and ledger state
+| Field | Value |
+| --- | --- |
+| Wave | W9 |
+| Status | planned |
+| Health | green |
+| Priority | high |
+| Owner lane | Execution and Fund Accounts |
+| Evidence posture | planned_evidence |
+| Last reviewed | 2026-07-21 |
+
+### Current Summary
+
+Rank 4 of the 2026-07 first-order improvement slate. Alpaca is the only turnkey live venue and its order feedback loop is broken; trade-update and fill events must stream back into order lifecycle state, positions, and the durable trade-fill posting path instead of relying on polling or manual refresh.
+
+### Exit Criteria
+
+- Alpaca trade-update and fill events stream into the execution gateway and drive order lifecycle state, including partial fills, cancels, and rejects, without polling.
+- Streamed fills flow into the existing durable trade-fill posting and ledger handoff path.
+- Reconnect recovery backfills fills missed during a disconnect, with tests covering duplicate and out-of-order delivery.
+
+### Source Modules
+
+- `SRC-EXECUTION`
+- `SRC-INFRASTRUCTURE`
+- `SRC-APP`
+
+## W9-REPORT-005 - Client-grade PDF/XLSX exports and partners-capital statement
+| Field | Value |
+| --- | --- |
+| Wave | W9 |
+| Status | planned |
+| Health | green |
+| Priority | high |
+| Owner lane | Accounting and Ledger |
+| Evidence posture | planned_evidence |
+| Last reviewed | 2026-07-21 |
+
+### Current Summary
+
+Rank 5 of the 2026-07 first-order improvement slate. Ops teams currently re-type every deliverable into Excel; governed report packs must export client-presentable PDF and XLSX artifacts, including a partners-capital statement, so the governed output is the deliverable rather than an input to manual reformatting.
+
+### Exit Criteria
+
+- Governed report packs export deterministic client-presentable PDF and XLSX artifacts with retained hash and provenance manifests.
+- A partners-capital statement covering opening balance, contributions, distributions, income/expense/gain allocations, fees, and closing balance renders per partner and per period from ledger-backed data.
+- Exported artifacts carry the same approval and provenance evidence chain as existing report-pack outputs.
+
+### Source Modules
+
+- `SRC-DESIGN-REPORTING`
+- `SRC-LEDGER`
+- `SRC-CONTRACTS`
+- `SRC-UI-SHARED`
+
+## W9-NAV-006 - Unitized NAV and real fee, waterfall, and capital-call economics
+| Field | Value |
+| --- | --- |
+| Wave | W9 |
+| Status | planned |
+| Health | green |
+| Priority | high |
+| Owner lane | Accounting and Ledger |
+| Evidence posture | planned_evidence |
+| Last reviewed | 2026-07-21 |
+
+### Current Summary
+
+Rank 6 of the 2026-07 first-order improvement slate. The hard math a fund accountant needs still lives in Excel; unitized NAV series, fee accruals with hurdles and crystallization, distribution waterfalls, and capital-call and commitment tracking must become ledger-backed first-class calculations.
+
+### Exit Criteria
+
+- Unitized NAV per share class is computed from ledger-backed valuations with an auditable calculation trail and restatement support.
+- Management fee, performance fee or carried interest with hurdle, high-water mark, and crystallization treatment, and expense accruals post governed ledger entries.
+- Distribution waterfall and capital-call or commitment schedules compute from capital-account records and reconcile to the partners-capital statement delivered by W9-REPORT-005.
+- Golden-file tests cover the calculation kernels against worked examples.
+
+### Source Modules
+
+- `SRC-LEDGER`
+- `SRC-FSHARP-LEDGER`
+- `SRC-DESIGN-FINANCIAL-OPERATIONS`
+- `SRC-CONTRACTS`
+
+## W9-SAFETY-007 - Kill-switch cancel-all and fat-finger, notional, and collar rules
+| Field | Value |
+| --- | --- |
+| Wave | W9 |
+| Status | planned |
+| Health | green |
+| Priority | high |
+| Owner lane | Execution and Fund Accounts |
+| Evidence posture | planned_evidence |
+| Last reviewed | 2026-07-21 |
+
+### Current Summary
+
+Rank 7 of the 2026-07 first-order improvement slate. Safety surfaces must never overpromise; the kill switch must actually cancel all open orders and halt routing, pre-trade rules must cover fat-finger, max-notional, and price-collar checks, and WPF safety buttons must be wired to the real shared controls or visibly demoted.
+
+### Exit Criteria
+
+- Kill-switch activation cancels all open orders across gateways, blocks new order submission, and persists breaker state fail-closed across restart.
+- Pre-trade risk includes fat-finger quantity and price-deviation, max-notional, and price-collar rules enforced by the single mandatory production risk validator.
+- Every WPF and browser safety control either invokes the real shared execution-control service or is disabled with an explicit not-wired state, leaving no dead safety buttons.
+- Activation, failure, and override events append to the execution audit trail.
+
+### Source Modules
+
+- `SRC-EXECUTION`
+- `SRC-RISK`
+- `SRC-WPF`
+- `SRC-UI-SHARED`
 
 ## W9-GOV-008 - Route-level authorization, fail-closed tenancy, and hash-chained accounting audit
 | Field | Value |
@@ -696,148 +810,34 @@ Rank 9 of the 2026-07 first-order improvement slate. Reconciliation value is cap
 - `SRC-CONTRACTS`
 - `SRC-UI-SHARED`
 
-## W9-NAV-006 - Unitized NAV and real fee, waterfall, and capital-call economics
+## W9-ASSET-010 - Asset Accounting Event Spine and atomic lot posting
 | Field | Value |
 | --- | --- |
 | Wave | W9 |
-| Status | planned |
+| Status | done |
 | Health | green |
-| Priority | high |
+| Priority | critical |
 | Owner lane | Accounting and Ledger |
-| Evidence posture | planned_evidence |
-| Last reviewed | 2026-07-21 |
+| Evidence posture | complete |
+| Last reviewed | 2026-07-28 |
 
 ### Current Summary
 
-Rank 6 of the 2026-07 first-order improvement slate. The hard math a fund accountant needs still lives in Excel; unitized NAV series, fee accruals with hurdles and crystallization, distribution waterfalls, and capital-call and commitment tracking must become ledger-backed first-class calculations.
+Completed 2026-07-28. One evidence-backed Asset Accounting Event Spine covers acquisition, capitalization, valuation, income, corporate action, impairment, depreciation/amortization, and disposal, resolving Security Master identity, versioned book position, ledger book, period, accounting basis, promoted rule pack, projection lineage, and complete typed retained evidence before candidate drafting. Expected, Projected, Drafted, Approved, Posted, Reconciled, and Reported remain distinct lifecycle states; only a retained immutable journal establishes Posted impact. Acquisition lot creation and versioned selected-lot disposal share one idempotent serializable journal-plus-lot transaction, and readiness and UI projections fail closed when retained evidence identity, hash, source, review, effective-date, version, or scope is incomplete. Focused contract, spine, storage, endpoint, shared-read-model, and readiness suites are green ahead of the authoritative GitHub Actions quality gate.
 
 ### Exit Criteria
 
-- Unitized NAV per share class is computed from ledger-backed valuations with an auditable calculation trail and restatement support.
-- Management fee, performance fee or carried interest with hurdle, high-water mark, and crystallization treatment, and expense accruals post governed ledger entries.
-- Distribution waterfall and capital-call or commitment schedules compute from capital-account records and reconcile to the partners-capital statement delivered by W9-REPORT-005.
-- Golden-file tests cover the calculation kernels against worked examples.
+- All eight canonical asset accounting event kinds resolve Security Master identity, authoritative book position and version, ledger book, period and version, accounting basis, promoted rule pack, projection lineage, and complete retained evidence before candidate drafting.
+- Lifecycle contracts and shared read models never collapse Expected or Projected into a candidate, Approved into Posted, or Reported into Published; journal impact is absent unless an immutable journal id, ledger book, period, balanced amounts, currency, and Posted status are retained.
+- Acquisition creates its lot with the journal, and disposal consumes explicitly selected lot ids and expected versions with retained selection evidence, relief policy, before/after snapshots, correction lineage, and replay-safe fingerprints in one database transaction.
+- Production-readiness flags, service or endpoint availability, navigation links, legacy full tokens, and synthesized obligations cannot substitute for complete typed retained evidence.
+- Focused contract, spine, storage, endpoint, shared-read-model, and readiness tests pass before the full repository CI and GitHub Actions authority gates.
 
 ### Source Modules
 
-- `SRC-LEDGER`
-- `SRC-FSHARP-LEDGER`
+- `SRC-CONTRACTS`
+- `SRC-DESIGN-INSTRUMENTS`
 - `SRC-DESIGN-FINANCIAL-OPERATIONS`
-- `SRC-CONTRACTS`
-
-## W9-PAPER-003 - Paper-trading realism with limit/stop matching and costs
-| Field | Value |
-| --- | --- |
-| Wave | W9 |
-| Status | planned |
-| Health | green |
-| Priority | critical |
-| Owner lane | Execution and Fund Accounts |
-| Evidence posture | planned_evidence |
-| Last reviewed | 2026-07-21 |
-
-### Current Summary
-
-Rank 3 of the 2026-07 first-order improvement slate. The promotion gate currently launders overfit strategies because paper fills ignore limit/stop semantics and trading costs and can print placeholder prices; paper evidence must stop overstating live viability before it feeds promotion review.
-
-### Exit Criteria
-
-- Paper matching honors order-type semantics - limit orders fill only at or better than the limit price, stops trigger per a documented trade/quote policy, and market orders fill from observed market data, never at placeholder prices such as one dollar.
-- Commission, fee, slippage, and spread cost models apply to every paper fill and are visible in paper-session economics.
-- A regression suite proves no paper fill can occur at a price outside the observed market-data envelope for the bar or tick in effect.
-- Promotion evidence records the matching and cost model version used by the paper session it cites.
-
-### Source Modules
-
-- `SRC-EXECUTION`
-- `SRC-APP`
-- `SRC-STRATEGIES`
-- `SRC-CONTRACTS`
-
-## W9-REPORT-005 - Client-grade PDF/XLSX exports and partners-capital statement
-| Field | Value |
-| --- | --- |
-| Wave | W9 |
-| Status | planned |
-| Health | green |
-| Priority | high |
-| Owner lane | Accounting and Ledger |
-| Evidence posture | planned_evidence |
-| Last reviewed | 2026-07-21 |
-
-### Current Summary
-
-Rank 5 of the 2026-07 first-order improvement slate. Ops teams currently re-type every deliverable into Excel; governed report packs must export client-presentable PDF and XLSX artifacts, including a partners-capital statement, so the governed output is the deliverable rather than an input to manual reformatting.
-
-### Exit Criteria
-
-- Governed report packs export deterministic client-presentable PDF and XLSX artifacts with retained hash and provenance manifests.
-- A partners-capital statement covering opening balance, contributions, distributions, income/expense/gain allocations, fees, and closing balance renders per partner and per period from ledger-backed data.
-- Exported artifacts carry the same approval and provenance evidence chain as existing report-pack outputs.
-
-### Source Modules
-
-- `SRC-DESIGN-REPORTING`
 - `SRC-LEDGER`
-- `SRC-CONTRACTS`
-- `SRC-UI-SHARED`
-
-## W9-SAFETY-007 - Kill-switch cancel-all and fat-finger, notional, and collar rules
-| Field | Value |
-| --- | --- |
-| Wave | W9 |
-| Status | planned |
-| Health | green |
-| Priority | high |
-| Owner lane | Execution and Fund Accounts |
-| Evidence posture | planned_evidence |
-| Last reviewed | 2026-07-21 |
-
-### Current Summary
-
-Rank 7 of the 2026-07 first-order improvement slate. Safety surfaces must never overpromise; the kill switch must actually cancel all open orders and halt routing, pre-trade rules must cover fat-finger, max-notional, and price-collar checks, and WPF safety buttons must be wired to the real shared controls or visibly demoted.
-
-### Exit Criteria
-
-- Kill-switch activation cancels all open orders across gateways, blocks new order submission, and persists breaker state fail-closed across restart.
-- Pre-trade risk includes fat-finger quantity and price-deviation, max-notional, and price-collar rules enforced by the single mandatory production risk validator.
-- Every WPF and browser safety control either invokes the real shared execution-control service or is disabled with an explicit not-wired state, leaving no dead safety buttons.
-- Activation, failure, and override events append to the execution audit trail.
-
-### Source Modules
-
-- `SRC-EXECUTION`
-- `SRC-RISK`
-- `SRC-WPF`
-- `SRC-UI-SHARED`
-
-## W9-TRUTH-001 - Loud fail-closed handling of simulated data and in-memory persistence
-| Field | Value |
-| --- | --- |
-| Wave | W9 |
-| Status | planned |
-| Health | green |
-| Priority | critical |
-| Owner lane | Data Confidence and Validation |
-| Evidence posture | planned_evidence |
-| Last reviewed | 2026-07-21 |
-
-### Current Summary
-
-Rank 1 of the 2026-07 first-order improvement slate. Fake-looking-real output is fatal for a prove-the-number product, so every simulated, sample, or synthetic surface must be loudly labeled and every in-memory or placeholder persistence selection must fail closed in supported production profiles, extending the PRD-000/PRD-005/PRD-007/PRD-012 posture in the production-readiness tracker.
-
-### Exit Criteria
-
-- Every simulated, sample, or synthetic data surface renders a persistent operator-visible simulation label in both the browser and WPF workstations.
-- Supported production profiles refuse startup when an in-memory, null, no-op, or placeholder persistence implementation is selected for a durable role, with startup rejection tests per prohibited binding.
-- Non-production adapters carry an explicit non-production marker and registration guards keep them out of production composition with focused test coverage.
-- No figure derived from simulated or seeded data can enter ledger, reconciliation, report-pack, or promotion evidence without a blocking simulation provenance mark.
-
-### Source Modules
-
-- `SRC-HOST`
-- `SRC-APP`
 - `SRC-STORAGE`
 - `SRC-UI-SHARED`
-- `SRC-UI-DASHBOARD`
-- `SRC-WPF`

--- a/docs/roadmap/generated/roadmap-register.md
+++ b/docs/roadmap/generated/roadmap-register.md
@@ -1,10 +1,10 @@
 <!--
 generated: true
 generator: build/scripts/docs/render-roadmap-docs.py
-generator_version: 1.0.0
+generator_version: 2.0.0
 render_contract: meridian.generated-docs.v1
 schema_versions:
-  - meridian.roadmap-items@1.0.0
+  - meridian.roadmap-items@1.1.0
 inputs:
   - docs/roadmap/data/decision-log.yml
   - docs/roadmap/data/document-index.yml

--- a/docs/roadmap/roadmap-item-template.md
+++ b/docs/roadmap/roadmap-item-template.md
@@ -40,6 +40,7 @@ Setting it on a row is an ordinary data update. `sequence` must be an integer of
 validation rejects anything else rather than letting a generated view order itself against the
 adopted rank.
 
-The optional field was introduced as a single minor schema change, and the registry's declared
-`schema.version` was bumped once when the first row started using it. Neither happens again per row;
-see [schema-versioning.md](schema-versioning.md).
+Introducing the optional field was a one-time minor schema change, so the registry now declares
+`meridian.roadmap-items@1.1.0` whether or not any row sets `sequence` — the contract changed the
+moment the property became accepted. Setting it on a row afterwards is an ordinary data update and
+bumps nothing. See [schema-versioning.md](schema-versioning.md).

--- a/docs/roadmap/roadmap-item-template.md
+++ b/docs/roadmap/roadmap-item-template.md
@@ -30,8 +30,16 @@ Checklist items should name implementation evidence, validation commands, and us
 
 ## Ordering within a wave
 
-Generated views order a wave by `sequence` when items declare it, and otherwise by the identifier's
-trailing number. Set `sequence` whenever a wave's adopted order is not the order its identifiers
-imply — for example a wave that numbers per area, where every row ends in `001` and the trailing
-number carries no rank. Adding it to any item in a wave is a minor schema change; see
-[schema-versioning.md](schema-versioning.md).
+Every generated roadmap view — the Mermaid diagram, `ROADMAP_SUMMARY.md`, and `roadmap-register.md`
+— shares one ordering: wave first, then rank within the wave. Rank comes from `sequence` when an
+item declares it, and otherwise from the identifier's trailing number.
+
+Set `sequence` whenever a wave's adopted order is not the order its identifiers imply — for example
+a wave that numbers per area, where every row ends in `001` and the trailing number carries no rank.
+Setting it on a row is an ordinary data update. `sequence` must be an integer of 1 or greater;
+validation rejects anything else rather than letting a generated view order itself against the
+adopted rank.
+
+The optional field was introduced as a single minor schema change, and the registry's declared
+`schema.version` was bumped once when the first row started using it. Neither happens again per row;
+see [schema-versioning.md](schema-versioning.md).

--- a/docs/roadmap/roadmap-item-template.md
+++ b/docs/roadmap/roadmap-item-template.md
@@ -6,6 +6,7 @@ Use this template when adding a roadmap item to `docs/roadmap/data/roadmap-items
 - id: W<wave>-<AREA>-<number>
   title: Plain English outcome
   wave: W<wave>
+  sequence: 1  # optional; rank within the wave for generated views
   stage_gates:
     - StageGateId
   workspace:
@@ -26,3 +27,11 @@ Use this template when adding a roadmap item to `docs/roadmap/data/roadmap-items
 ```
 
 Checklist items should name implementation evidence, validation commands, and user value. Avoid generic "finish feature" wording.
+
+## Ordering within a wave
+
+Generated views order a wave by `sequence` when items declare it, and otherwise by the identifier's
+trailing number. Set `sequence` whenever a wave's adopted order is not the order its identifiers
+imply — for example a wave that numbers per area, where every row ends in `001` and the trailing
+number carries no rank. Adding it to any item in a wave is a minor schema change; see
+[schema-versioning.md](schema-versioning.md).

--- a/docs/roadmap/schemas/roadmap-items.v1.schema.json
+++ b/docs/roadmap/schemas/roadmap-items.v1.schema.json
@@ -24,6 +24,7 @@
           "id": { "type": "string" },
           "title": { "type": "string" },
           "wave": { "type": "string" },
+          "sequence": { "type": "integer", "minimum": 1, "description": "Explicit rank within the wave for generated views. Optional; when absent, rank falls back to the identifier's trailing number." },
           "stage_gates": { "type": "array", "items": { "type": "string" } },
           "workspace": { "type": "array", "items": { "type": "string" } },
           "owner_lane": { "type": "string" },

--- a/docs/status/ROADMAP_SUMMARY.md
+++ b/docs/status/ROADMAP_SUMMARY.md
@@ -1,11 +1,11 @@
 <!--
 generated: true
 generator: build/scripts/docs/render-roadmap-docs.py
-generator_version: 1.0.0
+generator_version: 2.0.0
 render_contract: meridian.generated-docs.v1
 schema_versions:
   - meridian.program-state@1.0.0
-  - meridian.roadmap-items@1.0.0
+  - meridian.roadmap-items@1.1.0
 inputs:
   - docs/roadmap/data/decision-log.yml
   - docs/roadmap/data/document-index.yml

--- a/docs/status/ROADMAP_SUMMARY.md
+++ b/docs/status/ROADMAP_SUMMARY.md
@@ -40,13 +40,13 @@ Snapshot date: 2026-07-28
 | W7-LIVE-001 | Live-readiness governance | done | green | medium | Accounting and Ledger |
 | W8-UX-CONSOL-001 | Browser workstation screen consolidation | in_progress | on_track | medium | Workstation Shell and UX |
 | W8-WPF-PARITY-001 | WPF desktop workstation reactivation and web-UI parity | in_progress | on_track | high | Desktop Workstation |
-| W9-ALPACA-004 | Alpaca fill streaming into order and ledger state | planned | green | high | Execution and Fund Accounts |
-| W9-ASSET-010 | Asset Accounting Event Spine and atomic lot posting | done | green | critical | Accounting and Ledger |
+| W9-TRUTH-001 | Loud fail-closed handling of simulated data and in-memory persistence | planned | green | critical | Data Confidence and Validation |
 | W9-DEMO-002 | One-command seeded demo with durable storage | planned | green | critical | Workstation Shell and UX |
+| W9-PAPER-003 | Paper-trading realism with limit/stop matching and costs | planned | green | critical | Execution and Fund Accounts |
+| W9-ALPACA-004 | Alpaca fill streaming into order and ledger state | planned | green | high | Execution and Fund Accounts |
+| W9-REPORT-005 | Client-grade PDF/XLSX exports and partners-capital statement | planned | green | high | Accounting and Ledger |
+| W9-NAV-006 | Unitized NAV and real fee, waterfall, and capital-call economics | planned | green | high | Accounting and Ledger |
+| W9-SAFETY-007 | Kill-switch cancel-all and fat-finger, notional, and collar rules | planned | green | high | Execution and Fund Accounts |
 | W9-GOV-008 | Route-level authorization, fail-closed tenancy, and hash-chained accounting audit | planned | green | high | Platform Security and Governance |
 | W9-INGEST-009 | Institutional file ingestion (camt.053/BAI2) and sided reconciliation matcher | planned | green | high | Accounting and Ledger |
-| W9-NAV-006 | Unitized NAV and real fee, waterfall, and capital-call economics | planned | green | high | Accounting and Ledger |
-| W9-PAPER-003 | Paper-trading realism with limit/stop matching and costs | planned | green | critical | Execution and Fund Accounts |
-| W9-REPORT-005 | Client-grade PDF/XLSX exports and partners-capital statement | planned | green | high | Accounting and Ledger |
-| W9-SAFETY-007 | Kill-switch cancel-all and fat-finger, notional, and collar rules | planned | green | high | Execution and Fund Accounts |
-| W9-TRUTH-001 | Loud fail-closed handling of simulated data and in-memory persistence | planned | green | critical | Data Confidence and Validation |
+| W9-ASSET-010 | Asset Accounting Event Spine and atomic lot posting | done | green | critical | Accounting and Ledger |

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,11 +1,11 @@
 {
   "total_files": 637,
-  "total_lines": 115259,
+  "total_lines": 115267,
   "orphaned_count": 257,
   "no_heading_count": 148,
   "stale_count": 0,
   "todo_count": 218,
-  "average_lines": 180.9,
+  "average_lines": 181.0,
   "health_score": 79,
   "orphaned_files": [
     ".agents/skills/meridian-archive-organizer/SKILL.md",
@@ -3324,7 +3324,7 @@
     },
     {
       "path": "docs/roadmap/roadmap-item-template.md",
-      "line_count": 37,
+      "line_count": 45,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,7 +1,7 @@
 {
   "total_files": 637,
-  "total_lines": 115250,
-  "orphaned_count": 258,
+  "total_lines": 115259,
+  "orphaned_count": 257,
   "no_heading_count": 148,
   "stale_count": 0,
   "todo_count": 218,
@@ -231,7 +231,6 @@
     "docs/roadmap/generated-doc-policy.md",
     "docs/roadmap/roadmap-governance.md",
     "docs/roadmap/roadmap-item-template.md",
-    "docs/roadmap/schema-versioning.md",
     "docs/roadmap/status-taxonomy.md",
     "docs/security/buyer-packet/architecture-summary.md",
     "docs/security/buyer-packet/control-mapping.md",
@@ -3325,7 +3324,7 @@
     },
     {
       "path": "docs/roadmap/roadmap-item-template.md",
-      "line_count": 28,
+      "line_count": 37,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 637,
-  "total_lines": 115267,
+  "total_lines": 115268,
   "orphaned_count": 257,
   "no_heading_count": 148,
   "stale_count": 0,
@@ -3324,7 +3324,7 @@
     },
     {
       "path": "docs/roadmap/roadmap-item-template.md",
-      "line_count": 45,
+      "line_count": 46,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,9 +20,9 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 637 |
-| Total lines | 115,250 |
+| Total lines | 115,259 |
 | Average file size (lines) | 180.9 |
-| Orphaned files | 258 |
+| Orphaned files | 257 |
 | Files without headings | 148 |
 | Stale files (>90 days) | 0 |
 | TODO/FIXME markers | 218 |
@@ -85,7 +85,7 @@ These files are not linked from any other Markdown file in the repository:
 - `.agents/skills/meridian-simulated-user-panel/evals/golden/eval-06-provider-health-usability-lab.md`
 - `.agents/skills/meridian-simulated-user-panel/references/artifact-bundles.md`
 - `.agents/skills/meridian-simulated-user-panel/references/personas.md`
-- ... and 238 more
+- ... and 237 more
 
 ## Trend
 
@@ -93,7 +93,7 @@ These files are not linked from any other Markdown file in the repository:
 
 | Date | Score | Files | Orphans | Stale |
 | ------ | ------- | ------- | --------- | ------- |
-| 1970-01-01 | 79 | 637 | 258 | 0 |
+| 1970-01-01 | 79 | 637 | 257 | 0 |
 
 ---
 

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,8 +20,8 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 637 |
-| Total lines | 115,259 |
-| Average file size (lines) | 180.9 |
+| Total lines | 115,267 |
+| Average file size (lines) | 181.0 |
 | Orphaned files | 257 |
 | Files without headings | 148 |
 | Stale files (>90 days) | 0 |

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 637 |
-| Total lines | 115,267 |
+| Total lines | 115,268 |
 | Average file size (lines) | 181.0 |
 | Orphaned files | 257 |
 | Files without headings | 148 |

--- a/tests/scripts/test_render_roadmap_diagrams.py
+++ b/tests/scripts/test_render_roadmap_diagrams.py
@@ -28,19 +28,20 @@ items:
 """
 
 
-def _item(identifier: str, wave: str) -> str:
-    return (
+def _item(identifier: str, wave: str, sequence: int | None = None) -> str:
+    block = (
         f"  - id: {identifier}\n"
         f"    title: {identifier}\n"
         f"    wave: {wave}\n"
-        "    status: planned\n"
-        "    health: green\n"
     )
+    if sequence is not None:
+        block += f"    sequence: {sequence}\n"
+    return block + "    status: planned\n    health: green\n"
 
 
-def _registry(*entries: tuple[str, str]) -> str:
+def _registry(*entries: tuple[str, str] | tuple[str, str, int]) -> str:
     header = 'schema:\n  id: meridian.roadmap-items\n  version: "1.0.0"\nitems:\n'
-    return header + "".join(_item(identifier, wave) for identifier, wave in entries)
+    return header + "".join(_item(*entry) for entry in entries)
 
 
 class RenderRoadmapDiagramsTests(unittest.TestCase):
@@ -114,6 +115,48 @@ class RenderRoadmapDiagramsTests(unittest.TestCase):
         )
         self.assertEqual(
             ["W5_ACCT_001", "W5X_CONNECT_001", "W6_BTSTUDIO_001"],
+            self._node_order(diagram),
+        )
+
+    def test_explicit_sequence_orders_a_wave_that_numbers_per_area(self) -> None:
+        # W10 numbers per area, so every identifier ends in 001 and the trailing number carries no
+        # rank. Without an explicit sequence the tie falls through to an alphabetical area sort,
+        # which put rank-11 CONSOL first and drew an edge from it into rank-5 JRNL.
+        diagram = self._render(
+            _registry(
+                ("W10-CONSOL-001", "W10", 11),
+                ("W10-JRNL-001", "W10", 5),
+                ("W10-MARK-001", "W10", 1),
+                ("W10-PROV-001", "W10", 3),
+            )
+        )
+        self.assertEqual(
+            ["W10_MARK_001", "W10_PROV_001", "W10_JRNL_001", "W10_CONSOL_001"],
+            self._node_order(diagram),
+        )
+
+    def test_explicit_sequence_overrides_the_identifier_suffix(self) -> None:
+        diagram = self._render(
+            _registry(
+                ("W9-ASSET-010", "W9", 1),
+                ("W9-TRUTH-001", "W9", 2),
+            )
+        )
+        self.assertEqual(["W9_ASSET_010", "W9_TRUTH_001"], self._node_order(diagram))
+
+    def test_items_without_sequence_still_order_by_identifier_suffix(self) -> None:
+        # The field is optional, so waves that already encode rank in the suffix keep working and
+        # a wave may not be uniformly annotated. An unannotated item sorts on its suffix against
+        # an annotated neighbour's declared rank.
+        diagram = self._render(
+            _registry(
+                ("W9-ASSET-010", "W9"),
+                ("W9-DEMO-002", "W9", 20),
+                ("W9-TRUTH-001", "W9"),
+            )
+        )
+        self.assertEqual(
+            ["W9_TRUTH_001", "W9_ASSET_010", "W9_DEMO_002"],
             self._node_order(diagram),
         )
 

--- a/tests/scripts/test_roadmap_source_docs.py
+++ b/tests/scripts/test_roadmap_source_docs.py
@@ -75,6 +75,26 @@ class RoadmapSourceDocsTests(unittest.TestCase):
                     f"expected an invalid-sequence error for {declared!r}, got {[f.message for f in errors]}",
                 )
 
+    def test_wave_disagreeing_with_its_identifier_fails_registry_validation(self) -> None:
+        # The sort key parses the wave from the identifier while the diagram labels with the
+        # declared `wave`, so a mismatch would place an item among one wave's work while
+        # presenting it as another's.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = _registry_root(temp_dir, None)
+            items_path = root / "docs" / "roadmap" / "data" / "roadmap-items.yml"
+            text = items_path.read_text(encoding="utf-8")
+            items_path.write_text(
+                text.replace("  - id: W1-DATA-001\n    title: Provider trust gate and data confidence baseline\n    wave: W1\n",
+                             "  - id: W1-DATA-001\n    title: Provider trust gate and data confidence baseline\n    wave: W2\n", 1),
+                encoding="utf-8",
+            )
+            errors = [finding for finding in validate_roadmap.validate(root) if finding.severity == "error"]
+
+        self.assertTrue(
+            any("declares wave W2 but its identifier belongs to W1" in finding.message for finding in errors),
+            [finding.message for finding in errors],
+        )
+
     def test_generated_roadmap_views_share_one_ordering(self) -> None:
         # The diagram, summary, and register must not disagree about delivery sequence.
         items = [

--- a/tests/scripts/test_roadmap_source_docs.py
+++ b/tests/scripts/test_roadmap_source_docs.py
@@ -1,4 +1,5 @@
 import importlib.util
+import shutil
 import sys
 import tempfile
 import unittest
@@ -28,11 +29,68 @@ mark_stale = load_script("mark_stale_docs", ROOT / "build" / "scripts" / "docs" 
 common = load_script("docs_common", ROOT / "build" / "scripts" / "docs" / "common.py")
 
 
+def _registry_root(temp_dir: str, sequence_line: str | None) -> Path:
+    """Clone the real registries into a temp root, optionally injecting a sequence on one item."""
+    root = Path(temp_dir)
+    shutil.copytree(ROOT / "docs" / "roadmap" / "data", root / "docs" / "roadmap" / "data")
+    (root / "docs" / "source" / "data").mkdir(parents=True)
+    shutil.copy(
+        ROOT / "docs" / "source" / "data" / "source-modules.yml",
+        root / "docs" / "source" / "data" / "source-modules.yml",
+    )
+    if sequence_line is not None:
+        items_path = root / "docs" / "roadmap" / "data" / "roadmap-items.yml"
+        text = items_path.read_text(encoding="utf-8")
+        marker = "  - id: W1-DATA-001\n"
+        assert marker in text
+        items_path.write_text(text.replace(marker, marker + sequence_line, 1), encoding="utf-8")
+    return root
+
+
 class RoadmapSourceDocsTests(unittest.TestCase):
     def test_current_registries_validate(self) -> None:
         self.assertEqual([], [finding for finding in validate_roadmap.validate(ROOT) if finding.severity == "error"])
         self.assertEqual([], [finding for finding in validate_source.validate(ROOT) if finding.severity == "error"])
         self.assertEqual([], [finding for finding in scan_todos.validate(ROOT) if finding.severity == "error"])
+
+    def test_valid_sequence_passes_registry_validation(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = _registry_root(temp_dir, "    sequence: 3\n")
+            errors = [finding for finding in validate_roadmap.validate(root) if finding.severity == "error"]
+
+        self.assertEqual([], errors)
+
+    def test_out_of_range_or_wrong_typed_sequence_fails_registry_validation(self) -> None:
+        # The JSON Schema bounds sequence at integer >= 1 but nothing loads it, so without this
+        # check the renderers would silently fall back to the identifier suffix — ordering a
+        # generated view against its adopted rank while CI reported the data valid.
+        for declared in ("0", "-2", "abc", "1.5", "true"):
+            with self.subTest(sequence=declared):
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    root = _registry_root(temp_dir, f"    sequence: {declared}\n")
+                    errors = [finding for finding in validate_roadmap.validate(root) if finding.severity == "error"]
+
+                self.assertTrue(
+                    any("invalid sequence" in finding.message for finding in errors),
+                    f"expected an invalid-sequence error for {declared!r}, got {[f.message for f in errors]}",
+                )
+
+    def test_generated_roadmap_views_share_one_ordering(self) -> None:
+        # The diagram, summary, and register must not disagree about delivery sequence.
+        items = [
+            {"id": "W10-CONSOL-001", "sequence": 11},
+            {"id": "W2-TRD-001"},
+            {"id": "W10-MARK-001", "sequence": 1},
+            {"id": "W9-ASSET-010"},
+            {"id": "W9-TRUTH-001"},
+        ]
+
+        ordered = [item["id"] for item in sorted(items, key=common.roadmap_item_sort_key)]
+
+        self.assertEqual(
+            ["W2-TRD-001", "W9-TRUTH-001", "W9-ASSET-010", "W10-MARK-001", "W10-CONSOL-001"],
+            ordered,
+        )
 
     def test_generated_block_replacement_is_exact(self) -> None:
         original = "A\n<!-- begin -->\nold\n<!-- end -->\nB\n"


### PR DESCRIPTION
<!-- phase:PR6 -->

## Summary

Gives every generated roadmap view one ordering — wave first, then rank within the wave — and adds an optional integer `sequence` so a wave whose identifiers do not encode rank can declare it.

**Three defects, one root cause.** `diagram_sort_key` recovered rank from the identifier's trailing number, which only works for waves that encode rank there (`DEC-PRIORITY-SLATE-001` records that W9 does). Everything else fell through to an alphabetical area sort.

1. **A wave that numbers per area has no recoverable rank.** Every row ends in `001`, so the W10 depth slate in #2548 rendered `CONSOL(11) → JRNL(5) → MARK(1) → …` against an adopted order starting at MARK and ending at CONSOL. Because the renderer chains items with `-->`, the artifact drew rank-11 work as a prerequisite for rank-5 work.

2. **Only the diagram was ever fixed.** `render_summary` and `render_register` still sorted on the raw identifier string — the same lexicographic bug #2550 fixed for the diagram, still live in two artifacts. `ROADMAP_SUMMARY.md` renders `W1-DATA-001, W10-CONSOL-001, … W10-TAX-001, W2-PROMO-001` — W10 between W1 and W2 — and renders W9 alphabetically rather than in its adopted rank. #2550 fixed one view of three.

3. **`sequence` had no enforcement.** `validate-roadmap-registry.py` checks only the schema *header* and never loads `roadmap-items.v1.schema.json`, so `minimum: 1` and `type: integer` bound nothing. `0`, `-2`, `1.5`, `"abc"`, and `true` all passed `verify-docs`, after which the renderers either took a nonpositive rank or silently fell back to the suffix — producing a mis-ordered view from data CI had declared valid.

The sort key now lives in `common.py` as `roadmap_item_sort_key`; the diagram, summary, and register all consume it, so they cannot disagree about delivery sequence. Regenerating puts W9 in its adopted order:

```
W9-TRUTH-001 → W9-DEMO-002 → W9-PAPER-003 → W9-ALPACA-004 → W9-REPORT-005
→ W9-NAV-006 → W9-SAFETY-007 → W9-GOV-008 → W9-INGEST-009 → W9-ASSET-010
```

The `.mmd` is byte-identical — #2550 already fixed it. The summary and register reorder, which is defect 2 being corrected, not incidental churn.

## Reason

Raised on #2548 by both `chatgpt-codex-connector` and `copilot-pull-request-reviewer`, and deferred there twice because a generator change does not belong in a registry-data PR — the same reason #2550 was split out.

The in-scope workaround on #2548 was to renumber the W10 identifiers so their suffix encodes rank. Rejected deliberately: it would bake rank into identifiers that `decision-log.yml`, `risk-register.yml`, `document-index.yml`, and the slate document all reference, so any future re-rank would churn every one of them. Rank is view metadata and belongs in a field.

## Versioning

Per [`docs/roadmap/schema-versioning.md`](docs/roadmap/schema-versioning.md):

| Change | Rule | Applied |
| --- | --- | --- |
| Optional `sequence` property added | Add optional field → **Minor** | registry declares `meridian.roadmap-items@1.1.0` |
| Summary and register reordered | Change generated output semantics → **Major or renderer major** | `ROADMAP_RENDERER_VERSION = "2.0.0"`, emitted in generated headers and `MANIFEST.json`; `minimum_renderer_version: 2.0.0` |

The schema bump lands here rather than with first use: the contract changed the moment `sequence` became an accepted property, and a consumer needs to distinguish the extended schema from 1.0.0 whether or not current rows exercise it. `generated_header` and `write_manifest` take the version as an optional argument defaulting to `1.0.0`, so the four other generators sharing those helpers are untouched — per-generator versioning is what makes it auditable.

## Known limitation, stated deliberately

**The renderer still draws dependency arrows it has no data for.** Items are chained in sort order, so the edges express *ordering*, not dependency — including within a wave whose planning document says some rows are parallel and one is load-bearing for four others. This change makes the ordering correct; it does not make the arrows true.

The registry has no `depends_on` field, so a real dependency graph cannot be rendered from current data. The honest options are to add one, or to keep arrows only between waves. Both change generated output semantics again, and that is a roadmap-owner decision rather than something to fold in here.

## Testing performed

- [x] `bash scripts/ci.sh --lane verify-docs` — exit 0, 0 drift
- [x] Relevant unit tests were added or updated — seven new
- [ ] Relevant integration tests were added or updated — n/a
- [ ] `bash scripts/ci.sh` full quality-gate — not run locally; no compiled source is touched
- [ ] GitHub Actions `quality-gate` passed — pending on this PR

`python3 build/scripts/ci/run-script-tests.py` → **425 tests, 0 failures, 0 errors**.

| Test | Pins |
| --- | --- |
| `test_explicit_sequence_orders_a_wave_that_numbers_per_area` | defect 1 — MARK(1) → PROV(3) → JRNL(5) → CONSOL(11) |
| `test_explicit_sequence_overrides_the_identifier_suffix` | declared rank wins over a conflicting suffix |
| `test_items_without_sequence_still_order_by_identifier_suffix` | the field is optional; a partially annotated wave still orders sanely |
| `test_generated_roadmap_views_share_one_ordering` | defect 2 — one key across diagram, summary, register |
| `test_out_of_range_or_wrong_typed_sequence_fails_registry_validation` | defect 3 — `0`, `-2`, `abc`, `1.5`, `true` each rejected |
| `test_valid_sequence_passes_registry_validation` | a legitimate rank still validates |
| `test_wave_disagreeing_with_its_identifier_fails_registry_validation` | an item cannot sort as one wave while labelling itself another |
| existing ordering + label tests | unchanged, still passing |

`sequence` is validated as an integer ≥ 1 by a single `is_usable_sequence` predicate shared between the validator and the renderers, so the two cannot drift apart. `bool` is excluded explicitly — it is an `int` subclass, so `sequence: true` would otherwise sort as rank 1.

**Phase marker:** `phase:PR6`, declared as the HTML-comment marker at the top of this body and confirmed with `tools/roadmap/enforce_phase_scope.py`. Touches `build/**`, `docs/**`, and `tests/**`; PR6 is the narrowest phase covering all three. The first push declared the phase in prose only, which `scope-gate` correctly rejected — it requires the comment marker or a `phase:PRx` label.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

Touches `build/scripts/docs/{common,render-roadmap-diagrams,render-roadmap-docs,validate-roadmap-registry}.py`, `docs/roadmap/schemas/roadmap-items.v1.schema.json`, `docs/roadmap/roadmap-item-template.md`, the registry schema header, two test files, and regenerated outputs. No workflow, CODEOWNERS, `AGENTS.md`, or `scripts/ci.sh` changes.

## Follow-on for #2548

This bumps `roadmap-items.yml` to `1.1.0` / `2.0.0`, a two-line conflict with #2548's schema header, resolved by taking this version. #2548's W10 rows then add `sequence: 1..11`, closing the diagram-ordering finding with no further version change — setting the field on a row is an ordinary data update.