### PR TITLE
Serialize the tests that share ApiClientService.Instance

### DIFF
--- a/tests/Meridian.Ui.Tests/Services/AnalysisExportServiceBaseTests.cs
+++ b/tests/Meridian.Ui.Tests/Services/AnalysisExportServiceBaseTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Meridian.Ui.Tests.Services;
 
+[Collection("ApiClientService singleton serial")]
 public sealed class AnalysisExportServiceTests
 {
     [Fact]

--- a/tests/Meridian.Ui.Tests/Services/ApiClientServiceTests.cs
+++ b/tests/Meridian.Ui.Tests/Services/ApiClientServiceTests.cs
@@ -12,6 +12,7 @@ namespace Meridian.Ui.Tests.Services;
 /// <summary>
 /// Tests for <see cref="ApiClientService"/> HTTP communication logic.
 /// </summary>
+[Collection("ApiClientService singleton serial")]
 public sealed class ApiClientServiceTests
 {
     private readonly Mock<HttpMessageHandler> _httpHandlerMock;

--- a/tests/Meridian.Ui.Tests/Services/ApiClientSingletonCollection.cs
+++ b/tests/Meridian.Ui.Tests/Services/ApiClientSingletonCollection.cs
@@ -1,0 +1,32 @@
+namespace Meridian.Ui.Tests.Services;
+
+/// <summary>
+/// Serializes every test class that reaches the process-wide <c>ApiClientService.Instance</c>,
+/// directly or through a service built on it.
+///
+/// <para><c>ApiClientService.Configure</c> replaces and <b>disposes</b> the shared
+/// <c>HttpClient</c>. A consumer that has already read the old client into a local — as
+/// <c>PostWithResponseAsync</c> does before awaiting <c>SendAsync</c> — then calls a disposed
+/// client, and <c>HttpClient</c> raises <c>ObjectDisposedException</c> synchronously, ahead of any
+/// cancellation handling. The transport wrapper only rethrows <c>OperationCanceledException</c>,
+/// so the disposal is swallowed into a failed <c>ApiResponse</c> and surfaces as a null result
+/// rather than a throw. That is what made
+/// <c>SystemHealthServiceTests.TestConnectionAsync_WithProviderName_AcceptsValidProviders</c> fail
+/// intermittently on CI while passing locally and on re-runs.</para>
+///
+/// <para>Only <c>ApiClientServiceTests</c> mutates the singleton, but every class listed against
+/// this collection can observe the disposal, so they must not run concurrently with it. Membership
+/// is deliberately over-inclusive: a class that merely names one of these services costs nothing by
+/// being serialized, whereas omitting a real consumer reintroduces the race. The assembly runs in
+/// roughly three seconds, so the throughput cost is immaterial.</para>
+///
+/// <para>An assembly-level <c>CollectionBehavior(DisableTestParallelization = true)</c> would not
+/// work here: <c>tests/xunit.runner.json</c> is copied into every test project by
+/// <c>tests/Directory.Build.props</c> and sets <c>parallelizeTestCollections: true</c>, and xUnit
+/// gives the configuration file precedence over assembly attributes. Collection membership is
+/// honoured regardless of that setting.</para>
+/// </summary>
+[CollectionDefinition("ApiClientService singleton serial", DisableParallelization = true)]
+public sealed class ApiClientSingletonCollection
+{
+}

--- a/tests/Meridian.Ui.Tests/Services/DiagnosticsServiceTests.cs
+++ b/tests/Meridian.Ui.Tests/Services/DiagnosticsServiceTests.cs
@@ -9,6 +9,7 @@ namespace Meridian.Ui.Tests.Services;
 /// Note: The service methods require a running backend (ApiClientService),
 /// so these tests focus on the result models and their behavior.
 /// </summary>
+[Collection("ApiClientService singleton serial")]
 public sealed class DiagnosticsServiceTests
 {
     // ── Singleton ────────────────────────────────────────────────────

--- a/tests/Meridian.Ui.Tests/Services/LiveDataServiceTests.cs
+++ b/tests/Meridian.Ui.Tests/Services/LiveDataServiceTests.cs
@@ -7,6 +7,7 @@ namespace Meridian.Ui.Tests.Services;
 /// Tests for <see cref="LiveDataService"/> — singleton lifecycle, API method contracts,
 /// cancellation support, and DTO model validation.
 /// </summary>
+[Collection("ApiClientService singleton serial")]
 public sealed class LiveDataServiceTests
 {
     // ── Singleton ────────────────────────────────────────────────────

--- a/tests/Meridian.Ui.Tests/Services/ScheduleManagerServiceTests.cs
+++ b/tests/Meridian.Ui.Tests/Services/ScheduleManagerServiceTests.cs
@@ -6,6 +6,7 @@ namespace Meridian.Ui.Tests.Services;
 /// <summary>
 /// Tests for <see cref="ScheduleManagerService"/> and its associated DTO models.
 /// </summary>
+[Collection("ApiClientService singleton serial")]
 public sealed class ScheduleManagerServiceTests
 {
     // ── Singleton ────────────────────────────────────────────────────

--- a/tests/Meridian.Ui.Tests/Services/SystemHealthServiceTests.cs
+++ b/tests/Meridian.Ui.Tests/Services/SystemHealthServiceTests.cs
@@ -6,6 +6,7 @@ namespace Meridian.Ui.Tests.Services;
 /// <summary>
 /// Tests for <see cref="SystemHealthService"/> functionality.
 /// </summary>
+[Collection("ApiClientService singleton serial")]
 public sealed class SystemHealthServiceTests
 {
     [Fact]

--- a/tests/Meridian.Ui.Tests/Services/TimeSeriesAlignmentServiceTests.cs
+++ b/tests/Meridian.Ui.Tests/Services/TimeSeriesAlignmentServiceTests.cs
@@ -3,6 +3,7 @@ using Meridian.Ui.Services;
 
 namespace Meridian.Ui.Tests.Services;
 
+[Collection("ApiClientService singleton serial")]
 public class TimeSeriesAlignmentServiceTests
 {
     private readonly TimeSeriesAlignmentService _service = TimeSeriesAlignmentService.Instance;


### PR DESCRIPTION
<!-- phase:PR6 -->

## Summary

`SystemHealthServiceTests.TestConnectionAsync_WithProviderName_AcceptsValidProviders(provider: "Alpaca")` failed `verify-dotnet` on #2553 — a branch containing one Python script and two generated documents, and **no .NET code at all**:

```
Expected a <System.Exception> to be thrown, but no exception was thrown.   [36 ms]
```

This is the fourth independently racing area found this session, after storage, execution, and application/reconciliation. Unlike the other three it is **neither a wait-on-the-wrong-signal race nor environmental**. It is cross-test mutation of process-wide state.

### Mechanism

1. `ApiClientService.Configure` replaces and **disposes** the shared `HttpClient` (`ApiClientService.cs:97-99`).
2. `ApiClientServiceTests` drives that on nearly every case — its constructor sets one base URL, individual tests set others — so the client is disposed repeatedly through the run.
3. `tests/xunit.runner.json` sets `parallelizeTestCollections: true, maxParallelThreads: 2`, and neither class belonged to a collection, so `ApiClientServiceTests` ran **concurrently with consumers of the same singleton**.
4. `PostWithResponseAsync` reads `_httpClient` into a local and then awaits `SendAsync` on it (`:202-203`). When the other thread disposes in between, `HttpClient` raises `ObjectDisposedException` **synchronously, before any cancellation handling**.
5. The wrapper only rethrows `OperationCanceledException when ct.IsCancellationRequested` (`:378`), so the disposal falls through to the catch-all at `:392`, is swallowed into a failed `ApiResponse`, and `DataOrLoggedNull` returns `null`. `TestConnectionAsync` returns without throwing — which is why an *expected-exception* assertion failed rather than something more obviously transport-shaped.

The provider name is irrelevant: it is string-formatted into a route (`SystemHealthService.cs:89-92`) and never inspected. `"Alpaca"` is simply the first theory case. Sibling tests in the same class carry the same exposure at lower frequency.

### The fix

Only `ApiClientServiceTests` mutates the singleton, but every class that reaches it — directly or through a service built on it — can observe the disposal. All seven now share one non-parallel collection, following the `WatchlistService serial` precedent already in this assembly:

| Class | Relationship |
| --- | --- |
| `ApiClientServiceTests` | mutator — calls `Configure`, disposing the shared client |
| `SystemHealthServiceTests` | consumer via `SystemHealthService.Instance` |
| `DiagnosticsServiceTests` | references `ApiClientService` directly |
| `ScheduleManagerServiceTests`, `LiveDataServiceTests`, `AnalysisExportServiceTests`, `TimeSeriesAlignmentServiceTests` | consumers via services built on `ApiClientService.Instance` |

**Membership is deliberately over-inclusive.** Serializing a class that merely names one of these services costs nothing in an assembly that runs in about three seconds; omitting a real consumer reintroduces the race. I chose that bias explicitly after spending this session fixing a bug caused by enumerating three of four consumers correctly and missing the fourth.

### Two alternatives rejected

**Assembly-level `[assembly: CollectionBehavior(DisableTestParallelization = true)]`.** `tests/Directory.Build.props` copies `tests/xunit.runner.json` into *every* test project, and xUnit gives the configuration file precedence over assembly attributes — so the attribute would silently do nothing while looking like a fix. Collection membership is honoured regardless of that setting.

**Making the test build its own client.** `ApiClientService` has a private constructor behind a `Lazy<T>` singleton (`:16, :34`), so this would require a production seam to fix a test-isolation problem.

## Reason

Diagnosed while this failure blocked #2553. It has now caused a red `verify-dotnet` on a PR that could not possibly have caused it, which is the same pattern that made the earlier three worth fixing.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully — **not run: `dotnet` is not installed in this environment**
- [x] Relevant unit tests were added or updated — seven existing classes joined a serial collection
- [ ] Relevant integration tests were added or updated — n/a
- [ ] GitHub Actions `quality-gate` passed — pending on this PR

**Verified by CI, not locally.** I could not compile or execute the suite here, which is also why the diagnosis was read from CI logs and source rather than reproduction.

A green run is *especially* weak evidence for this one — the test already passes on most runs, so a single pass proves nothing. What supports the change is the mechanism: two threads, one disposing a client the other is about to use, and an exception filter that cannot see the resulting exception type.

**Phase marker:** `phase:PR6`, confirmed with `tools/roadmap/enforce_phase_scope.py` read by exit code. Touches `tests/**` only.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmjUgJo83aA3MMR5ZiGeHA)_