### PR TITLE
Keep exported event counters monotonic across a metrics reset

### DIFF
--- a/src/Meridian.Application/Monitoring/PrometheusMetrics.cs
+++ b/src/Meridian.Application/Monitoring/PrometheusMetrics.cs
@@ -439,20 +439,73 @@ public static class PrometheusMetrics
     /// Updates all Prometheus metrics from the current Metrics snapshot.
     /// Should be called periodically (e.g., every 1-5 seconds) to keep metrics current.
     /// </summary>
+    // Cumulative bases and last-seen values for each resettable source total, keyed by series.
+    // A reset is detected as "current is below what we last saw"; the pre-reset value is then
+    // added to the base so the exported counter never goes backwards and never stalls.
+    /// <summary>
+    /// Current value of <c>mdc_events_published_total</c> as exported.
+    /// </summary>
+    /// <remarks>
+    /// Exposed so the reset-crossing behaviour of <see cref="UpdateFromSnapshot"/> can be asserted
+    /// directly rather than by parsing the exposition text.
+    /// </remarks>
+    public static double PublishedEventsValue => PublishedEvents.Value;
+
+    private static readonly object ResettableTotalLock = new();
+    private static readonly Dictionary<string, (long Base, long Last)> ResettableTotals = new();
+
+    private const string PublishedKey = "published";
+    private const string DroppedKey = "dropped";
+    private const string IntegrityKey = "integrity";
+    private const string TradesKey = "trades";
+    private const string DepthUpdatesKey = "depth_updates";
+    private const string QuotesKey = "quotes";
+    private const string HistoricalBarsKey = "historical_bars";
+
+    /// <summary>
+    /// Translates a resettable source total into a monotonic counter value.
+    /// </summary>
+    /// <remarks>
+    /// Callers must hold <see cref="ResettableTotalLock"/>. Returns the value the Prometheus
+    /// counter should hold: the sum of every completed pre-reset run plus the current total.
+    /// </remarks>
+    private static long MirrorResettableTotal(string key, long current)
+    {
+        ResettableTotals.TryGetValue(key, out var state);
+
+        // A source total that moved backwards can only mean the underlying counter was reset.
+        if (current < state.Last)
+            state.Base += state.Last;
+
+        state.Last = current;
+        ResettableTotals[key] = state;
+        return state.Base + current;
+    }
+
     public static void UpdateFromSnapshot()
     {
         var combined = Meridian.Platform.Tracing.Metrics.GetCombinedSnapshot();
         var snapshot = combined.Core;
         var resubSnapshot = combined.Resubscription;
 
-        // Update counters (Prometheus counters only increase, so we set to current value)
-        PublishedEvents.IncTo(snapshot.Published);
-        DroppedEvents.IncTo(snapshot.Dropped);
-        IntegrityEvents.IncTo(snapshot.Integrity);
-        TradeEvents.IncTo(snapshot.Trades);
-        DepthUpdateEvents.IncTo(snapshot.DepthUpdates);
-        QuoteEvents.IncTo(snapshot.Quotes);
-        HistoricalBarEvents.IncTo(snapshot.HistoricalBars);
+        // Mirror the resettable source totals into monotonic counters. BackfillCoordinator.RunAsync
+        // calls Reset() on this same static snapshot, which zeroes every total; IncTo cannot
+        // decrease a counter, so the exported series froze at its pre-reset value until the fresh
+        // total climbed back past it. rate() and increase() read zero across that whole stretch,
+        // which is exactly what MeridianNoEventsPublished treats as a stalled feed — it would have
+        // paged during a healthy pipeline every time an operator started a backfill.
+        // MirrorResettableTotal carries the pre-reset total forward instead, so the counter keeps
+        // increasing across a reset and its rate stays true.
+        lock (ResettableTotalLock)
+        {
+            PublishedEvents.IncTo(MirrorResettableTotal(PublishedKey, snapshot.Published));
+            DroppedEvents.IncTo(MirrorResettableTotal(DroppedKey, snapshot.Dropped));
+            IntegrityEvents.IncTo(MirrorResettableTotal(IntegrityKey, snapshot.Integrity));
+            TradeEvents.IncTo(MirrorResettableTotal(TradesKey, snapshot.Trades));
+            DepthUpdateEvents.IncTo(MirrorResettableTotal(DepthUpdatesKey, snapshot.DepthUpdates));
+            QuoteEvents.IncTo(MirrorResettableTotal(QuotesKey, snapshot.Quotes));
+            HistoricalBarEvents.IncTo(MirrorResettableTotal(HistoricalBarsKey, snapshot.HistoricalBars));
+        }
 
         // Update rate gauges
         EventsPerSecond.Set(snapshot.EventsPerSecond);

--- a/tests/Meridian.Tests/Application/Monitoring/PrometheusResettableTotalCollection.cs
+++ b/tests/Meridian.Tests/Application/Monitoring/PrometheusResettableTotalCollection.cs
@@ -1,0 +1,17 @@
+using Xunit;
+
+namespace Meridian.Tests.Application.Monitoring;
+
+/// <summary>
+/// Serializes the test classes that mutate the process-wide <c>Meridian.Platform.Tracing.Metrics</c>
+/// snapshot or the prometheus-net default registry.
+///
+/// <para>Both are static and shared across the whole assembly. <c>PlatformMetrics.Reset()</c> and
+/// <c>PrometheusMetrics.UpdateFromSnapshot()</c> are only meaningful when read back in the same
+/// sequence they were written, so a class asserting counter deltas cannot run concurrently with
+/// another that publishes events or resets the snapshot underneath it.</para>
+/// </summary>
+[CollectionDefinition("PrometheusResettableTotals", DisableParallelization = true)]
+public sealed class PrometheusResettableTotalCollection
+{
+}

--- a/tests/Meridian.Tests/Application/Monitoring/PrometheusResettableTotalTests.cs
+++ b/tests/Meridian.Tests/Application/Monitoring/PrometheusResettableTotalTests.cs
@@ -1,0 +1,80 @@
+using FluentAssertions;
+using Meridian.Application.Monitoring;
+using Xunit;
+
+using PlatformMetrics = Meridian.Platform.Tracing.Metrics;
+
+namespace Meridian.Tests.Application.Monitoring;
+
+/// <summary>
+/// Tests that resettable source totals reach Prometheus as monotonic counters.
+/// </summary>
+/// <remarks>
+/// <see cref="BackfillCoordinator"/> calls <c>Reset()</c> on the process-wide
+/// <see cref="PlatformMetrics"/> snapshot, zeroing every total. A Prometheus counter cannot
+/// decrease, so mirroring the raw total with <c>IncTo</c> froze the exported series at its
+/// pre-reset value until the fresh total climbed back past it. Across that window
+/// <c>increase(mdc_events_published_total[10m])</c> reads zero, which is precisely the condition
+/// <c>MeridianNoEventsPublished</c> treats as a stalled feed — so starting a backfill on a
+/// healthy pipeline would page a responder.
+/// </remarks>
+[Collection("PrometheusResettableTotals")]
+public sealed class PrometheusResettableTotalTests
+{
+    [Fact]
+    public void UpdateFromSnapshot_AfterAReset_KeepsThePublishedCounterIncreasing()
+    {
+        PlatformMetrics.Reset();
+        PrometheusMetrics.UpdateFromSnapshot();
+        var start = PrometheusMetrics.PublishedEventsValue;
+
+        for (var i = 0; i < 500; i++)
+            PlatformMetrics.IncPublished();
+        PrometheusMetrics.UpdateFromSnapshot();
+
+        var beforeReset = PrometheusMetrics.PublishedEventsValue;
+        beforeReset.Should().BeApproximately(start + 500, 0.001);
+
+        // An operator starts a backfill: the source total goes to zero underneath us.
+        PlatformMetrics.Reset();
+        PrometheusMetrics.UpdateFromSnapshot();
+
+        PrometheusMetrics.PublishedEventsValue.Should().BeApproximately(beforeReset, 0.001,
+            because: "a reset publishes nothing, so the exported total must hold, not rewind");
+
+        // The feed keeps publishing after the reset. Those events must show up as an increase,
+        // not be swallowed while the fresh total climbs back to the old high-water mark.
+        for (var i = 0; i < 10; i++)
+            PlatformMetrics.IncPublished();
+        PrometheusMetrics.UpdateFromSnapshot();
+
+        PrometheusMetrics.PublishedEventsValue.Should().BeApproximately(beforeReset + 10, 0.001,
+            because: "post-reset publishing must move the counter, or rate() reads zero on a "
+                   + "healthy feed and MeridianNoEventsPublished pages for a working pipeline");
+    }
+
+    [Fact]
+    public void UpdateFromSnapshot_AcrossRepeatedResets_NeverDecreases()
+    {
+        PlatformMetrics.Reset();
+        PrometheusMetrics.UpdateFromSnapshot();
+
+        var previous = PrometheusMetrics.PublishedEventsValue;
+
+        for (var round = 0; round < 3; round++)
+        {
+            for (var i = 0; i < 25; i++)
+                PlatformMetrics.IncPublished();
+            PrometheusMetrics.UpdateFromSnapshot();
+
+            var afterPublishing = PrometheusMetrics.PublishedEventsValue;
+            afterPublishing.Should().BeApproximately(previous + 25, 0.001);
+
+            PlatformMetrics.Reset();
+            PrometheusMetrics.UpdateFromSnapshot();
+
+            PrometheusMetrics.PublishedEventsValue.Should().BeApproximately(afterPublishing, 0.001);
+            previous = afterPublishing;
+        }
+    }
+}


### PR DESCRIPTION
<!-- phase:PR7 -->

## Summary

Starting a backfill on a healthy pipeline could page a responder.

`BackfillCoordinator.RunAsync` (`BackfillCoordinator.cs:238`) calls `Reset()` on the process-wide `Platform.Tracing.Metrics` snapshot, and that `Reset()` (`Metrics.cs:282`) does `Interlocked.Exchange(ref _published, 0)` on every total. `PrometheusMetrics.UpdateFromSnapshot` mirrored those totals with `IncTo`, and a Prometheus counter cannot decrease — so `mdc_events_published_total` froze at its pre-reset value while the fresh total climbed back toward it. Across that whole stretch `increase(mdc_events_published_total[10m])` reads zero, which is exactly the condition `MeridianNoEventsPublished` treats as a stalled feed.

The same applies to the dropped, integrity, trade, depth-update, quote, and historical-bar counters, and to any rate built on them.

`MirrorResettableTotal` detects the reset — a source total below what was last seen — and carries the pre-reset value into a cumulative base. The exported counter holds steady over the reset instead of rewinding, and resumes increasing with the next event, so `rate()` and `increase()` stay true. The seven mirrored totals share one lock; the scrape is the only writer.

## Reason

Regression from #2562. Making the scrape refresh the registry is what connected these resettable totals to alert-visible series in the first place — before that they were declared but never scraped, so the reset had no observable effect. Reported in review on that PR; it merged before the fix landed.

## Testing performed

- [x] Relevant unit tests were added or updated
- [ ] `bash scripts/ci.sh` completed successfully — not run end to end; lanes below
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed — pending

Both new tests were mutation-verified: with `MirrorResettableTotal`'s reset detection disabled they fail 2/2, and pass with it restored. A test that cannot fail against the defect it names is not evidence.

| Lane | Result |
| --- | --- |
| `PrometheusResettableTotalTests` (2), `PrometheusMetricsTests`, `PrometheusExporterTests` | 21 passed |
| Same suite with the fix mutated out | 2 failed, as intended |
| `dotnet format whitespace Meridian.sln --verify-no-changes` | clean |

`PrometheusResettableTotalTests` runs in a non-parallel collection: the metrics snapshot and the prometheus-net registry are static and shared assembly-wide, so a class asserting counter deltas cannot run beside one publishing events underneath it.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

Backfill behaviour is unchanged — `Reset()` still resets. Only the translation into the exported counter changed, so nothing depending on the snapshot semantics is affected.

## Governance changes

- [x] No governance files changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz5UBbuEf499B7afwga2T6)_