### PR TITLE
Wait on the real signal in racing scheduler, OMS, and ingestion tests

### DIFF
--- a/tests/Meridian.Tests/Application/Reconciliation/DefaultReconciliationIngestionSchedulerTests.cs
+++ b/tests/Meridian.Tests/Application/Reconciliation/DefaultReconciliationIngestionSchedulerTests.cs
@@ -113,12 +113,18 @@ public sealed class DefaultReconciliationIngestionSchedulerTests
     public async Task CaptureAsync_AdapterIgnoringCancellation_IsTerminalWithoutRetry()
     {
         var adapter = new StubbornAdapter(ReconciliationSourceType.Prime);
+        // The scheduler dispatches each attempt through Task.Run with the attempt's token. On a
+        // loaded runner the work item can sit queued past a 40ms timeout, and Task.Run given an
+        // already-cancelled token never invokes the delegate at all - leaving Attempts at 0 and
+        // the non-cooperative adapter this test is about never entered. The budget is widened so
+        // pool-dispatch latency cannot consume the whole window; the deadline still fires well
+        // inside the test.
         var scheduler = CreateScheduler(new ReconciliationIngestionOptions
         {
             MaxAttemptsPerSource = 5,
             RetryBaseDelay = TimeSpan.FromMilliseconds(1),
-            PerSourceTimeout = TimeSpan.FromMilliseconds(40),
-            CancellationGracePeriod = TimeSpan.FromMilliseconds(25)
+            PerSourceTimeout = TimeSpan.FromMilliseconds(500),
+            CancellationGracePeriod = TimeSpan.FromMilliseconds(250)
         });
 
         var act = async () => await scheduler.CaptureAsync([adapter], Request, CancellationToken.None);
@@ -217,13 +223,16 @@ public sealed class DefaultReconciliationIngestionSchedulerTests
 
     private sealed class HangingAdapter(ReconciliationSourceType sourceType) : IReconciliationSourceAdapter
     {
+        private int _attempts;
+
         public ReconciliationSourceType SourceType { get; } = sourceType;
 
-        public int Attempts { get; private set; }
+        // Same cross-thread read as StubbornAdapter: the scheduler runs each attempt on the pool.
+        public int Attempts => Volatile.Read(ref _attempts);
 
         public async Task<DataSourceSnapshot> CaptureSnapshotAsync(ReconciliationIngestionRequest request, CancellationToken ct)
         {
-            Attempts++;
+            Interlocked.Increment(ref _attempts);
             await Task.Delay(Timeout.InfiniteTimeSpan, ct);
             throw new InvalidOperationException("unreachable");
         }
@@ -233,13 +242,17 @@ public sealed class DefaultReconciliationIngestionSchedulerTests
     // scheduler's hard deadline can end the attempt.
     private sealed class StubbornAdapter(ReconciliationSourceType sourceType) : IReconciliationSourceAdapter
     {
+        private int _attempts;
+
         public ReconciliationSourceType SourceType { get; } = sourceType;
 
-        public int Attempts { get; private set; }
+        // Written on a thread-pool thread and read from the test thread, so both sides need a
+        // barrier rather than a plain auto-property.
+        public int Attempts => Volatile.Read(ref _attempts);
 
         public async Task<DataSourceSnapshot> CaptureSnapshotAsync(ReconciliationIngestionRequest request, CancellationToken ct)
         {
-            Attempts++;
+            Interlocked.Increment(ref _attempts);
             await Task.Delay(TimeSpan.FromSeconds(5), CancellationToken.None);
             throw new InvalidOperationException("unreachable");
         }

--- a/tests/Meridian.Tests/Execution/OrderManagementSystemReportStreamTests.cs
+++ b/tests/Meridian.Tests/Execution/OrderManagementSystemReportStreamTests.cs
@@ -277,6 +277,9 @@ public sealed class OrderManagementSystemReportStreamTests
             "the oversized completion report reaches the tracked order");
 
         oms.GetOrder(result.OrderId)!.FilledQuantity.Should().Be(10m);
+
+        await WaitForPublishedFillAsync(oms, result.OrderId);
+
         portfolio.Positions["AAPL"].Quantity.Should().Be(10L,
             because: "the portfolio must only receive the originally authorized fill quantity");
         portfolio.Cash.Should().Be(100_000m - 1_500m);
@@ -345,6 +348,26 @@ public sealed class OrderManagementSystemReportStreamTests
             Commission = 0m,
             Timestamp = DateTimeOffset.UtcNow,
         };
+
+    /// <summary>
+    /// Waits until the OMS has published the fill for <paramref name="orderId"/> on its observer
+    /// stream, which is the only barrier these tests have for the portfolio side effect.
+    /// <c>ProcessFillReportAsync</c> applies the fill to the portfolio and only then writes to the
+    /// execution-report channel, so observing the report happens-after the portfolio mutation.
+    /// Order status is not a barrier: the OMS mutates it before calling
+    /// <c>ProcessFillReportAsync</c> at all, so a test that waits on <c>Status == Filled</c> and
+    /// then reads <c>portfolio.Positions</c> is racing an unfinished fill.
+    /// </summary>
+    private static async Task WaitForPublishedFillAsync(OrderManagementSystem oms, string orderId)
+    {
+        using var readCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        while (true)
+        {
+            var report = await oms.ExecutionReports.ReadAsync(readCts.Token);
+            if (report.OrderId == orderId)
+                return;
+        }
+    }
 
     private static async Task WaitUntilAsync(Func<bool> condition, string because)
     {

--- a/tests/Meridian.Tests/Execution/OrderManagementSystemReportStreamTests.cs
+++ b/tests/Meridian.Tests/Execution/OrderManagementSystemReportStreamTests.cs
@@ -138,16 +138,19 @@ public sealed class OrderManagementSystemReportStreamTests
         await WaitUntilAsync(() => oms.GetOrder(result.OrderId)!.Status == OrderStatus.Filled,
             "the completion report must reach tracked order state");
 
-        portfolio.Positions["AAPL"].Quantity.Should().Be(10,
-            because: "cumulative reports must apply as increments (5 + 5), never summed (5 + 10)");
-        portfolio.Cash.Should().Be(100_000m - 1_500m);
-
+        // Reading both published fills is the portfolio barrier: each increment is applied before
+        // its report is published, so observing the second one means both have landed. Order
+        // status is not a barrier - see WaitForPublishedFillAsync.
         using var readCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         var first = await oms.ExecutionReports.ReadAsync(readCts.Token);
         var second = await oms.ExecutionReports.ReadAsync(readCts.Token);
         first.FilledQuantity.Should().Be(5m);
         second.FilledQuantity.Should().Be(5m,
             because: "published fills must carry the increment, not the cumulative quantity");
+
+        portfolio.Positions["AAPL"].Quantity.Should().Be(10,
+            because: "cumulative reports must apply as increments (5 + 5), never summed (5 + 10)");
+        portfolio.Cash.Should().Be(100_000m - 1_500m);
     }
 
     [Fact]
@@ -182,14 +185,16 @@ public sealed class OrderManagementSystemReportStreamTests
         var order = oms.GetOrder(result.OrderId)!;
         order.FilledQuantity.Should().Be(10m,
             because: "streamed cumulative fill quantities must be capped to the original order quantity");
-        portfolio.Positions["AAPL"].Quantity.Should().Be(10L,
-            because: "portfolio side effects may only apply the remaining authorized quantity");
-        portfolio.Cash.Should().Be(100_000m - 1_500m);
 
+        // The published fill is the portfolio barrier - see WaitForPublishedFillAsync.
         using var readCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         var published = await oms.ExecutionReports.ReadAsync(readCts.Token);
         published.FilledQuantity.Should().Be(10m,
             because: "downstream consumers must receive the validated fill delta, not the oversized broker value");
+
+        portfolio.Positions["AAPL"].Quantity.Should().Be(10L,
+            because: "portfolio side effects may only apply the remaining authorized quantity");
+        portfolio.Cash.Should().Be(100_000m - 1_500m);
     }
 
     [Fact]
@@ -231,13 +236,15 @@ public sealed class OrderManagementSystemReportStreamTests
         order.Quantity.Should().Be(30m);
         order.FilledQuantity.Should().Be(30m,
             because: "fills must be capped to the broker-accepted amended quantity, not the original request");
-        portfolio.Positions["AAPL"].Quantity.Should().Be(30L);
-        portfolio.Cash.Should().Be(100_000m - 4_500m);
 
+        // The published fill is the portfolio barrier - see WaitForPublishedFillAsync.
         using var readCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         var published = await oms.ExecutionReports.ReadAsync(readCts.Token);
         published.FilledQuantity.Should().Be(30m,
             because: "downstream consumers must receive the full authorized amended fill increment");
+
+        portfolio.Positions["AAPL"].Quantity.Should().Be(30L);
+        portfolio.Cash.Should().Be(100_000m - 4_500m);
     }
 
     [Fact]

--- a/tests/Meridian.Tests/Storage/MaintenanceSchedulerTests.cs
+++ b/tests/Meridian.Tests/Storage/MaintenanceSchedulerTests.cs
@@ -439,12 +439,21 @@ public sealed class MaintenanceSchedulerTests : IDisposable
             await scheduler.ScheduleAsync(job, new ScheduleOptions());
 
             scheduler.Start();
-            for (var attempt = 0;
-                 attempt < 100 && scheduler.GetPendingJobs().All(pending => pending.Id != job.Id);
-                 attempt++)
-                await Task.Delay(20);
 
-            history.RunningAppendAttempts.Should().BeGreaterThan(0);
+            // ScheduleAsync already placed the job in the pending queue, so waiting for pending
+            // membership exits on the first iteration with the scheduler having done nothing yet.
+            // Wait for the admission attempt itself, which is the behaviour under test.
+            await WaitUntilAsync(
+                () => history.RunningAppendAttempts > 0,
+                "the scheduler must attempt to retain the running transition before admitting a job");
+
+            // The requeue happens after that append fails, so let the queue settle rather than
+            // sampling it mid-transition.
+            await WaitUntilAsync(
+                () => scheduler.GetPendingJobs().Any(pending => pending.Id == job.Id)
+                    && scheduler.GetRunningJobs().Count == 0,
+                "a job whose running transition cannot be retained must be requeued, not left running");
+
             scheduler.GetPendingJobs().Should().ContainSingle(pending => pending.Id == job.Id);
             scheduler.GetRunningJobs().Should().BeEmpty();
             scheduler.GetJobStatus(job.Id).Should().BeNull();
@@ -553,6 +562,24 @@ public sealed class MaintenanceSchedulerTests : IDisposable
                 new string('c', 64),
                 verified.Readback.CapturedAtUtc)
         };
+    }
+
+    /// <summary>
+    /// Polls <paramref name="condition"/> until it holds or the deadline passes, then asserts it so
+    /// a genuine failure still reports through FluentAssertions rather than as a timeout.
+    /// </summary>
+    private static async Task WaitUntilAsync(Func<bool> condition, string because)
+    {
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (condition())
+                return;
+
+            await Task.Delay(10);
+        }
+
+        condition().Should().BeTrue(because);
     }
 
     private static OperationalScheduleConfig AlwaysOpenConfig() =>


### PR DESCRIPTION
<!-- phase:PR6 -->

## Summary

Five tests across **three** files waited on a condition that did not order the state they then asserted. Three of them failed `verify-dotnet` on branches whose diff was **docs-only**, then passed on byte-identical trees. None is a regression.

### `MaintenanceSchedulerTests.ScheduledJob_WhenRunningAdmissionCannotBeRetained_IsObservedAndRequeued`

```
Expected history.RunningAppendAttempts to be greater than 0, but found 0.   [25 ms]
```

The loop polled for the job to appear in `GetPendingJobs()`, but `ScheduleAsync` places it there **before** `Start()` is called, so the exit condition was already true on iteration 0. It waited for nothing, then read the counter before the scheduler had attempted the admission. Now waits for the admission attempt, then for the queue to settle into the requeued state.

### The OMS report-stream tests (four)

```
KeyNotFoundException : The given key 'AAPL' was not present in the dictionary.   [1 ms]
```

`HandleExecutionReportAsync` mutates order state and only *then* calls `ProcessFillReportAsync`, so `Status == Filled` is observable strictly before the position exists. Inside `ProcessFillReportAsync`: `ApplyFill` (`:1219`) → trade event (`:1239`) → session (`:1259`) → `_executionChannel.Writer.WriteAsync` (`:1278`). **Observing a published fill happens-after the portfolio mutation; order status does not.**

- `UnsolicitedAcceptedModification_CannotIncreaseAuthorizedQuantity` (the one that failed) gains a `WaitForPublishedFillAsync` helper.
- `CumulativePartialFills`, `OversizedStreamedFill`, and `AcceptedQuantityIncrease` already read their published fills, but *after* asserting the portfolio. Those existing reads move above the assertions, becoming the barrier. No read added or removed — the helper would be wrong here, since it consumes reports these tests go on to assert against.

### `DefaultReconciliationIngestionSchedulerTests.CaptureAsync_AdapterIgnoringCancellation_IsTerminalWithoutRetry`

```
Expected adapter.Attempts to be 1 ... but found 0 (difference of -1).   [229 ms]
```

The scheduler dispatches each attempt as `Task.Run(() => adapter.CaptureSnapshotAsync(request, attemptCts.Token), attemptCts.Token)`. The test allowed 40 ms before that token fires; on a loaded runner the work item can still be queued then, and **`Task.Run` handed an already-cancelled token never invokes the delegate at all** — so the adapter is never entered and the non-cooperative behaviour under test is never exercised.

Two changes: `Attempts` was a plain auto-property written on a pool thread and read from the test thread with no barrier, so `StubbornAdapter` and `HangingAdapter` now use `Interlocked.Increment` / `Volatile.Read` (matching `FailRunningHistoryStore`); and the per-source budget widens to 500 ms / 250 ms.

> **This one is a mitigation, not a cure — raised in review and correct.** The widened budget still uses elapsed time as a proxy for task admission. A work item delayed past 500 ms is *still* cancelled before invocation, leaving `Attempts == 0`. It lowers the probability by more than an order of magnitude; it does not remove the race.
>
> Removing it properly needs one of:
> - an explicit adapter-entry signal with the timeout demoted to a hang guard — but if the token cancels before dispatch the delegate never runs, so the signal never fires and the wait would hang instead; or
> - **changing the scheduler's admission semantics** so queued work cannot be cancelled before invocation (e.g. not passing the token to `Task.Run` and letting the delegate observe cancellation itself).
>
> The second is a production behaviour change with real consequences for attempt accounting, and it is out of scope for a tests-only PR. Flagged for the owner rather than decided here.

## Reason

Diagnosed while triaging repeated `verify-dotnet` failures on #2548, a `phase:PR1` registry-data PR that cannot touch `tests/**` without failing `scope-gate`.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully — **not run: `dotnet` is not installed in this environment**
- [x] Relevant unit tests were added or updated — five existing tests corrected across three files
- [ ] Relevant integration tests were added or updated — n/a
- [ ] GitHub Actions `quality-gate` passed — pending on this PR

**Verified by CI, not locally.** I could not compile or execute the suite here, which is also why every diagnosis above was read from CI logs and source rather than reproduction.

A single green run is weak evidence for a flakiness fix — each failing tree already passed once on re-run. What supports the first two files is mechanism: the old wait condition provably did not order the asserted state, and the new one does. The third file is explicitly probabilistic, as stated above.

**Phase marker:** `phase:PR6`, confirmed with `tools/roadmap/enforce_phase_scope.py`. Touches `tests/**` only.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included — all three files are flaky-test corrections; an earlier revision of this body said "two files" and predated the third fix

## Governance changes

- [x] No governance files changed