### PR TITLE
Repair deterministic PostgreSQL test harness

### DIFF
--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -5524,6 +5524,7 @@ Meridian-main
 │   │   │   ├── ReportingDistributionStoreGuard.cs
 │   │   │   ├── ReportingGovernanceJsonContext.cs
 │   │   │   ├── ReportingGovernanceLegacyContracts.cs
+│   │   │   ├── ReportingGovernancePersistenceJson.cs
 │   │   │   ├── ReportingMigrationRunner.cs
 │   │   │   └── ReportingReconciliationEvidenceJsonContext.cs
 │   │   ├── Runtime

--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -3351,6 +3351,7 @@ Meridian-main
 │   │   │   ├── BankingStartup.cs
 │   │   │   ├── CircuitBreakerCallbackRouter.cs
 │   │   │   ├── DatabaseMigrationReadinessReceipt.cs
+│   │   │   ├── DefaultProviderSetupHandlerRegistration.cs
 │   │   │   ├── DirectLendingStartup.cs
 │   │   │   ├── FundAccountsStartup.cs
 │   │   │   ├── FundStructureStartup.cs
@@ -8594,6 +8595,7 @@ Meridian-main
 │   │   │   │   ├── EndpointMetadataTests.cs
 │   │   │   │   ├── EndpointTestCollection.cs
 │   │   │   │   ├── EndpointTestFixture.cs
+│   │   │   │   ├── EndpointTestFixtureProviderCatalogLifetimeTests.cs
 │   │   │   │   ├── EnvironmentDesignerEndpointTests.cs
 │   │   │   │   ├── FailoverEndpointTests.cs
 │   │   │   │   ├── FundStructureEndpointTests.cs
@@ -9006,7 +9008,9 @@ Meridian-main
 │   │   │   └── TestArtifactDirectory.cs
 │   │   ├── TestSupport
 │   │   │   ├── ControllableReportingReleaseConsistencyGate.cs
-│   │   │   └── ImmediateReportingReleaseConsistencyGate.cs
+│   │   │   ├── ImmediateReportingReleaseConsistencyGate.cs
+│   │   │   ├── PostgresTestSchemaTests.cs
+│   │   │   └── ProviderCatalogTestLease.cs
 │   │   ├── Treasury
 │   │   │   ├── MmfFamilyNormalizationTests.cs
 │   │   │   ├── MmfLiquidityServiceTests.cs
@@ -9192,6 +9196,7 @@ Meridian-main
 │   │   ├── Meridian.TestSupport.csproj
 │   │   ├── PostgresTestContainerOptions.cs
 │   │   ├── PostgresTestSchema.cs
+│   │   ├── PostgresTestSchemaEnvironmentScope.cs
 │   │   └── PostgresTestServer.cs
 │   ├── Meridian.Ui.Tests
 │   │   ├── Collections

--- a/docs/source/data/source-modules.yml
+++ b/docs/source/data/source-modules.yml
@@ -82,7 +82,7 @@ modules:
     diagrams:
       - DIA-ASSURANCE-LOOP
     todos: []
-    last_reviewed: 2026-06-07
+    last_reviewed: 2026-08-04
 
   - id: SRC-CONTRACTS
     path: src/Meridian.Contracts
@@ -440,7 +440,7 @@ modules:
     diagrams:
       - DIA-ASSURANCE-LOOP
     todos: []
-    last_reviewed: 2026-05-20
+    last_reviewed: 2026-08-04
 
   - id: SRC-FSHARP-DIRECTLENDING
     path: src/Meridian.FSharp.DirectLending.Aggregates
@@ -833,7 +833,7 @@ modules:
     diagrams:
       - DIA-ASSURANCE-LOOP
     todos: []
-    last_reviewed: 2026-07-15
+    last_reviewed: 2026-08-04
 
   - id: SRC-DESIGN-DOCUMENTS
     path: src/Meridian.Documents
@@ -956,7 +956,7 @@ modules:
     diagrams:
       - DIA-BROWSER-WORKSTATION
     todos: []
-    last_reviewed: 2026-07-18
+    last_reviewed: 2026-08-04
 
   - id: SRC-UI-DASHBOARD
     path: src/Meridian.Ui/dashboard

--- a/docs/source/data/source-modules.yml
+++ b/docs/source/data/source-modules.yml
@@ -259,7 +259,7 @@ modules:
       - DIA-ASSURANCE-LOOP
       - DIA-STORAGE-TOPOLOGY
     todos: []
-    last_reviewed: 2026-07-15
+    last_reviewed: 2026-08-04
 
   - id: SRC-EXECUTION
     path: src/Meridian.Execution
@@ -994,7 +994,7 @@ modules:
       - DIA-BROWSER-WORKSTATION-ROUTES
     todos:
       - TODO-SRC-UI-DASHBOARD-001
-    last_reviewed: 2026-07-18
+    last_reviewed: 2026-08-04
 
   - id: SRC-WPF
     path: src/Meridian.Wpf

--- a/docs/source/generated/MANIFEST.json
+++ b/docs/source/generated/MANIFEST.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "docs/source/data/source-modules.yml",
-      "sha256": "b55d2f2ccd65b2ca8bef4ea281d003b2a7e24ab64af19f1411f4165f07301b65"
+      "sha256": "3284815ca41a29eb2032c77d15fe0cfc595b0821493d124393ad1f9494d22615"
     },
     {
       "path": "docs/source/data/source-readme-coverage.yml",

--- a/docs/source/generated/MANIFEST.json
+++ b/docs/source/generated/MANIFEST.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "docs/source/data/source-modules.yml",
-      "sha256": "80d8451ed88007c721955240edcbedde34fbd5116dd735aca081bd5cc787c15e"
+      "sha256": "b55d2f2ccd65b2ca8bef4ea281d003b2a7e24ab64af19f1411f4165f07301b65"
     },
     {
       "path": "docs/source/data/source-readme-coverage.yml",

--- a/docs/source/generated/source-hash-manifest.json
+++ b/docs/source/generated/source-hash-manifest.json
@@ -248,7 +248,7 @@
       "path": "src/Meridian.Storage",
       "readme": "src/Meridian.Storage/README.md",
       "readme_hash": "30dfe9a083f66952698ea3ff22566b7ed65ace447dd95636484fb1c7da554a8d",
-      "source_hash": "dd30a046fdf199c8596399b80204f9bbb89837103258a16c098e1fa7828f88d9"
+      "source_hash": "699a783af368e1ed27f47702a0d71b832cdedf62c3342ba21b60d7bdb8f1c28d"
     },
     {
       "id": "SRC-STRATEGIES",

--- a/docs/source/generated/source-hash-manifest.json
+++ b/docs/source/generated/source-hash-manifest.json
@@ -9,8 +9,8 @@
       "id": "SRC-APP",
       "path": "src/Meridian.Application",
       "readme": "src/Meridian.Application/README.md",
-      "readme_hash": "7c5e003e9dfce6b416dc7890f4ef528c5f3d79a72fed6730186c689aa55ab236",
-      "source_hash": "6abfab5994131a1bae95881725d06ef7c2533211689f16e5b5561e52ead4c984"
+      "readme_hash": "6c14adbe4246b9a6b997b1b2465f1fe9f56e2d6e9b181147bf87c8202cda8aaa",
+      "source_hash": "46ea57cbd7e007f08fc9a1107bc046c9710b0e3825f11769b31f28012d5443b5"
     },
     {
       "id": "SRC-BACKTESTING",
@@ -114,8 +114,8 @@
       "id": "SRC-DESIGN-REPORTING",
       "path": "src/Meridian.Reporting",
       "readme": "src/Meridian.Reporting/README.md",
-      "readme_hash": "321d6c5225ec3770153616663690e5e0c89b2d1d90ceca7866be1f324f30d822",
-      "source_hash": "68f2b661a55b69b4d6ef226c08b821ebef424fed927f6ffb7468bda8fdd90a09"
+      "readme_hash": "c783982255105d581dc361d8be56eebefd7ad830db6501db6a2aa8dd819e0c25",
+      "source_hash": "6dc63733cbfb916075207e5188181bc0958efe712440c11e0233211bd70c987b"
     },
     {
       "id": "SRC-DESIGN-WORKFLOW",
@@ -149,8 +149,8 @@
       "id": "SRC-FSHARP",
       "path": "src/Meridian.FSharp",
       "readme": "src/Meridian.FSharp/README.md",
-      "readme_hash": "de256801dc5e083b293c0e558312db878ffdefd42b9f90e9435f2be6f2e01ec4",
-      "source_hash": "d0f51b23e69e476b9e4e31e01c418e7e5a21ae17da2a2d277255b7fe6a866f89"
+      "readme_hash": "211e99527e3447059f9049dd5c41e626cab8332b26a602544288390850b06692",
+      "source_hash": "652eb65cfcfc85964fb92ff874fa9acffc6d80b05b81d418675d6cefc0644a2d"
     },
     {
       "id": "SRC-FSHARP-DIRECTLENDING",
@@ -282,8 +282,8 @@
       "id": "SRC-UI-SHARED",
       "path": "src/Meridian.Ui.Shared",
       "readme": "src/Meridian.Ui.Shared/README.md",
-      "readme_hash": "9a51256f25ed84f59c9feb524b30a306fb21500125a86dda868e460c1fc7f539",
-      "source_hash": "6a5539f64ec5cc88c4567cf9552ef9efa8c1bf1be88afedb822a30e6021e193c"
+      "readme_hash": "e4f18896936601c486d2e48892c9c25de0594e9502da9eb00a57cfc62a67e7fc",
+      "source_hash": "da70d23a4596291b979a68b65dd8f25fb18f5c0bb271e1f8d7bf8b99f9401392"
     },
     {
       "id": "SRC-WPF",

--- a/docs/source/generated/source-hash-manifest.json
+++ b/docs/source/generated/source-hash-manifest.json
@@ -9,8 +9,8 @@
       "id": "SRC-APP",
       "path": "src/Meridian.Application",
       "readme": "src/Meridian.Application/README.md",
-      "readme_hash": "6c14adbe4246b9a6b997b1b2465f1fe9f56e2d6e9b181147bf87c8202cda8aaa",
-      "source_hash": "46ea57cbd7e007f08fc9a1107bc046c9710b0e3825f11769b31f28012d5443b5"
+      "readme_hash": "58e24c22be0cef0affdba7287b9015a2e855996b5c0865c42122441f5414a037",
+      "source_hash": "e4ec9587e9e3c03c82dfb47f0aed107597c94d87d8427f987338846f50dbc089"
     },
     {
       "id": "SRC-BACKTESTING",
@@ -247,8 +247,8 @@
       "id": "SRC-STORAGE",
       "path": "src/Meridian.Storage",
       "readme": "src/Meridian.Storage/README.md",
-      "readme_hash": "f6554046b71392d36a83333b5e3ec53a3321db77d2913064a2a96c541d375118",
-      "source_hash": "9a99a5472e25faedfe55b8ee0031a793e188d96e4349734b8328cbec55fdb2f2"
+      "readme_hash": "30dfe9a083f66952698ea3ff22566b7ed65ace447dd95636484fb1c7da554a8d",
+      "source_hash": "dd30a046fdf199c8596399b80204f9bbb89837103258a16c098e1fa7828f88d9"
     },
     {
       "id": "SRC-STRATEGIES",
@@ -268,8 +268,8 @@
       "id": "SRC-UI-DASHBOARD",
       "path": "src/Meridian.Ui/dashboard",
       "readme": "src/Meridian.Ui/dashboard/README.md",
-      "readme_hash": "530f8d9bd5a04db3bd5d48b44c68fc36089c12bd93b19b5d74869a78943bd6e4",
-      "source_hash": "73bcb54b5c021f13bc0870a7d063ad2f969057a1f258eb8e3cdfae9139f28764"
+      "readme_hash": "3dc6f66b4ea47cce2e67d364ad8ce3f1efcc1099425bde59b5fa2345820d8862",
+      "source_hash": "28568e1c3568018122b8ade78be43599747d7791da466c4023f15fe848a91d6b"
     },
     {
       "id": "SRC-UI-SERVICES",
@@ -282,8 +282,8 @@
       "id": "SRC-UI-SHARED",
       "path": "src/Meridian.Ui.Shared",
       "readme": "src/Meridian.Ui.Shared/README.md",
-      "readme_hash": "e4f18896936601c486d2e48892c9c25de0594e9502da9eb00a57cfc62a67e7fc",
-      "source_hash": "da70d23a4596291b979a68b65dd8f25fb18f5c0bb271e1f8d7bf8b99f9401392"
+      "readme_hash": "c294b3723cd5ba457a68ca39cc05700db5e3a87789e649337f53c8bbdfa7a252",
+      "source_hash": "d885d6d09f57947d6db22fa75c758fe3b275b52fdef70e28ff334bbf3797cca4"
     },
     {
       "id": "SRC-WPF",

--- a/docs/source/generated/stale-docs.json
+++ b/docs/source/generated/stale-docs.json
@@ -11,8 +11,22 @@
     "version": "1.0.0"
   },
   "source_hash_manifest": "docs/source/generated/source-hash-manifest.json",
-  "stale_count": 17,
+  "stale_count": 25,
   "stale_modules": [
+    {
+      "module_id": "SRC-BACKTESTING",
+      "path": "src/Meridian.Backtesting",
+      "readme": "src/Meridian.Backtesting/README.md",
+      "reasons": [
+        "source_hash_drift",
+        "readme_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "review README changes and rerender generated blocks if needed",
+        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
+      ]
+    },
     {
       "module_id": "SRC-BACKTESTING-SDK",
       "path": "src/Meridian.Backtesting.Sdk",
@@ -22,6 +36,46 @@
       ],
       "recommended_actions": [
         "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
+      ]
+    },
+    {
+      "module_id": "SRC-CONTRACTS",
+      "path": "src/Meridian.Contracts",
+      "readme": "src/Meridian.Contracts/README.md",
+      "reasons": [
+        "source_hash_drift",
+        "readme_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "review README changes and rerender generated blocks if needed",
+        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
+      ]
+    },
+    {
+      "module_id": "SRC-DESIGN-DOCUMENTS",
+      "path": "src/Meridian.Documents",
+      "readme": "src/Meridian.Documents/README.md",
+      "reasons": [
+        "readme_hash_drift"
+      ],
+      "recommended_actions": [
+        "review README changes and rerender generated blocks if needed",
+        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
+      ]
+    },
+    {
+      "module_id": "SRC-DESIGN-FINANCIAL-OPERATIONS",
+      "path": "src/Meridian.FinancialOperations",
+      "readme": "src/Meridian.FinancialOperations/README.md",
+      "reasons": [
+        "source_hash_drift",
+        "readme_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "review README changes and rerender generated blocks if needed",
         "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
       ]
     },
@@ -52,14 +106,28 @@
       ]
     },
     {
-      "module_id": "SRC-DESIGN-REPORTING",
-      "path": "src/Meridian.Reporting",
-      "readme": "src/Meridian.Reporting/README.md",
+      "module_id": "SRC-DOMAIN",
+      "path": "src/Meridian.Domain",
+      "readme": "src/Meridian.Domain/README.md",
       "reasons": [
         "source_hash_drift"
       ],
       "recommended_actions": [
         "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
+      ]
+    },
+    {
+      "module_id": "SRC-EXECUTION",
+      "path": "src/Meridian.Execution",
+      "readme": "src/Meridian.Execution/README.md",
+      "reasons": [
+        "source_hash_drift",
+        "readme_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "review README changes and rerender generated blocks if needed",
         "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
       ]
     },
@@ -68,22 +136,12 @@
       "path": "src/Meridian.Execution.Sdk",
       "readme": "src/Meridian.Execution.Sdk/README.md",
       "reasons": [
-        "source_hash_drift"
+        "source_hash_drift",
+        "readme_hash_drift"
       ],
       "recommended_actions": [
         "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
-        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
-      ]
-    },
-    {
-      "module_id": "SRC-FSHARP",
-      "path": "src/Meridian.FSharp",
-      "readme": "src/Meridian.FSharp/README.md",
-      "reasons": [
-        "source_hash_drift"
-      ],
-      "recommended_actions": [
-        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "review README changes and rerender generated blocks if needed",
         "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
       ]
     },
@@ -124,6 +182,20 @@
       ]
     },
     {
+      "module_id": "SRC-HOST",
+      "path": "src/Meridian",
+      "readme": "src/Meridian/README.md",
+      "reasons": [
+        "source_hash_drift",
+        "readme_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "review README changes and rerender generated blocks if needed",
+        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
+      ]
+    },
+    {
       "module_id": "SRC-IBAPI-SMOKESTUB",
       "path": "src/Meridian.IbApi.SmokeStub",
       "readme": "src/Meridian.IbApi.SmokeStub/README.md",
@@ -132,6 +204,20 @@
       ],
       "recommended_actions": [
         "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
+      ]
+    },
+    {
+      "module_id": "SRC-INFRASTRUCTURE",
+      "path": "src/Meridian.Infrastructure",
+      "readme": "src/Meridian.Infrastructure/README.md",
+      "reasons": [
+        "source_hash_drift",
+        "readme_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "review README changes and rerender generated blocks if needed",
         "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
       ]
     },
@@ -164,6 +250,20 @@
       "path": "src/Meridian.Risk",
       "readme": "src/Meridian.Risk/README.md",
       "reasons": [
+        "source_hash_drift",
+        "readme_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "review README changes and rerender generated blocks if needed",
+        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
+      ]
+    },
+    {
+      "module_id": "SRC-STORAGE",
+      "path": "src/Meridian.Storage",
+      "readme": "src/Meridian.Storage/README.md",
+      "reasons": [
         "source_hash_drift"
       ],
       "recommended_actions": [
@@ -176,10 +276,12 @@
       "path": "src/Meridian.Strategies",
       "readme": "src/Meridian.Strategies/README.md",
       "reasons": [
-        "source_hash_drift"
+        "source_hash_drift",
+        "readme_hash_drift"
       ],
       "recommended_actions": [
         "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "review README changes and rerender generated blocks if needed",
         "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
       ]
     },
@@ -188,10 +290,12 @@
       "path": "src/Meridian.Ui",
       "readme": "src/Meridian.Ui/README.md",
       "reasons": [
-        "source_hash_drift"
+        "source_hash_drift",
+        "readme_hash_drift"
       ],
       "recommended_actions": [
         "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "review README changes and rerender generated blocks if needed",
         "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
       ]
     },
@@ -214,10 +318,26 @@
       "path": "src/Meridian.Ui.Services",
       "readme": "src/Meridian.Ui.Services/README.md",
       "reasons": [
-        "source_hash_drift"
+        "source_hash_drift",
+        "readme_hash_drift"
       ],
       "recommended_actions": [
         "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "review README changes and rerender generated blocks if needed",
+        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
+      ]
+    },
+    {
+      "module_id": "SRC-WPF",
+      "path": "src/Meridian.Wpf",
+      "readme": "src/Meridian.Wpf/README.md",
+      "reasons": [
+        "source_hash_drift",
+        "readme_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "review README changes and rerender generated blocks if needed",
         "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
       ]
     }

--- a/docs/source/generated/stale-docs.md
+++ b/docs/source/generated/stale-docs.md
@@ -8,25 +8,33 @@ do_not_edit: true
 
 This report marks registered source modules whose code or README hashes differ from the reviewed baseline.
 
-- Stale modules: 17
+- Stale modules: 25
 - Removed module hash entries: 0
 
 | Module | Path | README | Reason |
 | --- | --- | --- | --- |
+| `SRC-BACKTESTING` | `src/Meridian.Backtesting` | `src/Meridian.Backtesting/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-BACKTESTING-SDK` | `src/Meridian.Backtesting.Sdk` | `src/Meridian.Backtesting.Sdk/README.md` | `source_hash_drift` |
+| `SRC-CONTRACTS` | `src/Meridian.Contracts` | `src/Meridian.Contracts/README.md` | `source_hash_drift`, `readme_hash_drift` |
+| `SRC-DESIGN-DOCUMENTS` | `src/Meridian.Documents` | `src/Meridian.Documents/README.md` | `readme_hash_drift` |
+| `SRC-DESIGN-FINANCIAL-OPERATIONS` | `src/Meridian.FinancialOperations` | `src/Meridian.FinancialOperations/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-DESIGN-IDENTITY` | `src/Meridian.Identity` | `src/Meridian.Identity/README.md` | `source_hash_drift` |
 | `SRC-DESIGN-PLATFORM` | `src/Meridian.Platform` | `src/Meridian.Platform/README.md` | `source_hash_drift`, `readme_hash_drift` |
-| `SRC-DESIGN-REPORTING` | `src/Meridian.Reporting` | `src/Meridian.Reporting/README.md` | `source_hash_drift` |
-| `SRC-EXECUTION-SDK` | `src/Meridian.Execution.Sdk` | `src/Meridian.Execution.Sdk/README.md` | `source_hash_drift` |
-| `SRC-FSHARP` | `src/Meridian.FSharp` | `src/Meridian.FSharp/README.md` | `source_hash_drift` |
+| `SRC-DOMAIN` | `src/Meridian.Domain` | `src/Meridian.Domain/README.md` | `source_hash_drift` |
+| `SRC-EXECUTION` | `src/Meridian.Execution` | `src/Meridian.Execution/README.md` | `source_hash_drift`, `readme_hash_drift` |
+| `SRC-EXECUTION-SDK` | `src/Meridian.Execution.Sdk` | `src/Meridian.Execution.Sdk/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-FSHARP-DIRECTLENDING` | `src/Meridian.FSharp.DirectLending.Aggregates` | `src/Meridian.FSharp.DirectLending.Aggregates/README.md` | `source_hash_drift` |
 | `SRC-FSHARP-LEDGER` | `src/Meridian.FSharp.Ledger` | `src/Meridian.FSharp.Ledger/README.md` | `source_hash_drift` |
 | `SRC-FSHARP-TRADING` | `src/Meridian.FSharp.Trading` | `src/Meridian.FSharp.Trading/README.md` | `source_hash_drift` |
+| `SRC-HOST` | `src/Meridian` | `src/Meridian/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-IBAPI-SMOKESTUB` | `src/Meridian.IbApi.SmokeStub` | `src/Meridian.IbApi.SmokeStub/README.md` | `source_hash_drift` |
+| `SRC-INFRASTRUCTURE` | `src/Meridian.Infrastructure` | `src/Meridian.Infrastructure/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-LEDGER` | `src/Meridian.Ledger` | `src/Meridian.Ledger/README.md` | `source_hash_drift` |
 | `SRC-LIFECYCLE-SUPERVISOR` | `src/Meridian.LifecycleSupervisor` | `src/Meridian.LifecycleSupervisor/README.md` | `source_hash_drift` |
-| `SRC-RISK` | `src/Meridian.Risk` | `src/Meridian.Risk/README.md` | `source_hash_drift` |
-| `SRC-STRATEGIES` | `src/Meridian.Strategies` | `src/Meridian.Strategies/README.md` | `source_hash_drift` |
-| `SRC-UI` | `src/Meridian.Ui` | `src/Meridian.Ui/README.md` | `source_hash_drift` |
+| `SRC-RISK` | `src/Meridian.Risk` | `src/Meridian.Risk/README.md` | `source_hash_drift`, `readme_hash_drift` |
+| `SRC-STORAGE` | `src/Meridian.Storage` | `src/Meridian.Storage/README.md` | `source_hash_drift` |
+| `SRC-STRATEGIES` | `src/Meridian.Strategies` | `src/Meridian.Strategies/README.md` | `source_hash_drift`, `readme_hash_drift` |
+| `SRC-UI` | `src/Meridian.Ui` | `src/Meridian.Ui/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-UI-DASHBOARD` | `src/Meridian.Ui/dashboard` | `src/Meridian.Ui/dashboard/README.md` | `source_hash_drift`, `readme_hash_drift` |
-| `SRC-UI-SERVICES` | `src/Meridian.Ui.Services` | `src/Meridian.Ui.Services/README.md` | `source_hash_drift` |
+| `SRC-UI-SERVICES` | `src/Meridian.Ui.Services` | `src/Meridian.Ui.Services/README.md` | `source_hash_drift`, `readme_hash_drift` |
+| `SRC-WPF` | `src/Meridian.Wpf` | `src/Meridian.Wpf/README.md` | `source_hash_drift`, `readme_hash_drift` |

--- a/docs/status/TODO.md
+++ b/docs/status/TODO.md
@@ -210,9 +210,9 @@ Total items: **230**
 | `tests/Meridian.Tests/Application/Backfill/BackfillWorkerServiceTests.cs` | 86 | `NOTE` | ❌ | // NOTE: Using null! dependencies - we only verify that ArgumentOutOfRangeException is not thrown |
 | `tests/Meridian.Tests/Application/Pipeline/FSharpEventValidatorTests.cs` | 72 | `NOTE` | ❌ | // Note: Trade.ctor only checks Price > 0, so $2,000,000 is constructible. |
 | `tests/Meridian.Tests/DataIntegration/Monitoring/DataQuality/DataFreshnessSlaMonitorTests.cs` | 525 | `NOTE` | ❌ | // NOTE: Actual result depends on current time, so we check the logic is working |
-| `tests/Meridian.Tests/Integration/EndpointTests/PilotAcceptanceHarnessTests.cs` | 1519 | `NOTE` | ❌ | note: "Canonical pilot run created from the certified renderer manifest."); |
-| `tests/Meridian.Tests/Integration/EndpointTests/PilotAcceptanceHarnessTests.cs` | 1532 | `NOTE` | ❌ | note: "Certified renderer output reconciliation started."); |
-| `tests/Meridian.Tests/Integration/EndpointTests/PilotAcceptanceHarnessTests.cs` | 1545 | `NOTE` | ❌ | note: "Exact certified renderer output was retained."); |
+| `tests/Meridian.Tests/Integration/EndpointTests/PilotAcceptanceHarnessTests.cs` | 1632 | `NOTE` | ❌ | note: "Canonical pilot run created from the certified renderer manifest."); |
+| `tests/Meridian.Tests/Integration/EndpointTests/PilotAcceptanceHarnessTests.cs` | 1645 | `NOTE` | ❌ | note: "Certified renderer output reconciliation started."); |
+| `tests/Meridian.Tests/Integration/EndpointTests/PilotAcceptanceHarnessTests.cs` | 1658 | `NOTE` | ❌ | note: "Exact certified renderer output was retained."); |
 | `tests/Meridian.Tests/SecurityMaster/Workbench/SecurityMasterWorkbenchCommandServiceTests.cs` | 258 | `NOTE` | ❌ | Note: "Ready for review."); |
 | `tests/Meridian.Tests/SecurityMaster/Workbench/SecurityMasterWorkbenchCommandServiceTests.cs` | 284 | `NOTE` | ❌ | Note: "Submit through gate.", |
 | `tests/Meridian.Tests/SecurityMaster/Workbench/SecurityMasterWorkbenchCommandServiceTests.cs` | 313 | `NOTE` | ❌ | Note: "Submit.", |

--- a/docs/status/coverage-report.md
+++ b/docs/status/coverage-report.md
@@ -5,7 +5,7 @@
 
 ## Overall Coverage
 
-**3835 / 8627** items documented (**44.5%**) &mdash; Grade: **D**
+**3836 / 8628** items documented (**44.5%**) &mdash; Grade: **D**
 
 ```text
 [=========-----------] 44.5%
@@ -15,7 +15,7 @@
 
 | Category | Documented | Total | Coverage | Grade |
 | ---------- | ----------- | ------- | ---------- | ------- |
-| Public Classes / Interfaces | 3701 | 8155 | 45.4% | D |
+| Public Classes / Interfaces | 3702 | 8156 | 45.4% | D |
 | API Endpoints | 120 | 319 | 37.6% | F |
 | Configuration Options | 3 | 142 | 2.1% | F |
 | Provider Implementations | 0 | 0 | 100.0% | A |

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 641,
-  "total_lines": 120231,
+  "total_lines": 120276,
   "orphaned_count": 255,
   "no_heading_count": 148,
   "stale_count": 0,
@@ -2578,7 +2578,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 9693,
+      "line_count": 9698,
       "has_heading": true,
       "todo_count": 8,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -3546,7 +3546,7 @@
     },
     {
       "path": "docs/source/generated/stale-docs.md",
-      "line_count": 32,
+      "line_count": 40,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -5010,7 +5010,7 @@
     },
     {
       "path": "src/Meridian.Application/README.md",
-      "line_count": 552,
+      "line_count": 561,
       "has_heading": true,
       "todo_count": 3,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -5138,7 +5138,7 @@
     },
     {
       "path": "src/Meridian.FSharp/README.md",
-      "line_count": 78,
+      "line_count": 81,
       "has_heading": true,
       "todo_count": 1,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -5250,7 +5250,7 @@
     },
     {
       "path": "src/Meridian.Reporting/README.md",
-      "line_count": 249,
+      "line_count": 252,
       "has_heading": true,
       "todo_count": 1,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -5274,7 +5274,7 @@
     },
     {
       "path": "src/Meridian.Storage/README.md",
-      "line_count": 535,
+      "line_count": 542,
       "has_heading": true,
       "todo_count": 1,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -5298,7 +5298,7 @@
     },
     {
       "path": "src/Meridian.Ui.Shared/README.md",
-      "line_count": 2204,
+      "line_count": 2214,
       "has_heading": true,
       "todo_count": 3,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 641,
-  "total_lines": 120276,
+  "total_lines": 120277,
   "orphaned_count": 255,
   "no_heading_count": 148,
   "stale_count": 0,
@@ -2578,7 +2578,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 9698,
+      "line_count": 9699,
       "has_heading": true,
       "todo_count": 8,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 641 |
-| Total lines | 120,231 |
+| Total lines | 120,276 |
 | Average file size (lines) | 187.6 |
 | Orphaned files | 255 |
 | Files without headings | 148 |

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 641 |
-| Total lines | 120,276 |
+| Total lines | 120,277 |
 | Average file size (lines) | 187.6 |
 | Orphaned files | 255 |
 | Files without headings | 148 |

--- a/src/Meridian.Application/Composition/DefaultProviderSetupHandlerRegistration.cs
+++ b/src/Meridian.Application/Composition/DefaultProviderSetupHandlerRegistration.cs
@@ -1,0 +1,36 @@
+using Meridian.DataIntegration.Credentials;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Application.Composition;
+
+/// <summary>
+/// Registers the complete built-in provider setup catalog once across composition layers.
+/// </summary>
+public static class DefaultProviderSetupHandlerRegistration
+{
+    /// <summary>
+    /// Adds every default setup handler in catalog order. A marker makes the operation idempotent
+    /// when the application composition root and workstation composition are both applied.
+    /// </summary>
+    public static IServiceCollection AddDefaultProviderSetupHandlers(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        if (services.Any(static descriptor =>
+                descriptor.ServiceType == typeof(DefaultProviderSetupHandlerRegistrationMarker)))
+        {
+            return services;
+        }
+
+        services.AddSingleton(new DefaultProviderSetupHandlerRegistrationMarker());
+        foreach (var handler in DefaultProviderSetupHandlers.Create())
+        {
+            // Multiple catalog entries intentionally share the generic implementation type.
+            // Explicit instances preserve each descriptor; TryAddEnumerable would deduplicate them.
+            services.AddSingleton(typeof(IProviderSetupHandler), handler);
+        }
+
+        return services;
+    }
+
+    private sealed class DefaultProviderSetupHandlerRegistrationMarker;
+}

--- a/src/Meridian.Application/Composition/Features/ProviderRoutingFeatureRegistration.cs
+++ b/src/Meridian.Application/Composition/Features/ProviderRoutingFeatureRegistration.cs
@@ -19,10 +19,7 @@ internal sealed class ProviderRoutingFeatureRegistration : IServiceFeatureRegist
 
         services.TryAddSingleton<ProviderConnectionService>();
         services.TryAddSingleton<ProviderBindingService>();
-        foreach (var handler in DefaultProviderSetupHandlers.Create())
-        {
-            services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IProviderSetupHandler), handler));
-        }
+        services.AddDefaultProviderSetupHandlers();
         services.TryAddSingleton<IProviderSetupRegistry, ProviderSetupRegistry>();
         services.TryAddSingleton<ProviderSetupService>();
         services.TryAddSingleton<KernelObservabilityService>();

--- a/src/Meridian.Application/README.md
+++ b/src/Meridian.Application/README.md
@@ -286,8 +286,12 @@ and UI presentation concerns in their owning layers.
   profile-backed `CustomAsset` and `OtherSecurity` payloads in projection and event evidence while
   reusing the existing generic-security domain backing model. The query service keeps ordinary text
   search delegated to the storage index and uses the projected Security Master universe only when
-  custom profile id, version, field-key, or field-value filters are supplied. Profile definitions
-  are governed by `SecurityAssetProfileGovernanceService`, which merges seeded starter definitions
+  custom profile id, version, field-key, or field-value filters are supplied. Identifier fallback
+  applies the same provider authority as the durable store: provider-bound
+  identifiers and aliases require the exact normalized provider, while providerless legacy primary
+  fields remain eligible only when no matching authoritative identifier row exists. Profile
+  definitions are governed by `SecurityAssetProfileGovernanceService`, which merges seeded starter
+  definitions
   with storage-root persisted drafts, approvals, rollback-created versions, and audit lineage.
   Security Master validation messages use operator-review wording for override audit remediation so
   application-layer guidance does not expose legacy Governance workspace language. Corporate-action

--- a/src/Meridian.Application/README.md
+++ b/src/Meridian.Application/README.md
@@ -6,7 +6,7 @@ module_id: SRC-APP
 path: src/Meridian.Application
 status: active
 owner_lane: Runtime Host
-last_reviewed: 2026-07-27
+last_reviewed: 2026-08-04
 ---
 
 # src/Meridian.Application
@@ -33,7 +33,9 @@ and UI presentation concerns in their owning layers.
   `Meridian.DataIntegration.Credentials`; Application no longer owns generic provider credential
   store contracts. Provider plugin assembly loading and `DataSourceRegistry` discovery now live in
   ProviderSdk; Application and WPF consume the loader instead of keeping reflection-based provider
-  discovery in Application services.
+  discovery in Application services. Default provider setup handlers are registered through one
+  idempotent composition helper so layered workstation composition retains every catalog entry and
+  alias exactly once, including entries that share a generic handler implementation type.
 - ETL commands, composition, and orchestration services consume
   `Meridian.DataIntegration.Etl` contracts, normalization services, and job service/orchestrator.
   Application composes Data Integration-owned ETL behavior through `IEtlIngestionJobCoordinator`
@@ -277,7 +279,10 @@ and UI presentation concerns in their owning layers.
   `Meridian.ReferenceData.SecurityMaster`; this folder consumes those reference-data contracts for
   validation, governance, readiness, projection rebuilds, and endpoint composition. Profile-backed
   validation rules still enforce approved profile-version pinning, typed no-code field values,
-  profile approval metadata, and identifier coverage. Security Master create/amend orchestration preserves pinned
+  profile approval metadata, and identifier coverage. The C# to F# identifier seam preserves
+  optional provider/source metadata without changing standard-identifier identity; a
+  `ProviderSymbol` kind remains the authoritative namespace and contradictory metadata fails
+  validation. Security Master create/amend orchestration preserves pinned
   profile-backed `CustomAsset` and `OtherSecurity` payloads in projection and event evidence while
   reusing the existing generic-security domain backing model. The query service keeps ordinary text
   search delegated to the storage index and uses the projected Security Master universe only when

--- a/src/Meridian.Application/SecurityMaster/SecurityMasterMapping.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityMasterMapping.cs
@@ -169,7 +169,8 @@ internal static class SecurityMasterMapping
             identifier.Value,
             identifier.IsPrimary,
             identifier.ValidFrom,
-            ToOption(identifier.ValidTo));
+            ToOption(identifier.ValidTo),
+            ToOption(identifier.Provider));
 
     private static IdentifierKind ToIdentifierKind(SecurityIdentifierKind kind, string? provider)
         => kind switch

--- a/src/Meridian.Application/SecurityMaster/SecurityMasterQueryService.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityMasterQueryService.cs
@@ -399,8 +399,12 @@ public sealed class SecurityMasterQueryService :
             return true;
         }
 
-        return string.Equals(candidate.PrimaryIdentifierKind, identifierKind.ToString(), StringComparison.OrdinalIgnoreCase)
-               && SecurityIdentifierNormalizer.NormalizeValue(identifierKind, candidate.PrimaryIdentifierValue).Equals(normalizedValue, StringComparison.Ordinal);
+        return MatchesLegacyPrimaryIdentifier(
+            candidate,
+            identifierKind,
+            identifierKind.ToString(),
+            normalizedValue,
+            normalizedProvider);
     }
 
     private static bool MatchesIdentifierIgnoringWindow(
@@ -427,17 +431,55 @@ public sealed class SecurityMasterQueryService :
             return true;
         }
 
-        return string.Equals(candidate.PrimaryIdentifierKind, identifierKindText, StringComparison.OrdinalIgnoreCase)
-               && SecurityIdentifierNormalizer.NormalizeValue(identifierKind, candidate.PrimaryIdentifierValue).Equals(normalizedValue, StringComparison.Ordinal);
+        return MatchesLegacyPrimaryIdentifier(
+            candidate,
+            identifierKind,
+            identifierKindText,
+            normalizedValue,
+            normalizedProvider);
     }
 
     private static bool ProviderMatches(string? provider, string normalizedProvider)
-        => normalizedProvider.Length == 0
-           || SecurityIdentifierNormalizer.NormalizeProvider(provider).Equals(normalizedProvider, StringComparison.Ordinal);
+    {
+        var candidateProvider = SecurityIdentifierNormalizer.NormalizeProvider(provider);
+        return normalizedProvider.Length == 0
+            ? candidateProvider.Length == 0
+            : candidateProvider.Equals(normalizedProvider, StringComparison.Ordinal);
+    }
 
     private static bool ProviderMatches(string? provider, string? normalizedProvider, string expectedNormalizedProvider)
-        => expectedNormalizedProvider.Length == 0
-           || SecurityIdentifierNormalizer.NormalizeProvider(normalizedProvider ?? provider).Equals(expectedNormalizedProvider, StringComparison.Ordinal);
+    {
+        var candidateProvider = string.IsNullOrWhiteSpace(normalizedProvider)
+            ? SecurityIdentifierNormalizer.NormalizeProvider(provider)
+            : SecurityIdentifierNormalizer.NormalizeProvider(normalizedProvider);
+        return expectedNormalizedProvider.Length == 0
+            ? candidateProvider.Length == 0
+            : candidateProvider.Equals(expectedNormalizedProvider, StringComparison.Ordinal);
+    }
+
+    private static bool MatchesLegacyPrimaryIdentifier(
+        SecurityProjectionRecord candidate,
+        SecurityIdentifierKind identifierKind,
+        string identifierKindText,
+        string normalizedValue,
+        string normalizedProvider)
+    {
+        if (normalizedProvider.Length != 0
+            || !string.Equals(candidate.PrimaryIdentifierKind, identifierKindText, StringComparison.OrdinalIgnoreCase)
+            || !SecurityIdentifierNormalizer.NormalizeValue(identifierKind, candidate.PrimaryIdentifierValue)
+                .Equals(normalizedValue, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // The denormalized primary fields predate authoritative identifier rows and carry no
+        // provider namespace. Use them only for genuinely legacy projections. Once a matching
+        // identifier row exists, its provider and validity window must remain authoritative.
+        return !candidate.Identifiers.Any(identifier =>
+            identifier.Kind == identifierKind
+            && SecurityIdentifierNormalizer.GetOrComputeNormalizedValue(identifier)
+                .Equals(normalizedValue, StringComparison.Ordinal));
+    }
 
     private static bool HasProfileSearchCriteria(SecuritySearchRequest request)
         => !string.IsNullOrWhiteSpace(request.CustomProfileId)

--- a/src/Meridian.FSharp/Domain/SecurityIdentifiers.fs
+++ b/src/Meridian.FSharp/Domain/SecurityIdentifiers.fs
@@ -37,6 +37,10 @@ type Identifier = {
     IsPrimary: bool
     ValidFrom: DateTimeOffset
     ValidTo: DateTimeOffset option
+    /// Optional source/provider namespace retained as identifier metadata. Identifier identity
+    /// continues to use the ProviderSymbol discriminant only, so adding source metadata to an
+    /// exchange-standard identifier does not change duplicate or expiry semantics.
+    Provider: string option
 }
 
 [<RequireQualifiedAccess>]
@@ -48,6 +52,18 @@ module SecurityIdentifier =
         match identifier.Kind with
         | IdentifierKind.ProviderSymbol provider -> Some provider
         | _ -> None
+
+    /// ProviderSymbol carries its identity namespace in the discriminant. When the optional
+    /// provider metadata is also populated, it may repeat that namespace but must not contradict
+    /// it. Provider metadata on every other identifier kind remains independent provenance.
+    let providerMetadataMatchesKind identifier =
+        match identifier.Kind, identifier.Provider with
+        | IdentifierKind.ProviderSymbol authoritativeProvider, Some metadataProvider ->
+            String.Equals(
+                normalizeValue authoritativeProvider,
+                normalizeValue metadataProvider,
+                StringComparison.Ordinal)
+        | _ -> true
 
     let kindName identifier =
         match identifier.Kind with

--- a/src/Meridian.FSharp/Domain/SecurityMasterCommands.fs
+++ b/src/Meridian.FSharp/Domain/SecurityMasterCommands.fs
@@ -235,6 +235,10 @@ module SecurityMaster =
            | IdentifierKind.ProviderSymbol provider ->
                requireNotBlank "identifier_provider_required" "Identifier.Provider" provider
            | _ -> [])
+        @ require (SecurityIdentifier.providerMetadataMatchesKind identifier)
+            (error
+                "identifier_provider_mismatch"
+                "ProviderSymbol metadata must match the authoritative provider namespace carried by Identifier.Kind.")
         @ require (identifier.ValidTo |> Option.forall (fun validTo -> validTo > identifier.ValidFrom))
             (error "identifier_date_range_invalid" "Identifier ValidTo must be later than ValidFrom when present.")
 

--- a/src/Meridian.FSharp/Interop.SecurityMaster.fs
+++ b/src/Meridian.FSharp/Interop.SecurityMaster.fs
@@ -19,10 +19,16 @@ module private NullableHelpers =
         | None -> Unchecked.defaultof<'T>
 
 type SecurityIdentifierSnapshot(identifier: Identifier) =
+    do
+        if not (SecurityIdentifier.providerMetadataMatchesKind identifier) then
+            invalidArg
+                (nameof identifier.Provider)
+                "ProviderSymbol metadata must match the authoritative provider namespace carried by Identifier.Kind."
+
     let provider =
         match identifier.Kind with
-        | IdentifierKind.ProviderSymbol provider -> provider
-        | _ -> null
+        | IdentifierKind.ProviderSymbol authoritativeProvider -> authoritativeProvider
+        | _ -> identifier.Provider |> toNullableRef
 
     let kind =
         match identifier.Kind with

--- a/src/Meridian.FSharp/README.md
+++ b/src/Meridian.FSharp/README.md
@@ -6,7 +6,7 @@ module_id: SRC-FSHARP
 path: src/Meridian.FSharp
 status: active
 owner_lane: Strategy Analytics
-last_reviewed: 2026-05-20
+last_reviewed: 2026-08-04
 ---
 
 # src/Meridian.FSharp
@@ -35,6 +35,9 @@ Use this module for deterministic business-rule kernels shared by strategy, trad
 ## API contract notes
 
 - C# callers should enter through C#-friendly interop wrappers and should not depend on internal F# domain types.
+- Security Master identifier interop retains optional provider/source metadata for standard
+  identifiers. For `ProviderSymbol`, the provider namespace carried by the identifier kind remains
+  authoritative and contradictory provider metadata is rejected as structured validation.
 - Operations kernels should remain pure and deterministic: inputs in, decisions/issues/statuses out.
 - Stream-oriented helpers should receive ordered, bounded inputs. Page large storage/backfill batches before crossing into F#, and keep `mergeStreams` / `bufferByTime` on timestamp-ordered streams so they can avoid whole-batch sorting and grouping.
 - Sensitive-action policy evaluates explicit guardrails such as MFA, dual approval, privileged roles, and segregation-of-duties before C# services write audit or workflow state.

--- a/src/Meridian.Reporting/README.md
+++ b/src/Meridian.Reporting/README.md
@@ -6,7 +6,7 @@ module_id: SRC-DESIGN-REPORTING
 path: src/Meridian.Reporting
 status: active
 owner_lane: Workstation Shell and UX
-last_reviewed: 2026-07-27
+last_reviewed: 2026-08-04
 ---
 
 # src/Meridian.Reporting
@@ -62,6 +62,9 @@ artifact, governance, restatement, and distribution contracts plus deterministic
 UI Shared adapts authenticated workstation requests and server-owned accounting sources; Storage
 implements PostgreSQL persistence. Browser and WPF remain thin consumers of shared DTOs and
 server-returned action availability.
+Canonical governance comparisons treat default and empty immutable permission/principal arrays as
+the same empty authority set, matching persisted round trips while retaining ordered value
+comparison for populated authority evidence.
 The host reporting-schedule adapter is the only due-work discovery and lease authority. It resolves
 the exact access scope, readiness, certification, and delivery handoff before calling
 `IReportingOrchestrationService.ExecuteAsync` with one certified job contract. The retained

--- a/src/Meridian.Reporting/ReportingGovernanceCanonicalValidation.cs
+++ b/src/Meridian.Reporting/ReportingGovernanceCanonicalValidation.cs
@@ -1239,10 +1239,15 @@ public static class ReportingGovernanceCanonicalValidation
         && StringComparer.Ordinal.Equals(left.TenantId, right.TenantId)
         && StringComparer.Ordinal.Equals(left.OrganizationId, right.OrganizationId)
         && StringComparer.Ordinal.Equals(left.CompanyId, right.CompanyId)
-        && left.Permissions.SequenceEqual(right.Permissions)
+        && Normalize(left.Permissions).SequenceEqual(Normalize(right.Permissions))
         && left.Origin == right.Origin
         && StringComparer.Ordinal.Equals(left.CorrelationId, right.CorrelationId)
-        && left.PrincipalIds.SequenceEqual(right.PrincipalIds, StringComparer.Ordinal);
+        && Normalize(left.PrincipalIds).SequenceEqual(
+            Normalize(right.PrincipalIds),
+            StringComparer.Ordinal);
+
+    private static ImmutableArray<T> Normalize<T>(ImmutableArray<T> values) =>
+        values.IsDefault ? ImmutableArray<T>.Empty : values;
 
     private static CanonicalParameterBinding ParseCanonicalParameters(string canonicalJson)
     {

--- a/src/Meridian.Reporting/ReportingGovernanceCanonicalValidation.cs
+++ b/src/Meridian.Reporting/ReportingGovernanceCanonicalValidation.cs
@@ -564,7 +564,7 @@ public static class ReportingGovernanceCanonicalValidation
                 throw new ReportingGovernanceException(
                     "Pending restatement state must be version 1 and cannot retain approval or draft fields.");
             }
-            if (!request.ChangedLines.SequenceEqual(request.RequestedChangedLines))
+            if (!SameChangedLines(request.ChangedLines, request.RequestedChangedLines))
             {
                 throw new ReportingGovernanceException(
                     "Pending restatement changed lines must exactly match the originally requested evidence.");
@@ -607,6 +607,31 @@ public static class ReportingGovernanceCanonicalValidation
         {
             ValidateRestatementAudit(request);
         }
+    }
+
+    private static bool SameChangedLines(
+        ImmutableArray<ReportingRestatementChangedLine> left,
+        ImmutableArray<ReportingRestatementChangedLine> right)
+    {
+        if (left.Length != right.Length)
+        {
+            return false;
+        }
+
+        for (var index = 0; index < left.Length; index++)
+        {
+            var leftLine = left[index];
+            var rightLine = right[index];
+            if (!StringComparer.Ordinal.Equals(leftLine.LineKey, rightLine.LineKey)
+                || !StringComparer.Ordinal.Equals(leftLine.PreviousValue, rightLine.PreviousValue)
+                || !StringComparer.Ordinal.Equals(leftLine.CurrentValue, rightLine.CurrentValue)
+                || !leftLine.EvidenceIds.SequenceEqual(rightLine.EvidenceIds, StringComparer.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/Meridian.Storage/Ledger/AccountingPostingCommandValidator.cs
+++ b/src/Meridian.Storage/Ledger/AccountingPostingCommandValidator.cs
@@ -415,7 +415,7 @@ public static class AccountingPostingCommandValidator
             LedgerBook = FirstText(metadata.LedgerBook, command.LedgerBookId?.ToString("D")),
             IdempotencyKey = FirstText(metadata.IdempotencyKey, treasury?.IdempotencyKey, command.IdempotencyKey),
             FundEventId = FirstText(metadata.FundEventId, treasury?.FundEventId),
-            FundEventType = FirstText(metadata.FundEventType, treasury?.FundEventType, command.SourceEventType),
+            FundEventType = FirstText(metadata.FundEventType, treasury?.FundEventType),
             CapitalAccountId = FirstText(metadata.CapitalAccountId, treasury?.CapitalAccountId),
             InvestorId = FirstText(metadata.InvestorId, treasury?.InvestorId),
             PaymentIntentId = FirstText(metadata.PaymentIntentId, treasury?.PaymentIntentId),

--- a/src/Meridian.Storage/README.md
+++ b/src/Meridian.Storage/README.md
@@ -6,7 +6,7 @@ module_id: SRC-STORAGE
 path: src/Meridian.Storage
 status: active
 owner_lane: Accounting and Ledger
-last_reviewed: 2026-07-27
+last_reviewed: 2026-08-04
 ---
 
 # src/Meridian.Storage
@@ -190,6 +190,10 @@ Canonical symbol resolution is Storage-owned because it wraps the durable symbol
 identifier indexes. Application composition registers the Storage implementation behind
 `Meridian.Contracts.Catalog.ICanonicalSymbolRegistry` for canonicalization and Security Master seed
 workflows.
+Security Master identifier lookup preserves provider authority: a provider-bound canonical
+identifier resolves only for the exact normalized provider. The legacy primary-identifier fallback
+is available only for providerless records that have no authoritative identifier row, so an omitted
+or incorrect provider cannot select a provider-bound security.
 The optional atomic-migration capability builds the complete candidate registry and lookup caches
 off to the side, persists that candidate through `AtomicFileWriter`, and publishes it only after
 the durable replacement succeeds. Conflict, cancellation, or write failure leaves both the live
@@ -409,8 +413,11 @@ across tenant/company boundaries.
 Governed reporting persistence stores each series revision under its immutable tenant and scope
 identity while lifecycle state advances through compare-and-swap aggregate versions. State payloads
 retain a SHA-256 checksum and are hydrated only when their indexed identity, tenant, lifecycle
-state, and checksum agree. Lifecycle audit events are appended in the same serializable transaction;
-database triggers require contiguous versions and the retained previous hash, and reject later
+state, and checksum agree. Lifecycle audit events are appended in the same serializable transaction.
+Optional immutable-array fields are canonicalized from their default value to an empty collection
+before source-generated JSON persistence and after hydration, keeping equivalent reporting state
+serializable and deterministic across callers. Database triggers require contiguous versions and
+the retained previous hash, and reject later
 updates or deletes. Restatement approval updates the request and creates the next report revision in
 one transaction, so a failed revision insert cannot leave an approved request without its draft.
 Reporting delivery persistence also keeps run and package identity separately, lists grants and

--- a/src/Meridian.Storage/Reporting/PostgresReportingGovernanceRepository.cs
+++ b/src/Meridian.Storage/Reporting/PostgresReportingGovernanceRepository.cs
@@ -410,13 +410,17 @@ public sealed class PostgresReportingGovernanceRepository : IReportingGovernance
                 ?? throw new ReportingGovernanceConcurrencyException(
                     $"Reporting run '{run.RunId}' version conflict: expected {expectedVersion}.");
             var current = await HydrateRunAsync(currentRow, cancellationToken).ConfigureAwait(false);
-            if (current.Version != expectedVersion
-                || !StringComparer.Ordinal.Equals(
-                    ReportingGovernanceCanonicalValidation.ComputeImmutableRunFingerprint(current),
-                    ReportingGovernanceCanonicalValidation.ComputeImmutableRunFingerprint(run)))
+            if (current.Version != expectedVersion)
             {
                 throw new ReportingGovernanceConcurrencyException(
-                    $"Reporting run '{run.RunId}' replacement attempted to change its immutable creation binding or stale version {expectedVersion}.");
+                    $"Reporting run '{run.RunId}' version conflict: expected {expectedVersion}, actual {current.Version}.");
+            }
+            if (!StringComparer.Ordinal.Equals(
+                ReportingGovernanceCanonicalValidation.ComputeImmutableRunFingerprint(current),
+                ReportingGovernanceCanonicalValidation.ComputeImmutableRunFingerprint(run)))
+            {
+                throw new ReportingGovernanceConcurrencyException(
+                    $"Reporting run '{run.RunId}' replacement attempted to change its immutable creation binding.");
             }
 
             var payload = SerializeRun(run with { AuditTrail = [] });
@@ -719,6 +723,8 @@ public sealed class PostgresReportingGovernanceRepository : IReportingGovernance
             {
                 throw Integrity("reporting run", row.RunId, "the retained state payload contains mutable audit history");
             }
+
+            ValidateRunShape(run, requireAudit: false);
 
             if (!StringComparer.Ordinal.Equals(run.Scope.TenantId, row.TenantId)
                 || !StringComparer.Ordinal.Equals(run.RunId, row.RunId)

--- a/src/Meridian.Storage/Reporting/PostgresReportingGovernanceRepository.cs
+++ b/src/Meridian.Storage/Reporting/PostgresReportingGovernanceRepository.cs
@@ -81,147 +81,6 @@ public sealed class PostgresReportingGovernanceRepository : IReportingGovernance
         }
     }
 
-    internal static string SerializeRunForPersistence(GovernedReportingRun run)
-    {
-        ArgumentNullException.ThrowIfNull(run);
-        return JsonSerializer.Serialize(
-            NormalizeForPersistence(run),
-            ReportingGovernanceJsonContext.Default.GovernedReportingRun);
-    }
-
-    internal static GovernedReportingRun DeserializeRunFromPersistence(string payload) =>
-        NormalizeForPersistence(
-            JsonSerializer.Deserialize(
-                payload,
-                ReportingGovernanceJsonContext.Default.GovernedReportingRun)
-            ?? throw new JsonException("The retained reporting run payload was null."));
-
-    internal static string SerializeRestatementForPersistence(ReportingRestatementRequest request)
-    {
-        ArgumentNullException.ThrowIfNull(request);
-        return JsonSerializer.Serialize(
-            NormalizeForPersistence(request),
-            ReportingGovernanceJsonContext.Default.ReportingRestatementRequest);
-    }
-
-    internal static ReportingRestatementRequest DeserializeRestatementFromPersistence(string payload) =>
-        NormalizeForPersistence(
-            JsonSerializer.Deserialize(
-                payload,
-                ReportingGovernanceJsonContext.Default.ReportingRestatementRequest)
-            ?? throw new JsonException("The retained reporting restatement payload was null."));
-
-    internal static string SerializeAuditForPersistence(ReportingGovernanceAuditEntry entry)
-    {
-        ArgumentNullException.ThrowIfNull(entry);
-        return JsonSerializer.Serialize(
-            NormalizeForPersistence(entry),
-            ReportingGovernanceJsonContext.Default.ReportingGovernanceAuditEntry);
-    }
-
-    internal static ReportingGovernanceAuditEntry DeserializeAuditFromPersistence(string payload) =>
-        NormalizeForPersistence(
-            JsonSerializer.Deserialize(
-                payload,
-                ReportingGovernanceJsonContext.Default.ReportingGovernanceAuditEntry)
-            ?? throw new JsonException("The retained reporting governance audit payload was null."));
-
-    private static GovernedReportingRun NormalizeForPersistence(GovernedReportingRun run) =>
-        run with
-        {
-            Access = NormalizeForPersistence(run.Access),
-            CreationAuthority = NormalizeForPersistence(run.CreationAuthority),
-            Readiness = NormalizeForPersistence(run.Readiness),
-            Approval = NormalizeForPersistence(run.Approval),
-            Release = NormalizeForPersistence(run.Release),
-            AuditTrail = NormalizeAudit(run.AuditTrail)
-        };
-
-    private static ReportingRestatementRequest NormalizeForPersistence(
-        ReportingRestatementRequest request) =>
-        request with
-        {
-            ChangedLines = NormalizeChangedLines(request.ChangedLines),
-            RequestedBy = NormalizeForPersistence(request.RequestedBy),
-            ApprovedBy = NormalizeOptionalAuthority(request.ApprovedBy),
-            AuditTrail = NormalizeAudit(request.AuditTrail),
-            RequestedChangedLines = NormalizeChangedLines(request.RequestedChangedLines)
-        };
-
-    private static ReportingAccessScope NormalizeForPersistence(ReportingAccessScope access) =>
-        access is null
-            ? null!
-            : access with { Principals = OrEmpty(access.Principals) };
-
-    private static ReportingAuthorityScope NormalizeForPersistence(ReportingAuthorityScope authority) =>
-        authority is null
-            ? null!
-            : authority with
-            {
-                Permissions = OrEmpty(authority.Permissions),
-                PrincipalIds = OrEmpty(authority.PrincipalIds)
-            };
-
-    private static ReportingAuthorityScope? NormalizeOptionalAuthority(ReportingAuthorityScope? authority) =>
-        authority is null ? null : NormalizeForPersistence(authority);
-
-    private static ReportingReadinessReceipt? NormalizeForPersistence(ReportingReadinessReceipt? readiness) =>
-        readiness is null
-            ? null
-            : readiness with { Checks = NormalizeReadinessChecks(readiness.Checks) };
-
-    private static ReportingApprovalReceipt? NormalizeForPersistence(ReportingApprovalReceipt? approval) =>
-        approval is null
-            ? null
-            : approval with { Authority = NormalizeForPersistence(approval.Authority) };
-
-    private static ReportingReleaseReceipt? NormalizeForPersistence(ReportingReleaseReceipt? release) =>
-        release is null
-            ? null
-            : release with
-            {
-                Authority = NormalizeForPersistence(release.Authority),
-                Artifacts = OrEmpty(release.Artifacts),
-                EvidenceIds = OrEmpty(release.EvidenceIds)
-            };
-
-    private static ReportingGovernanceAuditEntry NormalizeForPersistence(
-        ReportingGovernanceAuditEntry entry) =>
-        entry is null
-            ? null!
-            : entry with { Authority = NormalizeForPersistence(entry.Authority) };
-
-    private static ImmutableArray<ReportingReadinessCheck> NormalizeReadinessChecks(
-        ImmutableArray<ReportingReadinessCheck> checks) =>
-        checks.IsDefault
-            ? []
-            : checks
-                .Select(static check => check is null
-                    ? null!
-                    : check with { EvidenceIds = OrEmpty(check.EvidenceIds) })
-                .ToImmutableArray();
-
-    private static ImmutableArray<ReportingRestatementChangedLine> NormalizeChangedLines(
-        ImmutableArray<ReportingRestatementChangedLine> changedLines) =>
-        changedLines.IsDefault
-            ? []
-            : changedLines
-                .Select(static line => line is null
-                    ? null!
-                    : line with { EvidenceIds = OrEmpty(line.EvidenceIds) })
-                .ToImmutableArray();
-
-    private static ImmutableArray<ReportingGovernanceAuditEntry> NormalizeAudit(
-        ImmutableArray<ReportingGovernanceAuditEntry> audit) =>
-        audit.IsDefault
-            ? []
-            : audit
-                .Select(static entry => NormalizeForPersistence(entry))
-                .ToImmutableArray();
-
-    private static ImmutableArray<T> OrEmpty<T>(ImmutableArray<T> values) =>
-        values.IsDefault ? [] : values;
-
     private sealed class PostgresReportingGovernanceTransaction : IReportingGovernanceTransaction
     {
         private const int MaximumKeyLength = 256;
@@ -1957,13 +1816,13 @@ public sealed class PostgresReportingGovernanceRepository : IReportingGovernance
         }
 
         private static string SerializeRun(GovernedReportingRun run) =>
-            SerializeRunForPersistence(run);
+            ReportingGovernancePersistenceJson.SerializeRun(run);
 
         private static GovernedReportingRun DeserializeRun(string payload, string id)
         {
             try
             {
-                return DeserializeRunFromPersistence(payload);
+                return ReportingGovernancePersistenceJson.DeserializeRun(payload);
             }
             catch (JsonException exception)
             {
@@ -1991,13 +1850,13 @@ public sealed class PostgresReportingGovernanceRepository : IReportingGovernance
         }
 
         private static string SerializeRestatement(ReportingRestatementRequest request) =>
-            SerializeRestatementForPersistence(request);
+            ReportingGovernancePersistenceJson.SerializeRestatement(request);
 
         private static ReportingRestatementRequest DeserializeRestatement(string payload, string id)
         {
             try
             {
-                return DeserializeRestatementFromPersistence(payload);
+                return ReportingGovernancePersistenceJson.DeserializeRestatement(payload);
             }
             catch (JsonException exception)
             {
@@ -2028,13 +1887,13 @@ public sealed class PostgresReportingGovernanceRepository : IReportingGovernance
         }
 
         private static string SerializeAudit(ReportingGovernanceAuditEntry entry) =>
-            SerializeAuditForPersistence(entry);
+            ReportingGovernancePersistenceJson.SerializeAudit(entry);
 
         private static ReportingGovernanceAuditEntry DeserializeAudit(string payload, string id)
         {
             try
             {
-                return DeserializeAuditFromPersistence(payload);
+                return ReportingGovernancePersistenceJson.DeserializeAudit(payload);
             }
             catch (JsonException exception)
             {

--- a/src/Meridian.Storage/Reporting/PostgresReportingGovernanceRepository.cs
+++ b/src/Meridian.Storage/Reporting/PostgresReportingGovernanceRepository.cs
@@ -81,6 +81,147 @@ public sealed class PostgresReportingGovernanceRepository : IReportingGovernance
         }
     }
 
+    internal static string SerializeRunForPersistence(GovernedReportingRun run)
+    {
+        ArgumentNullException.ThrowIfNull(run);
+        return JsonSerializer.Serialize(
+            NormalizeForPersistence(run),
+            ReportingGovernanceJsonContext.Default.GovernedReportingRun);
+    }
+
+    internal static GovernedReportingRun DeserializeRunFromPersistence(string payload) =>
+        NormalizeForPersistence(
+            JsonSerializer.Deserialize(
+                payload,
+                ReportingGovernanceJsonContext.Default.GovernedReportingRun)
+            ?? throw new JsonException("The retained reporting run payload was null."));
+
+    internal static string SerializeRestatementForPersistence(ReportingRestatementRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return JsonSerializer.Serialize(
+            NormalizeForPersistence(request),
+            ReportingGovernanceJsonContext.Default.ReportingRestatementRequest);
+    }
+
+    internal static ReportingRestatementRequest DeserializeRestatementFromPersistence(string payload) =>
+        NormalizeForPersistence(
+            JsonSerializer.Deserialize(
+                payload,
+                ReportingGovernanceJsonContext.Default.ReportingRestatementRequest)
+            ?? throw new JsonException("The retained reporting restatement payload was null."));
+
+    internal static string SerializeAuditForPersistence(ReportingGovernanceAuditEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        return JsonSerializer.Serialize(
+            NormalizeForPersistence(entry),
+            ReportingGovernanceJsonContext.Default.ReportingGovernanceAuditEntry);
+    }
+
+    internal static ReportingGovernanceAuditEntry DeserializeAuditFromPersistence(string payload) =>
+        NormalizeForPersistence(
+            JsonSerializer.Deserialize(
+                payload,
+                ReportingGovernanceJsonContext.Default.ReportingGovernanceAuditEntry)
+            ?? throw new JsonException("The retained reporting governance audit payload was null."));
+
+    private static GovernedReportingRun NormalizeForPersistence(GovernedReportingRun run) =>
+        run with
+        {
+            Access = NormalizeForPersistence(run.Access),
+            CreationAuthority = NormalizeForPersistence(run.CreationAuthority),
+            Readiness = NormalizeForPersistence(run.Readiness),
+            Approval = NormalizeForPersistence(run.Approval),
+            Release = NormalizeForPersistence(run.Release),
+            AuditTrail = NormalizeAudit(run.AuditTrail)
+        };
+
+    private static ReportingRestatementRequest NormalizeForPersistence(
+        ReportingRestatementRequest request) =>
+        request with
+        {
+            ChangedLines = NormalizeChangedLines(request.ChangedLines),
+            RequestedBy = NormalizeForPersistence(request.RequestedBy),
+            ApprovedBy = NormalizeOptionalAuthority(request.ApprovedBy),
+            AuditTrail = NormalizeAudit(request.AuditTrail),
+            RequestedChangedLines = NormalizeChangedLines(request.RequestedChangedLines)
+        };
+
+    private static ReportingAccessScope NormalizeForPersistence(ReportingAccessScope access) =>
+        access is null
+            ? null!
+            : access with { Principals = OrEmpty(access.Principals) };
+
+    private static ReportingAuthorityScope NormalizeForPersistence(ReportingAuthorityScope authority) =>
+        authority is null
+            ? null!
+            : authority with
+            {
+                Permissions = OrEmpty(authority.Permissions),
+                PrincipalIds = OrEmpty(authority.PrincipalIds)
+            };
+
+    private static ReportingAuthorityScope? NormalizeOptionalAuthority(ReportingAuthorityScope? authority) =>
+        authority is null ? null : NormalizeForPersistence(authority);
+
+    private static ReportingReadinessReceipt? NormalizeForPersistence(ReportingReadinessReceipt? readiness) =>
+        readiness is null
+            ? null
+            : readiness with { Checks = NormalizeReadinessChecks(readiness.Checks) };
+
+    private static ReportingApprovalReceipt? NormalizeForPersistence(ReportingApprovalReceipt? approval) =>
+        approval is null
+            ? null
+            : approval with { Authority = NormalizeForPersistence(approval.Authority) };
+
+    private static ReportingReleaseReceipt? NormalizeForPersistence(ReportingReleaseReceipt? release) =>
+        release is null
+            ? null
+            : release with
+            {
+                Authority = NormalizeForPersistence(release.Authority),
+                Artifacts = OrEmpty(release.Artifacts),
+                EvidenceIds = OrEmpty(release.EvidenceIds)
+            };
+
+    private static ReportingGovernanceAuditEntry NormalizeForPersistence(
+        ReportingGovernanceAuditEntry entry) =>
+        entry is null
+            ? null!
+            : entry with { Authority = NormalizeForPersistence(entry.Authority) };
+
+    private static ImmutableArray<ReportingReadinessCheck> NormalizeReadinessChecks(
+        ImmutableArray<ReportingReadinessCheck> checks) =>
+        checks.IsDefault
+            ? []
+            : checks
+                .Select(static check => check is null
+                    ? null!
+                    : check with { EvidenceIds = OrEmpty(check.EvidenceIds) })
+                .ToImmutableArray();
+
+    private static ImmutableArray<ReportingRestatementChangedLine> NormalizeChangedLines(
+        ImmutableArray<ReportingRestatementChangedLine> changedLines) =>
+        changedLines.IsDefault
+            ? []
+            : changedLines
+                .Select(static line => line is null
+                    ? null!
+                    : line with { EvidenceIds = OrEmpty(line.EvidenceIds) })
+                .ToImmutableArray();
+
+    private static ImmutableArray<ReportingGovernanceAuditEntry> NormalizeAudit(
+        ImmutableArray<ReportingGovernanceAuditEntry> audit) =>
+        audit.IsDefault
+            ? []
+            : audit
+                .Select(static entry => NormalizeForPersistence(entry))
+                .ToImmutableArray();
+
+    private static ImmutableArray<T> OrEmpty<T>(ImmutableArray<T> values) =>
+        values.IsDefault ? [] : values;
+
     private sealed class PostgresReportingGovernanceTransaction : IReportingGovernanceTransaction
     {
         private const int MaximumKeyLength = 256;
@@ -1816,14 +1957,13 @@ public sealed class PostgresReportingGovernanceRepository : IReportingGovernance
         }
 
         private static string SerializeRun(GovernedReportingRun run) =>
-            JsonSerializer.Serialize(run, ReportingGovernanceJsonContext.Default.GovernedReportingRun);
+            SerializeRunForPersistence(run);
 
         private static GovernedReportingRun DeserializeRun(string payload, string id)
         {
             try
             {
-                return JsonSerializer.Deserialize(payload, ReportingGovernanceJsonContext.Default.GovernedReportingRun)
-                    ?? throw Integrity("reporting run", id, "the retained state payload is null");
+                return DeserializeRunFromPersistence(payload);
             }
             catch (JsonException exception)
             {
@@ -1851,16 +1991,13 @@ public sealed class PostgresReportingGovernanceRepository : IReportingGovernance
         }
 
         private static string SerializeRestatement(ReportingRestatementRequest request) =>
-            JsonSerializer.Serialize(request, ReportingGovernanceJsonContext.Default.ReportingRestatementRequest);
+            SerializeRestatementForPersistence(request);
 
         private static ReportingRestatementRequest DeserializeRestatement(string payload, string id)
         {
             try
             {
-                return JsonSerializer.Deserialize(
-                        payload,
-                        ReportingGovernanceJsonContext.Default.ReportingRestatementRequest)
-                    ?? throw Integrity("reporting restatement request", id, "the retained state payload is null");
+                return DeserializeRestatementFromPersistence(payload);
             }
             catch (JsonException exception)
             {
@@ -1891,16 +2028,13 @@ public sealed class PostgresReportingGovernanceRepository : IReportingGovernance
         }
 
         private static string SerializeAudit(ReportingGovernanceAuditEntry entry) =>
-            JsonSerializer.Serialize(entry, ReportingGovernanceJsonContext.Default.ReportingGovernanceAuditEntry);
+            SerializeAuditForPersistence(entry);
 
         private static ReportingGovernanceAuditEntry DeserializeAudit(string payload, string id)
         {
             try
             {
-                return JsonSerializer.Deserialize(
-                        payload,
-                        ReportingGovernanceJsonContext.Default.ReportingGovernanceAuditEntry)
-                    ?? throw Integrity("reporting governance audit event", id, "the retained event payload is null");
+                return DeserializeAuditFromPersistence(payload);
             }
             catch (JsonException exception)
             {

--- a/src/Meridian.Storage/Reporting/ReportingGovernancePersistenceJson.cs
+++ b/src/Meridian.Storage/Reporting/ReportingGovernancePersistenceJson.cs
@@ -1,0 +1,147 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using Meridian.Reporting;
+
+namespace Meridian.Storage.Reporting;
+
+/// <summary>
+/// Canonicalizes governed-reporting payloads at the durable JSON boundary. Default immutable
+/// arrays are semantically empty but are not directly serializable by the source-generated
+/// converters, so persistence always writes and hydrates their canonical empty representation.
+/// </summary>
+internal static class ReportingGovernancePersistenceJson
+{
+    internal static string SerializeRun(GovernedReportingRun run)
+    {
+        ArgumentNullException.ThrowIfNull(run);
+        return JsonSerializer.Serialize(
+            Normalize(run),
+            ReportingGovernanceJsonContext.Default.GovernedReportingRun);
+    }
+
+    internal static GovernedReportingRun DeserializeRun(string payload) =>
+        Normalize(
+            JsonSerializer.Deserialize(
+                payload,
+                ReportingGovernanceJsonContext.Default.GovernedReportingRun)
+            ?? throw new JsonException("The retained reporting run payload was null."));
+
+    internal static string SerializeRestatement(ReportingRestatementRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return JsonSerializer.Serialize(
+            Normalize(request),
+            ReportingGovernanceJsonContext.Default.ReportingRestatementRequest);
+    }
+
+    internal static ReportingRestatementRequest DeserializeRestatement(string payload) =>
+        Normalize(
+            JsonSerializer.Deserialize(
+                payload,
+                ReportingGovernanceJsonContext.Default.ReportingRestatementRequest)
+            ?? throw new JsonException("The retained reporting restatement payload was null."));
+
+    internal static string SerializeAudit(ReportingGovernanceAuditEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        return JsonSerializer.Serialize(
+            Normalize(entry),
+            ReportingGovernanceJsonContext.Default.ReportingGovernanceAuditEntry);
+    }
+
+    internal static ReportingGovernanceAuditEntry DeserializeAudit(string payload) =>
+        Normalize(
+            JsonSerializer.Deserialize(
+                payload,
+                ReportingGovernanceJsonContext.Default.ReportingGovernanceAuditEntry)
+            ?? throw new JsonException("The retained reporting governance audit payload was null."));
+
+    private static GovernedReportingRun Normalize(GovernedReportingRun run) =>
+        run with
+        {
+            Access = Normalize(run.Access),
+            CreationAuthority = Normalize(run.CreationAuthority),
+            Readiness = Normalize(run.Readiness),
+            Approval = Normalize(run.Approval),
+            Release = Normalize(run.Release),
+            AuditTrail = NormalizeAudit(run.AuditTrail)
+        };
+
+    private static ReportingRestatementRequest Normalize(ReportingRestatementRequest request) =>
+        request with
+        {
+            ChangedLines = NormalizeChangedLines(request.ChangedLines),
+            RequestedBy = Normalize(request.RequestedBy),
+            ApprovedBy = request.ApprovedBy is null ? null : Normalize(request.ApprovedBy),
+            AuditTrail = NormalizeAudit(request.AuditTrail),
+            RequestedChangedLines = NormalizeChangedLines(request.RequestedChangedLines)
+        };
+
+    private static ReportingAccessScope Normalize(ReportingAccessScope access) =>
+        access is null
+            ? null!
+            : access with { Principals = OrEmpty(access.Principals) };
+
+    private static ReportingAuthorityScope Normalize(ReportingAuthorityScope authority) =>
+        authority is null
+            ? null!
+            : authority with
+            {
+                Permissions = OrEmpty(authority.Permissions),
+                PrincipalIds = OrEmpty(authority.PrincipalIds)
+            };
+
+    private static ReportingReadinessReceipt? Normalize(ReportingReadinessReceipt? readiness) =>
+        readiness is null
+            ? null
+            : readiness with { Checks = NormalizeReadinessChecks(readiness.Checks) };
+
+    private static ReportingApprovalReceipt? Normalize(ReportingApprovalReceipt? approval) =>
+        approval is null
+            ? null
+            : approval with { Authority = Normalize(approval.Authority) };
+
+    private static ReportingReleaseReceipt? Normalize(ReportingReleaseReceipt? release) =>
+        release is null
+            ? null
+            : release with
+            {
+                Authority = Normalize(release.Authority),
+                Artifacts = OrEmpty(release.Artifacts),
+                EvidenceIds = OrEmpty(release.EvidenceIds)
+            };
+
+    private static ReportingGovernanceAuditEntry Normalize(ReportingGovernanceAuditEntry entry) =>
+        entry is null
+            ? null!
+            : entry with { Authority = Normalize(entry.Authority) };
+
+    private static ImmutableArray<ReportingReadinessCheck> NormalizeReadinessChecks(
+        ImmutableArray<ReportingReadinessCheck> checks) =>
+        checks.IsDefault
+            ? []
+            : checks
+                .Select(static check => check is null
+                    ? null!
+                    : check with { EvidenceIds = OrEmpty(check.EvidenceIds) })
+                .ToImmutableArray();
+
+    private static ImmutableArray<ReportingRestatementChangedLine> NormalizeChangedLines(
+        ImmutableArray<ReportingRestatementChangedLine> changedLines) =>
+        changedLines.IsDefault
+            ? []
+            : changedLines
+                .Select(static line => line is null
+                    ? null!
+                    : line with { EvidenceIds = OrEmpty(line.EvidenceIds) })
+                .ToImmutableArray();
+
+    private static ImmutableArray<ReportingGovernanceAuditEntry> NormalizeAudit(
+        ImmutableArray<ReportingGovernanceAuditEntry> audit) =>
+        audit.IsDefault
+            ? []
+            : audit.Select(static entry => Normalize(entry)).ToImmutableArray();
+
+    private static ImmutableArray<T> OrEmpty<T>(ImmutableArray<T> values) =>
+        values.IsDefault ? [] : values;
+}

--- a/src/Meridian.Storage/SecurityMaster/PostgresSecurityMasterStore.cs
+++ b/src/Meridian.Storage/SecurityMaster/PostgresSecurityMasterStore.cs
@@ -757,11 +757,18 @@ public sealed class PostgresSecurityMasterStore : ISecurityMasterStore
             limit 1;
             """,
             $"""
-            select security_id
-            from {Qualified("securities")}
-            where primary_identifier_kind = @identifier_kind
-              and normalized_primary_identifier_value = @normalized_identifier_value
-              and (@include_inactive = true or status = 'Active')
+            select s.security_id
+            from {Qualified("securities")} s
+            where s.primary_identifier_kind = @identifier_kind
+              and s.normalized_primary_identifier_value = @normalized_identifier_value
+              and @normalized_provider is null
+              and not exists (
+                  select 1
+                  from {Qualified("security_identifiers")} i
+                  where i.security_id = s.security_id
+                    and i.identifier_kind = @identifier_kind
+                    and i.normalized_identifier_value = @normalized_identifier_value)
+              and (@include_inactive = true or s.status = 'Active')
             limit 1;
             """
         })

--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -1284,6 +1284,11 @@ Reporting startup also integrity-reloads the one reconciliation queue shared by 
 casework, Operations Continuity, hard close, and Final evidence; readiness requires that receipt and
 the running schedule and secure-delivery workers with valid options. PostgreSQL-shaped source
 registrations without those completed source migrations remain blocked.
+During the delivery worker's explicit one-time initial-start state, the schedule worker excludes
+only the two worker-liveness receipts so independently starting workers do not deadlock on startup
+order. Once delivery succeeds, fails, stops, or becomes stale, its liveness blocks schedule polling
+again; every durable store, migration, configuration, and non-worker blocker always remains
+fail-closed.
 `GET /api/workstation/reporting` returns `503`
 when any component is missing instead of inheriting Accounting health or a fallback Reporting
 payload; workstation structured Reporting exports apply the same fail-closed posture. A successful

--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -6,7 +6,7 @@ module_id: SRC-UI-SHARED
 path: src/Meridian.Ui.Shared
 status: active
 owner_lane: Workstation Shell and UX
-last_reviewed: 2026-08-03
+last_reviewed: 2026-08-04
 ---
 
 # src/Meridian.Ui.Shared
@@ -21,6 +21,11 @@ one-use bootstrap token.
 
 UI shared contains shared UI read models, endpoint adapters, and compatibility shims for browser
 and desktop surfaces.
+
+`DemoTenantProvisioner` publishes its deterministic reconciliation casework through the same
+tenant/company-scoped queue contract as production workflows. Seeded demo breaks carry the fixed
+`DemoTenantBlueprint` tenant and company identifiers; authenticated demo hosts must resolve that
+scope to read the cases, and legacy unscoped queue rows remain inaccessible.
 
 ## Layer responsibility
 

--- a/src/Meridian.Ui.Shared/Services/DemoTenantBlueprint.cs
+++ b/src/Meridian.Ui.Shared/Services/DemoTenantBlueprint.cs
@@ -28,6 +28,10 @@ public static class DemoTenantBlueprint
     /// <summary>The provenance label onboarding renders for the seeded workspace.</summary>
     public const string SeededProvenanceLabel = "Seeded";
 
+    /// <summary>Fixed tenant/company authority for the isolated seeded demo workspace.</summary>
+    public const string TenantId = "meridian-seeded-demo";
+    public const string CompanyId = "meridian-seeded-demo";
+
     public const string PortfolioName = "Northstar Sample Portfolio";
     public const decimal Cash = 125_000m;
 

--- a/src/Meridian.Ui.Shared/Services/DemoTenantProvisioner.cs
+++ b/src/Meridian.Ui.Shared/Services/DemoTenantProvisioner.cs
@@ -39,6 +39,9 @@ public sealed class DemoTenantProvisioner(
         }
 
         var now = DateTimeOffset.UtcNow;
+        var authorityScope = new ReconciliationBreakQueueScope(
+            DemoTenantBlueprint.TenantId,
+            DemoTenantBlueprint.CompanyId);
         var seeded = 0;
         var loaded = true;
         foreach (var definition in DemoTenantBlueprint.BreakDefinitions)
@@ -60,9 +63,15 @@ public sealed class DemoTenantProvisioner(
                     Severity: definition.Severity,
                     ExplainabilitySummary: definition.Summary,
                     SourceType: DemoTenantBlueprint.SeededSourceType,
-                    SourceSystem: DemoTenantBlueprint.SeededSourceSystem);
+                    SourceSystem: DemoTenantBlueprint.SeededSourceSystem)
+                {
+                    TenantId = DemoTenantBlueprint.TenantId,
+                    CompanyId = DemoTenantBlueprint.CompanyId
+                };
 
-                if (await reconciliationBreaks.CreateIfMissingAsync(item, ct).ConfigureAwait(false))
+                if (await reconciliationBreaks
+                        .CreateIfMissingAsync(authorityScope, item, ct)
+                        .ConfigureAwait(false))
                 {
                     seeded++;
                 }

--- a/src/Meridian.Ui.Shared/Services/ReportingDeploymentReadinessService.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingDeploymentReadinessService.cs
@@ -17,8 +17,10 @@ public interface IReportingDeploymentReadinessService
 
     /// <summary>
     /// Returns deployment blockers for the schedule worker's own polling cycle. Implementations
-    /// may exclude only their scheduling-worker liveness receipt so that the first successful
-    /// cycle can earn that receipt. The default remains fully fail-closed.
+    /// may exclude the scheduling-worker liveness receipt so it can earn its first receipt. A
+    /// production implementation may also exclude the delivery-worker liveness receipt only while
+    /// that peer explicitly reports its one-time initial-start window. The default remains fully
+    /// fail-closed.
     /// </summary>
     IReadOnlyList<string> GetScheduleWorkerCycleBlockingReasons() =>
         ReportingDeploymentReadinessService.ResolveCapabilityBlockingReasons(Evaluate());
@@ -107,13 +109,21 @@ public sealed class ReportingScheduleWorkerReadinessState
 /// </summary>
 public sealed class ReportingDeliveryWorkerReadinessState
 {
+    private const int LifecycleNotStarted = 0;
+    private const int LifecycleInitialStart = 1;
+    private const int LifecycleOperational = 2;
+
     private int _ready;
     private int _consecutiveFailures;
+    private int _lifecycleState;
     private long _lastSuccessfulCycleUtcTicks;
 
     public bool IsReady => Volatile.Read(ref _ready) == 1;
 
     public int ConsecutiveFailures => Volatile.Read(ref _consecutiveFailures);
+
+    internal bool IsInitialStartInProgress =>
+        Volatile.Read(ref _lifecycleState) == LifecycleInitialStart;
 
     public DateTimeOffset? LastSuccessfulCycleUtc =>
         ReadTimestamp(ref _lastSuccessfulCycleUtcTicks);
@@ -126,20 +136,37 @@ public sealed class ReportingDeliveryWorkerReadinessState
             nowUtc,
             maximumHeartbeatAge);
 
-    internal void MarkReady(DateTimeOffset? completedAtUtc = null) =>
+    internal void MarkStarting()
+    {
+        Volatile.Write(ref _ready, 0);
+        _ = Interlocked.CompareExchange(
+            ref _lifecycleState,
+            LifecycleInitialStart,
+            LifecycleNotStarted);
+    }
+
+    internal void MarkReady(DateTimeOffset? completedAtUtc = null)
+    {
+        Volatile.Write(ref _lifecycleState, LifecycleOperational);
         WorkerReadinessState.MarkReady(
             ref _ready,
             ref _consecutiveFailures,
             ref _lastSuccessfulCycleUtcTicks,
             completedAtUtc);
+    }
 
     internal void MarkCycleFailed()
     {
+        Volatile.Write(ref _lifecycleState, LifecycleOperational);
         Interlocked.Increment(ref _consecutiveFailures);
         Volatile.Write(ref _ready, 0);
     }
 
-    internal void MarkNotReady() => Volatile.Write(ref _ready, 0);
+    internal void MarkNotReady()
+    {
+        Volatile.Write(ref _lifecycleState, LifecycleOperational);
+        Volatile.Write(ref _ready, 0);
+    }
 
     private static DateTimeOffset? ReadTimestamp(ref long ticks)
     {
@@ -191,6 +218,7 @@ public sealed class ReportingDeploymentReadinessService(
     IServiceProvider services) : IReportingDeploymentReadinessService
 {
     internal const string SchedulingWorkerComponentId = "scheduling-worker";
+    internal const string DeliveryWorkerComponentId = "delivery-worker";
 
     private static readonly IReadOnlyDictionary<string, ReportingDeploymentSchemaRequirement>
         SchemaRequirements =
@@ -680,10 +708,25 @@ public sealed class ReportingDeploymentReadinessService(
     }
 
     public IReadOnlyList<string> GetScheduleWorkerCycleBlockingReasons()
-        => ResolveScheduleWorkerCycleBlockingReasons(Evaluate());
+    {
+        var capability = Evaluate();
+        var deliveryWorkerReadiness =
+            _services.GetService<ReportingDeliveryWorkerReadinessState>();
+        return ResolveScheduleWorkerCycleBlockingReasons(
+            capability,
+            allowDeliveryWorkerInitialBootstrap:
+                deliveryWorkerReadiness?.IsInitialStartInProgress == true);
+    }
 
     internal static IReadOnlyList<string> ResolveScheduleWorkerCycleBlockingReasons(
-        ReportingDeploymentCapabilityDto capability)
+        ReportingDeploymentCapabilityDto capability) =>
+        ResolveScheduleWorkerCycleBlockingReasons(
+            capability,
+            allowDeliveryWorkerInitialBootstrap: false);
+
+    internal static IReadOnlyList<string> ResolveScheduleWorkerCycleBlockingReasons(
+        ReportingDeploymentCapabilityDto capability,
+        bool allowDeliveryWorkerInitialBootstrap)
     {
         var blockers = ResolveCapabilityBlockingReasons(capability).ToList();
         var schedulingWorker = capability.Components.SingleOrDefault(component =>
@@ -695,10 +738,8 @@ public sealed class ReportingDeploymentReadinessService(
         {
             blockers.Add(
                 "Reporting deployment readiness omitted the scheduling-worker component.");
-            return blockers;
         }
-
-        if (!schedulingWorker.IsReady)
+        else if (!schedulingWorker.IsReady)
         {
             var selfBlockerIndex = blockers.FindIndex(reason =>
                 string.Equals(
@@ -708,6 +749,29 @@ public sealed class ReportingDeploymentReadinessService(
             if (selfBlockerIndex >= 0)
             {
                 blockers.RemoveAt(selfBlockerIndex);
+            }
+        }
+
+        var deliveryWorker = capability.Components.SingleOrDefault(component =>
+            string.Equals(
+                component.ComponentId,
+                DeliveryWorkerComponentId,
+                StringComparison.Ordinal));
+        if (deliveryWorker is null)
+        {
+            blockers.Add(
+                "Reporting deployment readiness omitted the delivery-worker component.");
+        }
+        else if (allowDeliveryWorkerInitialBootstrap && !deliveryWorker.IsReady)
+        {
+            var peerBlockerIndex = blockers.FindIndex(reason =>
+                string.Equals(
+                    reason,
+                    deliveryWorker.Summary,
+                    StringComparison.Ordinal));
+            if (peerBlockerIndex >= 0)
+            {
+                blockers.RemoveAt(peerBlockerIndex);
             }
         }
 

--- a/src/Meridian.Ui.Shared/Services/ReportingSecureDistributionHostedService.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingSecureDistributionHostedService.cs
@@ -130,6 +130,15 @@ public sealed class ReportingSecureDistributionHostedService : BackgroundService
         return base.StartAsync(cancellationToken);
     }
 
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        // Fail closed as soon as shutdown begins. BackgroundService can complete StopAsync
+        // before the ExecuteAsync continuation reaches its finally block, especially when the
+        // first cycle is released concurrently with the stop request.
+        _readiness?.MarkNotReady();
+        await base.StopAsync(cancellationToken).ConfigureAwait(false);
+    }
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         var workerId = $"{_options.WorkerId}:hosted";

--- a/src/Meridian.Ui.Shared/Services/ReportingSecureDistributionHostedService.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingSecureDistributionHostedService.cs
@@ -124,6 +124,12 @@ public sealed class ReportingSecureDistributionHostedService : BackgroundService
         }
     }
 
+    public override Task StartAsync(CancellationToken cancellationToken)
+    {
+        _readiness?.MarkStarting();
+        return base.StartAsync(cancellationToken);
+    }
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         var workerId = $"{_options.WorkerId}:hosted";

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -265,10 +265,7 @@ public static class WorkstationServiceCollectionExtensions
         services.TryAddSingleton(BrokerageConnectionOptions.RobinhoodFromEnvironment());
         services.TryAddSingleton<BrokerageConnectionService>();
         services.TryAddSingleton<AlpacaBrokerageConnectionService>();
-        foreach (var handler in DefaultProviderSetupHandlers.Create())
-        {
-            services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IProviderSetupHandler), handler));
-        }
+        services.AddDefaultProviderSetupHandlers();
         services.TryAddSingleton<IProviderSetupRegistry, ProviderSetupRegistry>();
         services.TryAddSingleton<ProviderConnectionLifecycleService>();
         services.TryAddSingleton<ProviderReadinessService>();

--- a/src/Meridian.Ui/dashboard/README.md
+++ b/src/Meridian.Ui/dashboard/README.md
@@ -6,7 +6,7 @@ module_id: SRC-UI-DASHBOARD
 path: src/Meridian.Ui/dashboard
 status: active
 owner_lane: Workstation Shell and UX
-last_reviewed: 2026-08-03
+last_reviewed: 2026-08-04
 ---
 
 # src/Meridian.Ui/dashboard

--- a/src/Meridian.Ui/dashboard/package-lock.json
+++ b/src/Meridian.Ui/dashboard/package-lock.json
@@ -1845,9 +1845,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/tests/Meridian.DirectLending.Tests/DirectLendingPostgresTestDatabase.cs
+++ b/tests/Meridian.DirectLending.Tests/DirectLendingPostgresTestDatabase.cs
@@ -83,16 +83,24 @@ internal sealed class DirectLendingPostgresTestDatabase : IAsyncDisposable
             return null;
         }
 
-        var schema = PostgresTestSchema.NewSchemaName("dl");
         var server = await PostgresTestServer.CreateAsync(
                 EnvVar,
                 new PostgresTestContainerOptions { Database = "meridian_dl_test" })
             .ConfigureAwait(false);
+        var schema = server.CreateSchemaName("dl");
 
         var database = new DirectLendingPostgresTestDatabase(server, schema);
-        var runner = new DirectLendingMigrationRunner(database.Options);
-        await runner.EnsureMigratedAsync().ConfigureAwait(false);
-        return database;
+        try
+        {
+            var runner = new DirectLendingMigrationRunner(database.Options);
+            await runner.EnsureMigratedAsync().ConfigureAwait(false);
+            return database;
+        }
+        catch
+        {
+            await database.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
     }
 
     public async Task<long> CountSnapshotsAsync(Guid loanId)
@@ -117,17 +125,6 @@ internal sealed class DirectLendingPostgresTestDatabase : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        // External databases persist across runs, so the run-scoped schema must be dropped;
-        // containers are discarded whole by the shared server.
-        if (_server.UsesExternalConnection)
-        {
-            await using var connection = new NpgsqlConnection(ConnectionString);
-            await connection.OpenAsync().ConfigureAwait(false);
-            await using var command = connection.CreateCommand();
-            command.CommandText = $"drop schema if exists {Schema} cascade;";
-            await command.ExecuteNonQueryAsync().ConfigureAwait(false);
-        }
-
         await _server.DisposeAsync().ConfigureAwait(false);
     }
 

--- a/tests/Meridian.FSharp.Tests/DomainTests.fs
+++ b/tests/Meridian.FSharp.Tests/DomainTests.fs
@@ -334,7 +334,37 @@ let private createPrimaryTicker effectiveFrom = {
     IsPrimary = true
     ValidFrom = effectiveFrom
     ValidTo = None
+    Provider = None
 }
+
+[<Fact>]
+let ``Identifier source-provider metadata does not change canonical identity`` () =
+    let now = DateTimeOffset.UtcNow
+    let left = { createPrimaryTicker now with Provider = Some "XNAS" }
+    let right = { createPrimaryTicker now with Provider = Some "REFINITIV" }
+
+    SecurityIdentifier.sameIdentity left right |> should equal true
+
+[<Fact>]
+let ``ProviderSymbol snapshot rejects provider metadata that contradicts its discriminant`` () =
+    let identifier = {
+        createPrimaryTicker DateTimeOffset.UtcNow with
+            Kind = IdentifierKind.ProviderSymbol "XNAS"
+            Provider = Some "REFINITIV"
+    }
+
+    (fun () -> SecurityIdentifierSnapshot(identifier) |> ignore)
+    |> should throw typeof<ArgumentException>
+
+[<Fact>]
+let ``ProviderSymbol snapshot uses the authoritative discriminant for equivalent metadata`` () =
+    let identifier = {
+        createPrimaryTicker DateTimeOffset.UtcNow with
+            Kind = IdentifierKind.ProviderSymbol "XNAS"
+            Provider = Some " xnas "
+    }
+
+    SecurityIdentifierSnapshot(identifier).Provider |> should equal "XNAS"
 
 let private createConvertiblePreferredClassification () =
     let preferredTerms = {
@@ -376,6 +406,22 @@ let private createEquityCreateCommand classification =
         EffectiveFrom = effectiveFrom
         Provenance = createBaseProvenance effectiveFrom
     }
+
+[<Fact>]
+let ``SecurityMasterCommandFacade rejects contradictory ProviderSymbol metadata`` () =
+    let baseCommand = createEquityCreateCommand None
+    let identifier = {
+        createPrimaryTicker baseCommand.EffectiveFrom with
+            Kind = IdentifierKind.ProviderSymbol "XNAS"
+            Provider = Some "REFINITIV"
+    }
+    let result = SecurityMasterCommandFacade.Create({ baseCommand with Identifiers = [ identifier ] })
+
+    result.IsSuccess |> should equal false
+    obj.ReferenceEquals(result.Snapshot, null) |> should equal true
+    result.ErrorDetails
+    |> Array.exists (fun error -> error.Code = "identifier_provider_mismatch")
+    |> should equal true
 
 let private createSecurityRecord (classification: EquityClassification option) : SecurityMasterRecord =
     match SecurityMaster.create (createEquityCreateCommand classification) with

--- a/tests/Meridian.TestSupport/Meridian.TestSupport.csproj
+++ b/tests/Meridian.TestSupport/Meridian.TestSupport.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Npgsql" />
     <PackageReference Include="Testcontainers.PostgreSql" />
   </ItemGroup>
 

--- a/tests/Meridian.TestSupport/PostgresTestSchema.cs
+++ b/tests/Meridian.TestSupport/PostgresTestSchema.cs
@@ -5,10 +5,36 @@ namespace Meridian.TestSupport;
 /// </summary>
 public static class PostgresTestSchema
 {
+    /// <summary>PostgreSQL's maximum identifier size in bytes for ASCII schema names.</summary>
+    public const int MaxIdentifierLength = 63;
+
     /// <summary>
     /// Returns a unique schema name of the form <c>{prefix}_test_{guid:N}</c>, matching the
     /// per-run naming each module previously produced inline (for example
-    /// <c>ledger_test_…</c>, <c>dl_test_…</c>, <c>sm_test_…</c>).
+    /// <c>ledger_test_…</c>, <c>dl_test_…</c>, <c>sm_test_…</c>). Safe lowercase ASCII
+    /// prefixes are truncated when needed so PostgreSQL never silently truncates two generated
+    /// identifiers to the same 63-byte value.
     /// </summary>
-    public static string NewSchemaName(string prefix) => $"{prefix}_test_{Guid.NewGuid():N}";
+    public static string NewSchemaName(string prefix)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(prefix);
+        if ((prefix[0] != '_' && !char.IsAsciiLetterLower(prefix[0])) ||
+            !prefix.All(static c =>
+                char.IsAsciiLetterLower(c) || char.IsAsciiDigit(c) || c == '_'))
+        {
+            throw new ArgumentException(
+                "Schema prefixes must start with a lowercase ASCII letter or underscore and " +
+                "contain only lowercase ASCII letters, digits, and underscores.",
+                nameof(prefix));
+        }
+
+        const string separator = "_test_";
+        const int guidLength = 32;
+        var maximumPrefixLength = MaxIdentifierLength - separator.Length - guidLength;
+        var safePrefix = prefix.Length <= maximumPrefixLength
+            ? prefix
+            : prefix[..maximumPrefixLength];
+
+        return $"{safePrefix}{separator}{Guid.NewGuid():N}";
+    }
 }

--- a/tests/Meridian.TestSupport/PostgresTestSchemaEnvironmentScope.cs
+++ b/tests/Meridian.TestSupport/PostgresTestSchemaEnvironmentScope.cs
@@ -1,0 +1,128 @@
+namespace Meridian.TestSupport;
+
+/// <summary>
+/// Gives a process-configuration test fixture a uniquely named PostgreSQL schema whenever its
+/// domain connection string is supplied by the host. The caller must serialize environment
+/// mutation for the scope's lifetime.
+/// </summary>
+public sealed class PostgresTestSchemaEnvironmentScope : IAsyncDisposable
+{
+    private readonly string _connectionStringEnvironmentVariable;
+    private readonly string? _originalConnectionString;
+    private readonly bool _restoreConnectionString;
+    private readonly string _schemaEnvironmentVariable;
+    private readonly string? _originalSchema;
+    private PostgresTestServer? _server;
+
+    private PostgresTestSchemaEnvironmentScope(
+        PostgresTestServer server,
+        string connectionStringEnvironmentVariable,
+        string? originalConnectionString,
+        bool restoreConnectionString,
+        string schemaEnvironmentVariable,
+        string? originalSchema,
+        string schema)
+    {
+        _server = server;
+        _connectionStringEnvironmentVariable = connectionStringEnvironmentVariable;
+        _originalConnectionString = originalConnectionString;
+        _restoreConnectionString = restoreConnectionString;
+        _schemaEnvironmentVariable = schemaEnvironmentVariable;
+        _originalSchema = originalSchema;
+        Schema = schema;
+    }
+
+    public string Schema { get; }
+
+    /// <summary>
+    /// Returns <see langword="null"/> when the domain connection is not configured. Otherwise,
+    /// allocates and publishes a unique schema that is dropped when the scope is disposed.
+    /// </summary>
+    public static async Task<PostgresTestSchemaEnvironmentScope?> CreateIfConfiguredAsync(
+        string connectionStringEnvironmentVariable,
+        string schemaEnvironmentVariable,
+        string schemaPrefix,
+        string? fallbackConnectionStringEnvironmentVariable = null,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionStringEnvironmentVariable);
+        ArgumentException.ThrowIfNullOrWhiteSpace(schemaEnvironmentVariable);
+
+        var originalConnectionString =
+            Environment.GetEnvironmentVariable(connectionStringEnvironmentVariable);
+        var effectiveConnectionString = originalConnectionString;
+        if (string.IsNullOrWhiteSpace(effectiveConnectionString) &&
+            !string.IsNullOrWhiteSpace(fallbackConnectionStringEnvironmentVariable))
+        {
+            effectiveConnectionString =
+                Environment.GetEnvironmentVariable(fallbackConnectionStringEnvironmentVariable);
+        }
+
+        if (string.IsNullOrWhiteSpace(effectiveConnectionString))
+        {
+            return null;
+        }
+
+        var publishedFallbackConnection = string.IsNullOrWhiteSpace(originalConnectionString);
+        if (publishedFallbackConnection)
+        {
+            Environment.SetEnvironmentVariable(
+                connectionStringEnvironmentVariable,
+                effectiveConnectionString);
+        }
+
+        PostgresTestServer? server = null;
+        try
+        {
+            server = await PostgresTestServer.CreateAsync(
+                    connectionStringEnvironmentVariable,
+                    ct: ct)
+                .ConfigureAwait(false);
+            var schema = server.CreateSchemaName(schemaPrefix);
+            var originalSchema = Environment.GetEnvironmentVariable(schemaEnvironmentVariable);
+            Environment.SetEnvironmentVariable(schemaEnvironmentVariable, schema);
+            return new PostgresTestSchemaEnvironmentScope(
+                server,
+                connectionStringEnvironmentVariable,
+                originalConnectionString,
+                publishedFallbackConnection,
+                schemaEnvironmentVariable,
+                originalSchema,
+                schema);
+        }
+        catch
+        {
+            if (publishedFallbackConnection)
+            {
+                Environment.SetEnvironmentVariable(
+                    connectionStringEnvironmentVariable,
+                    originalConnectionString);
+            }
+            if (server is not null)
+            {
+                await server.DisposeAsync().ConfigureAwait(false);
+            }
+            throw;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        var server = Volatile.Read(ref _server);
+        if (server is null)
+        {
+            return;
+        }
+
+        Environment.SetEnvironmentVariable(_schemaEnvironmentVariable, _originalSchema);
+        if (_restoreConnectionString)
+        {
+            Environment.SetEnvironmentVariable(
+                _connectionStringEnvironmentVariable,
+                _originalConnectionString);
+        }
+
+        await server.DisposeAsync().ConfigureAwait(false);
+        Interlocked.CompareExchange(ref _server, null, server);
+    }
+}

--- a/tests/Meridian.TestSupport/PostgresTestServer.cs
+++ b/tests/Meridian.TestSupport/PostgresTestServer.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+using Npgsql;
 using Testcontainers.PostgreSql;
 
 namespace Meridian.TestSupport;
@@ -7,16 +9,19 @@ namespace Meridian.TestSupport;
 /// container-or-external-connection lifecycle that each Meridian test module previously
 /// hand-rolled. When the configured environment variable supplies a connection string the
 /// external database is used and container startup is short-circuited; otherwise a
-/// disposable <c>postgres</c> Testcontainers container is started.
+/// disposable <c>postgres</c> Testcontainers container is started. Schemas allocated through
+/// <see cref="CreateSchemaName"/> are owned by this server and dropped when an external
+/// database is released.
 /// </summary>
 /// <remarks>
-/// Per-run schema isolation, migration setup, and schema teardown remain the responsibility
-/// of the owning module. Callers inspect <see cref="UsesExternalConnection"/> to decide
-/// whether a run-scoped schema must be dropped on teardown.
+/// Migration setup remains the responsibility of the owning module. Test fixtures should
+/// allocate schemas through <see cref="CreateSchemaName"/> so teardown is deterministic even
+/// when migration or test setup fails before the module-specific cleanup path can run.
 /// </remarks>
 public sealed class PostgresTestServer : IAsyncDisposable
 {
     private readonly PostgreSqlContainer? _container;
+    private readonly ConcurrentDictionary<string, byte> _ownedSchemas = new(StringComparer.Ordinal);
 
     private PostgresTestServer(string connectionString, PostgreSqlContainer? container)
     {
@@ -34,6 +39,20 @@ public sealed class PostgresTestServer : IAsyncDisposable
     /// across runs, whereas containers are discarded whole.
     /// </summary>
     public bool UsesExternalConnection => _container is null;
+
+    /// <summary>
+    /// Allocates a unique schema name owned by this server. On an externally supplied database,
+    /// every allocated schema is dropped with <c>CASCADE</c> during <see cref="DisposeAsync"/>.
+    /// A container-backed server obtains the same isolation and releases the schemas when the
+    /// disposable container is removed.
+    /// </summary>
+    public string CreateSchemaName(string prefix)
+    {
+        var schema = PostgresTestSchema.NewSchemaName(prefix);
+        ValidateIdentifier(schema);
+        _ownedSchemas.TryAdd(schema, 0);
+        return schema;
+    }
 
     /// <summary>
     /// Creates a server from the connection string in
@@ -60,16 +79,55 @@ public sealed class PostgresTestServer : IAsyncDisposable
             .WithPassword(options.Password)
             .Build();
 
-        await container.StartAsync(ct).ConfigureAwait(false);
-        return new PostgresTestServer(container.GetConnectionString(), container);
+        try
+        {
+            await container.StartAsync(ct).ConfigureAwait(false);
+            return new PostgresTestServer(container.GetConnectionString(), container);
+        }
+        catch
+        {
+            await container.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
     }
 
-    /// <summary>Disposes the backing container, if any. A no-op for external connections.</summary>
+    /// <summary>
+    /// Drops owned schemas on an external database, then disposes the backing container when one
+    /// was created. Schema removal is idempotent so fixture-specific reset paths may coexist while
+    /// callers migrate to server-owned cleanup.
+    /// </summary>
     public async ValueTask DisposeAsync()
     {
+        if (UsesExternalConnection && !_ownedSchemas.IsEmpty)
+        {
+            await using var connection = new NpgsqlConnection(ConnectionString);
+            await connection.OpenAsync().ConfigureAwait(false);
+
+            foreach (var schema in _ownedSchemas.Keys.Order(StringComparer.Ordinal))
+            {
+                await using var command = connection.CreateCommand();
+                command.CommandText = $"DROP SCHEMA IF EXISTS \"{schema}\" CASCADE";
+                await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+            }
+
+            _ownedSchemas.Clear();
+        }
+
         if (_container is not null)
         {
             await _container.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private static void ValidateIdentifier(string identifier)
+    {
+        if (identifier.Length == 0 ||
+            !identifier.All(static c =>
+                char.IsAsciiLetterLower(c) || char.IsAsciiDigit(c) || c == '_'))
+        {
+            throw new ArgumentException(
+                $"Unsafe schema identifier: '{identifier}'",
+                nameof(identifier));
         }
     }
 }

--- a/tests/Meridian.Tests/Application/OperationsContinuityPostgresRoundTripTests.cs
+++ b/tests/Meridian.Tests/Application/OperationsContinuityPostgresRoundTripTests.cs
@@ -1,7 +1,6 @@
 using FluentAssertions;
 using Meridian.FinancialOperations.OperationsContinuity;
 using Meridian.Contracts.Ledger;
-using Meridian.Contracts.SecurityMaster;
 using Meridian.Contracts.Workstation;
 using Meridian.Ledger;
 using Meridian.Tests.Storage;
@@ -279,27 +278,13 @@ public sealed class OperationsContinuityPostgresRoundTripTests
                     "Cash",
                     LedgerAccountType.Asset.ToString(),
                     Debit: 125m,
-                    Credit: 0m,
-                    Symbol: "POSTGRES",
-                    SecurityId: securityId,
-                    SecurityMasterApproved: true,
-                    SecurityMasterProvenance: provenance,
-                    LedgerMappingReference: $"ledger-map:POSTGRES:{securityId:N}",
-                    SecurityMasterApprovalReference: "sm-approval:postgres-controller",
-                    SecurityMasterStatus: SecurityStatusDto.Active),
+                    Credit: 0m),
                 new OperationsLedgerJournalLineDto(
                     Guid.NewGuid(),
                     "Interest Income",
                     LedgerAccountType.Revenue.ToString(),
                     Debit: 0m,
-                    Credit: 125m,
-                    Symbol: "POSTGRES",
-                    SecurityId: securityId,
-                    SecurityMasterApproved: true,
-                    SecurityMasterProvenance: provenance,
-                    LedgerMappingReference: $"ledger-map:POSTGRES:{securityId:N}",
-                    SecurityMasterApprovalReference: "sm-approval:postgres-controller",
-                    SecurityMasterStatus: SecurityStatusDto.Active)
+                    Credit: 125m)
             ],
             CommandId: Guid.NewGuid(),
             CorrelationId: Guid.NewGuid(),

--- a/tests/Meridian.Tests/Application/OperationsContinuityPostgresRoundTripTests.cs
+++ b/tests/Meridian.Tests/Application/OperationsContinuityPostgresRoundTripTests.cs
@@ -1,15 +1,22 @@
+using System.Text.Json;
 using FluentAssertions;
 using Meridian.FinancialOperations.OperationsContinuity;
+using Meridian.Contracts.FundStructure;
 using Meridian.Contracts.Ledger;
+using Meridian.Contracts.SecurityMaster;
 using Meridian.Contracts.Workstation;
 using Meridian.Ledger;
+using Meridian.Storage.Ledger;
 using Meridian.Tests.Storage;
+using Moq;
 
 namespace Meridian.Tests.Application;
 
 [Trait("Category", "Integration")]
 public sealed class OperationsContinuityPostgresRoundTripTests
 {
+    private static readonly Guid SecurityId = Guid.Parse("D3B32FA8-A6FD-4571-ACDA-56D5D6F6C92C");
+
     [LedgerDatabaseFact]
     public async Task PostgresOperationsContinuityStore_ShouldRejectBookScopedWorkflowWhenTenantCannotBeResolved()
     {
@@ -80,15 +87,19 @@ public sealed class OperationsContinuityPostgresRoundTripTests
             "operations_continuity_audit"
         ]);
 
-        var openPeriod = await database.SavePeriodAsync(Guid.NewGuid(), "Open");
+        var openContext = await CreateLedgerContextAsync(database, "posted", "Open");
+        var openPeriod = openContext.Period;
         var fundAccountId = Guid.NewGuid();
         var workflow = await CreateLedgerValidatedWorkflowAsync(
             service,
             fundAccountId,
-            "2026-05-postgres-happy");
+            openPeriod.PeriodId.ToString("D"),
+            openContext.Book.LedgerBookId);
         var journalCandidate = CreateJournalCandidate(
             openPeriod.PeriodId,
             fundAccountId,
+            openContext.Book.LedgerBookId,
+            openPeriod.Version,
             "postgres-fixture-posting");
 
         var posted = await service.PostLedgerEntriesAsync(
@@ -104,8 +115,9 @@ public sealed class OperationsContinuityPostgresRoundTripTests
                 EvidenceLinks: EvidenceLinks(),
                 JournalCandidate: journalCandidate));
 
-        posted.Success.Should().BeTrue(posted.ErrorMessage);
+        posted.Success.Should().BeTrue(DescribeFailure(posted));
         posted.Workflow!.LedgerPostingState.Should().Be(OperationsLedgerPostingStateDto.Complete);
+        posted.Workflow.LedgerBookId.Should().Be(openContext.Book.LedgerBookId);
         posted.Workflow.Gates
             .Single(static gate => gate.GateKey == OperationsGateKeyDto.LedgerPosting)
             .Status.Should().Be(OperationsGateStatusDto.Passed);
@@ -126,12 +138,16 @@ public sealed class OperationsContinuityPostgresRoundTripTests
         journalEntry.Entry.JournalEntryId.Should().Be(journalCandidate.JournalEntryId!.Value);
         journalEntry.AggregateId.Should().Be(fundAccountId);
         journalEntry.Entry.IsBalanced.Should().BeTrue();
+        journalEntry.Entry.Metadata.LedgerBook.Should().Be(openContext.Book.LedgerBookId.ToString("D"));
+        journalEntry.Entry.Metadata.Tags.Should().ContainKey("securityMasterLineage");
 
-        var hardClosedPeriod = await database.SavePeriodAsync(Guid.NewGuid(), "HardClosed");
+        var rejectedContext = await CreateLedgerContextAsync(database, "rejected", "HardClosed");
+        var hardClosedPeriod = rejectedContext.Period;
         var rejectedWorkflow = await CreateLedgerValidatedWorkflowAsync(
             service,
             Guid.NewGuid(),
-            "2026-05-postgres-rejected");
+            hardClosedPeriod.PeriodId.ToString("D"),
+            rejectedContext.Book.LedgerBookId);
         var rejectedVersion = rejectedWorkflow.Version;
 
         var rejected = await service.PostLedgerEntriesAsync(
@@ -148,6 +164,8 @@ public sealed class OperationsContinuityPostgresRoundTripTests
                 JournalCandidate: CreateJournalCandidate(
                     hardClosedPeriod.PeriodId,
                     rejectedWorkflow.FundAccountId,
+                    rejectedContext.Book.LedgerBookId,
+                    hardClosedPeriod.Version,
                     "postgres-fixture-rejected")));
 
         rejected.Success.Should().BeFalse();
@@ -168,17 +186,39 @@ public sealed class OperationsContinuityPostgresRoundTripTests
     }
 
     private static OperationsContinuityWorkflowService CreateService(LedgerPostgresTestDatabase database)
-        => new(
+    {
+        var securityMaster = new Mock<ISecurityMasterQueryService>(MockBehavior.Strict);
+        var emptyObject = JsonSerializer.SerializeToElement(new { });
+        securityMaster
+            .Setup(service => service.GetByIdAsync(SecurityId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SecurityDetailDto(
+                SecurityId,
+                "Equity",
+                SecurityStatusDto.Active,
+                "PostgreSQL fixture security",
+                "USD",
+                emptyObject,
+                emptyObject,
+                [],
+                [],
+                1,
+                DateTimeOffset.Parse("2026-05-01T00:00:00Z"),
+                null));
+
+        return new OperationsContinuityWorkflowService(
             database.OperationsStore,
             database.OperationsStore,
             database.StatusDerivation,
             ledgerJournalStore: null,
-            transactionalCommitStore: database.OperationsStore);
+            transactionalCommitStore: database.OperationsStore,
+            securityMasterQueryService: securityMaster.Object);
+    }
 
     private static async Task<OperationsContinuityWorkflowDto> CreateLedgerValidatedWorkflowAsync(
         OperationsContinuityWorkflowService service,
         Guid fundAccountId,
-        string periodId)
+        string periodId,
+        Guid ledgerBookId)
     {
         var start = RequireSuccess(await service.StartWorkflowAsync(
             new OperationsStartWorkflowRequestDto(
@@ -189,7 +229,8 @@ public sealed class OperationsContinuityPostgresRoundTripTests
                 Actor: "ops-user",
                 Rationale: "Start PostgreSQL round-trip workflow.",
                 CorrelationId: $"start-{periodId}",
-                EvidenceLinks: EvidenceLinks())));
+                EvidenceLinks: EvidenceLinks(),
+                LedgerBookId: ledgerBookId)));
 
         var imported = RequireSuccess(await service.ImportBrokerDataAsync(
             start.WorkflowId,
@@ -257,13 +298,14 @@ public sealed class OperationsContinuityPostgresRoundTripTests
     private static OperationsLedgerJournalCandidateDto CreateJournalCandidate(
         Guid periodId,
         Guid aggregateId,
+        Guid ledgerBookId,
+        long expectedLedgerVersion,
         string description)
     {
         var journalEntryId = Guid.NewGuid();
         var timestamp = DateTimeOffset.Parse("2026-05-15T16:00:00Z");
-        var securityId = Guid.Parse("D3B32FA8-A6FD-4571-ACDA-56D5D6F6C92C");
-        var idempotencyKey = $"{securityId:N}:postgres:20260515:AccrueInterestIncome:test-source-hash";
-        var provenance = $"security-master:{securityId:N};snapshot:test-source-hash;approved:true;status:active";
+        var idempotencyKey = $"{SecurityId:N}:postgres:20260515:AccrueInterestIncome:test-source-hash";
+        var provenance = $"security-master:{SecurityId:N};snapshot:test-source-hash;approved:true;status:active";
 
         return new OperationsLedgerJournalCandidateDto(
             journalEntryId,
@@ -284,7 +326,14 @@ public sealed class OperationsContinuityPostgresRoundTripTests
                     "Interest Income",
                     LedgerAccountType.Revenue.ToString(),
                     Debit: 0m,
-                    Credit: 125m)
+                    Credit: 125m,
+                    Symbol: "POSTGRES",
+                    SecurityId: SecurityId,
+                    SecurityMasterApproved: true,
+                    SecurityMasterProvenance: provenance,
+                    LedgerMappingReference: $"ledger-map:postgres-interest-income:{SecurityId:N}",
+                    SecurityMasterApprovalReference: "sm-approval:postgres-controller",
+                    SecurityMasterStatus: SecurityStatusDto.Active)
             ],
             CommandId: Guid.NewGuid(),
             CorrelationId: Guid.NewGuid(),
@@ -300,16 +349,66 @@ public sealed class OperationsContinuityPostgresRoundTripTests
             Metadata: new OperationsJournalEntryMetadataDto(
                 ActivityType: "interest",
                 Symbol: "POSTGRES",
-                SecurityId: securityId,
-                LedgerBook: "legacy",
+                SecurityId: SecurityId,
+                LedgerBook: ledgerBookId.ToString("D"),
                 Tags: new Dictionary<string, string>
                 {
                     ["fixture"] = "operations-continuity-postgres"
                 }),
             IdempotencyKey: idempotencyKey,
             SecurityMasterProvenance: provenance,
-            ExpectedLedgerVersion: 1);
+            ExpectedLedgerVersion: expectedLedgerVersion);
     }
+
+    private static async Task<(LedgerBookRecord Book, LedgerAccountingPeriod Period)> CreateLedgerContextAsync(
+        LedgerPostgresTestDatabase database,
+        string scenario,
+        string periodStatus)
+    {
+        var fundProfileId = $"fund-operations-continuity-{scenario}";
+        var recordedAt = DateTimeOffset.Parse("2026-05-01T00:00:00Z");
+        var tenancy = new PostgresFundProfileTenancyRegistry(database.Options);
+        await tenancy.BindAsync(
+            fundProfileId,
+            "tenant-operations-continuity",
+            "company-operations-continuity");
+
+        var book = await database.JournalStore.SaveLedgerBookAsync(new LedgerBookRecord(
+            Guid.NewGuid(),
+            fundProfileId,
+            Guid.NewGuid(),
+            FundStructureNodeKindDto.Fund,
+            $"Operations Continuity {scenario} book",
+            "USD",
+            recordedAt,
+            recordedAt));
+
+        var period = await database.JournalStore.SavePeriodAsync(
+            new LedgerAccountingPeriod(
+                Guid.NewGuid(),
+                book.LedgerBookId,
+                2026,
+                5,
+                $"2026-05-{scenario}",
+                new DateOnly(2026, 5, 1),
+                new DateOnly(2026, 5, 31),
+                periodStatus,
+                recordedAt,
+                string.Equals(periodStatus, "Open", StringComparison.Ordinal)
+                    ? null
+                    : DateTimeOffset.Parse("2026-05-31T23:59:59Z"),
+                Version: 0),
+            expectedVersion: 0);
+
+        return (book, period);
+    }
+
+    private static string DescribeFailure(OperationsTransitionResultDto result)
+        => string.Join(
+            "; ",
+            new[] { result.ErrorMessage }
+                .Concat(result.Blockers.Select(static blocker => $"{blocker.Code}: {blocker.Message}"))
+                .Where(static message => !string.IsNullOrWhiteSpace(message)));
 
     private static IReadOnlyList<OperationsEvidenceLinkDto> EvidenceLinks() =>
     [
@@ -342,4 +441,5 @@ public sealed class OperationsContinuityPostgresRoundTripTests
         chain.Should().HaveCount(timeline.Count);
         byPreviousHash.Should().BeEmpty();
     }
+
 }

--- a/tests/Meridian.Tests/Application/OperationsContinuityPostgresRoundTripTests.cs
+++ b/tests/Meridian.Tests/Application/OperationsContinuityPostgresRoundTripTests.cs
@@ -140,6 +140,11 @@ public sealed class OperationsContinuityPostgresRoundTripTests
         journalEntry.Entry.IsBalanced.Should().BeTrue();
         journalEntry.Entry.Metadata.LedgerBook.Should().Be(openContext.Book.LedgerBookId.ToString("D"));
         journalEntry.Entry.Metadata.Tags.Should().ContainKey("securityMasterLineage");
+        journalEntry.Entry.Metadata.ActivityType.Should().Be("interest");
+        journalEntry.Entry.Metadata.IdempotencyKey.Should().Be(journalCandidate.IdempotencyKey);
+        journalEntry.Entry.Metadata.FundEventId.Should().BeNull();
+        journalEntry.Entry.Metadata.FundEventType.Should().BeNull(
+            "a generic source event type must not be reclassified as private-capital fund-event metadata");
 
         var rejectedContext = await CreateLedgerContextAsync(database, "rejected", "HardClosed");
         var hardClosedPeriod = rejectedContext.Period;

--- a/tests/Meridian.Tests/Application/SecurityMaster/SecurityMasterMappingInteropTests.cs
+++ b/tests/Meridian.Tests/Application/SecurityMaster/SecurityMasterMappingInteropTests.cs
@@ -172,6 +172,46 @@ public sealed class SecurityMasterMappingInteropTests
         otherSecurity.Item.Maturity.Value.Should().Be(new DateOnly(2032, 6, 30));
     }
 
+    [Fact]
+    public void ToCreateCommand_NonProviderSymbolIdentifier_PreservesProviderMetadata()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var request = new CreateSecurityRequest(
+            SecurityId: Guid.NewGuid(),
+            AssetClass: "Equity",
+            CommonTerms: JsonSerializer.SerializeToElement(new
+            {
+                displayName = "Provider-scoped ISIN",
+                currency = "USD"
+            }),
+            AssetSpecificTerms: JsonSerializer.SerializeToElement(new { shareClass = "Common" }),
+            Identifiers:
+            [
+                new SecurityIdentifierDto(
+                    SecurityIdentifierKind.Isin,
+                    "us-0378331005",
+                    true,
+                    now,
+                    Provider: "xnas")
+            ],
+            EffectiveFrom: now,
+            SourceSystem: "interop-tests",
+            UpdatedBy: "interop-tests",
+            SourceRecordId: "provider-metadata",
+            Reason: "Provider metadata must survive the C# and F# command seam");
+
+        var command = SecurityMasterMapping.ToCreateCommand(request);
+        var result = SecurityMasterCommandFacade.Create(command);
+
+        result.IsSuccess.Should().BeTrue(
+            string.Join("; ", result.ErrorDetails.Select(error => $"{error.Code}: {error.Message}")));
+        var identifier = SecurityMasterMapping.ToProjection(result.Snapshot).Identifiers.Should().ContainSingle().Subject;
+        identifier.Kind.Should().Be(SecurityIdentifierKind.Isin);
+        identifier.Provider.Should().Be("xnas");
+        identifier.NormalizedValue.Should().Be("US0378331005");
+        identifier.NormalizedProvider.Should().Be("XNAS");
+    }
+
     /// <summary>
     /// Serializes a fully populated asset-specific-terms payload through the F# snapshot writer, reads
     /// it back through the C# <see cref="SecurityMasterMapping"/> deserializer, and re-serializes it,

--- a/tests/Meridian.Tests/AssetOperations/AssetOperationsMigrationRunnerTests.cs
+++ b/tests/Meridian.Tests/AssetOperations/AssetOperationsMigrationRunnerTests.cs
@@ -20,7 +20,7 @@ public sealed class AssetOperationsMigrationRunnerTests : IAsyncLifetime
         _options = new AssetOperationsOptions
         {
             ConnectionString = _server.ConnectionString,
-            Schema = PostgresTestSchema.NewSchemaName("asset_ops")
+            Schema = _server.CreateSchemaName("asset_ops")
         };
     }
 
@@ -85,8 +85,21 @@ public sealed class AssetOperationsMigrationRunnerTests : IAsyncLifetime
 
         await using var migrationLedgerCommand = connection.CreateCommand();
         migrationLedgerCommand.CommandText =
-            $"select count(*) from \"{_options.Schema}\".asset_operations_schema_migrations;";
-        ((long)(await migrationLedgerCommand.ExecuteScalarAsync() ?? 0L)).Should().Be(3);
+            $"select migration_id from \"{_options.Schema}\".asset_operations_schema_migrations order by migration_id;";
+        var appliedMigrations = new List<string>();
+        await using (var migrationReader = await migrationLedgerCommand.ExecuteReaderAsync())
+        {
+            while (await migrationReader.ReadAsync())
+            {
+                appliedMigrations.Add(migrationReader.GetString(0));
+            }
+        }
+
+        appliedMigrations.Should().Equal(
+            "001_asset_operations.sql",
+            "002_instrument_position_projections.sql",
+            "003_instrument_position_projection_guards.sql",
+            "004_asset_accounting_event_spine.sql");
 
         await using var guardColumnCommand = connection.CreateCommand();
         guardColumnCommand.CommandText =

--- a/tests/Meridian.Tests/AssetOperations/InstrumentPositionProjectionStoreTests.cs
+++ b/tests/Meridian.Tests/AssetOperations/InstrumentPositionProjectionStoreTests.cs
@@ -75,7 +75,7 @@ public sealed class PostgresInstrumentPositionProjectionStoreTests : IAsyncLifet
         _options = new AssetOperationsOptions
         {
             ConnectionString = _server.ConnectionString,
-            Schema = PostgresTestSchema.NewSchemaName("asset_position")
+            Schema = _server.CreateSchemaName("asset_position")
         };
     }
 
@@ -159,6 +159,7 @@ public sealed class PostgresInstrumentPositionProjectionStoreTests : IAsyncLifet
         }
 
         var originalPosition = projection.BookPositions.Single();
+        var conflictingLedgerBookId = Guid.NewGuid();
         var conflicting = projection with
         {
             BookPositions =
@@ -166,7 +167,14 @@ public sealed class PostgresInstrumentPositionProjectionStoreTests : IAsyncLifet
                 originalPosition with
                 {
                     Version = originalPosition.Version + 1,
-                    BookContext = originalPosition.BookContext with { LedgerBookId = Guid.NewGuid() }
+                    BookContext = originalPosition.BookContext with
+                    {
+                        LedgerBookId = conflictingLedgerBookId,
+                        Dimensions = originalPosition.BookContext.Dimensions! with
+                        {
+                            BookId = conflictingLedgerBookId.ToString("D")
+                        }
+                    }
                 }
             ],
             PositionEconomicStates = [],
@@ -267,10 +275,16 @@ public sealed class PostgresInstrumentPositionProjectionStoreTests : IAsyncLifet
         await replayWithStaleExpectedVersion.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*stale*");
 
+        var staleState = advanced.State with { Version = 3 };
+        var stalePosition = advanced.Position with
+        {
+            Version = 3,
+            CurrentEconomicState = staleState
+        };
         var stale = () => store.UpsertAsync(
             advanced.Role,
-            advanced.Position with { Version = 3 },
-            advanced.State with { Version = 3 },
+            stalePosition,
+            staleState,
             expectedVersion: 1,
             InstrumentPositionProjectionFixture.Approval);
         await stale.Should().ThrowAsync<InvalidOperationException>()

--- a/tests/Meridian.Tests/Demo/DemoWorkspaceSeederTests.cs
+++ b/tests/Meridian.Tests/Demo/DemoWorkspaceSeederTests.cs
@@ -62,12 +62,16 @@ public sealed class DemoWorkspaceSeederTests
         var breaks = new FileReconciliationBreakQueueRepository(
             Path.Combine(seeder.DemoRoot, "workstation"),
             NullLogger<FileReconciliationBreakQueueRepository>.Instance);
-        var reloaded = await breaks.GetAllAsync();
+        var reloaded = await breaks.GetAllAsync(new ReconciliationBreakQueueScope(
+            DemoTenantBlueprint.TenantId,
+            DemoTenantBlueprint.CompanyId));
 
         reloaded.Should().HaveCount(DemoTenantBlueprint.BreakDefinitions.Count);
         reloaded.Should().OnlyContain(item =>
             item.SourceType == DemoTenantBlueprint.SeededSourceType &&
-            item.SourceSystem == DemoTenantBlueprint.SeededSourceSystem);
+            item.SourceSystem == DemoTenantBlueprint.SeededSourceSystem &&
+            item.TenantId == DemoTenantBlueprint.TenantId &&
+            item.CompanyId == DemoTenantBlueprint.CompanyId);
 
         var strategy = new StrategyRunStore(new FileOperationalCaseHistoryStore(seeder.DemoRoot));
         var run = await strategy.GetRunByIdAsync(DemoTenantBlueprint.StrategyRunId);

--- a/tests/Meridian.Tests/Demo/DemoWorkspaceSmokeTests.cs
+++ b/tests/Meridian.Tests/Demo/DemoWorkspaceSmokeTests.cs
@@ -6,7 +6,11 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Meridian.Contracts.Api;
 using Meridian.Identity.Auth;
+using Meridian.Storage;
+using Meridian.TestSupport;
+using Meridian.Tests.TestSupport;
 using Meridian.Ui.Shared.Endpoints;
 using Meridian.Ui.Shared.Services;
 using Microsoft.AspNetCore.Builder;
@@ -14,6 +18,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Xunit;
 using ConfigStore = Meridian.Ui.Shared.Services.ConfigStore;
 
@@ -25,6 +30,7 @@ namespace Meridian.Tests.Demo;
 /// fails this check instead of a first evaluation.
 /// </summary>
 [Trait("Category", "Integration")]
+[Collection("Sequential")]
 public sealed class DemoWorkspaceSmokeTests : IAsyncLifetime
 {
     private static readonly JsonSerializerOptions ServerJsonOptions = new()
@@ -35,10 +41,37 @@ public sealed class DemoWorkspaceSmokeTests : IAsyncLifetime
 
     private readonly EnvironmentSnapshot _env = new();
     private WebApplication? _app;
+    private bool _appStopped;
     private HttpClient? _client;
     private string? _tempRoot;
+    private ProviderCatalogTestLease? _providerCatalogLease;
+    private readonly List<PostgresTestSchemaEnvironmentScope> _databaseSchemaScopes = [];
 
     public async Task InitializeAsync()
+    {
+        try
+        {
+            await InitializeCoreAsync();
+        }
+        catch (Exception initializationError)
+        {
+            try
+            {
+                await DisposeAsync();
+            }
+            catch (Exception cleanupError)
+            {
+                throw new AggregateException(
+                    "Demo smoke initialization and cleanup failed.",
+                    initializationError,
+                    cleanupError);
+            }
+
+            throw;
+        }
+    }
+
+    private async Task InitializeCoreAsync()
     {
         _env.Capture(
             "MDC_AUTH_MODE",
@@ -49,7 +82,15 @@ public sealed class DemoWorkspaceSmokeTests : IAsyncLifetime
             "MDC_DISABLE_RATE_LIMIT",
             "MERIDIAN_USE_INMEMORY_GOVERNANCE",
             "DOTNET_ENVIRONMENT",
-            "ASPNETCORE_ENVIRONMENT");
+            "ASPNETCORE_ENVIRONMENT",
+            "LEAN_PATH",
+            "LEAN_DATA_PATH",
+            "LEAN_EXPORT_INTERVAL_SECONDS");
+        _env.Capture(MeridianDatabaseEnvironment.PropagatedConnectionStringVariables.ToArray());
+        _env.Capture(
+            "MERIDIAN_DIRECT_LENDING_CONNECTION_STRING",
+            "MERIDIAN_REPORTING_CONNECTION_STRING");
+        MeridianDatabaseEnvironment.ApplyUnifiedDatabaseUrl();
 
         Environment.SetEnvironmentVariable("MDC_AUTH_MODE", "optional");
         Environment.SetEnvironmentVariable("MDC_API_KEY", null);
@@ -60,6 +101,11 @@ public sealed class DemoWorkspaceSmokeTests : IAsyncLifetime
         Environment.SetEnvironmentVariable("MERIDIAN_USE_INMEMORY_GOVERNANCE", "true");
         Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", "Test");
         Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Test");
+        Environment.SetEnvironmentVariable("LEAN_PATH", null);
+        Environment.SetEnvironmentVariable("LEAN_DATA_PATH", null);
+        Environment.SetEnvironmentVariable("LEAN_EXPORT_INTERVAL_SECONDS", null);
+
+        await ConfigureIsolatedDatabaseSchemasAsync();
 
         _tempRoot = Path.Combine(Path.GetTempPath(), "meridian-demo-smoke", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_tempRoot);
@@ -80,15 +126,20 @@ public sealed class DemoWorkspaceSmokeTests : IAsyncLifetime
         builder.WebHost.UseTestServer();
         builder.Environment.EnvironmentName = "Test";
         builder.Services.AddSingleton(new ConfigStore(demoConfigPath));
+        // Keep the demo host on its intended file-backed Reporting seams even when the certification
+        // process exports an ambient ledger database. Whitespace is non-null for the fallback lookup
+        // and still treated as unconfigured by the composition branch.
+        Environment.SetEnvironmentVariable("MERIDIAN_REPORTING_CONNECTION_STRING", " ");
         builder.Services.AddUiSharedServices(demoConfigPath);
 
         _app = builder.Build();
+        _providerCatalogLease = ProviderCatalogTestLease.Capture(_app.Services);
         _app.Use(async (context, next) =>
         {
             context.Items[LoginSessionMiddleware.CurrentUserKey] = "demo-smoke";
             context.Items[LoginSessionMiddleware.CurrentUserPermissionsKey] = UserPermission.AdminMaintenance;
-            context.Items[LoginSessionMiddleware.CurrentUserCompanyIdKey] = "demo-smoke-tenant";
-            context.Items[LoginSessionMiddleware.CurrentTenantIdKey] = "demo-smoke-tenant";
+            context.Items[LoginSessionMiddleware.CurrentUserCompanyIdKey] = DemoTenantBlueprint.CompanyId;
+            context.Items[LoginSessionMiddleware.CurrentTenantIdKey] = DemoTenantBlueprint.TenantId;
             await next();
         });
         _app.MapWorkstationEndpoints(ServerJsonOptions);
@@ -123,24 +174,165 @@ public sealed class DemoWorkspaceSmokeTests : IAsyncLifetime
 
     public async Task DisposeAsync()
     {
-        _client?.Dispose();
-        if (_app is not null)
+        var cleanupErrors = new List<Exception>();
+
+        if (_app is not null && !_appStopped)
         {
-            await _app.DisposeAsync();
+            var applicationLifetime = _app.Services.GetRequiredService<IHostApplicationLifetime>();
+            try
+            {
+                using var stopTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                await _app.StopAsync(stopTimeout.Token);
+                _appStopped = true;
+            }
+            catch (Exception stopError)
+            {
+                if (!applicationLifetime.ApplicationStopped.IsCancellationRequested)
+                {
+                    throw new AggregateException(
+                        "Demo smoke host did not stop; owned resources were retained.",
+                        stopError);
+                }
+
+                _appStopped = true;
+                cleanupErrors.Add(stopError);
+            }
         }
 
-        _env.Restore();
+        try
+        {
+            _providerCatalogLease?.Dispose();
+            _providerCatalogLease = null;
+        }
+        catch (Exception ex)
+        {
+            cleanupErrors.Add(ex);
+        }
+
+        try
+        {
+            _client?.Dispose();
+            _client = null;
+        }
+        catch (Exception ex)
+        {
+            cleanupErrors.Add(ex);
+        }
+
+        if (_app is not null)
+        {
+            try
+            {
+                await _app.DisposeAsync();
+                _app = null;
+            }
+            catch (Exception ex)
+            {
+                cleanupErrors.Add(ex);
+            }
+        }
+
+        for (var index = _databaseSchemaScopes.Count - 1; index >= 0; index--)
+        {
+            try
+            {
+                await _databaseSchemaScopes[index].DisposeAsync();
+                _databaseSchemaScopes.RemoveAt(index);
+            }
+            catch (Exception ex)
+            {
+                cleanupErrors.Add(ex);
+            }
+        }
+
+        try
+        {
+            _env.Restore();
+        }
+        catch (Exception ex)
+        {
+            cleanupErrors.Add(ex);
+        }
 
         if (_tempRoot is not null && Directory.Exists(_tempRoot))
         {
             try
             {
                 Directory.Delete(_tempRoot, recursive: true);
+                _tempRoot = null;
             }
-            catch (IOException)
+            catch (Exception ex)
             {
-                // Best-effort cleanup of the temp workspace.
+                cleanupErrors.Add(ex);
             }
+        }
+
+        if (cleanupErrors.Count > 0)
+        {
+            throw new AggregateException("Demo workspace cleanup failed.", cleanupErrors);
+        }
+    }
+
+    private async Task ConfigureIsolatedDatabaseSchemasAsync()
+    {
+        await AddDatabaseSchemaScopeAsync(
+            "MERIDIAN_LEDGER_CONNECTION_STRING",
+            "MERIDIAN_LEDGER_SCHEMA",
+            "demo_ledger");
+        await AddDatabaseSchemaScopeAsync(
+            "MERIDIAN_ASSET_OPERATIONS_CONNECTION_STRING",
+            "MERIDIAN_ASSET_OPERATIONS_SCHEMA",
+            "demo_asset_ops");
+        await AddDatabaseSchemaScopeAsync(
+            "MERIDIAN_DIRECT_LENDING_CONNECTION_STRING",
+            "MERIDIAN_DIRECT_LENDING_SCHEMA",
+            "demo_direct_lending",
+            "MERIDIAN_SECURITY_MASTER_CONNECTION_STRING");
+        await AddDatabaseSchemaScopeAsync(
+            "MERIDIAN_FUND_ACCOUNTS_CONNECTION_STRING",
+            "MERIDIAN_FUND_ACCOUNTS_SCHEMA",
+            "demo_fund_accounts");
+        await AddDatabaseSchemaScopeAsync(
+            "MERIDIAN_FUND_STRUCTURE_CONNECTION_STRING",
+            "MERIDIAN_FUND_STRUCTURE_SCHEMA",
+            "demo_fund_structure");
+        await AddDatabaseSchemaScopeAsync(
+            "MERIDIAN_REPORTING_CONNECTION_STRING",
+            "MERIDIAN_REPORTING_SCHEMA",
+            "demo_reporting",
+            "MERIDIAN_LEDGER_CONNECTION_STRING");
+        await AddDatabaseSchemaScopeAsync(
+            "MERIDIAN_SCOPED_ACCESS_CONNECTION_STRING",
+            "MERIDIAN_SCOPED_ACCESS_SCHEMA",
+            "demo_scoped_access");
+        await AddDatabaseSchemaScopeAsync(
+            "MERIDIAN_SECURITY_MASTER_CONNECTION_STRING",
+            "MERIDIAN_SECURITY_MASTER_SCHEMA",
+            "demo_security");
+        await AddDatabaseSchemaScopeAsync(
+            "MERIDIAN_BANKING_CONNECTION_STRING",
+            "MERIDIAN_BANKING_SCHEMA",
+            "demo_banking");
+        await AddDatabaseSchemaScopeAsync(
+            "MERIDIAN_MONEY_MARKET_CONNECTION_STRING",
+            "MERIDIAN_MONEY_MARKET_SCHEMA",
+            "demo_money_market");
+    }
+
+    private async Task AddDatabaseSchemaScopeAsync(
+        string connectionStringEnvironmentVariable,
+        string schemaEnvironmentVariable,
+        string schemaPrefix,
+        string? fallbackConnectionStringEnvironmentVariable = null)
+    {
+        var scope = await PostgresTestSchemaEnvironmentScope.CreateIfConfiguredAsync(
+            connectionStringEnvironmentVariable,
+            schemaEnvironmentVariable,
+            schemaPrefix,
+            fallbackConnectionStringEnvironmentVariable);
+        if (scope is not null)
+        {
+            _databaseSchemaScopes.Add(scope);
         }
     }
 
@@ -162,6 +354,53 @@ public sealed class DemoWorkspaceSmokeTests : IAsyncLifetime
             {
                 Environment.SetEnvironmentVariable(pair.Key, pair.Value);
             }
+        }
+    }
+}
+
+[Trait("Category", "Integration")]
+[Collection("Sequential")]
+public sealed class DemoWorkspaceSmokeFixtureLifecycleTests
+{
+    [Fact]
+    public async Task Dispose_StopsHostClearsOwnedCatalogAndRestoresDedicatedConnections()
+    {
+        var originalCatalogProvider = ProviderCatalog.RuntimeCatalogProvider;
+        var originalCatalogEntryProvider = ProviderCatalog.RuntimeCatalogEntryProvider;
+        var originalReportingConnection =
+            Environment.GetEnvironmentVariable("MERIDIAN_REPORTING_CONNECTION_STRING");
+        var originalDirectLendingConnection =
+            Environment.GetEnvironmentVariable("MERIDIAN_DIRECT_LENDING_CONNECTION_STRING");
+        var fixture = new DemoWorkspaceSmokeTests();
+
+        try
+        {
+            await fixture.InitializeAsync();
+            Environment.GetEnvironmentVariable("MERIDIAN_REPORTING_CONNECTION_STRING")
+                .Should().Be(" ");
+
+            await fixture.DisposeAsync();
+
+            ProviderCatalog.RuntimeCatalogProvider.Should().BeNull();
+            ProviderCatalog.RuntimeCatalogEntryProvider.Should().BeNull();
+            var readCatalog = () => ProviderCatalog.GetAll();
+            readCatalog.Should().NotThrow();
+            Environment.GetEnvironmentVariable("MERIDIAN_REPORTING_CONNECTION_STRING")
+                .Should().Be(originalReportingConnection);
+            Environment.GetEnvironmentVariable("MERIDIAN_DIRECT_LENDING_CONNECTION_STRING")
+                .Should().Be(originalDirectLendingConnection);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+            ProviderCatalog.RuntimeCatalogProvider = originalCatalogProvider;
+            ProviderCatalog.RuntimeCatalogEntryProvider = originalCatalogEntryProvider;
+            Environment.SetEnvironmentVariable(
+                "MERIDIAN_REPORTING_CONNECTION_STRING",
+                originalReportingConnection);
+            Environment.SetEnvironmentVariable(
+                "MERIDIAN_DIRECT_LENDING_CONNECTION_STRING",
+                originalDirectLendingConnection);
         }
     }
 }

--- a/tests/Meridian.Tests/Integration/EndpointTests/AdminEndpointPermissionTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/AdminEndpointPermissionTests.cs
@@ -17,7 +17,7 @@ namespace Meridian.Tests.Integration.EndpointTests;
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class AdminEndpointPermissionTests
+public sealed class AdminEndpointPermissionTests : IClassFixture<EndpointTestFixture>
 {
     private readonly HttpClient _client;
 

--- a/tests/Meridian.Tests/Integration/EndpointTests/AuthEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/AuthEndpointTests.cs
@@ -283,7 +283,7 @@ public sealed class AuthEndpointTests : EndpointIntegrationTestBase
 
             response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
             var body = await response.Content.ReadAsStringAsync();
-            body.Should().Contain("Authentication is required but not configured");
+            body.Should().Contain("Authentication is required but is not configured");
         }
         finally
         {
@@ -305,7 +305,7 @@ public sealed class AuthEndpointTests : EndpointIntegrationTestBase
 
             response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
             var body = await response.Content.ReadAsStringAsync();
-            body.Should().Contain("Authentication is required but not configured");
+            body.Should().Contain("Authentication is required but is not configured");
         }
         finally
         {
@@ -316,6 +316,7 @@ public sealed class AuthEndpointTests : EndpointIntegrationTestBase
     [Fact]
     public async Task ApiKeyMiddleware_DoesNotAcceptQueryStringApiKey()
     {
+        var originalApiKey = Environment.GetEnvironmentVariable("MDC_API_KEY");
         Environment.SetEnvironmentVariable("MDC_API_KEY", "integration-test-key");
         try
         {
@@ -327,13 +328,14 @@ public sealed class AuthEndpointTests : EndpointIntegrationTestBase
         }
         finally
         {
-            Environment.SetEnvironmentVariable("MDC_API_KEY", null);
+            Environment.SetEnvironmentVariable("MDC_API_KEY", originalApiKey);
         }
     }
 
     [Fact]
     public async Task ApiKeyMiddleware_AcceptsHeaderApiKey()
     {
+        var originalApiKey = Environment.GetEnvironmentVariable("MDC_API_KEY");
         Environment.SetEnvironmentVariable("MDC_API_KEY", "integration-test-key");
         try
         {
@@ -346,13 +348,14 @@ public sealed class AuthEndpointTests : EndpointIntegrationTestBase
         }
         finally
         {
-            Environment.SetEnvironmentVariable("MDC_API_KEY", null);
+            Environment.SetEnvironmentVariable("MDC_API_KEY", originalApiKey);
         }
     }
 
     [Fact]
     public async Task ApiKeyMiddleware_MissingHeader_ReturnsUnauthorized()
     {
+        var originalApiKey = Environment.GetEnvironmentVariable("MDC_API_KEY");
         Environment.SetEnvironmentVariable("MDC_API_KEY", "integration-test-key");
         try
         {
@@ -364,13 +367,14 @@ public sealed class AuthEndpointTests : EndpointIntegrationTestBase
         }
         finally
         {
-            Environment.SetEnvironmentVariable("MDC_API_KEY", null);
+            Environment.SetEnvironmentVariable("MDC_API_KEY", originalApiKey);
         }
     }
 
     [Fact]
     public async Task ApiKeyMiddleware_WrongKey_ReturnsUnauthorized()
     {
+        var originalApiKey = Environment.GetEnvironmentVariable("MDC_API_KEY");
         Environment.SetEnvironmentVariable("MDC_API_KEY", "integration-test-key");
         try
         {
@@ -383,7 +387,7 @@ public sealed class AuthEndpointTests : EndpointIntegrationTestBase
         }
         finally
         {
-            Environment.SetEnvironmentVariable("MDC_API_KEY", null);
+            Environment.SetEnvironmentVariable("MDC_API_KEY", originalApiKey);
         }
     }
 
@@ -418,6 +422,7 @@ public sealed class AuthEndpointTests : EndpointIntegrationTestBase
         // A session-authenticated request (emulated via the fixture's X-Test-Auth marker,
         // which sets the same context items LoginSessionMiddleware sets) must pass the
         // API-key gate even when MDC_API_KEY is configured.
+        var originalApiKey = Environment.GetEnvironmentVariable("MDC_API_KEY");
         Environment.SetEnvironmentVariable("MDC_API_KEY", "integration-test-key");
         try
         {
@@ -430,7 +435,7 @@ public sealed class AuthEndpointTests : EndpointIntegrationTestBase
         }
         finally
         {
-            Environment.SetEnvironmentVariable("MDC_API_KEY", null);
+            Environment.SetEnvironmentVariable("MDC_API_KEY", originalApiKey);
         }
     }
 }

--- a/tests/Meridian.Tests/Integration/EndpointTests/BackfillEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/BackfillEndpointTests.cs
@@ -18,7 +18,7 @@ namespace Meridian.Tests.Integration.EndpointTests;
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class BackfillEndpointTests : IDisposable
+public sealed class BackfillEndpointTests : IDisposable, IClassFixture<EndpointTestFixture>
 {
     private readonly HttpClient _client;
     private readonly EndpointTestFixture _fixture;

--- a/tests/Meridian.Tests/Integration/EndpointTests/CatalogEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/CatalogEndpointTests.cs
@@ -10,7 +10,7 @@ namespace Meridian.Tests.Integration.EndpointTests;
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class CatalogEndpointTests
+public sealed class CatalogEndpointTests : IClassFixture<EndpointTestFixture>
 {
     private readonly HttpClient _client;
 

--- a/tests/Meridian.Tests/Integration/EndpointTests/CheckpointEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/CheckpointEndpointTests.cs
@@ -21,7 +21,7 @@ namespace Meridian.Tests.Integration.EndpointTests;
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class CheckpointEndpointTests
+public sealed class CheckpointEndpointTests : IClassFixture<EndpointTestFixture>
 {
     private readonly HttpClient _client;
     private readonly string _dataRoot;

--- a/tests/Meridian.Tests/Integration/EndpointTests/ConfigDirectLendingAuthorizationTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/ConfigDirectLendingAuthorizationTests.cs
@@ -18,7 +18,7 @@ namespace Meridian.Tests.Integration.EndpointTests;
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class ConfigDirectLendingAuthorizationTests : IDisposable
+public sealed class ConfigDirectLendingAuthorizationTests : IDisposable, IClassFixture<EndpointTestFixture>
 {
     private readonly EndpointTestFixture _fixture;
     private readonly HttpClient _unauthenticatedClient;

--- a/tests/Meridian.Tests/Integration/EndpointTests/ConfigEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/ConfigEndpointTests.cs
@@ -14,28 +14,25 @@ namespace Meridian.Tests.Integration.EndpointTests;
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class ConfigEndpointTests : IDisposable
+public sealed class ConfigEndpointTests : IClassFixture<EndpointTestFixture>
 {
     private const string ConfigPasswordHash = "pbkdf2-sha256$210000$MZbfWqYODb9fl/pT/2g2Wg==$hsDcSOJ5uPYBFGsUp2lD6DhaPQAeWDEc5+j0D/gk3RA=";
 
-    private readonly HttpClient _client;
+    private readonly EndpointTestFixture _fixture;
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
     public ConfigEndpointTests(EndpointTestFixture fixture)
     {
-        // SEC-001: configuration routes now require ViewConfig/ModifyConfig. Authorize this suite's
-        // client so the existing functional assertions continue to exercise the handlers.
-        _client = fixture.CreatePermittedClient(UserPermission.ViewConfig, UserPermission.ModifyConfig);
+        _fixture = fixture;
     }
-
-    public void Dispose() => _client.Dispose();
 
     #region GET /api/config
 
     [Fact]
     public async Task GetConfig_ReturnsJsonWithExpectedFields()
     {
-        var response = await _client.GetAsync("/api/config");
+        using var client = _fixture.CreatePermittedClient(UserPermission.ViewConfig);
+        var response = await client.GetAsync("/api/config");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Content.Headers.ContentType!.MediaType.Should().Be("application/json");
@@ -50,7 +47,8 @@ public sealed class ConfigEndpointTests : IDisposable
     [Fact]
     public async Task GetConfig_ContainsConfiguredSymbols()
     {
-        var response = await _client.GetAsync("/api/config");
+        using var client = _fixture.CreatePermittedClient(UserPermission.ViewConfig);
+        var response = await client.GetAsync("/api/config");
         var json = await DeserializeAsync(response);
 
         json.Should().ContainKey("symbols");
@@ -67,36 +65,40 @@ public sealed class ConfigEndpointTests : IDisposable
     [Fact]
     public async Task AddSymbol_WithValidData_WithoutPermission_ReturnsUnauthorized()
     {
+        using var client = _fixture.CreateNoRedirectClient();
         var payload = new { Symbol = "MSFT", SubscribeTrades = true, SubscribeDepth = false, DepthLevels = 10, SecurityType = "STK", Exchange = "SMART", Currency = "USD" };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
 
-        var response = await _client.PostAsync("/api/config/symbols", content);
+        var response = await client.PostAsync("/api/config/symbols", content);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
     [Fact]
-    public async Task AddSymbol_WithEmptySymbol_WithoutPermission_ReturnsUnauthorized()
+    public async Task AddSymbol_WithEmptySymbol_WithModifyPermission_ReturnsBadRequest()
     {
+        using var client = _fixture.CreatePermittedClient(UserPermission.ModifyConfig);
         var payload = new { Symbol = "", SubscribeTrades = true };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
 
-        var response = await _client.PostAsync("/api/config/symbols", content);
+        var response = await client.PostAsync("/api/config/symbols", content);
 
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]
     public async Task AddSymbol_WithoutPermission_DoesNotPersistInConfig()
     {
+        using var unauthenticatedClient = _fixture.CreateNoRedirectClient();
         var payload = new { Symbol = "TSLA", SubscribeTrades = true, SubscribeDepth = false, DepthLevels = 5, SecurityType = "STK", Exchange = "SMART", Currency = "USD" };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
 
-        var addResponse = await _client.PostAsync("/api/config/symbols", content);
+        var addResponse = await unauthenticatedClient.PostAsync("/api/config/symbols", content);
         addResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
 
-        // Verify the symbol appears in config
-        var configResponse = await _client.GetAsync("/api/config");
+        // Verify the unauthorized mutation did not change the configuration.
+        using var viewClient = _fixture.CreatePermittedClient(UserPermission.ViewConfig);
+        var configResponse = await viewClient.GetAsync("/api/config");
         var json = await DeserializeAsync(configResponse);
         var symbols = json["symbols"].EnumerateArray()
             .Select(s => s.GetProperty("symbol").GetString())
@@ -112,12 +114,15 @@ public sealed class ConfigEndpointTests : IDisposable
     [Fact]
     public async Task DeleteSymbol_WithoutPermission_ReturnsUnauthorized()
     {
+        using var modifyClient = _fixture.CreatePermittedClient(UserPermission.ModifyConfig);
         // First add a symbol to delete
         var addPayload = new { Symbol = "GOOG", SubscribeTrades = true, SubscribeDepth = false, DepthLevels = 5, SecurityType = "STK", Exchange = "SMART", Currency = "USD" };
-        await _client.PostAsync("/api/config/symbols",
+        var addResponse = await modifyClient.PostAsync("/api/config/symbols",
             new StringContent(JsonSerializer.Serialize(addPayload), Encoding.UTF8, "application/json"));
+        addResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var response = await _client.DeleteAsync("/api/config/symbols/GOOG");
+        using var unauthenticatedClient = _fixture.CreateNoRedirectClient();
+        var response = await unauthenticatedClient.DeleteAsync("/api/config/symbols/GOOG");
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -125,23 +130,27 @@ public sealed class ConfigEndpointTests : IDisposable
     [Fact]
     public async Task DeleteSymbol_WithoutPermission_LeavesConfigurationUnchanged()
     {
+        using var modifyClient = _fixture.CreatePermittedClient(UserPermission.ModifyConfig);
         // Add a symbol
         var addPayload = new { Symbol = "NFLX", SubscribeTrades = true, SubscribeDepth = false, DepthLevels = 5, SecurityType = "STK", Exchange = "SMART", Currency = "USD" };
-        await _client.PostAsync("/api/config/symbols",
+        var addResponse = await modifyClient.PostAsync("/api/config/symbols",
             new StringContent(JsonSerializer.Serialize(addPayload), Encoding.UTF8, "application/json"));
+        addResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        // Delete it
-        var deleteResponse = await _client.DeleteAsync("/api/config/symbols/NFLX");
+        // An unauthenticated caller cannot delete it.
+        using var unauthenticatedClient = _fixture.CreateNoRedirectClient();
+        var deleteResponse = await unauthenticatedClient.DeleteAsync("/api/config/symbols/NFLX");
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
 
-        // Verify it's gone
-        var configResponse = await _client.GetAsync("/api/config");
+        // Verify the symbol remains configured after the rejected mutation.
+        using var viewClient = _fixture.CreatePermittedClient(UserPermission.ViewConfig);
+        var configResponse = await viewClient.GetAsync("/api/config");
         var json = await DeserializeAsync(configResponse);
         var symbols = json["symbols"].EnumerateArray()
             .Select(s => s.GetProperty("symbol").GetString())
             .ToList();
 
-        symbols.Should().NotContain("NFLX");
+        symbols.Should().Contain("NFLX");
     }
 
     #endregion
@@ -151,7 +160,8 @@ public sealed class ConfigEndpointTests : IDisposable
     [Fact]
     public async Task GetDerivatives_ReturnsJson()
     {
-        var response = await _client.GetAsync("/api/config/derivatives");
+        using var client = _fixture.CreatePermittedClient(UserPermission.ViewConfig);
+        var response = await client.GetAsync("/api/config/derivatives");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Content.Headers.ContentType!.MediaType.Should().Be("application/json");
@@ -164,28 +174,31 @@ public sealed class ConfigEndpointTests : IDisposable
     [Fact]
     public async Task UpdateDataSource_WithValidValue_WithoutPermission_ReturnsUnauthorized()
     {
+        using var client = _fixture.CreateNoRedirectClient();
         var payload = new { DataSource = "Alpaca" };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
 
-        var response = await _client.PostAsync("/api/config/datasource", content);
+        var response = await client.PostAsync("/api/config/datasource", content);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
     [Fact]
-    public async Task UpdateDataSource_WithInvalidValue_WithoutPermission_ReturnsUnauthorized()
+    public async Task UpdateDataSource_WithInvalidValue_WithModifyPermission_ReturnsBadRequest()
     {
+        using var client = _fixture.CreatePermittedClient(UserPermission.ModifyConfig);
         var payload = new { DataSource = "InvalidProvider" };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
 
-        var response = await _client.PostAsync("/api/config/datasource", content);
+        var response = await client.PostAsync("/api/config/datasource", content);
 
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]
     public async Task UpdateDataSource_WithCookieAuth_RequiresCsrfHeader()
     {
+        using var client = _fixture.CreateNoRedirectClient();
         var originalUsername = Environment.GetEnvironmentVariable("MDC_USERNAME");
         var originalPasswordHash = Environment.GetEnvironmentVariable("MDC_PASSWORD_HASH");
         Environment.SetEnvironmentVariable("MDC_USERNAME", "config-admin");
@@ -195,7 +208,7 @@ public sealed class ConfigEndpointTests : IDisposable
         {
             var loginPayload = new { Username = "config-admin", Password = "config-password" };
             var loginContent = new StringContent(JsonSerializer.Serialize(loginPayload), Encoding.UTF8, "application/json");
-            var loginResponse = await _client.PostAsync("/api/auth/login", loginContent);
+            var loginResponse = await client.PostAsync("/api/auth/login", loginContent);
             loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
             var setCookies = loginResponse.Headers
@@ -216,7 +229,7 @@ public sealed class ConfigEndpointTests : IDisposable
                 Content = new StringContent(requestBody, Encoding.UTF8, "application/json")
             };
             noCsrfRequest.Headers.Add("Cookie", cookieHeader);
-            var noCsrfResponse = await _client.SendAsync(noCsrfRequest);
+            var noCsrfResponse = await client.SendAsync(noCsrfRequest);
             noCsrfResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
             using var withCsrfRequest = new HttpRequestMessage(HttpMethod.Post, "/api/config/datasource")
@@ -225,7 +238,7 @@ public sealed class ConfigEndpointTests : IDisposable
             };
             withCsrfRequest.Headers.Add("Cookie", cookieHeader);
             withCsrfRequest.Headers.Add("X-CSRF-Token", csrfCookie);
-            var withCsrfResponse = await _client.SendAsync(withCsrfRequest);
+            var withCsrfResponse = await client.SendAsync(withCsrfRequest);
             withCsrfResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         }
         finally

--- a/tests/Meridian.Tests/Integration/EndpointTests/CoveredCallEndpointAuthorizationTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/CoveredCallEndpointAuthorizationTests.cs
@@ -21,7 +21,7 @@ namespace Meridian.Tests.Integration.EndpointTests;
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class CoveredCallEndpointAuthorizationTests
+public sealed class CoveredCallEndpointAuthorizationTests : IClassFixture<EndpointTestFixture>
 {
     private readonly EndpointTestFixture _fixture;
 

--- a/tests/Meridian.Tests/Integration/EndpointTests/DirectLendingEndpointMutationTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/DirectLendingEndpointMutationTests.cs
@@ -11,7 +11,7 @@ namespace Meridian.Tests.Integration.EndpointTests;
 
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class DirectLendingEndpointMutationTests
+public sealed class DirectLendingEndpointMutationTests : IClassFixture<EndpointTestFixture>
 {
     private readonly EndpointTestFixture _fixture;
 

--- a/tests/Meridian.Tests/Integration/EndpointTests/EndpointIntegrationTestBase.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/EndpointIntegrationTestBase.cs
@@ -11,7 +11,7 @@ namespace Meridian.Tests.Integration.EndpointTests;
 /// Implements improvement B2/#7 from the structural improvements analysis.
 /// </summary>
 [Collection("Endpoint")]
-public abstract class EndpointIntegrationTestBase
+public abstract class EndpointIntegrationTestBase : IClassFixture<EndpointTestFixture>
 {
     protected readonly HttpClient Client;
     protected readonly EndpointTestFixture Fixture;

--- a/tests/Meridian.Tests/Integration/EndpointTests/EndpointMetadataTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/EndpointMetadataTests.cs
@@ -10,7 +10,7 @@ namespace Meridian.Tests.Integration.EndpointTests;
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class EndpointMetadataTests
+public sealed class EndpointMetadataTests : IClassFixture<EndpointTestFixture>
 {
     private readonly EndpointTestFixture _fixture;
 

--- a/tests/Meridian.Tests/Integration/EndpointTests/EndpointTestCollection.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/EndpointTestCollection.cs
@@ -3,13 +3,11 @@ using Xunit;
 namespace Meridian.Tests.Integration.EndpointTests;
 
 /// <summary>
-/// Collection definition that shares a single EndpointTestFixture instance
-/// across all endpoint test classes. Without this, each class using
-/// IClassFixture&lt;EndpointTestFixture&gt; creates its own WebApplication TestServer,
-/// which is expensive. Using a shared collection fixture reduces the number of
-/// WebApplication instances from 16+ down to 1.
+/// Serialization boundary for endpoint tests that mutate process-wide environment variables.
+/// Each test class owns its own <see cref="EndpointTestFixture"/> so authentication, configuration,
+/// and in-memory application state cannot leak between classes.
 /// </summary>
-[CollectionDefinition("Endpoint")]
-public sealed class EndpointTestCollection : ICollectionFixture<EndpointTestFixture>
+[CollectionDefinition("Endpoint", DisableParallelization = true)]
+public sealed class EndpointTestCollection
 {
 }

--- a/tests/Meridian.Tests/Integration/EndpointTests/EndpointTestFixture.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/EndpointTestFixture.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text.Json;
+using Meridian.Application.Composition;
 using Meridian.Application.DirectLending;
 using Meridian.PortfolioRecords.FundAccounts;
 using Meridian.Identity.Auth;
@@ -214,6 +215,17 @@ public sealed class EndpointTestFixture : IAsyncLifetime
         _configureTestServices?.Invoke(builder.Services);
 
         _app = builder.Build();
+        if (FundAccountsStartup.IsConfigured())
+        {
+            // AddUiSharedServices selects the PostgreSQL fund-account adapter when the hosted
+            // certification lane publishes a database URL, but this direct TestServer host does
+            // not pass through HostStartup's database-readiness phase. Migrate the fixture-owned
+            // schema before any endpoint test can resolve the adapter.
+            await FundAccountsStartup
+                .EnsureDatabaseReadyAsync(_app.Services)
+                .ConfigureAwait(false);
+        }
+
         // Mirror the production UiServer pipeline order: session auth first so the API-key
         // gate can exempt session-authenticated browser requests. The X-Test-Auth marker
         // middleware emulates LoginSessionMiddleware's session validation (setting the

--- a/tests/Meridian.Tests/Integration/EndpointTests/EndpointTestFixture.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/EndpointTestFixture.cs
@@ -8,6 +8,7 @@ using Meridian.Contracts.Services;
 using Meridian.Application.Monitoring;
 using Meridian.Application.Pipeline;
 using Meridian.Application.UI;
+using Meridian.Contracts.Api;
 using Meridian.Contracts.Domain.Models;
 using Meridian.Infrastructure;
 using Meridian.Infrastructure.Adapters.Core;
@@ -15,6 +16,8 @@ using Meridian.Infrastructure.Adapters.Failover;
 using Meridian.Infrastructure.Adapters.Stooq;
 using Meridian.Infrastructure.Adapters.Synthetic;
 using Meridian.Infrastructure.Adapters.YahooFinance;
+using Meridian.Storage;
+using Meridian.TestSupport;
 using Meridian.Ui.Shared;
 using Meridian.Ui.Shared.Endpoints;
 using Microsoft.AspNetCore.Builder;
@@ -23,6 +26,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Xunit;
 using Meridian.Contracts.Monitoring;
 using Meridian.Contracts.Pipeline;
@@ -30,13 +34,19 @@ using Meridian.Contracts.Pipeline;
 namespace Meridian.Tests.Integration.EndpointTests;
 
 /// <summary>
-/// Shared test fixture that sets up an in-memory ASP.NET Core test server
+/// Per-class test fixture that sets up an in-memory ASP.NET Core test server
 /// with all UI endpoints mapped. Uses TestServer for zero-network-overhead
 /// request/response testing.
 /// </summary>
 public sealed class EndpointTestFixture : IAsyncLifetime
 {
+    private static readonly object ProviderCatalogBindingLock = new();
+    private static EndpointTestFixture? s_activeProviderCatalogOwner;
+
+    private readonly Action? _afterProviderCatalogBound;
+    private readonly Action<IServiceCollection>? _configureTestServices;
     private Microsoft.AspNetCore.Builder.WebApplication? _app;
+    private bool _appStopped;
     private string? _tempConfigDir;
     private string? _originalAuthMode;
     private string? _originalApiKey;
@@ -47,10 +57,34 @@ public sealed class EndpointTestFixture : IAsyncLifetime
     private string? _originalUseInMemoryGovernance;
     private string? _originalDotnetEnvironment;
     private string? _originalAspNetCoreEnvironment;
+    private string? _originalLeanPath;
+    private string? _originalLeanDataPath;
+    private string? _originalLeanExportIntervalSeconds;
+    private EndpointTestFixture? _previousProviderCatalogOwner;
+    private Func<IReadOnlyList<ProviderCatalogEntry>>? _ownedRuntimeCatalogProvider;
+    private Func<string, ProviderCatalogEntry?>? _ownedRuntimeCatalogEntryProvider;
+    private bool _providerCatalogBindingActive;
+    private readonly List<PostgresTestSchemaEnvironmentScope> _databaseSchemaScopes = [];
+    private readonly Dictionary<string, string?> _databaseConnectionEnvironment =
+        new(StringComparer.Ordinal);
 
     public HttpClient Client { get; private set; } = null!;
     public string DataRoot { get; private set; } = null!;
     public IServiceProvider Services => _app!.Services;
+
+    public EndpointTestFixture()
+    {
+    }
+
+    internal EndpointTestFixture(Action afterProviderCatalogBound)
+    {
+        _afterProviderCatalogBound = afterProviderCatalogBound;
+    }
+
+    internal EndpointTestFixture(Action<IServiceCollection> configureTestServices)
+    {
+        _configureTestServices = configureTestServices;
+    }
 
     /// <summary>
     /// Header understood only by the in-memory test host (see <see cref="InitializeAsync"/>) that grants
@@ -84,6 +118,30 @@ public sealed class EndpointTestFixture : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
+        try
+        {
+            await InitializeCoreAsync().ConfigureAwait(false);
+        }
+        catch (Exception initializationError)
+        {
+            try
+            {
+                await DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception cleanupError)
+            {
+                throw new AggregateException(
+                    "Endpoint test fixture initialization and cleanup failed.",
+                    initializationError,
+                    cleanupError);
+            }
+
+            throw;
+        }
+    }
+
+    private async Task InitializeCoreAsync()
+    {
         _originalAuthMode = Environment.GetEnvironmentVariable("MDC_AUTH_MODE");
         _originalApiKey = Environment.GetEnvironmentVariable("MDC_API_KEY");
         _originalUsername = Environment.GetEnvironmentVariable("MDC_USERNAME");
@@ -93,6 +151,11 @@ public sealed class EndpointTestFixture : IAsyncLifetime
         _originalUseInMemoryGovernance = Environment.GetEnvironmentVariable("MERIDIAN_USE_INMEMORY_GOVERNANCE");
         _originalDotnetEnvironment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
         _originalAspNetCoreEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        _originalLeanPath = Environment.GetEnvironmentVariable("LEAN_PATH");
+        _originalLeanDataPath = Environment.GetEnvironmentVariable("LEAN_DATA_PATH");
+        _originalLeanExportIntervalSeconds = Environment.GetEnvironmentVariable("LEAN_EXPORT_INTERVAL_SECONDS");
+        CaptureDatabaseConnectionEnvironment();
+        MeridianDatabaseEnvironment.ApplyUnifiedDatabaseUrl();
         Environment.SetEnvironmentVariable("MDC_AUTH_MODE", "optional");
         Environment.SetEnvironmentVariable("MDC_API_KEY", null);
         Environment.SetEnvironmentVariable("MDC_USERNAME", null);
@@ -104,6 +167,11 @@ public sealed class EndpointTestFixture : IAsyncLifetime
         Environment.SetEnvironmentVariable("MDC_DISABLE_RATE_LIMIT", "true");
         Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", "Test");
         Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Test");
+        Environment.SetEnvironmentVariable("LEAN_PATH", null);
+        Environment.SetEnvironmentVariable("LEAN_DATA_PATH", null);
+        Environment.SetEnvironmentVariable("LEAN_EXPORT_INTERVAL_SECONDS", null);
+
+        await ConfigureIsolatedDatabaseSchemasAsync().ConfigureAwait(false);
 
         _tempConfigDir = Path.Combine(Path.GetTempPath(), $"mdc-endpoint-tests-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempConfigDir);
@@ -122,10 +190,20 @@ public sealed class EndpointTestFixture : IAsyncLifetime
         // Register the Ui.Shared ConfigStore wrapper (endpoints resolve this type).
         // The core ConfigStore (Application.UI.ConfigStore) is registered separately by AddMarketDataServices.
         builder.Services.AddSingleton(new Meridian.Ui.Shared.Services.ConfigStore(configPath));
+        // This host deliberately exercises file/in-memory workstation seams. A non-null whitespace
+        // sentinel prevents AddWorkstationSharedServices from falling back to the process-wide
+        // ledger database for Reporting while leaving production configuration semantics unchanged.
+        Environment.SetEnvironmentVariable("MERIDIAN_REPORTING_CONNECTION_STRING", " ");
         builder.Services.AddUiSharedServices(statusHandlers, configPath);
+        builder.Services.RemoveAll<Meridian.Ui.Shared.Services.RiskRuleRuntimeOptions>();
+        builder.Services.AddSingleton(new Meridian.Ui.Shared.Services.RiskRuleRuntimeOptions(
+            Path.Combine(DataRoot, "risk-rules.json")));
         builder.Services.TryAddSingleton<StreamingFailoverRegistry>();
         builder.Services.RemoveAll<ProviderRegistry>();
-        builder.Services.AddSingleton(_ => CreateTestProviderRegistry());
+        var testProviderRegistry = CreateTestProviderRegistry();
+        builder.Services.AddSingleton(testProviderRegistry);
+        BindProviderCatalogToTestRegistry(testProviderRegistry);
+        _afterProviderCatalogBound?.Invoke();
         builder.Services.RemoveAll<IDirectLendingService>();
         builder.Services.AddSingleton<IDirectLendingService, InMemoryDirectLendingService>();
         builder.Services.RemoveAll<IFundStructureService>();
@@ -133,6 +211,7 @@ public sealed class EndpointTestFixture : IAsyncLifetime
             new InMemoryFundStructureService(
                 sp.GetRequiredService<IFundAccountService>(),
                 persistencePath: null));
+        _configureTestServices?.Invoke(builder.Services);
 
         _app = builder.Build();
         // Mirror the production UiServer pipeline order: session auth first so the API-key
@@ -199,9 +278,181 @@ public sealed class EndpointTestFixture : IAsyncLifetime
 
     public async Task DisposeAsync()
     {
-        Client?.Dispose();
-        if (_app != null)
-            await _app.DisposeAsync();
+        var cleanupErrors = new List<Exception>();
+
+        if (_app is not null && !_appStopped)
+        {
+            var applicationLifetime = _app.Services.GetRequiredService<IHostApplicationLifetime>();
+            try
+            {
+                using var stopTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                await _app.StopAsync(stopTimeout.Token).ConfigureAwait(false);
+                _appStopped = true;
+            }
+            catch (Exception stopError)
+            {
+                if (!applicationLifetime.ApplicationStopped.IsCancellationRequested)
+                {
+                    // The host may still be using schemas, files, ambient configuration, and the
+                    // catalog binding. Retaining those resources is safer than destroying them
+                    // beneath live hosted services; fail closed instead of poisoning cleanup order.
+                    throw new AggregateException(
+                        "Endpoint test fixture host did not stop; owned resources were retained.",
+                        stopError);
+                }
+
+                // Host.StopAsync aggregates hosted-service stop errors after completing the stop
+                // lifecycle. Once ApplicationStopped is signaled, cleanup is safe and must proceed
+                // so a single faulty StopAsync implementation cannot poison every later class.
+                _appStopped = true;
+                cleanupErrors.Add(stopError);
+            }
+        }
+
+        RestoreProviderCatalogCallbacksIfOwned();
+
+        try
+        {
+            Client?.Dispose();
+        }
+        catch (Exception ex)
+        {
+            cleanupErrors.Add(ex);
+        }
+
+        if (_app is not null)
+        {
+            try
+            {
+                await _app.DisposeAsync();
+                _app = null;
+            }
+            catch (Exception ex)
+            {
+                cleanupErrors.Add(ex);
+            }
+        }
+
+        for (var index = _databaseSchemaScopes.Count - 1; index >= 0; index--)
+        {
+            try
+            {
+                await _databaseSchemaScopes[index].DisposeAsync().ConfigureAwait(false);
+                _databaseSchemaScopes.RemoveAt(index);
+            }
+            catch (Exception ex)
+            {
+                cleanupErrors.Add(ex);
+            }
+        }
+
+        try
+        {
+            RestoreProcessEnvironment();
+        }
+        catch (Exception ex)
+        {
+            cleanupErrors.Add(ex);
+        }
+
+        if (_tempConfigDir != null && Directory.Exists(_tempConfigDir))
+        {
+            try
+            {
+                Directory.Delete(_tempConfigDir, recursive: true);
+                _tempConfigDir = null;
+            }
+            catch (Exception ex)
+            {
+                cleanupErrors.Add(ex);
+            }
+        }
+
+        if (cleanupErrors.Count > 0)
+        {
+            throw new AggregateException("Endpoint test fixture cleanup failed.", cleanupErrors);
+        }
+    }
+
+    private async Task ConfigureIsolatedDatabaseSchemasAsync()
+    {
+        await AddDatabaseSchemaScopeAsync(
+            "MERIDIAN_LEDGER_CONNECTION_STRING",
+            "MERIDIAN_LEDGER_SCHEMA",
+            "endpoint_ledger").ConfigureAwait(false);
+        await AddDatabaseSchemaScopeAsync(
+            "MERIDIAN_ASSET_OPERATIONS_CONNECTION_STRING",
+            "MERIDIAN_ASSET_OPERATIONS_SCHEMA",
+            "endpoint_asset_ops").ConfigureAwait(false);
+        await AddDatabaseSchemaScopeAsync(
+            "MERIDIAN_DIRECT_LENDING_CONNECTION_STRING",
+            "MERIDIAN_DIRECT_LENDING_SCHEMA",
+            "endpoint_direct_lending",
+            "MERIDIAN_SECURITY_MASTER_CONNECTION_STRING").ConfigureAwait(false);
+        await AddDatabaseSchemaScopeAsync(
+            "MERIDIAN_FUND_ACCOUNTS_CONNECTION_STRING",
+            "MERIDIAN_FUND_ACCOUNTS_SCHEMA",
+            "endpoint_fund_accounts").ConfigureAwait(false);
+        await AddDatabaseSchemaScopeAsync(
+            "MERIDIAN_FUND_STRUCTURE_CONNECTION_STRING",
+            "MERIDIAN_FUND_STRUCTURE_SCHEMA",
+            "endpoint_fund_structure").ConfigureAwait(false);
+        await AddDatabaseSchemaScopeAsync(
+            "MERIDIAN_REPORTING_CONNECTION_STRING",
+            "MERIDIAN_REPORTING_SCHEMA",
+            "endpoint_reporting",
+            "MERIDIAN_LEDGER_CONNECTION_STRING").ConfigureAwait(false);
+        await AddDatabaseSchemaScopeAsync(
+            "MERIDIAN_SCOPED_ACCESS_CONNECTION_STRING",
+            "MERIDIAN_SCOPED_ACCESS_SCHEMA",
+            "endpoint_scoped_access").ConfigureAwait(false);
+        await AddDatabaseSchemaScopeAsync(
+            "MERIDIAN_SECURITY_MASTER_CONNECTION_STRING",
+            "MERIDIAN_SECURITY_MASTER_SCHEMA",
+            "endpoint_security").ConfigureAwait(false);
+        await AddDatabaseSchemaScopeAsync(
+            "MERIDIAN_BANKING_CONNECTION_STRING",
+            "MERIDIAN_BANKING_SCHEMA",
+            "endpoint_banking").ConfigureAwait(false);
+        await AddDatabaseSchemaScopeAsync(
+            "MERIDIAN_MONEY_MARKET_CONNECTION_STRING",
+            "MERIDIAN_MONEY_MARKET_SCHEMA",
+            "endpoint_money_market").ConfigureAwait(false);
+    }
+
+    private async Task AddDatabaseSchemaScopeAsync(
+        string connectionStringEnvironmentVariable,
+        string schemaEnvironmentVariable,
+        string schemaPrefix,
+        string? fallbackConnectionStringEnvironmentVariable = null)
+    {
+        var scope = await PostgresTestSchemaEnvironmentScope.CreateIfConfiguredAsync(
+                connectionStringEnvironmentVariable,
+                schemaEnvironmentVariable,
+                schemaPrefix,
+                fallbackConnectionStringEnvironmentVariable)
+            .ConfigureAwait(false);
+        if (scope is not null)
+        {
+            _databaseSchemaScopes.Add(scope);
+        }
+    }
+
+    private void CaptureDatabaseConnectionEnvironment()
+    {
+        foreach (var variable in MeridianDatabaseEnvironment.PropagatedConnectionStringVariables.Concat(
+                     [
+                         "MERIDIAN_DIRECT_LENDING_CONNECTION_STRING",
+                         "MERIDIAN_REPORTING_CONNECTION_STRING"
+                     ]))
+        {
+            _databaseConnectionEnvironment[variable] =
+                Environment.GetEnvironmentVariable(variable);
+        }
+    }
+
+    private void RestoreProcessEnvironment()
+    {
         Environment.SetEnvironmentVariable("MDC_AUTH_MODE", _originalAuthMode);
         Environment.SetEnvironmentVariable("MDC_API_KEY", _originalApiKey);
         Environment.SetEnvironmentVariable("MDC_USERNAME", _originalUsername);
@@ -211,11 +462,12 @@ public sealed class EndpointTestFixture : IAsyncLifetime
         Environment.SetEnvironmentVariable("MERIDIAN_USE_INMEMORY_GOVERNANCE", _originalUseInMemoryGovernance);
         Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", _originalDotnetEnvironment);
         Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", _originalAspNetCoreEnvironment);
-        if (_tempConfigDir != null && Directory.Exists(_tempConfigDir))
+        Environment.SetEnvironmentVariable("LEAN_PATH", _originalLeanPath);
+        Environment.SetEnvironmentVariable("LEAN_DATA_PATH", _originalLeanDataPath);
+        Environment.SetEnvironmentVariable("LEAN_EXPORT_INTERVAL_SECONDS", _originalLeanExportIntervalSeconds);
+        foreach (var pair in _databaseConnectionEnvironment)
         {
-            try
-            { Directory.Delete(_tempConfigDir, recursive: true); }
-            catch { /* best-effort cleanup */ }
+            Environment.SetEnvironmentVariable(pair.Key, pair.Value);
         }
     }
 
@@ -254,6 +506,98 @@ public sealed class EndpointTestFixture : IAsyncLifetime
         registry.Register(new StooqHistoricalDataProvider(), priorityOverride: 20);
         registry.Register(new YahooFinanceHistoricalDataProvider(), priorityOverride: 30);
         return registry;
+    }
+
+    private void BindProviderCatalogToTestRegistry(ProviderRegistry registry)
+    {
+        // ProviderCatalog is process-wide. Production composition binds it to the host's
+        // IServiceProvider, but this fixture replaces ProviderRegistry after composition.
+        // Use an immutable catalog snapshot so a preceding host cannot leave callbacks that
+        // resolve services from its disposed container, and so this fixture does not publish
+        // callbacks tied to its own disposable registry.
+        var entries = registry.GetProviderCatalog().ToArray();
+        _ownedRuntimeCatalogProvider = () => entries;
+        _ownedRuntimeCatalogEntryProvider = providerId => entries.FirstOrDefault(entry =>
+            string.Equals(entry.ProviderId, providerId, StringComparison.OrdinalIgnoreCase));
+        lock (ProviderCatalogBindingLock)
+        {
+            var candidateOwner = s_activeProviderCatalogOwner;
+            var candidateStillOwnsPair =
+                candidateOwner is { _providerCatalogBindingActive: true } &&
+                ReferenceEquals(
+                    ProviderCatalog.RuntimeCatalogProvider,
+                    candidateOwner._ownedRuntimeCatalogProvider) &&
+                ReferenceEquals(
+                    ProviderCatalog.RuntimeCatalogEntryProvider,
+                    candidateOwner._ownedRuntimeCatalogEntryProvider);
+            if (!candidateStillOwnsPair && candidateOwner is not null)
+            {
+                candidateOwner._providerCatalogBindingActive = false;
+                s_activeProviderCatalogOwner = null;
+            }
+
+            _previousProviderCatalogOwner = candidateStillOwnsPair
+                ? candidateOwner
+                : null;
+            ProviderCatalog.InitializeFromRegistry(
+                _ownedRuntimeCatalogProvider,
+                _ownedRuntimeCatalogEntryProvider);
+            _providerCatalogBindingActive = true;
+            s_activeProviderCatalogOwner = this;
+        }
+    }
+
+    private void RestoreProviderCatalogCallbacksIfOwned()
+    {
+        lock (ProviderCatalogBindingLock)
+        {
+            if (!_providerCatalogBindingActive)
+            {
+                return;
+            }
+
+            _providerCatalogBindingActive = false;
+            if (!ReferenceEquals(s_activeProviderCatalogOwner, this))
+            {
+                return;
+            }
+
+            var callbacksStillOwned =
+                ReferenceEquals(ProviderCatalog.RuntimeCatalogProvider, _ownedRuntimeCatalogProvider) &&
+                ReferenceEquals(ProviderCatalog.RuntimeCatalogEntryProvider, _ownedRuntimeCatalogEntryProvider);
+            if (!callbacksStillOwned)
+            {
+                // A later non-fixture owner replaced the process-wide callbacks. Do not clobber it.
+                s_activeProviderCatalogOwner = null;
+                return;
+            }
+
+            var priorOwner = _previousProviderCatalogOwner;
+            while (priorOwner is not null && !priorOwner._providerCatalogBindingActive)
+            {
+                priorOwner = priorOwner._previousProviderCatalogOwner;
+            }
+
+            if (priorOwner is not null)
+            {
+                ProviderCatalog.InitializeFromRegistry(
+                    priorOwner._ownedRuntimeCatalogProvider!,
+                    priorOwner._ownedRuntimeCatalogEntryProvider!);
+                s_activeProviderCatalogOwner = priorOwner;
+            }
+            else
+            {
+                // Never resurrect arbitrary callbacks from a predecessor host: they may close over
+                // a disposed service provider. Only another active EndpointTestFixture is restorable.
+                ProviderCatalog.RuntimeCatalogProvider = null;
+                ProviderCatalog.RuntimeCatalogEntryProvider = null;
+                s_activeProviderCatalogOwner = null;
+            }
+
+            _ownedRuntimeCatalogProvider = null;
+            _ownedRuntimeCatalogEntryProvider = null;
+            _previousProviderCatalogOwner = null;
+        }
     }
 
     private static string GetMinimalConfig()

--- a/tests/Meridian.Tests/Integration/EndpointTests/EndpointTestFixture.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/EndpointTestFixture.cs
@@ -215,6 +215,17 @@ public sealed class EndpointTestFixture : IAsyncLifetime
         _configureTestServices?.Invoke(builder.Services);
 
         _app = builder.Build();
+        if (LedgerStartup.IsConfigured())
+        {
+            // AddUiSharedServices selects the PostgreSQL ledger adapter when the hosted
+            // certification lane publishes a database URL, but this direct TestServer host does
+            // not pass through HostStartup's database-readiness phase. Migrate the fixture-owned
+            // schema before workspace endpoints can resolve the ledger store.
+            await LedgerStartup
+                .EnsureDatabaseReadyAsync(_app.Services)
+                .ConfigureAwait(false);
+        }
+
         if (FundAccountsStartup.IsConfigured())
         {
             // AddUiSharedServices selects the PostgreSQL fund-account adapter when the hosted

--- a/tests/Meridian.Tests/Integration/EndpointTests/EndpointTestFixtureProviderCatalogLifetimeTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/EndpointTestFixtureProviderCatalogLifetimeTests.cs
@@ -1,0 +1,298 @@
+using System.Net;
+using FluentAssertions;
+using Meridian.Contracts.Api;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Meridian.Tests.Integration.EndpointTests;
+
+/// <summary>
+/// Guards the endpoint-host restart scenario where a prior host leaves process-wide provider
+/// catalog callbacks that can no longer resolve services from its disposed container.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("Endpoint")]
+public sealed class EndpointTestFixtureProviderCatalogLifetimeTests
+{
+    [Fact]
+    public async Task ProviderComparison_PreviousHostCatalogWasDisposed_ReturnsCurrentFixtureResponse()
+    {
+        var originalCatalogProvider = ProviderCatalog.RuntimeCatalogProvider;
+        var originalCatalogEntryProvider = ProviderCatalog.RuntimeCatalogEntryProvider;
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        ProviderCatalog.InitializeFromRegistry(
+            static () => throw new ObjectDisposedException("previous-host"),
+            static _ => throw new ObjectDisposedException("previous-host"));
+
+        var fixture = new EndpointTestFixture();
+        try
+        {
+            await fixture.InitializeAsync().WaitAsync(timeout.Token);
+
+            using var response = await fixture.Client.GetAsync(
+                "/api/providers/comparison",
+                timeout.Token);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+            var applicationLifetime = fixture.Services.GetRequiredService<IHostApplicationLifetime>();
+            await fixture.DisposeAsync().WaitAsync(timeout.Token);
+
+            applicationLifetime.ApplicationStopped.IsCancellationRequested.Should().BeTrue();
+            ProviderCatalog.RuntimeCatalogProvider.Should().BeNull();
+            ProviderCatalog.RuntimeCatalogEntryProvider.Should().BeNull();
+            var readCatalog = () => ProviderCatalog.GetAll();
+            readCatalog.Should().NotThrow();
+        }
+        finally
+        {
+            using var cleanupTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await fixture.DisposeAsync().WaitAsync(cleanupTimeout.Token);
+            ProviderCatalog.RuntimeCatalogProvider = originalCatalogProvider;
+            ProviderCatalog.RuntimeCatalogEntryProvider = originalCatalogEntryProvider;
+        }
+    }
+
+    [Fact]
+    public async Task ProviderComparison_InnerFixtureWasDisposed_OuterFixtureRemainsBound()
+    {
+        var originalCatalogProvider = ProviderCatalog.RuntimeCatalogProvider;
+        var originalCatalogEntryProvider = ProviderCatalog.RuntimeCatalogEntryProvider;
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        var outer = new EndpointTestFixture();
+        var inner = new EndpointTestFixture();
+
+        try
+        {
+            await outer.InitializeAsync().WaitAsync(timeout.Token);
+            var outerCatalogProvider = ProviderCatalog.RuntimeCatalogProvider;
+            var outerCatalogEntryProvider = ProviderCatalog.RuntimeCatalogEntryProvider;
+            await inner.InitializeAsync().WaitAsync(timeout.Token);
+            await inner.DisposeAsync().WaitAsync(timeout.Token);
+
+            ProviderCatalog.RuntimeCatalogProvider.Should().BeSameAs(outerCatalogProvider);
+            ProviderCatalog.RuntimeCatalogEntryProvider.Should().BeSameAs(outerCatalogEntryProvider);
+
+            using var response = await outer.Client.GetAsync(
+                "/api/providers/comparison",
+                timeout.Token);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+        }
+        finally
+        {
+            await inner.DisposeAsync().WaitAsync(timeout.Token);
+            await outer.DisposeAsync().WaitAsync(timeout.Token);
+            ProviderCatalog.RuntimeCatalogProvider.Should().BeNull();
+            ProviderCatalog.RuntimeCatalogEntryProvider.Should().BeNull();
+            ProviderCatalog.RuntimeCatalogProvider = originalCatalogProvider;
+            ProviderCatalog.RuntimeCatalogEntryProvider = originalCatalogEntryProvider;
+        }
+    }
+
+    [Fact]
+    public async Task ProviderComparison_NewerNonFixtureOwnerWasInstalled_DisposeDoesNotClobberIt()
+    {
+        var originalCatalogProvider = ProviderCatalog.RuntimeCatalogProvider;
+        var originalCatalogEntryProvider = ProviderCatalog.RuntimeCatalogEntryProvider;
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var fixture = new EndpointTestFixture();
+        ProviderCatalogEntry[] replacementEntries = [];
+        Func<IReadOnlyList<ProviderCatalogEntry>> replacementCatalogProvider = () => replacementEntries;
+        Func<string, ProviderCatalogEntry?> replacementCatalogEntryProvider = _ => null;
+
+        try
+        {
+            await fixture.InitializeAsync().WaitAsync(timeout.Token);
+            ProviderCatalog.InitializeFromRegistry(
+                replacementCatalogProvider,
+                replacementCatalogEntryProvider);
+
+            await fixture.DisposeAsync().WaitAsync(timeout.Token);
+
+            ProviderCatalog.RuntimeCatalogProvider.Should().BeSameAs(replacementCatalogProvider);
+            ProviderCatalog.RuntimeCatalogEntryProvider.Should().BeSameAs(replacementCatalogEntryProvider);
+        }
+        finally
+        {
+            await fixture.DisposeAsync().WaitAsync(timeout.Token);
+            ProviderCatalog.RuntimeCatalogProvider = originalCatalogProvider;
+            ProviderCatalog.RuntimeCatalogEntryProvider = originalCatalogEntryProvider;
+        }
+    }
+
+    [Fact]
+    public async Task ProviderComparison_NonFixturePairReplacedOuter_InnerDoesNotResurrectOuter()
+    {
+        var originalCatalogProvider = ProviderCatalog.RuntimeCatalogProvider;
+        var originalCatalogEntryProvider = ProviderCatalog.RuntimeCatalogEntryProvider;
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        var outer = new EndpointTestFixture();
+        var inner = new EndpointTestFixture();
+        Func<IReadOnlyList<ProviderCatalogEntry>> replacementCatalogProvider =
+            static () => Array.Empty<ProviderCatalogEntry>();
+        Func<string, ProviderCatalogEntry?> replacementCatalogEntryProvider = static _ => null;
+
+        try
+        {
+            await outer.InitializeAsync().WaitAsync(timeout.Token);
+            var detachedOuterCatalogProvider = ProviderCatalog.RuntimeCatalogProvider;
+            var detachedOuterCatalogEntryProvider = ProviderCatalog.RuntimeCatalogEntryProvider;
+            ProviderCatalog.InitializeFromRegistry(
+                replacementCatalogProvider,
+                replacementCatalogEntryProvider);
+
+            await inner.InitializeAsync().WaitAsync(timeout.Token);
+            await inner.DisposeAsync().WaitAsync(timeout.Token);
+
+            ProviderCatalog.RuntimeCatalogProvider.Should().BeNull();
+            ProviderCatalog.RuntimeCatalogEntryProvider.Should().BeNull();
+            ProviderCatalog.RuntimeCatalogProvider.Should().NotBeSameAs(detachedOuterCatalogProvider);
+            ProviderCatalog.RuntimeCatalogEntryProvider.Should().NotBeSameAs(detachedOuterCatalogEntryProvider);
+        }
+        finally
+        {
+            await inner.DisposeAsync().WaitAsync(timeout.Token);
+            await outer.DisposeAsync().WaitAsync(timeout.Token);
+            ProviderCatalog.RuntimeCatalogProvider = originalCatalogProvider;
+            ProviderCatalog.RuntimeCatalogEntryProvider = originalCatalogEntryProvider;
+        }
+    }
+
+    [Fact]
+    public async Task ProviderComparison_InnerFixtureInitializationFails_OuterFixtureIsRestored()
+    {
+        var originalCatalogProvider = ProviderCatalog.RuntimeCatalogProvider;
+        var originalCatalogEntryProvider = ProviderCatalog.RuntimeCatalogEntryProvider;
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        var outer = new EndpointTestFixture();
+        var failingInner = new EndpointTestFixture(
+            static () => throw new InvalidOperationException("synthetic initialization failure"));
+
+        try
+        {
+            await outer.InitializeAsync().WaitAsync(timeout.Token);
+            var outerCatalogProvider = ProviderCatalog.RuntimeCatalogProvider;
+            var outerCatalogEntryProvider = ProviderCatalog.RuntimeCatalogEntryProvider;
+
+            var initialize = () => failingInner.InitializeAsync().WaitAsync(timeout.Token);
+            await initialize.Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage("synthetic initialization failure");
+
+            ProviderCatalog.RuntimeCatalogProvider.Should().BeSameAs(outerCatalogProvider);
+            ProviderCatalog.RuntimeCatalogEntryProvider.Should().BeSameAs(outerCatalogEntryProvider);
+
+            using var response = await outer.Client.GetAsync(
+                "/api/providers/comparison",
+                timeout.Token);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+        }
+        finally
+        {
+            await failingInner.DisposeAsync().WaitAsync(timeout.Token);
+            await outer.DisposeAsync().WaitAsync(timeout.Token);
+            ProviderCatalog.RuntimeCatalogProvider.Should().BeNull();
+            ProviderCatalog.RuntimeCatalogEntryProvider.Should().BeNull();
+            ProviderCatalog.RuntimeCatalogProvider = originalCatalogProvider;
+            ProviderCatalog.RuntimeCatalogEntryProvider = originalCatalogEntryProvider;
+        }
+    }
+
+    [Fact]
+    public async Task InitializeAndDispose_SeededLeanEnvironment_IsClearedThenRestored()
+    {
+        var originalLeanPath = Environment.GetEnvironmentVariable("LEAN_PATH");
+        var originalLeanDataPath = Environment.GetEnvironmentVariable("LEAN_DATA_PATH");
+        var originalInterval = Environment.GetEnvironmentVariable("LEAN_EXPORT_INTERVAL_SECONDS");
+        var originalReportingConnection =
+            Environment.GetEnvironmentVariable("MERIDIAN_REPORTING_CONNECTION_STRING");
+        var originalDirectLendingConnection =
+            Environment.GetEnvironmentVariable("MERIDIAN_DIRECT_LENDING_CONNECTION_STRING");
+        var seededLeanPath = Path.Combine(Path.GetTempPath(), $"lean-install-{Guid.NewGuid():N}");
+        var seededDataPath = Path.Combine(Path.GetTempPath(), $"lean-data-{Guid.NewGuid():N}");
+        var fixture = new EndpointTestFixture();
+
+        try
+        {
+            Environment.SetEnvironmentVariable("LEAN_PATH", seededLeanPath);
+            Environment.SetEnvironmentVariable("LEAN_DATA_PATH", seededDataPath);
+            Environment.SetEnvironmentVariable("LEAN_EXPORT_INTERVAL_SECONDS", "1");
+
+            await fixture.InitializeAsync();
+
+            Environment.GetEnvironmentVariable("LEAN_PATH").Should().BeNull();
+            Environment.GetEnvironmentVariable("LEAN_DATA_PATH").Should().BeNull();
+            Environment.GetEnvironmentVariable("LEAN_EXPORT_INTERVAL_SECONDS").Should().BeNull();
+            Environment.GetEnvironmentVariable("MERIDIAN_REPORTING_CONNECTION_STRING")
+                .Should().Be(" ");
+
+            await fixture.DisposeAsync();
+
+            Environment.GetEnvironmentVariable("LEAN_PATH").Should().Be(seededLeanPath);
+            Environment.GetEnvironmentVariable("LEAN_DATA_PATH").Should().Be(seededDataPath);
+            Environment.GetEnvironmentVariable("LEAN_EXPORT_INTERVAL_SECONDS").Should().Be("1");
+            Environment.GetEnvironmentVariable("MERIDIAN_REPORTING_CONNECTION_STRING")
+                .Should().Be(originalReportingConnection);
+            Environment.GetEnvironmentVariable("MERIDIAN_DIRECT_LENDING_CONNECTION_STRING")
+                .Should().Be(originalDirectLendingConnection);
+            Directory.Exists(seededDataPath).Should().BeFalse();
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+            Environment.SetEnvironmentVariable("LEAN_PATH", originalLeanPath);
+            Environment.SetEnvironmentVariable("LEAN_DATA_PATH", originalLeanDataPath);
+            Environment.SetEnvironmentVariable("LEAN_EXPORT_INTERVAL_SECONDS", originalInterval);
+            Environment.SetEnvironmentVariable(
+                "MERIDIAN_REPORTING_CONNECTION_STRING",
+                originalReportingConnection);
+            Environment.SetEnvironmentVariable(
+                "MERIDIAN_DIRECT_LENDING_CONNECTION_STRING",
+                originalDirectLendingConnection);
+        }
+    }
+
+    [Fact]
+    public async Task Dispose_HostedServiceStopThrowsAfterHostStops_CleansOwnedStateAndReportsError()
+    {
+        var originalCatalogProvider = ProviderCatalog.RuntimeCatalogProvider;
+        var originalCatalogEntryProvider = ProviderCatalog.RuntimeCatalogEntryProvider;
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        var fixture = new EndpointTestFixture(static services =>
+            services.AddSingleton<IHostedService, ThrowingStopHostedService>());
+
+        try
+        {
+            await fixture.InitializeAsync().WaitAsync(timeout.Token);
+            var applicationLifetime = fixture.Services.GetRequiredService<IHostApplicationLifetime>();
+            var fixtureRoot = Path.GetDirectoryName(fixture.DataRoot)!;
+
+            var dispose = () => fixture.DisposeAsync().WaitAsync(timeout.Token);
+            await dispose.Should().ThrowAsync<AggregateException>()
+                .WithMessage("Endpoint test fixture cleanup failed.*");
+
+            applicationLifetime.ApplicationStopped.IsCancellationRequested.Should().BeTrue();
+            ProviderCatalog.RuntimeCatalogProvider.Should().BeNull();
+            ProviderCatalog.RuntimeCatalogEntryProvider.Should().BeNull();
+            Directory.Exists(fixtureRoot).Should().BeFalse();
+        }
+        finally
+        {
+            await fixture.DisposeAsync().WaitAsync(timeout.Token);
+            ProviderCatalog.RuntimeCatalogProvider = originalCatalogProvider;
+            ProviderCatalog.RuntimeCatalogEntryProvider = originalCatalogEntryProvider;
+        }
+    }
+
+    private sealed class ThrowingStopHostedService : IHostedService
+    {
+        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task StopAsync(CancellationToken cancellationToken) =>
+            Task.FromException(new InvalidOperationException("synthetic hosted-service stop failure"));
+    }
+}

--- a/tests/Meridian.Tests/Integration/EndpointTests/EnvironmentDesignerEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/EnvironmentDesignerEndpointTests.cs
@@ -9,7 +9,7 @@ namespace Meridian.Tests.Integration.EndpointTests;
 
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class EnvironmentDesignerEndpointTests
+public sealed class EnvironmentDesignerEndpointTests : IClassFixture<EndpointTestFixture>
 {
     private readonly HttpClient _client;
 

--- a/tests/Meridian.Tests/Integration/EndpointTests/FailoverEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/FailoverEndpointTests.cs
@@ -18,7 +18,7 @@ namespace Meridian.Tests.Integration.EndpointTests;
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class FailoverEndpointTests : IDisposable
+public sealed class FailoverEndpointTests : IDisposable, IClassFixture<EndpointTestFixture>
 {
     private readonly EndpointTestFixture _fixture;
     private readonly HttpClient _client;

--- a/tests/Meridian.Tests/Integration/EndpointTests/FundStructureEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/FundStructureEndpointTests.cs
@@ -9,6 +9,7 @@ using Meridian.Application.FundStructure;
 using Meridian.Backtesting.Sdk;
 using Meridian.Contracts.FundStructure;
 using Meridian.Contracts.Services;
+using Meridian.Identity;
 using Meridian.Identity.Auth;
 using Meridian.Contracts.Workstation;
 using Meridian.Ui.Shared.Services;
@@ -26,7 +27,7 @@ namespace Meridian.Tests.Integration.EndpointTests;
 
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class FundStructureEndpointTests
+public sealed class FundStructureEndpointTests : IClassFixture<EndpointTestFixture>
 {
     private const string TestPassHash = "pbkdf2-sha256$210000$DdocJLRlUqhBZlBR8YAatA==$MpNJJHhFb6+it6jMKuIzwHtg9Lq/WehIjKrC1m6TRQU=";
 
@@ -67,13 +68,16 @@ public sealed class FundStructureEndpointTests
 
         try
         {
+            var session = await LoginAndGetAuthenticatedSessionAsync("fund-ops", "test-pass");
+            session.Role.Should().Be(nameof(UserRole.Accounting));
+            session.PermissionNames.Should().Contain(nameof(UserPermission.ManageDirectLending));
             var draft = CreateSetupDraft();
-            var sessionCookie = await LoginAndGetSessionCookieAsync("fund-ops", "test-pass");
             using var request = new HttpRequestMessage(HttpMethod.Post, "/api/fund-structure/setup-drafts/create")
             {
                 Content = JsonContent.Create(draft)
             };
-            request.Headers.Add("Cookie", sessionCookie);
+            request.Headers.Add("Cookie", session.CookieHeader);
+            request.Headers.Add("X-CSRF-Token", session.CsrfToken);
 
             var response = await _client.SendAsync(request);
 
@@ -83,8 +87,9 @@ public sealed class FundStructureEndpointTests
             payload!.Organization.Code.Should().Be("ORG-SETUP");
             payload.BusinessLane.Code.Should().Be("BUS-SETUP");
             payload.Fund.Should().NotBeNull();
+            payload.InvestmentPortfolio.Code.Should().Be("PORT-SETUP");
             payload.AccountHandoffAssignment.AssignmentType.Should().Be(FundStructureSetupWorkflowService.AccountHandoffAssignmentType);
-            payload.Graph.Nodes.Should().Contain(node => node.Kind == FundStructureNodeKindDto.InvestmentPortfolio && node.Code == "PORT-SETUP");
+            payload.AccountHandoffAssignment.NodeId.Should().Be(payload.InvestmentPortfolio.InvestmentPortfolioId);
         }
         finally
         {
@@ -102,13 +107,16 @@ public sealed class FundStructureEndpointTests
 
         try
         {
+            var session = await LoginAndGetAuthenticatedSessionAsync("read-only", "test-pass");
+            session.Role.Should().Be(nameof(UserRole.ReadOnly));
+            session.PermissionNames.Should().NotContain(nameof(UserPermission.ManageDirectLending));
             var draft = CreateSetupDraft() with { RequestedBy = "spoofed-admin" };
-            var sessionCookie = await LoginAndGetSessionCookieAsync("read-only", "test-pass");
             using var request = new HttpRequestMessage(HttpMethod.Post, "/api/fund-structure/setup-drafts/create")
             {
                 Content = JsonContent.Create(draft)
             };
-            request.Headers.Add("Cookie", sessionCookie);
+            request.Headers.Add("Cookie", session.CookieHeader);
+            request.Headers.Add("X-CSRF-Token", session.CsrfToken);
 
             var response = await _client.SendAsync(request);
 
@@ -216,7 +224,7 @@ public sealed class FundStructureEndpointTests
         var organizationId = Guid.NewGuid();
         var businessId = Guid.NewGuid();
         var fundId = Guid.NewGuid();
-        var portfolioId = Guid.NewGuid();
+        var entityId = Guid.NewGuid();
         var linkId = Guid.NewGuid();
         var now = new DateTimeOffset(2026, 04, 12, 0, 0, 0, TimeSpan.Zero);
 
@@ -244,22 +252,25 @@ public sealed class FundStructureEndpointTests
             now,
             "endpoint-test",
             BusinessId: businessId));
-        await structureService.CreateInvestmentPortfolioAsync(new CreateInvestmentPortfolioRequest(
-            portfolioId,
-            businessId,
-            $"PRT-{Guid.NewGuid():N}"[..12].ToUpperInvariant(),
-            "Ownership Endpoint Portfolio",
+        await structureService.CreateLegalEntityAsync(new CreateLegalEntityRequest(
+            entityId,
+            LegalEntityTypeDto.Fund,
+            $"ENT-{Guid.NewGuid():N}"[..12].ToUpperInvariant(),
+            "Ownership Endpoint Entity",
+            "US-DE",
             "USD",
             now,
-            "endpoint-test",
-            FundId: fundId));
+            "endpoint-test"));
         await structureService.LinkNodesAsync(new LinkFundStructureNodesRequest(
             linkId,
             fundId,
-            portfolioId,
-            OwnershipRelationshipTypeDto.AllocatesTo,
+            entityId,
+            OwnershipRelationshipTypeDto.Owns,
             now,
-            "endpoint-test"));
+            "endpoint-test",
+            OwnershipPercent: 100m,
+            IsPrimary: true,
+            Notes: "endpoint-test"));
 
         var updateResponse = await client.PutAsJsonAsync(
             $"/api/fund-structure/links/{linkId}",
@@ -333,7 +344,7 @@ public sealed class FundStructureEndpointTests
                 Guid.Empty,
                 Guid.NewGuid(),
                 seed.FundId,
-                seed.PortfolioId,
+                seed.ChildNodeId,
                 OwnershipRelationshipTypeDto.Owns,
                 seed.EffectiveFrom.AddDays(2),
                 "readonly-operator",
@@ -349,9 +360,9 @@ public sealed class FundStructureEndpointTests
             new FundStructureQuery(AsOf: seed.EffectiveFrom.AddDays(3)));
         graph.OwnershipLinks.Should().HaveCount(1);
         var unchanged = graph.OwnershipLinks.Single(link => link.OwnershipLinkId == seed.LinkId);
-        unchanged.RelationshipType.Should().Be(OwnershipRelationshipTypeDto.AllocatesTo);
-        unchanged.OwnershipPercent.Should().BeNull();
-        unchanged.IsPrimary.Should().BeFalse();
+        unchanged.RelationshipType.Should().Be(OwnershipRelationshipTypeDto.Owns);
+        unchanged.OwnershipPercent.Should().Be(100m);
+        unchanged.IsPrimary.Should().BeTrue();
         unchanged.EffectiveTo.Should().BeNull();
         unchanged.Notes.Should().Be("endpoint-test");
     }
@@ -480,9 +491,10 @@ public sealed class FundStructureEndpointTests
     public async Task GetReportPacks_WithSeededFundProfile_ReturnsHistory()
     {
         var seed = await SeedFundWorkspaceAsync();
-        var generated = await GenerateReportPackAsync(seed);
+        var generated = await SeedLegacyReportPackAsync(seed);
+        using var client = _fixture.CreatePermittedClient(UserPermission.ViewReporting);
 
-        var response = await _client.GetAsync(
+        var response = await client.GetAsync(
             $"/api/fund-structure/report-packs?fundProfileId={Uri.EscapeDataString(seed.FundProfileId)}&limit=5");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -501,16 +513,17 @@ public sealed class FundStructureEndpointTests
     public async Task GetReportPack_ReturnsDetailOrNotFound()
     {
         var seed = await SeedFundWorkspaceAsync();
-        var generated = await GenerateReportPackAsync(seed);
+        var generated = await SeedLegacyReportPackAsync(seed);
+        using var client = _fixture.CreatePermittedClient(UserPermission.ViewReporting);
 
-        var detailResponse = await _client.GetAsync($"/api/fund-structure/report-packs/{generated.ReportId}");
+        var detailResponse = await client.GetAsync($"/api/fund-structure/report-packs/{generated.ReportId}");
         detailResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         var detail = await detailResponse.Content.ReadFromJsonAsync<FundReportPackSnapshotDto>();
         detail.Should().NotBeNull();
         detail!.ReportId.Should().Be(generated.ReportId);
         detail.SchemaVersion.Should().Be(GovernanceReportPackContract.CurrentSchemaVersion);
 
-        var missingResponse = await _client.GetAsync($"/api/fund-structure/report-packs/{Guid.NewGuid()}");
+        var missingResponse = await client.GetAsync($"/api/fund-structure/report-packs/{Guid.NewGuid()}");
         missingResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
@@ -580,7 +593,8 @@ public sealed class FundStructureEndpointTests
     [Fact]
     public async Task GetCashFlowView_WithCanonicalizedUnassignedLedgerGroupId_ReturnsNormalizedScope()
     {
-        var response = await _client.GetAsync("/api/fund-structure/cash-flow-view?scopeKind=LedgerGroup&ledgerGroupId=%20UNASSIGNED%20");
+        using var client = _fixture.CreatePermittedClient(UserPermission.AdminMaintenance);
+        var response = await client.GetAsync("/api/fund-structure/cash-flow-view?scopeKind=LedgerGroup&ledgerGroupId=%20UNASSIGNED%20");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var payload = await response.Content.ReadFromJsonAsync<GovernanceCashFlowViewDto>();
@@ -594,7 +608,8 @@ public sealed class FundStructureEndpointTests
     [Fact]
     public async Task GetCashFlowView_WithUnassignedLedgerGroupAndNoScope_ReturnsEmptyWindowedView()
     {
-        var response = await _client.GetAsync(
+        using var client = _fixture.CreatePermittedClient(UserPermission.AdminMaintenance);
+        var response = await client.GetAsync(
             "/api/fund-structure/cash-flow-view?scopeKind=LedgerGroup&ledgerGroupId=unassigned&asOf=2026-04-12T15%3A45%3A00Z&currency=EUR&historicalDays=3&forecastDays=5&bucketDays=2");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -630,9 +645,11 @@ public sealed class FundStructureEndpointTests
     }
 
     [Fact]
-    public async Task AssignLedgerMapping_WithAccountingSession_UpdatesWorkbenchMappingAndUsesAuthenticatedActor()
+    public async Task AssignLedgerMapping_WithSyntheticAccountingPermissionContext_UpdatesWorkbenchMappingAndUsesInjectedActor()
     {
         var seed = await SeedFundWorkspaceAsync();
+        using var client = _fixture.CreatePermittedClient(UserPermission.ManageFundStructure);
+        client.DefaultRequestHeaders.Add("X-Test-Auth", "fund-accounting");
         var request = new LedgerMappingAssignmentRequestDto(
             AccountId: seed.BankAccountId,
             LedgerGroupId: "ENDPOINT-ALT",
@@ -646,9 +663,7 @@ public sealed class FundStructureEndpointTests
         {
             Content = JsonContent.Create(request)
         };
-        httpRequest.Headers.Add("X-Test-Auth", "fund-accounting");
-
-        var response = await _client.SendAsync(httpRequest);
+        var response = await client.SendAsync(httpRequest);
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
         var result = await response.Content.ReadFromJsonAsync<LedgerMappingAssignmentResultDto>();
@@ -672,40 +687,25 @@ public sealed class FundStructureEndpointTests
     }
 
     [Fact]
-    public async Task AssignLedgerMapping_WithReadOnlySession_ReturnsForbidden()
+    public async Task AssignLedgerMapping_WithSyntheticReadOnlyPermissionContext_ReturnsForbidden()
     {
-        var originalUsers = Environment.GetEnvironmentVariable("MDC_USERS");
-        Environment.SetEnvironmentVariable(
-            "MDC_USERS",
-            $$"""[{"username":"read-only","passwordHash":"{{TestPassHash}}","role":"ReadOnly"}]""");
+        var seed = await SeedFundWorkspaceAsync();
+        using var client = _fixture.CreatePermittedClient(UserPermission.ViewAnalytics);
+        client.DefaultRequestHeaders.Add("X-Test-Auth", "fund-accounting");
+        var request = new LedgerMappingAssignmentRequestDto(
+            AccountId: seed.BankAccountId,
+            LedgerGroupId: "ENDPOINT-ALT",
+            RequestedBy: "read-only",
+            Rationale: "Attempt to alter ledger mapping without fund accounting authority.",
+            EffectiveFrom: new DateTimeOffset(2026, 4, 11, 0, 0, 0, TimeSpan.Zero),
+            CorrelationId: "ledger-map-readonly-test",
+            AssignmentId: Guid.NewGuid());
 
-        try
-        {
-            var seed = await SeedFundWorkspaceAsync();
-            var sessionCookie = await LoginAndGetSessionCookieAsync("read-only", "test-pass");
-            var request = new LedgerMappingAssignmentRequestDto(
-                AccountId: seed.BankAccountId,
-                LedgerGroupId: "ENDPOINT-ALT",
-                RequestedBy: "read-only",
-                Rationale: "Attempt to alter ledger mapping without fund accounting authority.",
-                EffectiveFrom: new DateTimeOffset(2026, 4, 11, 0, 0, 0, TimeSpan.Zero),
-                CorrelationId: "ledger-map-readonly-test",
-                AssignmentId: Guid.NewGuid());
+        var response = await client.PostAsJsonAsync(
+            "/api/fund-structure/ledger-mapping-assignments",
+            request);
 
-            using var httpRequest = new HttpRequestMessage(HttpMethod.Post, "/api/fund-structure/ledger-mapping-assignments")
-            {
-                Content = JsonContent.Create(request)
-            };
-            httpRequest.Headers.Add("Cookie", sessionCookie);
-
-            var response = await _client.SendAsync(httpRequest);
-
-            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("MDC_USERS", originalUsers);
-        }
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 
     [Fact]
@@ -743,28 +743,12 @@ public sealed class FundStructureEndpointTests
     }
 
     [Fact]
-    public async Task AccountReadinessAndSyncHistoryEndpoints_ReturnSharedAccountSyncState()
+    public async Task AccountReadinessAndSyncHistoryEndpoints_WithScopedAccountingAccess_ReturnSharedAccountSyncState()
     {
-        var originalUsers = Environment.GetEnvironmentVariable("MDC_USERS");
-        Environment.SetEnvironmentVariable(
-            "MDC_USERS",
-            $$"""[{"username":"fund-ops","passwordHash":"{{TestPassHash}}","role":"Accounting"}]""");
-
-        try
-        {
-            var loginResponse = await _client.PostAsJsonAsync(
-                "/api/auth/login",
-                new { Username = "fund-ops", Password = "test-pass" });
-            var sessionCookie = loginResponse.Headers
-                .Where(header => header.Key.Equals("Set-Cookie", StringComparison.OrdinalIgnoreCase))
-                .SelectMany(header => header.Value)
-                .FirstOrDefault(value => value.Contains("mdc-session", StringComparison.OrdinalIgnoreCase));
-
-            loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-            sessionCookie.Should().NotBeNullOrWhiteSpace("fund account endpoints require an authenticated accounting role");
-
-            var accountService = _fixture.Services.GetRequiredService<IFundAccountService>();
-            var account = await accountService.CreateAccountAsync(new CreateAccountRequest(
+        using var client = _fixture.CreatePermittedClient(UserPermission.ManageDirectLending);
+        client.DefaultRequestHeaders.Add("X-Test-Auth", "fund-accounting");
+        var accountService = _fixture.Services.GetRequiredService<IFundAccountService>();
+        var account = await accountService.CreateAccountAsync(new CreateAccountRequest(
                 AccountId: Guid.NewGuid(),
                 AccountType: AccountTypeDto.Bank,
                 AccountCode: $"BANK-{Guid.NewGuid():N}"[..13].ToUpperInvariant(),
@@ -785,7 +769,7 @@ public sealed class FundStructureEndpointTests
                     IntermediaryBankName: null,
                     BeneficiaryName: null,
                     BeneficiaryAddress: null)));
-            await accountService.RecordSyncHistoryAsync(new RecordAccountSyncHistoryRequest(
+        await accountService.RecordSyncHistoryAsync(new RecordAccountSyncHistoryRequest(
                 AccountId: account.AccountId,
                 Capability: "bank-balances",
                 Status: AccountSyncStatusDto.Succeeded,
@@ -795,38 +779,48 @@ public sealed class FundStructureEndpointTests
                 FreshUntil: DateTimeOffset.UtcNow.AddHours(1),
                 RawEvidencePath: "artifacts/account-sync/bank/raw.json",
                 CorrelationId: "endpoint-sync-history"));
+        var scopedAccess = _fixture.Services.GetRequiredService<IScopedAccessAssignmentService>();
+        var accessGrant = await scopedAccess.CreateAsync(
+            new UserAccessAssignmentCreateRequestDto(
+                PrincipalId: "fund-ops",
+                PrincipalKind: AccessPrincipalKindDto.User,
+                ScopeKind: AccessScopeKindDto.Account,
+                ScopeId: account.AccountId,
+                Role: nameof(UserRole.Accounting),
+                RoleProfileName: null,
+                PermissionNames: [nameof(UserPermission.ManageDirectLending)],
+                EffectiveFrom: DateTimeOffset.UtcNow.AddMinutes(-1),
+                EffectiveTo: null,
+                RequestedBy: "endpoint-test",
+                Rationale: "Exercise account readiness through the least-privilege accounting scope.",
+                CorrelationId: $"endpoint-account-access-{account.AccountId:N}"),
+            actor: "endpoint-test");
 
-            using var historyRequest = new HttpRequestMessage(
-                HttpMethod.Get,
-                $"/api/fund-accounts/{account.AccountId}/sync-history?capability=bank-balances");
-            using var readinessRequest = new HttpRequestMessage(
-                HttpMethod.Get,
-                $"/api/fund-accounts/{account.AccountId}/readiness");
-            historyRequest.Headers.Add("Cookie", sessionCookie!);
-            readinessRequest.Headers.Add("Cookie", sessionCookie!);
+        accessGrant.Assignment.PrincipalId.Should().Be("fund-ops");
+        accessGrant.Assignment.ScopeKind.Should().Be(AccessScopeKindDto.Account);
+        accessGrant.Assignment.ScopeId.Should().Be(account.AccountId);
+        accessGrant.Assignment.PermissionNames.Should().ContainSingle()
+            .Which.Should().Be(nameof(UserPermission.ManageDirectLending));
 
-            var historyResponse = await _client.SendAsync(historyRequest);
-            var readinessResponse = await _client.SendAsync(readinessRequest);
+        var historyResponse = await client.GetAsync(
+            $"/api/fund-accounts/{account.AccountId}/sync-history?capability=bank-balances");
+        var readinessResponse = await client.GetAsync(
+            $"/api/fund-accounts/{account.AccountId}/readiness");
 
-            historyResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-            readinessResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-            var history = await historyResponse.Content.ReadFromJsonAsync<AccountSyncHistoryEntryDto[]>();
-            var readiness = await readinessResponse.Content.ReadFromJsonAsync<AccountReadinessSnapshotDto>();
+        historyResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        readinessResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var history = await historyResponse.Content.ReadFromJsonAsync<AccountSyncHistoryEntryDto[]>();
+        var readiness = await readinessResponse.Content.ReadFromJsonAsync<AccountReadinessSnapshotDto>();
 
-            history.Should().NotBeNull();
-            history!.Should().ContainSingle(entry =>
-                entry.AccountId == account.AccountId
-                && entry.Status == AccountSyncStatusDto.Succeeded
-                && entry.ProviderId == "meridian-bank");
-            readiness.Should().NotBeNull();
-            readiness!.IsReady.Should().BeTrue();
-            readiness.ProviderLinkStatus.Should().Be(AccountProviderLinkStatusDto.Verified);
-            readiness.Issues.Should().BeEmpty();
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("MDC_USERS", originalUsers);
-        }
+        history.Should().NotBeNull();
+        history!.Should().ContainSingle(entry =>
+            entry.AccountId == account.AccountId
+            && entry.Status == AccountSyncStatusDto.Succeeded
+            && entry.ProviderId == "meridian-bank");
+        readiness.Should().NotBeNull();
+        readiness!.IsReady.Should().BeTrue();
+        readiness.ProviderLinkStatus.Should().Be(AccountProviderLinkStatusDto.Verified);
+        readiness.Issues.Should().BeEmpty();
     }
 
 
@@ -953,15 +947,75 @@ public sealed class FundStructureEndpointTests
         return new SeededFundWorkspace(fundProfileId, displayName, bankAccount.AccountId);
     }
 
-    private async Task<FundReportPackSnapshotDto> GenerateReportPackAsync(SeededFundWorkspace seed)
+    private async Task<FundReportPackSnapshotDto> SeedLegacyReportPackAsync(SeededFundWorkspace seed)
     {
-        var service = _fixture.Services.GetRequiredService<FundOperationsWorkspaceReadService>();
-        return await service.GenerateReportPackAsync(
-            new FundReportPackGenerateRequestDto(
-                FundProfileId: seed.FundProfileId,
-                AuditActor: "integration-seed",
-                AsOf: new DateTimeOffset(2026, 4, 11, 16, 0, 0, TimeSpan.Zero),
-                Formats: [GovernanceReportArtifactFormatDto.Json]));
+        var repository = _fixture.Services.GetRequiredService<IGovernanceReportPackRepository>();
+        var reportId = Guid.NewGuid();
+        var generatedAt = new DateTimeOffset(2026, 4, 11, 16, 0, 0, TimeSpan.Zero);
+        var snapshot = new FundReportPackSnapshotDto(
+            ReportId: reportId,
+            FundProfileId: seed.FundProfileId,
+            DisplayName: seed.DisplayName,
+            ReportKind: GovernanceReportKindDto.TrialBalance,
+            Currency: "USD",
+            AsOf: generatedAt,
+            GeneratedAt: generatedAt,
+            TotalNetAssets: 2_500m,
+            AuditActor: "integration-seed",
+            CorrelationId: $"endpoint-report-pack-{reportId:N}",
+            DecisionRationale: "Seeded legacy compatibility-read evidence.",
+            Provenance: new FundReportPackProvenanceDto(
+                RelatedRunIds: [],
+                JournalEntryCount: 0,
+                LedgerEntryCount: 0,
+                TrialBalanceLineCount: 1,
+                ReconciliationRunCount: 0,
+                OpenReconciliationBreakCount: 0,
+                SecurityResolvedCount: 0,
+                SecurityMissingCount: 1,
+                LineagePointers: [],
+                SourceSnapshotHash: new string('a', 64)),
+            Artifacts: [],
+            Warnings: ["Security Master coverage requires review."])
+        {
+            Status = GovernanceReportPackStatusDto.ReviewRequired,
+            ValidationIssues =
+            [
+                new FundReportPackValidationIssueDto(
+                    Code: "security-coverage",
+                    Severity: GovernanceReportValidationSeverityDto.Warning,
+                    Title: "Security Master coverage requires review",
+                    Message: "The compatibility fixture retains one unresolved security line.",
+                    AffectedReportId: reportId)
+            ],
+            LifecycleEvents =
+            [
+                new FundReportPackLifecycleEventDto(
+                    FromStatus: GovernanceReportPackStatusDto.Draft,
+                    ToStatus: GovernanceReportPackStatusDto.Generated,
+                    ChangedAt: generatedAt,
+                    Actor: "integration-seed",
+                    Reason: "Compatibility report pack seeded.",
+                    CorrelationId: $"endpoint-report-pack-{reportId:N}"),
+                new FundReportPackLifecycleEventDto(
+                    FromStatus: GovernanceReportPackStatusDto.Generated,
+                    ToStatus: GovernanceReportPackStatusDto.ReviewRequired,
+                    ChangedAt: generatedAt,
+                    Actor: "integration-seed",
+                    Reason: "Validation requires operator review.",
+                    CorrelationId: $"endpoint-report-pack-{reportId:N}")
+            ]
+        };
+
+        return await repository.SaveAsync(
+            snapshot,
+            [
+                new GovernanceReportPackArtifactContent(
+                    "trial-balance",
+                    GovernanceReportArtifactFormatDto.Json,
+                    "trial-balance.json",
+                    Encoding.UTF8.GetBytes("""{"status":"review-required"}"""))
+            ]);
     }
 
     private static StrategyRunEntry BuildRun(
@@ -1059,7 +1113,8 @@ public sealed class FundStructureEndpointTests
             LedgerReference = $"{strategyId}-paper-ledger",
             AuditReference = $"audit-{runId}",
             FundProfileId = fundProfileId,
-            FundDisplayName = fundDisplayName
+            FundDisplayName = fundDisplayName,
+            InputHashSha256 = null
         };
     }
 
@@ -1127,7 +1182,7 @@ public sealed class FundStructureEndpointTests
         var organizationId = Guid.NewGuid();
         var businessId = Guid.NewGuid();
         var fundId = Guid.NewGuid();
-        var portfolioId = Guid.NewGuid();
+        var entityId = Guid.NewGuid();
         var linkId = Guid.NewGuid();
         var now = new DateTimeOffset(2026, 04, 12, 0, 0, 0, TimeSpan.Zero);
 
@@ -1155,44 +1210,87 @@ public sealed class FundStructureEndpointTests
             now,
             "endpoint-test",
             BusinessId: businessId));
-        await structureService.CreateInvestmentPortfolioAsync(new CreateInvestmentPortfolioRequest(
-            portfolioId,
-            businessId,
-            $"PRT-{Guid.NewGuid():N}"[..12].ToUpperInvariant(),
-            "Ownership Endpoint Portfolio",
+        await structureService.CreateLegalEntityAsync(new CreateLegalEntityRequest(
+            entityId,
+            LegalEntityTypeDto.Fund,
+            $"ENT-{Guid.NewGuid():N}"[..12].ToUpperInvariant(),
+            "Ownership Endpoint Entity",
+            "US-DE",
             "USD",
             now,
-            "endpoint-test",
-            FundId: fundId));
+            "endpoint-test"));
         await structureService.LinkNodesAsync(new LinkFundStructureNodesRequest(
             linkId,
             fundId,
-            portfolioId,
-            OwnershipRelationshipTypeDto.AllocatesTo,
+            entityId,
+            OwnershipRelationshipTypeDto.Owns,
             now,
-            "endpoint-test"));
+            "endpoint-test",
+            OwnershipPercent: 100m,
+            IsPrimary: true,
+            Notes: "endpoint-test"));
 
-        return new SeededOwnershipLink(fundId, portfolioId, linkId, now);
+        return new SeededOwnershipLink(fundId, entityId, linkId, now);
     }
 
-    private async Task<string> LoginAndGetSessionCookieAsync(string username, string password)
+    private async Task<AuthenticatedSession> LoginAndGetAuthenticatedSessionAsync(string username, string password)
     {
-        var loginResponse = await _client.PostAsJsonAsync(
+        using var loginResponse = await _client.PostAsJsonAsync(
             "/api/auth/login",
             new { Username = username, Password = password });
 
         loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-        var sessionCookie = loginResponse.Headers
+        var payload = await loginResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var role = payload.GetProperty("role").GetString();
+        var permissionNames = payload.GetProperty("permissionNames")
+            .EnumerateArray()
+            .Select(permission => permission.GetString())
+            .Where(permission => !string.IsNullOrWhiteSpace(permission))
+            .Select(permission => permission!)
+            .ToArray();
+        var setCookies = loginResponse.Headers
             .Where(header => header.Key.Equals("Set-Cookie", StringComparison.OrdinalIgnoreCase))
             .SelectMany(header => header.Value)
-            .FirstOrDefault(value => value.Contains("mdc-session", StringComparison.OrdinalIgnoreCase));
+            .ToArray();
+        var sessionCookie = ExtractCookieValue(setCookies, "mdc-session");
+        var csrfCookie = ExtractCookieValue(setCookies, "mdc-csrf");
 
-        sessionCookie.Should().NotBeNullOrWhiteSpace("ledger mapping assignments require an authenticated fund-accounting session");
-        return sessionCookie!;
+        role.Should().NotBeNullOrWhiteSpace("the login response must expose the built-in role mapping");
+        sessionCookie.Should().NotBeNullOrWhiteSpace("authenticated endpoint requests require a session cookie");
+        csrfCookie.Should().NotBeNullOrWhiteSpace("cookie-authenticated writes require a CSRF cookie");
+
+        return new AuthenticatedSession(
+            $"mdc-session={sessionCookie}; mdc-csrf={csrfCookie}",
+            csrfCookie!,
+            role!,
+            permissionNames);
+    }
+
+    private static string? ExtractCookieValue(IEnumerable<string> setCookies, string cookieName)
+    {
+        var prefix = cookieName + "=";
+        foreach (var setCookie in setCookies)
+        {
+            var segment = setCookie
+                .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .FirstOrDefault(part => part.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+            if (segment is not null)
+            {
+                return segment[prefix.Length..];
+            }
+        }
+
+        return null;
     }
 
     private static Guid TranslateFundProfileId(string fundProfileId)
         => new(MD5.HashData(Encoding.UTF8.GetBytes(fundProfileId.Trim())));
+
+    private sealed record AuthenticatedSession(
+        string CookieHeader,
+        string CsrfToken,
+        string Role,
+        IReadOnlyList<string> PermissionNames);
 
     private sealed record SeededFundWorkspace(
         string FundProfileId,
@@ -1201,7 +1299,7 @@ public sealed class FundStructureEndpointTests
 
     private sealed record SeededOwnershipLink(
         Guid FundId,
-        Guid PortfolioId,
+        Guid ChildNodeId,
         Guid LinkId,
         DateTimeOffset EffectiveFrom);
 }

--- a/tests/Meridian.Tests/Integration/EndpointTests/FundStructureEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/FundStructureEndpointTests.cs
@@ -911,8 +911,9 @@ public sealed class FundStructureEndpointTests : IClassFixture<EndpointTestFixtu
             PendingSettlement: 125m))
             ;
 
+        var bankStatementBatchId = Guid.NewGuid();
         await accountService.IngestBankStatementAsync(new IngestBankStatementRequest(
-            BatchId: Guid.NewGuid(),
+            BatchId: bankStatementBatchId,
             AccountId: bankAccount.AccountId,
             StatementDate: new DateOnly(2026, 4, 11),
             BankName: "Meridian Bank",
@@ -921,7 +922,7 @@ public sealed class FundStructureEndpointTests : IClassFixture<EndpointTestFixtu
             [
                 new BankStatementLineDto(
                     LineId: Guid.NewGuid(),
-                    BatchId: Guid.NewGuid(),
+                    BatchId: bankStatementBatchId,
                     AccountId: bankAccount.AccountId,
                     TransactionDate: new DateOnly(2026, 4, 11),
                     ValueDate: new DateOnly(2026, 4, 11),

--- a/tests/Meridian.Tests/Integration/EndpointTests/HistoricalEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/HistoricalEndpointTests.cs
@@ -12,7 +12,7 @@ namespace Meridian.Tests.Integration.EndpointTests;
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class HistoricalEndpointTests
+public sealed class HistoricalEndpointTests : IClassFixture<EndpointTestFixture>
 {
     private readonly HttpClient _client;
 

--- a/tests/Meridian.Tests/Integration/EndpointTests/IBEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/IBEndpointTests.cs
@@ -10,14 +10,16 @@ namespace Meridian.Tests.Integration.EndpointTests;
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class IBEndpointTests
+public sealed class IBEndpointTests : IDisposable, IClassFixture<EndpointTestFixture>
 {
     private readonly HttpClient _client;
 
     public IBEndpointTests(EndpointTestFixture fixture)
     {
-        _client = fixture.Client;
+        _client = fixture.CreateNoRedirectClient();
     }
+
+    public void Dispose() => _client.Dispose();
 
     [Fact]
     public async Task IBStatus_ReturnsJson()
@@ -30,8 +32,9 @@ public sealed class IBEndpointTests
         await using var body = await response.Content.ReadAsStreamAsync();
         using var json = await JsonDocument.ParseAsync(body);
 
-        json.RootElement.GetProperty("buildMode").GetString().Should().NotBeNullOrWhiteSpace();
-        json.RootElement.GetProperty("runtimeTarget").GetString().Should().BeOneOf("paper", "live");
+        json.RootElement.GetProperty("provider").GetString().Should().Be("Interactive Brokers");
+        json.RootElement.GetProperty("buildMode").GetString().Should().BeOneOf("guidance", "smoke", "vendor");
+        json.RootElement.GetProperty("ibApiAvailable").ValueKind.Should().BeOneOf(JsonValueKind.True, JsonValueKind.False);
         json.RootElement.GetProperty("socket").GetProperty("configured").ValueKind.Should().BeOneOf(JsonValueKind.True, JsonValueKind.False);
         json.RootElement.GetProperty("clientPortal").GetProperty("enabled").ValueKind.Should().BeOneOf(JsonValueKind.True, JsonValueKind.False);
     }

--- a/tests/Meridian.Tests/Integration/EndpointTests/LeanEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/LeanEndpointTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text;
 using System.Text.Json;
 using FluentAssertions;
+using Meridian.Identity.Auth;
 using Xunit;
 
 namespace Meridian.Tests.Integration.EndpointTests;
@@ -13,14 +14,18 @@ namespace Meridian.Tests.Integration.EndpointTests;
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class LeanEndpointTests
+public sealed class LeanEndpointTests : IDisposable, IClassFixture<EndpointTestFixture>
 {
     private readonly HttpClient _client;
+    private readonly HttpClient _strategyMutationClient;
 
     public LeanEndpointTests(EndpointTestFixture fixture)
     {
         _client = fixture.Client;
+        _strategyMutationClient = fixture.CreatePermittedClient(UserPermission.ManageStrategies);
     }
+
+    public void Dispose() => _strategyMutationClient.Dispose();
 
     // -------------------------------------------------------------------------
     // GET /api/lean/status
@@ -319,7 +324,7 @@ public sealed class LeanEndpointTests
         var payload = new { resultsFilePath = (string?)null };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
 
-        var response = await _client.PostAsync("/api/lean/results/ingest", content);
+        var response = await _strategyMutationClient.PostAsync("/api/lean/results/ingest", content);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
@@ -333,7 +338,7 @@ public sealed class LeanEndpointTests
         var payload = new { resultsFilePath = "/nonexistent/path/results.json" };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
 
-        var response = await _client.PostAsync("/api/lean/results/ingest", content);
+        var response = await _strategyMutationClient.PostAsync("/api/lean/results/ingest", content);
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
@@ -350,7 +355,7 @@ public sealed class LeanEndpointTests
             var payload = new { resultsFilePath = tempFile };
             var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
 
-            var response = await _client.PostAsync("/api/lean/results/ingest", content);
+            var response = await _strategyMutationClient.PostAsync("/api/lean/results/ingest", content);
 
             response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
             var body = await response.Content.ReadAsStringAsync();
@@ -385,7 +390,7 @@ public sealed class LeanEndpointTests
             var payload = new { resultsFilePath = tempFile, algorithmName = "TestAlgorithm" };
             var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
 
-            var response = await _client.PostAsync("/api/lean/results/ingest", content);
+            var response = await _strategyMutationClient.PostAsync("/api/lean/results/ingest", content);
 
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 

--- a/tests/Meridian.Tests/Integration/EndpointTests/LiveDataEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/LiveDataEndpointTests.cs
@@ -12,7 +12,7 @@ namespace Meridian.Tests.Integration.EndpointTests;
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class LiveDataEndpointTests
+public sealed class LiveDataEndpointTests : IClassFixture<EndpointTestFixture>
 {
     private readonly HttpClient _client;
 

--- a/tests/Meridian.Tests/Integration/EndpointTests/MaintenanceEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/MaintenanceEndpointTests.cs
@@ -13,7 +13,7 @@ namespace Meridian.Tests.Integration.EndpointTests;
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class MaintenanceEndpointTests
+public sealed class MaintenanceEndpointTests : IClassFixture<EndpointTestFixture>
 {
     private readonly HttpClient _client;
 

--- a/tests/Meridian.Tests/Integration/EndpointTests/NegativePathEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/NegativePathEndpointTests.cs
@@ -15,9 +15,11 @@ namespace Meridian.Tests.Integration.EndpointTests;
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class NegativePathEndpointTests : IDisposable
+public sealed class NegativePathEndpointTests : IDisposable, IClassFixture<EndpointTestFixture>
 {
     private readonly HttpClient _client;
+    private readonly HttpClient _backfillClient;
+    private readonly HttpClient _providerClient;
     // SEC-001: configuration routes now require ViewConfig/ModifyConfig. Config-specific negative
     // paths use an authorized client so the handler (not the authorization gate) produces the
     // asserted 400/200 responses.
@@ -26,11 +28,21 @@ public sealed class NegativePathEndpointTests : IDisposable
 
     public NegativePathEndpointTests(EndpointTestFixture fixture)
     {
-        _client = fixture.Client;
+        _client = fixture.CreateNoRedirectClient();
+        _backfillClient = fixture.CreatePermittedClient(
+            UserPermission.ViewHistoricalData,
+            UserPermission.TriggerBackfill);
+        _providerClient = fixture.CreatePermittedClient(UserPermission.ManageProviders);
         _configClient = fixture.CreatePermittedClient(UserPermission.ViewConfig, UserPermission.ModifyConfig);
     }
 
-    public void Dispose() => _configClient.Dispose();
+    public void Dispose()
+    {
+        _client.Dispose();
+        _backfillClient.Dispose();
+        _providerClient.Dispose();
+        _configClient.Dispose();
+    }
 
     // ================================================================
     // Health / Status negative paths
@@ -253,7 +265,7 @@ public sealed class NegativePathEndpointTests : IDisposable
     {
         var payload = new { Provider = "stooq", Symbols = Array.Empty<string>() };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
-        var response = await _client.PostAsync("/api/backfill/run", content);
+        var response = await _backfillClient.PostAsync("/api/backfill/run", content);
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
@@ -262,7 +274,7 @@ public sealed class NegativePathEndpointTests : IDisposable
     {
         var payload = new { Provider = "stooq", Symbols = new[] { "INVALID SYMBOL WITH SPACES!!!" } };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
-        var response = await _client.PostAsync("/api/backfill/run", content);
+        var response = await _backfillClient.PostAsync("/api/backfill/run", content);
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
@@ -271,7 +283,7 @@ public sealed class NegativePathEndpointTests : IDisposable
     {
         var payload = new { Provider = "stooq", Symbols = new[] { "SPY" }, From = "2024-12-31", To = "2024-01-01" };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
-        var response = await _client.PostAsync("/api/backfill/run", content);
+        var response = await _backfillClient.PostAsync("/api/backfill/run", content);
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
@@ -281,7 +293,7 @@ public sealed class NegativePathEndpointTests : IDisposable
         var symbols = Enumerable.Range(1, 101).Select(i => $"SYM{i}").ToArray();
         var payload = new { Provider = "stooq", Symbols = symbols };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
-        var response = await _client.PostAsync("/api/backfill/run", content);
+        var response = await _backfillClient.PostAsync("/api/backfill/run", content);
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
@@ -290,7 +302,7 @@ public sealed class NegativePathEndpointTests : IDisposable
     {
         var payload = new { Provider = "stooq", Symbols = Array.Empty<string>() };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
-        var response = await _client.PostAsync("/api/backfill/run/preview", content);
+        var response = await _backfillClient.PostAsync("/api/backfill/run/preview", content);
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
@@ -298,14 +310,14 @@ public sealed class NegativePathEndpointTests : IDisposable
     public async Task BackfillStatus_WhenNoBackfillRun_ReturnsNotFound()
     {
         // No backfill has been run in test fixture — expect 404
-        var response = await _client.GetAsync("/api/backfill/status");
+        var response = await _backfillClient.GetAsync("/api/backfill/status");
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
     [Fact]
     public async Task BackfillProviders_ReturnsJsonArray()
     {
-        var response = await _client.GetAsync("/api/backfill/providers");
+        var response = await _backfillClient.GetAsync("/api/backfill/providers");
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Content.Headers.ContentType!.MediaType.Should().Be("application/json");
     }
@@ -313,7 +325,7 @@ public sealed class NegativePathEndpointTests : IDisposable
     [Fact]
     public async Task BackfillProgress_WhenNoActiveBackfill_ReturnsTypedEmptySnapshot()
     {
-        var response = await _client.GetAsync("/api/backfill/progress");
+        var response = await _backfillClient.GetAsync("/api/backfill/progress");
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var json = await DeserializeAsync(response);
@@ -330,21 +342,21 @@ public sealed class NegativePathEndpointTests : IDisposable
     {
         var payload = new { Symbols = Array.Empty<string>() };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
-        var response = await _client.PostAsync("/api/backfill/gap-fill", content);
+        var response = await _backfillClient.PostAsync("/api/backfill/gap-fill", content);
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]
     public async Task BackfillScheduleById_NonExistent_ReturnsNotFound()
     {
-        var response = await _client.GetAsync("/api/backfill/schedules/nonexistent-schedule-id-xyz");
+        var response = await _backfillClient.GetAsync("/api/backfill/schedules/nonexistent-schedule-id-xyz");
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
     [Fact]
     public async Task DeleteBackfillSchedule_NonExistent_ReturnsNotFoundOr503()
     {
-        var response = await _client.DeleteAsync("/api/backfill/schedules/nonexistent-schedule-id-xyz");
+        var response = await _backfillClient.DeleteAsync("/api/backfill/schedules/nonexistent-schedule-id-xyz");
         // 404 if schedule manager available but ID not found; 503 if manager unavailable
         response.StatusCode.Should().BeOneOf(HttpStatusCode.NotFound, HttpStatusCode.ServiceUnavailable);
     }
@@ -376,7 +388,7 @@ public sealed class NegativePathEndpointTests : IDisposable
     {
         var payload = new { Enabled = true };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
-        var response = await _client.PostAsync("/api/config/data-sources/nonexistent-id/toggle", content);
+        var response = await _providerClient.PostAsync("/api/config/data-sources/nonexistent-id/toggle", content);
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
@@ -385,7 +397,7 @@ public sealed class NegativePathEndpointTests : IDisposable
     {
         var payload = new { Name = "", Provider = "Alpaca", Enabled = true, Type = "RealTime", Priority = 10 };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
-        var response = await _client.PostAsync("/api/config/data-sources", content);
+        var response = await _providerClient.PostAsync("/api/config/data-sources", content);
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 

--- a/tests/Meridian.Tests/Integration/EndpointTests/OptionsEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/OptionsEndpointTests.cs
@@ -10,7 +10,7 @@ namespace Meridian.Tests.Integration.EndpointTests;
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class OptionsEndpointTests
+public sealed class OptionsEndpointTests : IClassFixture<EndpointTestFixture>
 {
     private readonly HttpClient _client;
 

--- a/tests/Meridian.Tests/Integration/EndpointTests/PilotAcceptanceHarnessTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/PilotAcceptanceHarnessTests.cs
@@ -21,6 +21,8 @@ using Meridian.Strategies.Promotions;
 using Meridian.Strategies.Services;
 using Meridian.Strategies.Storage;
 using Meridian.Identity.Auth;
+using Meridian.Storage;
+using Meridian.Tests.TestSupport;
 using Meridian.Ui.Shared;
 using Meridian.Ui.Shared.Endpoints;
 using Meridian.Ui.Shared.Evidence;
@@ -30,6 +32,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -40,6 +43,7 @@ namespace Meridian.Tests.Integration.EndpointTests;
 /// paper-session replay, promotion audit, reconciliation, and governed report-pack lineage.
 /// </summary>
 [Trait("Category", "Integration")]
+[Collection("Sequential")]
 public sealed class PilotAcceptanceHarnessTests
 {
     private const string DatasetEvidenceId = "dataset/pilot/golden-aapl-2026-04-11";
@@ -439,91 +443,200 @@ public sealed class PilotAcceptanceHarnessTests
         gate.SupportEvidenceIds.Should().Contain("evidence-vault/report-pack-001/manifest.json");
     }
 
+    [Fact]
+    public async Task PilotHost_Dispose_StopsHostAndRestoresAmbientProcessState()
+    {
+        var originalEnvironment = CapturePilotHostEnvironment();
+        var originalCatalogProvider = Meridian.Contracts.Api.ProviderCatalog.RuntimeCatalogProvider;
+        var originalCatalogEntryProvider = Meridian.Contracts.Api.ProviderCatalog.RuntimeCatalogEntryProvider;
+        PilotTestApp? pilot = null;
+
+        try
+        {
+            pilot = await CreatePilotAppAsync();
+            var root = pilot.Root;
+            var applicationLifetime = pilot.App.Services.GetRequiredService<IHostApplicationLifetime>();
+            foreach (var variable in originalEnvironment.Keys)
+            {
+                Environment.GetEnvironmentVariable(variable).Should().BeNull();
+            }
+
+            await pilot.DisposeAsync();
+
+            applicationLifetime.ApplicationStopped.IsCancellationRequested.Should().BeTrue();
+            Meridian.Contracts.Api.ProviderCatalog.RuntimeCatalogProvider.Should().BeNull();
+            Meridian.Contracts.Api.ProviderCatalog.RuntimeCatalogEntryProvider.Should().BeNull();
+            var readCatalog = () => Meridian.Contracts.Api.ProviderCatalog.GetAll();
+            readCatalog.Should().NotThrow();
+            Directory.Exists(root).Should().BeFalse();
+            foreach (var pair in originalEnvironment)
+            {
+                Environment.GetEnvironmentVariable(pair.Key).Should().Be(pair.Value);
+            }
+        }
+        finally
+        {
+            if (pilot is not null)
+            {
+                await pilot.DisposeAsync();
+            }
+
+            RestorePilotHostEnvironment(originalEnvironment);
+            Meridian.Contracts.Api.ProviderCatalog.RuntimeCatalogProvider = originalCatalogProvider;
+            Meridian.Contracts.Api.ProviderCatalog.RuntimeCatalogEntryProvider = originalCatalogEntryProvider;
+        }
+    }
+
     private static async Task<PilotTestApp> CreatePilotAppAsync()
     {
         var root = Path.Combine(Path.GetTempPath(), "meridian-tests", "pilot-acceptance", Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(root);
-        var configPath = Path.Combine(root, "appsettings.json");
-        await File.WriteAllTextAsync(configPath, CreateMinimalConfig(root));
-
-        var automationRoot = Path.Combine(root, "provider-validation", "_automation");
-        WriteReadyDk1Packet(automationRoot);
-
-        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        var originalEnvironment = CapturePilotHostEnvironment();
+        foreach (var variable in originalEnvironment.Keys)
         {
-            EnvironmentName = "Test"
-        });
-        builder.WebHost.UseTestServer();
-
-        builder.Services.AddSingleton(new Meridian.Ui.Shared.Services.ConfigStore(configPath));
-        builder.Services.AddSingleton(new Dk1TrustGateReadinessOptions(automationRoot));
-        builder.Services.AddSingleton<IGovernanceReportPackRepository>(_ =>
-            new FileGovernanceReportPackRepository(
-                Path.Combine(root, "report-packs"),
-                NullLogger<FileGovernanceReportPackRepository>.Instance));
-        builder.Services.AddSingleton<IReconciliationBreakQueueRepository>(_ =>
-            new FileReconciliationBreakQueueRepository(
-                Path.Combine(root, "break-queue"),
-                NullLogger<FileReconciliationBreakQueueRepository>.Instance));
-        builder.Services.AddSingleton<IPromotionRecordStore>(_ =>
-            new JsonlPromotionRecordStore(
-                Path.Combine(root, "promotions"),
-                NullLogger<JsonlPromotionRecordStore>.Instance));
-        builder.Services.AddSingleton<IReportingAuthoritativeSource, PilotReportingAuthoritativeSource>();
-        builder.Services.AddSingleton<IReportingReconciliationEvidenceSource, PilotReportingReconciliationEvidenceSource>();
-        builder.Services.AddSingleton<IReportingRunReadinessDependencyEvaluator, PilotReportingReadinessDependencyEvaluator>();
-        builder.Services.AddSingleton<IReportingGovernanceEndpointCoordinator, PilotReportingGovernanceCoordinator>();
-        builder.Services.AddSingleton<IReportingDeploymentReadinessService, PilotReportingDeploymentReadinessService>();
-
-        using (InMemoryGovernanceFixtureProfile.Enable())
-        {
-            builder.Services.AddUiSharedServices(configPath);
+            Environment.SetEnvironmentVariable(variable, null);
         }
 
-        builder.Services.AddSingleton(_ => new ExecutionAuditTrailService(
-            new ExecutionAuditTrailOptions(Path.Combine(root, "audit")),
-            NullLogger<ExecutionAuditTrailService>.Instance));
-        builder.Services.AddSingleton<IPaperSessionStore>(_ =>
-            new JsonlFilePaperSessionStore(
-                Path.Combine(root, "sessions"),
-                NullLogger<JsonlFilePaperSessionStore>.Instance));
-        builder.Services.AddSingleton<PaperSessionPersistenceService>(sp => new PaperSessionPersistenceService(
-            NullLogger<PaperSessionPersistenceService>.Instance,
-            sp.GetRequiredService<IPaperSessionStore>(),
-            sp.GetRequiredService<ExecutionAuditTrailService>()));
-        builder.Services.AddSingleton<ExecutionOperatorControlService>(sp => new ExecutionOperatorControlService(
-            new ExecutionOperatorControlOptions(Path.Combine(root, "controls")),
-            NullLogger<ExecutionOperatorControlService>.Instance,
-            sp.GetRequiredService<ExecutionAuditTrailService>()));
-        builder.Services.AddSingleton<PromotionService>(sp => new PromotionService(
-            sp.GetRequiredService<IStrategyRepository>(),
-            sp.GetRequiredService<BacktestToLivePromoter>(),
-            sp.GetRequiredService<IPromotionRecordStore>(),
-            NullLogger<PromotionService>.Instance,
-            operatorControls: sp.GetRequiredService<ExecutionOperatorControlService>(),
-            auditTrail: sp.GetRequiredService<ExecutionAuditTrailService>()));
-
-        var app = builder.Build();
-        app.Use(async (context, next) =>
+        PilotTestApp? pilot = null;
+        try
         {
-            var actor = context.Request.Headers.TryGetValue("X-Pilot-Actor", out var requestedActor)
-                && !string.IsNullOrWhiteSpace(requestedActor.ToString())
-                    ? requestedActor.ToString().Trim()
-                    : "pilot.operator";
-            context.Items[LoginSessionMiddleware.CurrentUserKey] = actor;
-            context.Items[LoginSessionMiddleware.CurrentUserPermissionsKey] = RolePermissions.For(UserRole.Admin);
-            context.Items[LoginSessionMiddleware.CurrentUserCompanyIdKey] = "pilot-acceptance-tenant";
-            context.Items[LoginSessionMiddleware.CurrentTenantIdKey] = "pilot-acceptance-tenant";
-            await next();
-        });
-        app.MapWorkstationEndpoints(ServerJsonOptions);
-        app.MapEvidenceEndpoints(ServerJsonOptions);
-        app.MapExecutionEndpoints(ServerJsonOptions);
-        app.MapFundStructureEndpoints(ServerJsonOptions);
-        app.MapReportingGovernanceEndpoints(ServerJsonOptions);
-        await app.StartAsync();
+            Directory.CreateDirectory(root);
+            var configPath = Path.Combine(root, "appsettings.json");
+            await File.WriteAllTextAsync(configPath, CreateMinimalConfig(root));
 
-        return new PilotTestApp(app, root);
+            var automationRoot = Path.Combine(root, "provider-validation", "_automation");
+            WriteReadyDk1Packet(automationRoot);
+
+            var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+            {
+                EnvironmentName = "Test"
+            });
+            builder.WebHost.UseTestServer();
+
+            builder.Services.AddSingleton(new Meridian.Ui.Shared.Services.ConfigStore(configPath));
+            builder.Services.AddSingleton(new Dk1TrustGateReadinessOptions(automationRoot));
+            builder.Services.AddSingleton<IGovernanceReportPackRepository>(_ =>
+                new FileGovernanceReportPackRepository(
+                    Path.Combine(root, "report-packs"),
+                    NullLogger<FileGovernanceReportPackRepository>.Instance));
+            builder.Services.AddSingleton<IReconciliationBreakQueueRepository>(_ =>
+                new FileReconciliationBreakQueueRepository(
+                    Path.Combine(root, "break-queue"),
+                    NullLogger<FileReconciliationBreakQueueRepository>.Instance));
+            builder.Services.AddSingleton<IPromotionRecordStore>(_ =>
+                new JsonlPromotionRecordStore(
+                    Path.Combine(root, "promotions"),
+                    NullLogger<JsonlPromotionRecordStore>.Instance));
+            builder.Services.AddSingleton<IReportingAuthoritativeSource, PilotReportingAuthoritativeSource>();
+            builder.Services.AddSingleton<IReportingReconciliationEvidenceSource, PilotReportingReconciliationEvidenceSource>();
+            builder.Services.AddSingleton<IReportingRunReadinessDependencyEvaluator, PilotReportingReadinessDependencyEvaluator>();
+            builder.Services.AddSingleton<IReportingGovernanceEndpointCoordinator, PilotReportingGovernanceCoordinator>();
+            builder.Services.AddSingleton<IReportingDeploymentReadinessService, PilotReportingDeploymentReadinessService>();
+
+            using (InMemoryGovernanceFixtureProfile.Enable())
+            {
+                builder.Services.AddUiSharedServices(configPath);
+            }
+
+            builder.Services.AddSingleton(_ => new ExecutionAuditTrailService(
+                new ExecutionAuditTrailOptions(Path.Combine(root, "audit")),
+                NullLogger<ExecutionAuditTrailService>.Instance));
+            builder.Services.AddSingleton<IPaperSessionStore>(_ =>
+                new JsonlFilePaperSessionStore(
+                    Path.Combine(root, "sessions"),
+                    NullLogger<JsonlFilePaperSessionStore>.Instance));
+            builder.Services.AddSingleton<PaperSessionPersistenceService>(sp => new PaperSessionPersistenceService(
+                NullLogger<PaperSessionPersistenceService>.Instance,
+                sp.GetRequiredService<IPaperSessionStore>(),
+                sp.GetRequiredService<ExecutionAuditTrailService>()));
+            builder.Services.AddSingleton<ExecutionOperatorControlService>(sp => new ExecutionOperatorControlService(
+                new ExecutionOperatorControlOptions(Path.Combine(root, "controls")),
+                NullLogger<ExecutionOperatorControlService>.Instance,
+                sp.GetRequiredService<ExecutionAuditTrailService>()));
+            builder.Services.AddSingleton<PromotionService>(sp => new PromotionService(
+                sp.GetRequiredService<IStrategyRepository>(),
+                sp.GetRequiredService<BacktestToLivePromoter>(),
+                sp.GetRequiredService<IPromotionRecordStore>(),
+                NullLogger<PromotionService>.Instance,
+                operatorControls: sp.GetRequiredService<ExecutionOperatorControlService>(),
+                auditTrail: sp.GetRequiredService<ExecutionAuditTrailService>()));
+
+            var app = builder.Build();
+            pilot = new PilotTestApp(app, root, originalEnvironment);
+            pilot.CaptureProviderCatalogLease();
+            app.Use(async (context, next) =>
+            {
+                var actor = context.Request.Headers.TryGetValue("X-Pilot-Actor", out var requestedActor)
+                    && !string.IsNullOrWhiteSpace(requestedActor.ToString())
+                        ? requestedActor.ToString().Trim()
+                        : "pilot.operator";
+                context.Items[LoginSessionMiddleware.CurrentUserKey] = actor;
+                context.Items[LoginSessionMiddleware.CurrentUserPermissionsKey] = RolePermissions.For(UserRole.Admin);
+                context.Items[LoginSessionMiddleware.CurrentUserCompanyIdKey] = "pilot-acceptance-tenant";
+                context.Items[LoginSessionMiddleware.CurrentTenantIdKey] = "pilot-acceptance-tenant";
+                await next();
+            });
+            app.MapWorkstationEndpoints(ServerJsonOptions);
+            app.MapEvidenceEndpoints(ServerJsonOptions);
+            app.MapExecutionEndpoints(ServerJsonOptions);
+            app.MapFundStructureEndpoints(ServerJsonOptions);
+            app.MapReportingGovernanceEndpoints(ServerJsonOptions);
+            pilot.MarkStartAttempted();
+            await app.StartAsync();
+
+            return pilot;
+        }
+        catch (Exception initializationError)
+        {
+            try
+            {
+                if (pilot is not null)
+                {
+                    await pilot.DisposeAsync();
+                }
+                else
+                {
+                    RestorePilotHostEnvironment(originalEnvironment);
+                    if (Directory.Exists(root))
+                    {
+                        Directory.Delete(root, recursive: true);
+                    }
+                }
+            }
+            catch (Exception cleanupError)
+            {
+                throw new AggregateException(
+                    "Pilot test host initialization and cleanup failed.",
+                    initializationError,
+                    cleanupError);
+            }
+
+            throw;
+        }
+    }
+
+    private static Dictionary<string, string?> CapturePilotHostEnvironment() =>
+        MeridianDatabaseEnvironment.PropagatedConnectionStringVariables
+            .Concat(
+            [
+                MeridianDatabaseEnvironment.UnifiedVariable,
+                "MERIDIAN_DIRECT_LENDING_CONNECTION_STRING",
+                "MERIDIAN_REPORTING_CONNECTION_STRING",
+                "LEAN_PATH",
+                "LEAN_DATA_PATH",
+                "LEAN_EXPORT_INTERVAL_SECONDS"
+            ])
+            .Distinct(StringComparer.Ordinal)
+            .ToDictionary(
+                static variable => variable,
+                static variable => Environment.GetEnvironmentVariable(variable),
+                StringComparer.Ordinal);
+
+    private static void RestorePilotHostEnvironment(IReadOnlyDictionary<string, string?> environment)
+    {
+        foreach (var pair in environment)
+        {
+            Environment.SetEnvironmentVariable(pair.Key, pair.Value);
+        }
     }
 
     private static async Task<PilotSeed> SeedPilotWorkspaceAsync(IServiceProvider services)
@@ -1874,11 +1987,113 @@ public sealed class PilotAcceptanceHarnessTests
                 BlockingReasons: []);
     }
 
-    private sealed record PilotTestApp(WebApplication App, string Root) : IAsyncDisposable
+    private sealed class PilotTestApp : IAsyncDisposable
     {
+        private readonly IReadOnlyDictionary<string, string?> _originalEnvironment;
+        private ProviderCatalogTestLease? _providerCatalogLease;
+        private bool _startAttempted;
+        private bool _appStopped;
+        private bool _appDisposed;
+        private bool _environmentRestored;
+
+        public PilotTestApp(
+            WebApplication app,
+            string root,
+            IReadOnlyDictionary<string, string?> originalEnvironment)
+        {
+            App = app;
+            Root = root;
+            _originalEnvironment = originalEnvironment;
+        }
+
+        public WebApplication App { get; }
+
+        public string Root { get; }
+
+        public void CaptureProviderCatalogLease() =>
+            _providerCatalogLease = ProviderCatalogTestLease.Capture(App.Services);
+
+        public void MarkStartAttempted() => _startAttempted = true;
+
         public async ValueTask DisposeAsync()
         {
-            await App.DisposeAsync();
+            var cleanupErrors = new List<Exception>();
+
+            if (_startAttempted && !_appStopped)
+            {
+                var applicationLifetime = App.Services.GetRequiredService<IHostApplicationLifetime>();
+                try
+                {
+                    using var stopTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                    await App.StopAsync(stopTimeout.Token);
+                    _appStopped = true;
+                }
+                catch (Exception stopError)
+                {
+                    if (!applicationLifetime.ApplicationStopped.IsCancellationRequested)
+                    {
+                        throw new AggregateException(
+                            "Pilot test host did not stop; owned resources were retained.",
+                            stopError);
+                    }
+
+                    _appStopped = true;
+                    cleanupErrors.Add(stopError);
+                }
+            }
+
+            try
+            {
+                _providerCatalogLease?.Dispose();
+                _providerCatalogLease = null;
+            }
+            catch (Exception ex)
+            {
+                cleanupErrors.Add(ex);
+            }
+
+            if (!_appDisposed)
+            {
+                try
+                {
+                    await App.DisposeAsync();
+                    _appDisposed = true;
+                }
+                catch (Exception ex)
+                {
+                    cleanupErrors.Add(ex);
+                }
+            }
+
+            if (!_environmentRestored)
+            {
+                try
+                {
+                    RestorePilotHostEnvironment(_originalEnvironment);
+                    _environmentRestored = true;
+                }
+                catch (Exception ex)
+                {
+                    cleanupErrors.Add(ex);
+                }
+            }
+
+            if (Directory.Exists(Root))
+            {
+                try
+                {
+                    Directory.Delete(Root, recursive: true);
+                }
+                catch (Exception ex)
+                {
+                    cleanupErrors.Add(ex);
+                }
+            }
+
+            if (cleanupErrors.Count > 0)
+            {
+                throw new AggregateException("Pilot test host cleanup failed.", cleanupErrors);
+            }
         }
     }
 

--- a/tests/Meridian.Tests/Integration/EndpointTests/ProviderConnectionHonestyEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/ProviderConnectionHonestyEndpointTests.cs
@@ -6,7 +6,7 @@ namespace Meridian.Tests.Integration.EndpointTests;
 
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class ProviderConnectionHonestyEndpointTests
+public sealed class ProviderConnectionHonestyEndpointTests : IClassFixture<EndpointTestFixture>
 {
     private readonly HttpClient _client;
 

--- a/tests/Meridian.Tests/Integration/EndpointTests/ProviderDataProjectionAuthorizationTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/ProviderDataProjectionAuthorizationTests.cs
@@ -10,7 +10,7 @@ namespace Meridian.Tests.Integration.EndpointTests;
 
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class ProviderDataProjectionAuthorizationTests : IDisposable
+public sealed class ProviderDataProjectionAuthorizationTests : IDisposable, IClassFixture<EndpointTestFixture>
 {
     private const string Route = "/api/providers/data-projection";
     private readonly EndpointTestFixture _fixture;

--- a/tests/Meridian.Tests/Integration/EndpointTests/ProviderEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/ProviderEndpointTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text;
 using System.Text.Json;
 using FluentAssertions;
+using Meridian.Identity.Auth;
 using Xunit;
 
 namespace Meridian.Tests.Integration.EndpointTests;
@@ -12,13 +13,25 @@ namespace Meridian.Tests.Integration.EndpointTests;
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class ProviderEndpointTests
+public sealed class ProviderEndpointTests : IDisposable, IClassFixture<EndpointTestFixture>
 {
     private readonly HttpClient _client;
+    private readonly HttpClient _providerMutationClient;
+    private readonly HttpClient _credentialMutationClient;
 
     public ProviderEndpointTests(EndpointTestFixture fixture)
     {
         _client = fixture.Client;
+        _providerMutationClient = fixture.CreatePermittedClient(UserPermission.ManageProviders);
+        _credentialMutationClient = fixture.CreatePermittedClient(
+            UserPermission.ManageProviders,
+            UserPermission.ManageCredentials);
+    }
+
+    public void Dispose()
+    {
+        _providerMutationClient.Dispose();
+        _credentialMutationClient.Dispose();
     }
 
     #region GET /api/providers/catalog
@@ -190,7 +203,7 @@ public sealed class ProviderEndpointTests
         };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
 
-        var response = await _client.PostAsync("/api/providers/configure", content);
+        var response = await _credentialMutationClient.PostAsync("/api/providers/configure", content);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var json = await DeserializeAsync(response);
@@ -215,10 +228,13 @@ public sealed class ProviderEndpointTests
         };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
 
-        var response = await _client.PostAsync("/api/providers/configure", content);
-
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var response = await _providerMutationClient.PostAsync("/api/providers/configure", content);
         var result = await DeserializeAsync(response);
+
+        response.StatusCode.Should().Be(
+            HttpStatusCode.OK,
+            "Yahoo is a credential-free historical provider supported by the setup registry: {0}",
+            result["error"].GetString());
         result["success"].GetBoolean().Should().BeTrue();
         result["providerId"].GetString().Should().StartWith("yahoo");
         result["providerName"].GetString().Should().Be(displayName);
@@ -249,7 +265,7 @@ public sealed class ProviderEndpointTests
         };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
 
-        var response = await _client.PostAsync("/api/providers/configure", content);
+        var response = await _credentialMutationClient.PostAsync("/api/providers/configure", content);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var json = await DeserializeAsync(response);
@@ -278,7 +294,7 @@ public sealed class ProviderEndpointTests
         };
 
         var configureContent = new StringContent(JsonSerializer.Serialize(configurePayload), Encoding.UTF8, "application/json");
-        var configureResponse = await _client.PostAsync("/api/providers/configure", configureContent);
+        var configureResponse = await _credentialMutationClient.PostAsync("/api/providers/configure", configureContent);
         configureResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var response = await _client.GetAsync("/api/config/datasources");
@@ -310,7 +326,7 @@ public sealed class ProviderEndpointTests
         };
 
         var configureContent = new StringContent(JsonSerializer.Serialize(configurePayload), Encoding.UTF8, "application/json");
-        var configureResponse = await _client.PostAsync("/api/providers/configure", configureContent);
+        var configureResponse = await _credentialMutationClient.PostAsync("/api/providers/configure", configureContent);
         configureResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var response = await _client.GetAsync("/api/config/datasources");
@@ -344,7 +360,7 @@ public sealed class ProviderEndpointTests
         };
 
         var configureContent = new StringContent(JsonSerializer.Serialize(configurePayload), Encoding.UTF8, "application/json");
-        var configureResponse = await _client.PostAsync("/api/providers/configure", configureContent);
+        var configureResponse = await _credentialMutationClient.PostAsync("/api/providers/configure", configureContent);
         configureResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var response = await _client.GetAsync("/api/config/data-sources");
@@ -375,7 +391,7 @@ public sealed class ProviderEndpointTests
         };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
 
-        var setupResponse = await _client.PostAsync("/api/providers/configure", content);
+        var setupResponse = await _credentialMutationClient.PostAsync("/api/providers/configure", content);
         setupResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var response = await _client.GetAsync("/api/config/datasources");
@@ -421,7 +437,7 @@ public sealed class ProviderEndpointTests
         };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
 
-        var response = await _client.PostAsync("/api/config/datasources", content);
+        var response = await _providerMutationClient.PostAsync("/api/config/datasources", content);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var json = await DeserializeAsync(response);
@@ -434,7 +450,7 @@ public sealed class ProviderEndpointTests
         var payload = new { Name = "", Provider = "IB", Enabled = true };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
 
-        var response = await _client.PostAsync("/api/config/datasources", content);
+        var response = await _providerMutationClient.PostAsync("/api/config/datasources", content);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
@@ -445,7 +461,7 @@ public sealed class ProviderEndpointTests
         var payload = new { Enabled = false };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
 
-        var response = await _client.PostAsync("/api/config/datasources/nonexistent/toggle", content);
+        var response = await _providerMutationClient.PostAsync("/api/config/datasources/nonexistent/toggle", content);
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }

--- a/tests/Meridian.Tests/Integration/EndpointTests/ResponseSchemaSnapshotTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/ResponseSchemaSnapshotTests.cs
@@ -1,7 +1,11 @@
 using System.Net;
 using System.Text.Json;
 using FluentAssertions;
+using Meridian.Core.Config;
+using Meridian.DataIntegration.Monitoring;
 using Meridian.Identity.Auth;
+using Meridian.Infrastructure.Adapters.Failover;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Meridian.Tests.Integration.EndpointTests;
@@ -17,21 +21,32 @@ namespace Meridian.Tests.Integration.EndpointTests;
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class ResponseSchemaSnapshotTests : IDisposable
+public sealed class ResponseSchemaSnapshotTests : IDisposable, IClassFixture<EndpointTestFixture>
 {
+    private readonly EndpointTestFixture _fixture;
     private readonly HttpClient _client;
     // SEC-001: /api/config reads now require a configuration permission. Route config schema reads
     // through an authorized client so the snapshot assertions keep exercising the real payload.
     private readonly HttpClient _configClient;
+    private readonly HttpClient _backfillReadClient;
+    private readonly HttpClient _failoverReadClient;
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
     public ResponseSchemaSnapshotTests(EndpointTestFixture fixture)
     {
+        _fixture = fixture;
         _client = fixture.Client;
         _configClient = fixture.CreatePermittedClient(UserPermission.ViewConfig, UserPermission.ModifyConfig);
+        _backfillReadClient = fixture.CreatePermittedClient(UserPermission.ViewHistoricalData);
+        _failoverReadClient = fixture.CreatePermittedClient(UserPermission.ViewDiagnostics);
     }
 
-    public void Dispose() => _configClient.Dispose();
+    public void Dispose()
+    {
+        _configClient.Dispose();
+        _backfillReadClient.Dispose();
+        _failoverReadClient.Dispose();
+    }
 
     #region /api/status
 
@@ -266,7 +281,7 @@ public sealed class ResponseSchemaSnapshotTests : IDisposable
     [Fact]
     public async Task BackfillProviders_Schema_IsJsonArray()
     {
-        var response = await _client.GetAsync("/api/backfill/providers");
+        var response = await _backfillReadClient.GetAsync("/api/backfill/providers");
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var content = await response.Content.ReadAsStringAsync();
@@ -281,7 +296,7 @@ public sealed class ResponseSchemaSnapshotTests : IDisposable
     [Fact]
     public async Task BackfillStatus_Schema_Returns404WhenNoBackfillRan()
     {
-        var response = await _client.GetAsync("/api/backfill/status");
+        var response = await _backfillReadClient.GetAsync("/api/backfill/status");
 
         // 404 is the expected schema when no backfill has run
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
@@ -401,11 +416,68 @@ public sealed class ResponseSchemaSnapshotTests : IDisposable
 
     private async Task<Dictionary<string, JsonElement>> GetJsonObjectAsync(string url)
     {
-        // SEC-001: configuration reads require ViewConfig/ModifyConfig — use the authorized client.
-        var client = url.StartsWith("/api/config", StringComparison.OrdinalIgnoreCase) ? _configClient : _client;
-        var response = await client.GetAsync(url);
-        response.StatusCode.Should().Be(HttpStatusCode.OK, $"GET {url} should return 200 OK");
-        return await DeserializeObjectAsync(response);
+        HttpResponseMessage response;
+        if (url.StartsWith("/api/failover/", StringComparison.OrdinalIgnoreCase))
+        {
+            response = await GetWithLiveFailoverRuntimeAsync(url);
+        }
+        else
+        {
+            var client = url switch
+            {
+                _ when url.StartsWith("/api/config", StringComparison.OrdinalIgnoreCase) => _configClient,
+                _ when url.StartsWith("/api/backfill/", StringComparison.OrdinalIgnoreCase) => _backfillReadClient,
+                _ => _client
+            };
+            response = await client.GetAsync(url);
+        }
+
+        using (response)
+        {
+            response.StatusCode.Should().Be(HttpStatusCode.OK, $"GET {url} should return 200 OK");
+            return await DeserializeObjectAsync(response);
+        }
+    }
+
+    private async Task<HttpResponseMessage> GetWithLiveFailoverRuntimeAsync(string url)
+    {
+        var registry = _fixture.Services.GetRequiredService<StreamingFailoverRegistry>();
+        using var healthMonitor = new ConnectionHealthMonitor();
+        using var service = CreateFailoverService(healthMonitor);
+        registry.Service = service;
+
+        try
+        {
+            return await _failoverReadClient.GetAsync(url);
+        }
+        finally
+        {
+            registry.Service = null;
+        }
+    }
+
+    private StreamingFailoverService CreateFailoverService(ConnectionHealthMonitor healthMonitor)
+    {
+        var configured = _fixture.Services
+            .GetRequiredService<Meridian.Ui.Shared.Services.ConfigStore>()
+            .Load()
+            .DataSources ?? new DataSourcesConfig();
+        var rules = configured.FailoverRules ?? Array.Empty<FailoverRuleConfig>();
+        var service = new StreamingFailoverService(healthMonitor);
+        foreach (var providerId in rules
+                     .SelectMany(rule => new[] { rule.PrimaryProviderId }.Concat(rule.BackupProviderIds))
+                     .Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            service.RegisterProvider(providerId);
+        }
+
+        service.Start(configured with
+        {
+            EnableFailover = true,
+            HealthCheckIntervalSeconds = 3600,
+            FailoverRules = rules
+        });
+        return service;
     }
 
     private static async Task<Dictionary<string, JsonElement>> DeserializeObjectAsync(HttpResponseMessage response)

--- a/tests/Meridian.Tests/Integration/EndpointTests/ResponseSchemaValidationTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/ResponseSchemaValidationTests.cs
@@ -13,7 +13,7 @@ namespace Meridian.Tests.Integration.EndpointTests;
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class ResponseSchemaValidationTests : IDisposable
+public sealed class ResponseSchemaValidationTests : IDisposable, IClassFixture<EndpointTestFixture>
 {
     private readonly HttpClient _client;
     // SEC-001: /api/config reads now require a configuration permission.

--- a/tests/Meridian.Tests/Integration/EndpointTests/RiskEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/RiskEndpointTests.cs
@@ -1,23 +1,40 @@
 using System.Net;
 using System.Net.Http.Json;
+using Meridian.Identity.Auth;
 using Meridian.Ui.Shared.Services;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Meridian.Tests.Integration.EndpointTests;
 
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class RiskEndpointTests : EndpointIntegrationTestBase
+public sealed class RiskEndpointTests : EndpointIntegrationTestBase, IDisposable
 {
+    private readonly HttpClient _riskClient;
+
     public RiskEndpointTests(EndpointTestFixture fixture)
         : base(fixture)
     {
+        _riskClient = fixture.CreatePermittedClient(
+            UserPermission.ViewTrades,
+            UserPermission.ManageOrders);
+    }
+
+    public void Dispose() => _riskClient.Dispose();
+
+    [Fact]
+    public void RuntimeOptions_UseFixturePrivateDataRoot()
+    {
+        var options = Fixture.Services.GetRequiredService<RiskRuleRuntimeOptions>();
+
+        Assert.Equal(Path.Combine(Fixture.DataRoot, "risk-rules.json"), options.SnapshotPath);
     }
 
     [Fact]
     public async Task GetRiskRules_ReturnsKnownRuleSet()
     {
-        var response = await GetAsync("/api/risk/rules");
+        var response = await _riskClient.GetAsync("/api/risk/rules");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         var payload = await response.Content.ReadFromJsonAsync<List<RiskRuleStatusDto>>(JsonOptions);
@@ -30,23 +47,40 @@ public sealed class RiskEndpointTests : EndpointIntegrationTestBase
     [Fact]
     public async Task DrawdownConfig_CanBeReadAndUpdated()
     {
-        var before = await GetJsonAsync<RiskRuleConfigDto>("/api/risk/rules/DrawdownCircuitBreaker/config");
+        var beforeResponse = await _riskClient.GetAsync("/api/risk/rules/DrawdownCircuitBreaker/config");
+        Assert.Equal(HttpStatusCode.OK, beforeResponse.StatusCode);
+        var before = await beforeResponse.Content.ReadFromJsonAsync<RiskRuleConfigDto>(JsonOptions);
         Assert.NotNull(before);
 
-        var updateResponse = await Client.PutAsJsonAsync(
-            "/api/risk/rules/DrawdownCircuitBreaker/config",
-            new RiskRuleConfigUpdateRequest(MaxDrawdownPercent: 6m, Reason: "test update"));
-        Assert.Equal(HttpStatusCode.OK, updateResponse.StatusCode);
+        try
+        {
+            var updateResponse = await _riskClient.PutAsJsonAsync(
+                "/api/risk/rules/DrawdownCircuitBreaker/config",
+                new RiskRuleConfigUpdateRequest(MaxDrawdownPercent: 6m, Reason: "test update"));
+            Assert.Equal(HttpStatusCode.OK, updateResponse.StatusCode);
 
-        var updated = await updateResponse.Content.ReadFromJsonAsync<RiskRuleConfigDto>(JsonOptions);
-        Assert.NotNull(updated);
-        Assert.Equal(6m, updated!.MaxDrawdownPercent);
+            var updated = await updateResponse.Content.ReadFromJsonAsync<RiskRuleConfigDto>(JsonOptions);
+            Assert.NotNull(updated);
+            Assert.Equal(6m, updated!.MaxDrawdownPercent);
+        }
+        finally
+        {
+            if (before!.MaxDrawdownPercent is { } originalMaxDrawdownPercent)
+            {
+                var restoreResponse = await _riskClient.PutAsJsonAsync(
+                    "/api/risk/rules/DrawdownCircuitBreaker/config",
+                    new RiskRuleConfigUpdateRequest(
+                        MaxDrawdownPercent: originalMaxDrawdownPercent,
+                        Reason: "restore endpoint test fixture state"));
+                Assert.Equal(HttpStatusCode.OK, restoreResponse.StatusCode);
+            }
+        }
     }
 
     [Fact]
     public async Task UnknownRiskRule_ReturnsNotFound()
     {
-        var response = await GetAsync("/api/risk/rules/unknown/status");
+        var response = await _riskClient.GetAsync("/api/risk/rules/unknown/status");
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 }

--- a/tests/Meridian.Tests/Integration/EndpointTests/RoleAuthorizationTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/RoleAuthorizationTests.cs
@@ -275,11 +275,12 @@ public sealed class RoleAuthorizationTests : EndpointIntegrationTestBase
     [Fact]
     public async Task AuthRoleProfiles_WithManageUsers_CreatesCustomProfileAndPreservesSessionPermissions()
     {
+        await using var isolated = await IsolatedEndpointTestScope.CreateAsync();
         var profileName = $"Close Reviewer {Guid.NewGuid():N}";
         Environment.SetEnvironmentVariable("MDC_USERS", $$"""[{"username":"admin","passwordHash":"{{PwHash}}","role":"Admin"}]""");
         try
         {
-            using var cookieClient = Fixture.CreateNoRedirectClient();
+            using var cookieClient = isolated.Fixture.CreateNoRedirectClient();
             var loginResp = await cookieClient.PostAsJsonAsync("/api/auth/login", new { Username = "admin", Password = "pw" });
             loginResp.StatusCode.Should().Be(HttpStatusCode.OK);
             var authCookies = ExtractAuthCookies(loginResp);
@@ -316,7 +317,7 @@ public sealed class RoleAuthorizationTests : EndpointIntegrationTestBase
         Environment.SetEnvironmentVariable("MDC_USERS", $$"""[{"username":"reviewer","passwordHash":"{{PwHash}}","role":"Accounting","roleProfileName":"{{profileName}}"}]""");
         try
         {
-            using var reviewerClient = Fixture.CreateNoRedirectClient();
+            using var reviewerClient = isolated.Fixture.CreateNoRedirectClient();
             var loginResp = await reviewerClient.PostAsJsonAsync("/api/auth/login", new { Username = "reviewer", Password = "pw" });
             loginResp.StatusCode.Should().Be(HttpStatusCode.OK);
             var sessionCookie = loginResp.Headers
@@ -348,10 +349,11 @@ public sealed class RoleAuthorizationTests : EndpointIntegrationTestBase
     [Fact]
     public async Task AuthRoleProfiles_InvalidPermission_ReturnsBadRequest()
     {
+        await using var isolated = await IsolatedEndpointTestScope.CreateAsync();
         Environment.SetEnvironmentVariable("MDC_USERS", $$"""[{"username":"admin","passwordHash":"{{PwHash}}","role":"Admin"}]""");
         try
         {
-            using var cookieClient = Fixture.CreateNoRedirectClient();
+            using var cookieClient = isolated.Fixture.CreateNoRedirectClient();
             var loginResp = await cookieClient.PostAsJsonAsync("/api/auth/login", new { Username = "admin", Password = "pw" });
             loginResp.StatusCode.Should().Be(HttpStatusCode.OK);
             var authCookies = ExtractAuthCookies(loginResp);
@@ -734,8 +736,9 @@ public sealed class RoleAuthorizationTests : EndpointIntegrationTestBase
     [Fact]
     public async Task AuthAccounts_WithManageUsers_AdministersAccountLifecycleAndRevokesSessions()
     {
+        await using var isolated = await IsolatedEndpointTestScope.CreateAsync();
         var username = $"ops-{Guid.NewGuid():N}";
-        using var adminClient = Fixture.CreatePermittedClient(UserPermission.ManageUsers);
+        using var adminClient = isolated.Fixture.CreatePermittedClient(UserPermission.ManageUsers);
 
         var createResponse = await adminClient.PutAsJsonAsync(
             $"/api/auth/accounts/{username}",
@@ -765,7 +768,7 @@ public sealed class RoleAuthorizationTests : EndpointIntegrationTestBase
         listJson.Should().NotContain("passwordHash");
         listJson.Should().NotContain("initial-pass");
 
-        using var sessionClient = Fixture.CreateNoRedirectClient();
+        using var sessionClient = isolated.Fixture.CreateNoRedirectClient();
         var loginResponse = await sessionClient.PostAsJsonAsync("/api/auth/login", new { Username = username, Password = "initial-pass" });
         loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         var loginBody = await loginResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOpts);
@@ -835,7 +838,8 @@ public sealed class RoleAuthorizationTests : EndpointIntegrationTestBase
     [Fact]
     public async Task AuthScopedAccess_WithAutomationOrigin_ReturnsBadRequestWithoutMutatingAuthority()
     {
-        using var adminClient = Fixture.CreatePermittedClient(UserPermission.ManageUsers);
+        await using var isolated = await IsolatedEndpointTestScope.CreateAsync();
+        using var adminClient = isolated.Fixture.CreatePermittedClient(UserPermission.ManageUsers);
         var blockedPrincipal = $"assistant-admin-{Guid.NewGuid():N}";
         var createResponse = await adminClient.PostAsJsonAsync(
             "/api/auth/access-assignments",
@@ -938,5 +942,35 @@ public sealed class RoleAuthorizationTests : EndpointIntegrationTestBase
     }
 
     private sealed record AuthCookies(string CookieHeader, string CsrfToken);
+
+    /// <summary>
+    /// Owns a disposable endpoint host for scenarios that persist account, role-profile, or scoped-access state.
+    /// The host's unique data root prevents one destructive authorization scenario from changing later logins.
+    /// </summary>
+    private sealed class IsolatedEndpointTestScope : IAsyncDisposable
+    {
+        private readonly EndpointTestFixture _fixture;
+
+        private IsolatedEndpointTestScope(EndpointTestFixture fixture) => _fixture = fixture;
+
+        public EndpointTestFixture Fixture => _fixture;
+
+        public static async Task<IsolatedEndpointTestScope> CreateAsync()
+        {
+            var fixture = new EndpointTestFixture();
+            try
+            {
+                await fixture.InitializeAsync();
+                return new IsolatedEndpointTestScope(fixture);
+            }
+            catch
+            {
+                await fixture.DisposeAsync();
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync() => await _fixture.DisposeAsync();
+    }
 
 }

--- a/tests/Meridian.Tests/Integration/EndpointTests/StatusEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/StatusEndpointTests.cs
@@ -11,7 +11,7 @@ namespace Meridian.Tests.Integration.EndpointTests;
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class StatusEndpointTests
+public sealed class StatusEndpointTests : IClassFixture<EndpointTestFixture>
 {
     private readonly HttpClient _client;
 

--- a/tests/Meridian.Tests/Integration/EndpointTests/StorageEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/StorageEndpointTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text;
 using System.Text.Json;
 using FluentAssertions;
+using Meridian.Identity.Auth;
 using Xunit;
 
 namespace Meridian.Tests.Integration.EndpointTests;
@@ -13,14 +14,18 @@ namespace Meridian.Tests.Integration.EndpointTests;
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class StorageEndpointTests
+public sealed class StorageEndpointTests : IDisposable, IClassFixture<EndpointTestFixture>
 {
+    private readonly EndpointTestFixture _fixture;
     private readonly HttpClient _client;
 
     public StorageEndpointTests(EndpointTestFixture fixture)
     {
-        _client = fixture.Client;
+        _fixture = fixture;
+        _client = fixture.CreateNoRedirectClient();
     }
+
+    public void Dispose() => _client.Dispose();
 
     #region Storage Endpoints
 
@@ -89,7 +94,8 @@ public sealed class StorageEndpointTests
     [Fact]
     public async Task SymbolMappings_ReturnsJson()
     {
-        var response = await _client.GetAsync("/api/symbols/mappings");
+        using var client = _fixture.CreatePermittedClient(UserPermission.ViewConfig);
+        var response = await client.GetAsync("/api/symbols/mappings");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Content.Headers.ContentType!.MediaType.Should().Be("application/json");
@@ -98,7 +104,8 @@ public sealed class StorageEndpointTests
     [Fact]
     public async Task CanonicalSymbolRegistry_ReturnsAdditiveIdentityAndMigrationContract()
     {
-        var response = await _client.GetAsync("/api/symbols/registry");
+        using var client = _fixture.CreatePermittedClient(UserPermission.ViewConfig);
+        var response = await client.GetAsync("/api/symbols/registry");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
@@ -112,6 +119,7 @@ public sealed class StorageEndpointTests
     [Fact]
     public async Task AddSymbolMapping_ReturnsOk()
     {
+        using var client = _fixture.CreatePermittedClient(UserPermission.ModifyConfig);
         var payload = new
         {
             canonicalSymbol = "BRK.B"
@@ -119,7 +127,7 @@ public sealed class StorageEndpointTests
         var content = new StringContent(
             JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
 
-        var response = await _client.PostAsync("/api/symbols/mappings", content);
+        var response = await client.PostAsync("/api/symbols/mappings", content);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
@@ -127,7 +135,8 @@ public sealed class StorageEndpointTests
     [Fact]
     public async Task DeleteSymbolMapping_ForUnknown_Returns404()
     {
-        var response = await _client.DeleteAsync("/api/symbols/mappings/DOESNOTEXIST999");
+        using var client = _fixture.CreatePermittedClient(UserPermission.ModifyConfig);
+        var response = await client.DeleteAsync("/api/symbols/mappings/DOESNOTEXIST999");
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }

--- a/tests/Meridian.Tests/Integration/EndpointTests/SymbolEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/SymbolEndpointTests.cs
@@ -11,15 +11,17 @@ namespace Meridian.Tests.Integration.EndpointTests;
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("Endpoint")]
-public sealed class SymbolEndpointTests
+public sealed class SymbolEndpointTests : IDisposable, IClassFixture<EndpointTestFixture>
 {
     private readonly HttpClient _client;
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
     public SymbolEndpointTests(EndpointTestFixture fixture)
     {
-        _client = fixture.Client;
+        _client = fixture.CreateNoRedirectClient();
     }
+
+    public void Dispose() => _client.Dispose();
 
     #region GET Endpoints
 
@@ -104,7 +106,7 @@ public sealed class SymbolEndpointTests
     [Fact]
     public async Task AddSymbol_WithValidData_ReturnsOk()
     {
-        var payload = new { symbols = new[] { "MSFT" } };
+        var payload = new { symbol = "MSFT" };
         var content = new StringContent(
             JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
 

--- a/tests/Meridian.Tests/PortfolioRecords/FundAccounts/PostgresFundAccountServiceContractTests.cs
+++ b/tests/Meridian.Tests/PortfolioRecords/FundAccounts/PostgresFundAccountServiceContractTests.cs
@@ -14,8 +14,7 @@ namespace Meridian.Tests.PortfolioRecords.FundAccounts;
 /// unavailable.
 /// </summary>
 [Trait("Category", "Integration")]
-[Collection(nameof(FundAccountDatabaseCollection))]
-public sealed class PostgresFundAccountServiceContractTests : FundAccountServiceContractTests
+public sealed class PostgresFundAccountServiceContractTests : FundAccountServiceContractTests, IClassFixture<FundAccountDatabaseFixture>
 {
     private readonly FundAccountDatabaseFixture _fixture;
 

--- a/tests/Meridian.Tests/Reporting/ReportingGovernanceCanonicalValidationTests.cs
+++ b/tests/Meridian.Tests/Reporting/ReportingGovernanceCanonicalValidationTests.cs
@@ -36,6 +36,31 @@ public sealed class ReportingGovernanceCanonicalValidationTests
     }
 
     [Fact]
+    public async Task GovernedLifecycle_TreatsDefaultAndEmptyPrincipalAudiencesAsEquivalent()
+    {
+        var scenario = NewScenario();
+        var authorityWithoutAudience = scenario.Creator with
+        {
+            PrincipalIds = default
+        };
+        var run = await scenario.Service.CreateRunAsync(
+            scenario.Request,
+            authorityWithoutAudience);
+        run = await scenario.Service.BeginExecutionAsync(
+            run.RunId,
+            run.Version,
+            authorityWithoutAudience with { PrincipalIds = [] });
+
+        var validate = () =>
+            ReportingGovernanceCanonicalValidation.ValidateGovernedRun(run);
+
+        validate.Should().NotThrow(
+            "default ImmutableArray values deserialize as the same empty authority audience");
+        run.CreationAuthority.PrincipalIds.IsDefault.Should().BeTrue();
+        run.AuditTrail[^1].Authority.PrincipalIds.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task GovernedLifecycle_RejectsReceiptScopeAndMakerCheckerDrift()
     {
         var scenario = NewScenario();

--- a/tests/Meridian.Tests/SecurityMaster/PostgresOperatorOverridesStoreTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/PostgresOperatorOverridesStoreTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using FluentAssertions;
 using Meridian.Contracts.SecurityMaster;
 using Meridian.Storage.SecurityMaster;
@@ -21,8 +22,7 @@ namespace Meridian.Tests.SecurityMaster;
 ///   • IOperatorOverridesStore.RecordApprovalDecisionAsync is added.
 /// </summary>
 [Trait("Category", "Integration")]
-[Collection(nameof(SecurityMasterDatabaseCollection))]
-public sealed class PostgresOperatorOverridesStoreTests
+public sealed class PostgresOperatorOverridesStoreTests : IClassFixture<SecurityMasterDatabaseFixture>
 {
     private readonly SecurityMasterDatabaseFixture _fixture;
 
@@ -45,7 +45,7 @@ public sealed class PostgresOperatorOverridesStoreTests
     public async Task PatchAsync_ThenGetAsync_PersistsPendingStatusAndAuditEntry()
     {
         var store = NewStore();
-        var securityId = Guid.NewGuid();
+        var securityId = await CreateCanonicalSecurityAsync();
 
         await store.PatchAsync(securityId, Patch("rating", "AA", "annotation-correction"), "operator-1");
 
@@ -67,7 +67,7 @@ public sealed class PostgresOperatorOverridesStoreTests
     public async Task PatchAsync_AfterApproval_ResetsToPendingAndKeepsPriorAudit()
     {
         var store = NewStore();
-        var securityId = Guid.NewGuid();
+        var securityId = await CreateCanonicalSecurityAsync();
 
         await store.PatchAsync(securityId, Patch("rating", "AA", "initial"), "operator-1");
         await store.RecordApprovalDecisionAsync(
@@ -91,7 +91,7 @@ public sealed class PostgresOperatorOverridesStoreTests
     public async Task RecordApprovalDecisionAsync_Approved_StampsReviewerAndReviewedAt()
     {
         var store = NewStore();
-        var securityId = Guid.NewGuid();
+        var securityId = await CreateCanonicalSecurityAsync();
         var before = DateTimeOffset.UtcNow.AddSeconds(-1);
 
         await store.PatchAsync(securityId, Patch("sector", "Tech", "reclassification"), "operator-1");
@@ -120,7 +120,7 @@ public sealed class PostgresOperatorOverridesStoreTests
     public async Task RecordApprovalDecisionAsync_Rejected_StampsReviewerAndAppendsRejectedAudit()
     {
         var store = NewStore();
-        var securityId = Guid.NewGuid();
+        var securityId = await CreateCanonicalSecurityAsync();
 
         await store.PatchAsync(securityId, Patch("rating", "AA", "correction"), "operator-1");
 
@@ -153,7 +153,7 @@ public sealed class PostgresOperatorOverridesStoreTests
     public async Task RecordApprovalDecisionAsync_NonPending_ThrowsInvalidOperation()
     {
         var store = NewStore();
-        var securityId = Guid.NewGuid();
+        var securityId = await CreateCanonicalSecurityAsync();
 
         await store.PatchAsync(securityId, Patch("rating", "AA", "correction"), "operator-1");
         await store.RecordApprovalDecisionAsync(
@@ -172,7 +172,7 @@ public sealed class PostgresOperatorOverridesStoreTests
     public async Task RecordApprovalDecisionAsync_InvalidDecision_ThrowsArgument()
     {
         var store = NewStore();
-        var securityId = Guid.NewGuid();
+        var securityId = await CreateCanonicalSecurityAsync();
 
         await store.PatchAsync(securityId, Patch("rating", "AA", "correction"), "operator-1");
 
@@ -188,7 +188,7 @@ public sealed class PostgresOperatorOverridesStoreTests
     public async Task GetAsync_LegacyRowMissingApprovalColumns_DefaultsToNotRequested()
     {
         var store = NewStore();
-        var securityId = Guid.NewGuid();
+        var securityId = await CreateCanonicalSecurityAsync();
 
         // Simulate a pre-Track-C row: insert only the base columns and let the migration-added
         // approval columns fall back to their defaults (NotRequested / empty trail).
@@ -200,6 +200,49 @@ public sealed class PostgresOperatorOverridesStoreTests
         loaded.ReviewedBy.Should().BeNull();
         loaded.ReviewedAt.Should().BeNull();
         loaded.AuditTrail.Should().BeEmpty();
+    }
+
+    private async Task<Guid> CreateCanonicalSecurityAsync()
+    {
+        var securityId = Guid.NewGuid();
+        var identifierValue = $"OVERRIDE-{securityId:N}";
+        var effectiveFrom = DateTimeOffset.UtcNow.AddMinutes(-1);
+        var identifier = new SecurityIdentifierDto(
+            SecurityIdentifierKind.InternalCode,
+            identifierValue,
+            true,
+            effectiveFrom);
+        var projection = new SecurityProjectionRecord(
+            securityId,
+            "Equity",
+            SecurityStatusDto.Active,
+            $"Operator override fixture {securityId:N}",
+            "USD",
+            SecurityIdentifierKind.InternalCode.ToString(),
+            identifierValue,
+            JsonSerializer.SerializeToElement(new
+            {
+                displayName = $"Operator override fixture {securityId:N}",
+                currency = "USD",
+                exchange = "XNAS",
+                lotSize = 1,
+                tickSize = 0.01m
+            }),
+            JsonSerializer.SerializeToElement(new { shareClass = "Common" }),
+            JsonSerializer.SerializeToElement(new
+            {
+                sourceSystem = "integration-test",
+                updatedBy = "operator-override-fixture"
+            }),
+            1,
+            effectiveFrom,
+            null,
+            [identifier],
+            []);
+
+        await new PostgresSecurityMasterStore(_fixture.Options)
+            .UpsertProjectionAsync(projection);
+        return securityId;
     }
 
     private async Task InsertBaseOnlyRowAsync(Guid securityId)

--- a/tests/Meridian.Tests/SecurityMaster/PostgresSecurityMasterConflictServiceTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/PostgresSecurityMasterConflictServiceTests.cs
@@ -14,8 +14,7 @@ namespace Meridian.Tests.SecurityMaster;
 /// process instances, so the audit guarantee survives restarts and horizontal scale-out.
 /// </summary>
 [Trait("Category", "Integration")]
-[Collection(nameof(SecurityMasterDatabaseCollection))]
-public sealed class PostgresSecurityMasterConflictServiceTests
+public sealed class PostgresSecurityMasterConflictServiceTests : IClassFixture<SecurityMasterDatabaseFixture>
 {
     private readonly SecurityMasterDatabaseFixture _fixture;
 

--- a/tests/Meridian.Tests/SecurityMaster/PostgresSecurityMasterRevisionStoreTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/PostgresSecurityMasterRevisionStoreTests.cs
@@ -11,8 +11,7 @@ namespace Meridian.Tests.SecurityMaster;
 /// lifecycle state across process instances so publish authority survives restarts.
 /// </summary>
 [Trait("Category", "Integration")]
-[Collection(nameof(SecurityMasterDatabaseCollection))]
-public sealed class PostgresSecurityMasterRevisionStoreTests
+public sealed class PostgresSecurityMasterRevisionStoreTests : IClassFixture<SecurityMasterDatabaseFixture>
 {
     private readonly SecurityMasterDatabaseFixture _fixture;
 

--- a/tests/Meridian.Tests/SecurityMaster/SecurityMasterDatabaseFixture.cs
+++ b/tests/Meridian.Tests/SecurityMaster/SecurityMasterDatabaseFixture.cs
@@ -18,16 +18,24 @@ public sealed class SecurityMasterDatabaseFixture : IAsyncLifetime
     public async Task InitializeAsync()
     {
         _server = await PostgresTestServer.CreateAsync(EnvVar).ConfigureAwait(false);
-
-        Options = new SecurityMasterOptions
+        try
         {
-            ConnectionString = _server.ConnectionString,
-            Schema = PostgresTestSchema.NewSchemaName("sm"),
-            PreloadProjectionCache = false
-        };
+            Options = new SecurityMasterOptions
+            {
+                ConnectionString = _server.ConnectionString,
+                Schema = _server.CreateSchemaName("sm"),
+                PreloadProjectionCache = false
+            };
 
-        var runner = new SecurityMasterMigrationRunner(Options);
-        await runner.EnsureMigratedAsync().ConfigureAwait(false);
+            var runner = new SecurityMasterMigrationRunner(Options);
+            await runner.EnsureMigratedAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            await _server.DisposeAsync().ConfigureAwait(false);
+            _server = null;
+            throw;
+        }
     }
 
     public async Task DisposeAsync()
@@ -37,19 +45,6 @@ public sealed class SecurityMasterDatabaseFixture : IAsyncLifetime
             return;
         }
 
-        // External databases persist across runs, so the run-scoped schema is reset;
-        // containers are discarded whole by the shared server.
-        if (_server.UsesExternalConnection)
-        {
-            var runner = new SecurityMasterMigrationRunner(Options);
-            await runner.ResetSchemaAsync().ConfigureAwait(false);
-        }
-
         await _server.DisposeAsync().ConfigureAwait(false);
     }
-}
-
-[CollectionDefinition(nameof(SecurityMasterDatabaseCollection), DisableParallelization = true)]
-public sealed class SecurityMasterDatabaseCollection : ICollectionFixture<SecurityMasterDatabaseFixture>
-{
 }

--- a/tests/Meridian.Tests/SecurityMaster/SecurityMasterMigrationRunnerTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/SecurityMasterMigrationRunnerTests.cs
@@ -4,8 +4,7 @@ using Npgsql;
 namespace Meridian.Tests.SecurityMaster;
 
 [Trait("Category", "Integration")]
-[Collection(nameof(SecurityMasterDatabaseCollection))]
-public sealed class SecurityMasterMigrationRunnerTests
+public sealed class SecurityMasterMigrationRunnerTests : IClassFixture<SecurityMasterDatabaseFixture>
 {
     private readonly SecurityMasterDatabaseFixture _fixture;
 

--- a/tests/Meridian.Tests/SecurityMaster/SecurityMasterPostgresRoundTripTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/SecurityMasterPostgresRoundTripTests.cs
@@ -193,6 +193,12 @@ public sealed class SecurityMasterPostgresRoundTripTests : IClassFixture<Securit
             null,
             DateTimeOffset.UtcNow,
             includeInactive: false);
+        var resolvedWithWrongProvider = await store.GetByIdentifierAsync(
+            SecurityIdentifierKind.Isin,
+            "US0378331005",
+            "BLOOMBERG",
+            DateTimeOffset.UtcNow,
+            includeInactive: false);
 
         resolvedByIdentifier.Should().NotBeNull();
         resolvedByIdentifier!.SecurityId.Should().Be(securityId);
@@ -204,5 +210,6 @@ public sealed class SecurityMasterPostgresRoundTripTests : IClassFixture<Securit
         resolvedByAlias!.SecurityId.Should().Be(securityId);
 
         resolvedWithoutProvider.Should().BeNull();
+        resolvedWithWrongProvider.Should().BeNull();
     }
 }

--- a/tests/Meridian.Tests/SecurityMaster/SecurityMasterPostgresRoundTripTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/SecurityMasterPostgresRoundTripTests.cs
@@ -8,8 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Meridian.Tests.SecurityMaster;
 
 [Trait("Category", "Integration")]
-[Collection(nameof(SecurityMasterDatabaseCollection))]
-public sealed class SecurityMasterPostgresRoundTripTests
+public sealed class SecurityMasterPostgresRoundTripTests : IClassFixture<SecurityMasterDatabaseFixture>
 {
     private readonly SecurityMasterDatabaseFixture _fixture;
 

--- a/tests/Meridian.Tests/SecurityMaster/SecurityMasterQueryServiceEquityTermsTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/SecurityMasterQueryServiceEquityTermsTests.cs
@@ -216,6 +216,74 @@ public sealed class SecurityMasterQueryServiceEquityTermsTests
     }
 
     [Fact]
+    public async Task GetByIdentifierAsync_UniverseFallback_RejectsOmittedProviderForProviderScopedIdentifier()
+    {
+        var projection = CreateIsinProjection(Guid.NewGuid(), provider: "xnas", includeIdentifier: true);
+        var store = CreateUniverseFallbackStore(projection);
+        var service = CreateQueryService(store);
+
+        var result = await service.GetByIdentifierAsync(
+            SecurityIdentifierKind.Isin,
+            "US0378331005",
+            provider: null);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByIdentifierAsync_UniverseFallback_RejectsWrongProviderAndPrimaryFieldFallback()
+    {
+        var projection = CreateIsinProjection(Guid.NewGuid(), provider: "xnas", includeIdentifier: true);
+        var store = CreateUniverseFallbackStore(projection);
+        var service = CreateQueryService(store);
+
+        var result = await service.GetByIdentifierAsync(
+            SecurityIdentifierKind.Isin,
+            "US0378331005",
+            provider: "refinitiv");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByIdentifierAsync_UniverseFallback_ResolvesExactNormalizedProvider()
+    {
+        var securityId = Guid.NewGuid();
+        var projection = CreateIsinProjection(securityId, provider: "xnas", includeIdentifier: true);
+        var store = CreateUniverseFallbackStore(projection);
+        var service = CreateQueryService(store);
+
+        var result = await service.GetByIdentifierAsync(
+            SecurityIdentifierKind.Isin,
+            "us-0378331005",
+            provider: " XnAs ");
+
+        result.Should().NotBeNull();
+        result!.SecurityId.Should().Be(securityId);
+        result.Identifiers.Should().ContainSingle(identifier =>
+            identifier.NormalizedValue == "US0378331005"
+            && identifier.NormalizedProvider == "XNAS");
+    }
+
+    [Fact]
+    public async Task GetByIdentifierAsync_UniverseFallback_PreservesProviderlessLegacyPrimaryMatch()
+    {
+        var securityId = Guid.NewGuid();
+        var projection = CreateIsinProjection(securityId, provider: null, includeIdentifier: false);
+        var store = CreateUniverseFallbackStore(projection);
+        var service = CreateQueryService(store);
+
+        var result = await service.GetByIdentifierAsync(
+            SecurityIdentifierKind.Isin,
+            "US0378331005",
+            provider: null);
+
+        result.Should().NotBeNull();
+        result!.SecurityId.Should().Be(securityId);
+        result.Identifiers.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task GetByIdentifierAsync_UsesRequestedAsOfTimestamp_ForEffectiveDatedLookup()
     {
         var securityId = Guid.NewGuid();
@@ -381,6 +449,49 @@ public sealed class SecurityMasterQueryServiceEquityTermsTests
         var rebuilder = new SecurityMasterAggregateRebuilder(eventStore, snapshotStore);
         return new SecurityMasterQueryService(eventStore, store, rebuilder);
     }
+
+    private static ISecurityMasterStore CreateUniverseFallbackStore(SecurityProjectionRecord projection)
+    {
+        var store = Substitute.For<ISecurityMasterStore>();
+        store.GetByIdentifierAsync(
+                Arg.Any<SecurityIdentifierKind>(),
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<DateTimeOffset>(),
+                true,
+                Arg.Any<CancellationToken>())
+            .Returns((SecurityProjectionRecord?)null);
+        store.LoadAllAsync(Arg.Any<CancellationToken>())
+            .Returns([projection]);
+        return store;
+    }
+
+    private static SecurityProjectionRecord CreateIsinProjection(
+        Guid securityId,
+        string? provider,
+        bool includeIdentifier)
+        => CreateEquityProjection(
+            securityId,
+            JsonSerializer.SerializeToElement(new
+            {
+                schemaVersion = 1,
+                shareClass = "Common",
+                classification = "Common"
+            })) with
+        {
+            PrimaryIdentifierKind = SecurityIdentifierKind.Isin.ToString(),
+            PrimaryIdentifierValue = "us-0378331005",
+            Identifiers = includeIdentifier
+                ? [
+                    new SecurityIdentifierDto(
+                        SecurityIdentifierKind.Isin,
+                        "us-0378331005",
+                        true,
+                        DateTimeOffset.UtcNow.AddDays(-10),
+                        Provider: provider)
+                ]
+                : []
+        };
 
     private static SecurityProjectionRecord CreateEquityProjection(Guid securityId, JsonElement assetSpecificTerms)
         => new(

--- a/tests/Meridian.Tests/SecurityMaster/SecurityMasterSnapshotStoreTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/SecurityMasterSnapshotStoreTests.cs
@@ -6,8 +6,7 @@ using Meridian.Storage.SecurityMaster;
 namespace Meridian.Tests.SecurityMaster;
 
 [Trait("Category", "Integration")]
-[Collection(nameof(SecurityMasterDatabaseCollection))]
-public sealed class SecurityMasterSnapshotStoreTests
+public sealed class SecurityMasterSnapshotStoreTests : IClassFixture<SecurityMasterDatabaseFixture>
 {
     private readonly SecurityMasterDatabaseFixture _fixture;
 

--- a/tests/Meridian.Tests/Storage/FundAccounts/FundAccountDatabaseFixture.cs
+++ b/tests/Meridian.Tests/Storage/FundAccounts/FundAccountDatabaseFixture.cs
@@ -24,14 +24,23 @@ public sealed class FundAccountDatabaseFixture : IAsyncLifetime
     public async Task InitializeAsync()
     {
         _server = await PostgresTestServer.CreateAsync(EnvVar).ConfigureAwait(false);
-        Options = new FundAccountStoreOptions
+        try
         {
-            ConnectionString = _server.ConnectionString,
-            Schema = PostgresTestSchema.NewSchemaName("fa")
-        };
+            Options = new FundAccountStoreOptions
+            {
+                ConnectionString = _server.ConnectionString,
+                Schema = _server.CreateSchemaName("fa")
+            };
 
-        var runner = new FundAccountMigrationRunner(Options);
-        await runner.EnsureMigratedAsync().ConfigureAwait(false);
+            var runner = new FundAccountMigrationRunner(Options);
+            await runner.EnsureMigratedAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            await _server.DisposeAsync().ConfigureAwait(false);
+            _server = null;
+            throw;
+        }
     }
 
     public async Task DisposeAsync()
@@ -39,13 +48,6 @@ public sealed class FundAccountDatabaseFixture : IAsyncLifetime
         if (_server is null)
         {
             return;
-        }
-
-        // FundAccountMigrationRunner has no schema reset; external databases persist across
-        // runs so the run-scoped schema is dropped directly. Containers are discarded whole.
-        if (_server.UsesExternalConnection)
-        {
-            await DropSchemaAsync(Options.ConnectionString, Options.Schema).ConfigureAwait(false);
         }
 
         await _server.DisposeAsync().ConfigureAwait(false);
@@ -64,14 +66,12 @@ public sealed class FundAccountDatabaseFixture : IAsyncLifetime
     private static void ValidateIdentifier(string identifier)
     {
         if (identifier.Length == 0 ||
-            !identifier.All(c => char.IsAsciiLetterLower(c) || char.IsAsciiDigit(c) || c == '_'))
+            !identifier.All(static c =>
+                char.IsAsciiLetterLower(c) || char.IsAsciiDigit(c) || c == '_'))
         {
-            throw new ArgumentException($"Unsafe schema identifier: '{identifier}'", nameof(identifier));
+            throw new ArgumentException(
+                $"Unsafe schema identifier: '{identifier}'",
+                nameof(identifier));
         }
     }
-}
-
-[CollectionDefinition(nameof(FundAccountDatabaseCollection), DisableParallelization = true)]
-public sealed class FundAccountDatabaseCollection : ICollectionFixture<FundAccountDatabaseFixture>
-{
 }

--- a/tests/Meridian.Tests/Storage/FundAccounts/PostgresFundAccountStoreTests.cs
+++ b/tests/Meridian.Tests/Storage/FundAccounts/PostgresFundAccountStoreTests.cs
@@ -16,8 +16,7 @@ namespace Meridian.Tests.Storage.FundAccounts;
 /// across tenants, or lost in the SQL layer.
 /// </summary>
 [Trait("Category", "Integration")]
-[Collection(nameof(FundAccountDatabaseCollection))]
-public sealed class PostgresFundAccountStoreTests
+public sealed class PostgresFundAccountStoreTests : IClassFixture<FundAccountDatabaseFixture>
 {
     private readonly FundAccountDatabaseFixture _fixture;
 

--- a/tests/Meridian.Tests/Storage/FundStructure/PostgresFundStructureStoreTests.cs
+++ b/tests/Meridian.Tests/Storage/FundStructure/PostgresFundStructureStoreTests.cs
@@ -9,8 +9,7 @@ using Xunit;
 namespace Meridian.Tests.Storage.FundStructure;
 
 [Trait("Category", "Integration")]
-[Collection(nameof(FundAccountDatabaseCollection))]
-public sealed class PostgresFundStructureStoreTests
+public sealed class PostgresFundStructureStoreTests : IClassFixture<FundAccountDatabaseFixture>
 {
     private readonly FundAccountDatabaseFixture _fixture;
 

--- a/tests/Meridian.Tests/Storage/LedgerPostgresTestDatabase.cs
+++ b/tests/Meridian.Tests/Storage/LedgerPostgresTestDatabase.cs
@@ -42,7 +42,7 @@ internal sealed class LedgerPostgresTestDatabase : IAsyncDisposable
         var options = new LedgerJournalStoreOptions
         {
             ConnectionString = server.ConnectionString,
-            SchemaName = PostgresTestSchema.NewSchemaName("ledger")
+            SchemaName = server.CreateSchemaName("ledger")
         };
 
         var database = new LedgerPostgresTestDatabase(server, options);
@@ -113,41 +113,6 @@ internal sealed class LedgerPostgresTestDatabase : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        // External databases persist across runs, so the run-scoped schema must be dropped;
-        // containers are discarded whole by the shared server.
-        if (_server.UsesExternalConnection)
-        {
-            await DropSchemaAsync().ConfigureAwait(false);
-        }
-
         await _server.DisposeAsync().ConfigureAwait(false);
-    }
-
-    private async Task DropSchemaAsync()
-    {
-        await using var connection = new NpgsqlConnection(Options.ConnectionString);
-        await connection.OpenAsync().ConfigureAwait(false);
-
-        await using var command = connection.CreateCommand();
-        command.CommandText = $"drop schema if exists {ValidateIdentifier(Options.SchemaName)} cascade;";
-        await command.ExecuteNonQueryAsync().ConfigureAwait(false);
-    }
-
-    private static string ValidateIdentifier(string value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            throw new InvalidOperationException("Schema name is required.");
-        }
-
-        foreach (var c in value)
-        {
-            if (!(char.IsAsciiLetterOrDigit(c) || c == '_'))
-            {
-                throw new InvalidOperationException("Schema name contains an invalid identifier character.");
-            }
-        }
-
-        return value;
     }
 }

--- a/tests/Meridian.Tests/Storage/Reporting/ReportingArtifactCatalogAuditStoreTests.cs
+++ b/tests/Meridian.Tests/Storage/Reporting/ReportingArtifactCatalogAuditStoreTests.cs
@@ -11,7 +11,9 @@ using Xunit;
 namespace Meridian.Tests.Storage.Reporting;
 
 [Trait("Category", "Integration")]
-public sealed class ReportingArtifactCatalogAuditStoreTests : IClassFixture<ReportingArtifactDatabaseFixture>
+public sealed class ReportingArtifactCatalogAuditStoreTests :
+    IClassFixture<ReportingArtifactDatabaseFixture>,
+    IAsyncLifetime
 {
     private static readonly DateTimeOffset StoredAtUtc =
         new(2026, 7, 15, 8, 30, 0, TimeSpan.Zero);
@@ -26,6 +28,10 @@ public sealed class ReportingArtifactCatalogAuditStoreTests : IClassFixture<Repo
         _catalog = new PostgresReportingArtifactCatalog(database.Options);
         _audit = new PostgresReportingArtifactAuditStore(database.Options);
     }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public Task DisposeAsync() => _database.ResetAsync();
 
     [ReportingDatabaseFact]
     public async Task AddPackageAsync_IsAtomicTenantScopedAndExactlyIdempotent()

--- a/tests/Meridian.Tests/Storage/Reporting/ReportingArtifactStoreTests.cs
+++ b/tests/Meridian.Tests/Storage/Reporting/ReportingArtifactStoreTests.cs
@@ -11,7 +11,9 @@ using Xunit;
 namespace Meridian.Tests.Storage.Reporting;
 
 [Trait("Category", "Integration")]
-public sealed class ReportingArtifactStoreTests : IClassFixture<ReportingArtifactDatabaseFixture>
+public sealed class ReportingArtifactStoreTests :
+    IClassFixture<ReportingArtifactDatabaseFixture>,
+    IAsyncLifetime
 {
     private readonly ReportingArtifactDatabaseFixture _database;
 
@@ -19,6 +21,10 @@ public sealed class ReportingArtifactStoreTests : IClassFixture<ReportingArtifac
     {
         _database = database;
     }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public Task DisposeAsync() => _database.ResetAsync();
 
     [ReportingDatabaseFact]
     public async Task StoreAsync_PersistsContentAddressedBytesIdempotently()
@@ -132,7 +138,7 @@ public sealed class ReportingArtifactDatabaseFixture : IAsyncLifetime
         Options = new ReportingArtifactStoreOptions
         {
             ConnectionString = _server.ConnectionString,
-            Schema = PostgresTestSchema.NewSchemaName("reporting_artifact")
+            Schema = _server.CreateSchemaName("reporting_artifact")
         };
 
         try
@@ -154,12 +160,24 @@ public sealed class ReportingArtifactDatabaseFixture : IAsyncLifetime
             return;
         }
 
-        if (_server.UsesExternalConnection)
+        await _server.DisposeAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Drops and recreates this class fixture's private schema after each test method so a
+    /// destructive or interrupted scenario cannot leak rows or disabled triggers to the next one.
+    /// </summary>
+    public async Task ResetAsync()
+    {
+        if (_server is null)
         {
-            await new ReportingMigrationRunner(Options).ResetSchemaAsync().ConfigureAwait(false);
+            throw new InvalidOperationException("The reporting database fixture is not initialized.");
         }
 
-        await _server.DisposeAsync().ConfigureAwait(false);
+        var migrationRunner = new ReportingMigrationRunner(Options);
+        await migrationRunner.ResetSchemaAsync().ConfigureAwait(false);
+        await migrationRunner.EnsureMigratedAsync().ConfigureAwait(false);
+        Store = new PostgresReportingArtifactStore(Options);
     }
 
     public async Task<long> CountRowsAsync(ReportingArtifactIdentity identity)

--- a/tests/Meridian.Tests/Storage/Reporting/ReportingDistributionStoreTests.cs
+++ b/tests/Meridian.Tests/Storage/Reporting/ReportingDistributionStoreTests.cs
@@ -11,7 +11,9 @@ using Xunit;
 namespace Meridian.Tests.Storage.Reporting;
 
 [Trait("Category", "Integration")]
-public sealed class ReportingDistributionStoreTests : IClassFixture<ReportingArtifactDatabaseFixture>
+public sealed class ReportingDistributionStoreTests :
+    IClassFixture<ReportingArtifactDatabaseFixture>,
+    IAsyncLifetime
 {
     private static readonly DateTimeOffset FixedNow = new(2026, 7, 15, 12, 0, 0, TimeSpan.Zero);
     private readonly ReportingArtifactDatabaseFixture _database;
@@ -24,6 +26,10 @@ public sealed class ReportingDistributionStoreTests : IClassFixture<ReportingArt
         _grantStore = new PostgresReportingAccessGrantStore(database.Options);
         _deliveryStore = new PostgresReportingDeliveryStore(database.Options);
     }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public Task DisposeAsync() => _database.ResetAsync();
 
     [ReportingDatabaseFact]
     public async Task ReportingDistributionMigration_RetainsReadIndexAndGrantConsumptionAuthority()
@@ -136,7 +142,8 @@ public sealed class ReportingDistributionStoreTests : IClassFixture<ReportingArt
         };
         (await _grantStore.TryUpdateAsync(grant.GrantId, first.Version, second))
             .Should().BeTrue();
-        (await _grantStore.GetAsync(grant.GrantId)).Should().Be(second);
+        (await _grantStore.GetAsync(grant.GrantId)).Should()
+            .BeEquivalentTo(second, options => options.WithStrictOrdering());
 
         Func<Task> removeConsumedArtifact = () => ExecuteAsync(
             $"""
@@ -189,7 +196,8 @@ public sealed class ReportingDistributionStoreTests : IClassFixture<ReportingArt
         };
         (await _grantStore.TryUpdateAsync(legacy.GrantId, legacy.Version, initialized))
             .Should().BeTrue();
-        (await _grantStore.GetAsync(legacy.GrantId)).Should().Be(initialized);
+        (await _grantStore.GetAsync(legacy.GrantId)).Should()
+            .BeEquivalentTo(initialized, options => options.WithStrictOrdering());
     }
 
     [ReportingDatabaseFact]
@@ -334,7 +342,8 @@ public sealed class ReportingDistributionStoreTests : IClassFixture<ReportingArt
             Version = 1
         };
         (await _grantStore.TryUpdateAsync(grant.GrantId, 0, revoked)).Should().BeTrue();
-        (await _grantStore.GetAsync(grant.GrantId)).Should().Be(revoked);
+        (await _grantStore.GetAsync(grant.GrantId)).Should()
+            .BeEquivalentTo(revoked, options => options.WithStrictOrdering());
 
         Func<Task> mutateTenant = () => ExecuteAsync(
             $"update {QualifiedGrantTable} set tenant_id = @value where grant_id = @id;",
@@ -406,8 +415,10 @@ public sealed class ReportingDistributionStoreTests : IClassFixture<ReportingArt
                 deliveryWithReceipt));
 
         status.Should().Be(ReportingDeliveryGrantDownloadCommitStatus.Committed);
-        (await _grantStore.GetAsync(grant.GrantId)).Should().Be(consumedGrant);
-        (await _deliveryStore.GetAsync(job.JobId)).Should().Be(deliveryWithReceipt);
+        (await _grantStore.GetAsync(grant.GrantId)).Should()
+            .BeEquivalentTo(consumedGrant, options => options.WithStrictOrdering());
+        (await _deliveryStore.GetAsync(job.JobId)).Should()
+            .BeEquivalentTo(deliveryWithReceipt, options => options.WithStrictOrdering());
     }
 
     [ReportingDatabaseFact]
@@ -836,7 +847,8 @@ public sealed class ReportingDistributionStoreTests : IClassFixture<ReportingArt
         };
 
         (await _deliveryStore.TryUpdateAsync(job.JobId, retry.Version, failed)).Should().BeTrue();
-        (await _deliveryStore.GetAsync(job.JobId))!.Should().Be(failed);
+        (await _deliveryStore.GetAsync(job.JobId))!.Should()
+            .BeEquivalentTo(failed, options => options.WithStrictOrdering());
         (await _deliveryStore.ListPendingAccessGrantRevocationsAsync(10))
             .Should().ContainSingle(candidate =>
                 candidate.JobId == job.JobId

--- a/tests/Meridian.Tests/Storage/Reporting/ReportingGovernanceRepositoryTests.cs
+++ b/tests/Meridian.Tests/Storage/Reporting/ReportingGovernanceRepositoryTests.cs
@@ -857,8 +857,8 @@ public sealed class ReportingGovernancePersistenceSerializationTests
                 EvidenceIds: default),
             [audit]);
 
-        var payload = PostgresReportingGovernanceRepository.SerializeRunForPersistence(run);
-        var retained = PostgresReportingGovernanceRepository.DeserializeRunFromPersistence(payload);
+        var payload = ReportingGovernancePersistenceJson.SerializeRun(run);
+        var retained = ReportingGovernancePersistenceJson.DeserializeRun(payload);
 
         retained.Access.Principals.IsDefault.Should().BeFalse();
         retained.CreationAuthority.PrincipalIds.IsDefault.Should().BeFalse();
@@ -899,8 +899,8 @@ public sealed class ReportingGovernancePersistenceSerializationTests
                     default)
             ]);
 
-        var payload = PostgresReportingGovernanceRepository.SerializeRestatementForPersistence(request);
-        var retained = PostgresReportingGovernanceRepository.DeserializeRestatementFromPersistence(payload);
+        var payload = ReportingGovernancePersistenceJson.SerializeRestatement(request);
+        var retained = ReportingGovernancePersistenceJson.DeserializeRestatement(payload);
 
         retained.ChangedLines.Single().EvidenceIds.IsDefault.Should().BeFalse();
         retained.RequestedBy.PrincipalIds.IsDefault.Should().BeFalse();
@@ -912,10 +912,10 @@ public sealed class ReportingGovernancePersistenceSerializationTests
     [Fact]
     public void AuditPayload_DefaultPrincipalAudience_RoundTripsAsCanonicalEmptyCollection()
     {
-        var payload = PostgresReportingGovernanceRepository.SerializeAuditForPersistence(
+        var payload = ReportingGovernancePersistenceJson.SerializeAudit(
             NewAudit(NewAuthority()));
 
-        var retained = PostgresReportingGovernanceRepository.DeserializeAuditFromPersistence(payload);
+        var retained = ReportingGovernancePersistenceJson.DeserializeAudit(payload);
 
         retained.Authority.PrincipalIds.IsDefault.Should().BeFalse();
     }

--- a/tests/Meridian.Tests/Storage/Reporting/ReportingGovernanceRepositoryTests.cs
+++ b/tests/Meridian.Tests/Storage/Reporting/ReportingGovernanceRepositoryTests.cs
@@ -35,6 +35,7 @@ public sealed class ReportingGovernanceRepositoryTests :
     public async Task Lifecycle_PersistsTenantBoundStateAndImmutableAuditAcrossRepositoryInstances()
     {
         var scenario = NewScenario();
+        scenario.Creator.PrincipalIds.IsDefault.Should().BeTrue();
         var released = await CreateReleasedRunAsync(_database.Repository, scenario);
 
         var restarted = new PostgresReportingGovernanceRepository(_database.Options);
@@ -44,6 +45,8 @@ public sealed class ReportingGovernanceRepositoryTests :
         retained.Should().BeEquivalentTo(released);
         retained!.GovernanceState.Should().Be(GovernedReportingState.Released);
         retained.Release.Should().NotBeNull();
+        retained.CreationAuthority.PrincipalIds.IsDefault.Should().BeFalse();
+        retained.AuditTrail.Should().OnlyContain(entry => !entry.Authority.PrincipalIds.IsDefault);
         ReportingGovernanceAuditChain.Verify(retained.AuditTrail).Should().BeTrue();
         (await _database.CountAuditRowsAsync(
             scenario.TenantId,
@@ -798,6 +801,179 @@ public sealed class ReportingGovernanceRepositoryTests :
         ReportingAuthorityScope Approver,
         ReportingAuthorityScope Releaser,
         ReportingAuthorityScope RestatementApprover);
+}
+
+/// <summary>
+/// Guards governed-report persistence when an identity provider supplies no additional principal
+/// audiences and optional immutable collections therefore arrive in their default state.
+/// </summary>
+public sealed class ReportingGovernancePersistenceSerializationTests
+{
+    [Fact]
+    public void RunPayload_DefaultImmutableCollections_RoundTripsAsCanonicalEmptyCollections()
+    {
+        var authority = NewAuthority();
+        var audit = NewAudit(authority);
+        var run = new GovernedReportingRun(
+            "run-default-audiences",
+            "series-default-audiences",
+            Revision: 1,
+            "template-monthly-financials",
+            "1.0.0",
+            NewScope(),
+            new ReportingAccessScope(
+                "policy-default-audiences",
+                "1",
+                ReportingGovernanceAccessMode.CompanyWide,
+                OwnerPrincipalId: null,
+                AllowOwnerAccess: false,
+                Principals: default,
+                PolicyHash: new string('b', 64)),
+            NewSnapshot(),
+            authority,
+            FixedUtc,
+            RestatementOfRunId: null,
+            GovernedReportingExecutionState.Succeeded,
+            GovernedReportingState.Released,
+            Version: 1,
+            new ReportingReadinessReceipt(
+                "readiness-default-audiences",
+                new string('c', 64),
+                "run-default-audiences",
+                "tenant-default-audiences",
+                "organization-default-audiences",
+                "company-default-audiences",
+                "snapshot-default-audiences",
+                new string('d', 64),
+                FixedUtc,
+                [new ReportingReadinessCheck("ledger-ready", true, default)]),
+            new ReportingApprovalReceipt(authority, FixedUtc, "Approved"),
+            new ReportingReleaseReceipt(
+                authority,
+                FixedUtc,
+                "manifest-default-audiences",
+                new string('e', 64),
+                Artifacts: default,
+                EvidenceIds: default),
+            [audit]);
+
+        var payload = PostgresReportingGovernanceRepository.SerializeRunForPersistence(run);
+        var retained = PostgresReportingGovernanceRepository.DeserializeRunFromPersistence(payload);
+
+        retained.Access.Principals.IsDefault.Should().BeFalse();
+        retained.CreationAuthority.PrincipalIds.IsDefault.Should().BeFalse();
+        retained.Readiness!.Checks.Single().EvidenceIds.IsDefault.Should().BeFalse();
+        retained.Approval!.Authority.PrincipalIds.IsDefault.Should().BeFalse();
+        retained.Release!.Authority.PrincipalIds.IsDefault.Should().BeFalse();
+        retained.Release.Artifacts.IsDefault.Should().BeFalse();
+        retained.Release.EvidenceIds.IsDefault.Should().BeFalse();
+        retained.AuditTrail.Single().Authority.PrincipalIds.IsDefault.Should().BeFalse();
+    }
+
+    [Fact]
+    public void RestatementPayload_DefaultImmutableCollections_RoundTripsAsCanonicalEmptyCollections()
+    {
+        var authority = NewAuthority();
+        var request = new ReportingRestatementRequest(
+            "restatement-default-audiences",
+            "run-default-audiences",
+            "series-default-audiences",
+            PredecessorRevision: 1,
+            PredecessorVersion: 1,
+            "Correct retained source data",
+            [new ReportingRestatementChangedLine("nav.total", "100", "101", default)],
+            authority,
+            FixedUtc,
+            ReportingRestatementRequestState.Approved,
+            Version: 2,
+            authority,
+            FixedUtc,
+            "run-restated-default-audiences",
+            AuditTrail: default,
+            RequestedChangedLines:
+            [
+                new ReportingRestatementChangedLine(
+                    "nav.total",
+                    "100",
+                    "101",
+                    default)
+            ]);
+
+        var payload = PostgresReportingGovernanceRepository.SerializeRestatementForPersistence(request);
+        var retained = PostgresReportingGovernanceRepository.DeserializeRestatementFromPersistence(payload);
+
+        retained.ChangedLines.Single().EvidenceIds.IsDefault.Should().BeFalse();
+        retained.RequestedBy.PrincipalIds.IsDefault.Should().BeFalse();
+        retained.ApprovedBy!.PrincipalIds.IsDefault.Should().BeFalse();
+        retained.AuditTrail.IsDefault.Should().BeFalse();
+        retained.RequestedChangedLines.Single().EvidenceIds.IsDefault.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AuditPayload_DefaultPrincipalAudience_RoundTripsAsCanonicalEmptyCollection()
+    {
+        var payload = PostgresReportingGovernanceRepository.SerializeAuditForPersistence(
+            NewAudit(NewAuthority()));
+
+        var retained = PostgresReportingGovernanceRepository.DeserializeAuditFromPersistence(payload);
+
+        retained.Authority.PrincipalIds.IsDefault.Should().BeFalse();
+    }
+
+    private static readonly DateTimeOffset FixedUtc =
+        new(2026, 8, 4, 20, 0, 0, TimeSpan.Zero);
+
+    private static ReportingOperationalScope NewScope() =>
+        new(
+            "tenant-default-audiences",
+            "organization-default-audiences",
+            "company-default-audiences",
+            "fund-default-audiences",
+            "book-default-audiences",
+            "period-default-audiences");
+
+    private static ReportingCertifiedSnapshotScope NewSnapshot() =>
+        new(
+            "tenant-default-audiences",
+            "organization-default-audiences",
+            "company-default-audiences",
+            "fund-default-audiences",
+            "book-default-audiences",
+            "period-default-audiences",
+            "snapshot-default-audiences",
+            new string('d', 64),
+            "reconciliation-default-audiences",
+            FixedUtc);
+
+    private static ReportingAuthorityScope NewAuthority() =>
+        new(
+            "operator-default-audiences",
+            "tenant-default-audiences",
+            "organization-default-audiences",
+            "company-default-audiences",
+            [ReportingGovernancePermission.CreateRun],
+            ReportingCommandOrigin.HumanOperator,
+            "correlation-default-audiences");
+
+    private static ReportingGovernanceAuditEntry NewAudit(ReportingAuthorityScope authority) =>
+        new(
+            "event-default-audiences",
+            ReportingGovernanceAuditAggregateKind.Run,
+            "run-default-audiences",
+            AggregateVersion: 1,
+            FixedUtc,
+            ReportingGovernanceAuditAction.RunCreated,
+            authority,
+            ReportingGovernancePermission.CreateRun,
+            FromExecutionState: null,
+            ToExecutionState: GovernedReportingExecutionState.Queued,
+            FromGovernanceState: null,
+            ToGovernanceState: GovernedReportingState.Draft,
+            FromRestatementState: null,
+            ToRestatementState: null,
+            null,
+            null,
+            new string('f', 64));
 }
 
 public sealed class ReportingGovernanceDatabaseFixture : IAsyncLifetime

--- a/tests/Meridian.Tests/Storage/Reporting/ReportingGovernanceRepositoryTests.cs
+++ b/tests/Meridian.Tests/Storage/Reporting/ReportingGovernanceRepositoryTests.cs
@@ -469,9 +469,15 @@ public sealed class ReportingGovernanceRepositoryTests :
         await _database.MutateRunPayloadAndRehashAsync(
             scenario.TenantId,
             released.RunId,
-            root => RequiredObject(root, "Readiness", "readiness")[
-                PropertyName(RequiredObject(root, "Readiness", "readiness"), "OrganizationId", "organizationId")]
-                = "other-organization");
+            root =>
+            {
+                var readiness = RequiredObject(root, "Readiness", "readiness");
+                readiness[PropertyName(readiness, "OrganizationId", "organizationId")]
+                    = "other-organization";
+                var mutatedRun = ReportingGovernancePersistenceJson.DeserializeRun(root.ToJsonString());
+                readiness[PropertyName(readiness, "ReceiptHash", "receiptHash")]
+                    = ReportingGovernanceCanonicalValidation.ComputeReadinessReceiptHash(mutatedRun.Readiness!);
+            });
 
         Func<Task> read = async () =>
             await LoadRunAsync(_database.Repository, scenario.TenantId, released.RunId);
@@ -809,6 +815,46 @@ public sealed class ReportingGovernanceRepositoryTests :
 /// </summary>
 public sealed class ReportingGovernancePersistenceSerializationTests
 {
+    [Fact]
+    public void PendingRestatementPayload_EquivalentChangedLineEvidence_PassesCanonicalValidation()
+    {
+        var changedLines = ImmutableArray.Create(
+            new ReportingRestatementChangedLine(
+                "nav.total",
+                "100",
+                "101",
+                ["evidence-default-audiences"]));
+        var request = new ReportingRestatementRequest(
+            "restatement-equivalent-evidence",
+            "run-default-audiences",
+            "series-default-audiences",
+            PredecessorRevision: 1,
+            PredecessorVersion: 1,
+            "Correct retained source data",
+            changedLines,
+            NewAuthority() with
+            {
+                Permissions = [ReportingGovernancePermission.RequestRestatement]
+            },
+            FixedUtc,
+            ReportingRestatementRequestState.PendingApproval,
+            Version: 1,
+            ApprovedBy: null,
+            ApprovedAtUtc: null,
+            DraftRunId: null,
+            AuditTrail: [],
+            RequestedChangedLines: changedLines);
+
+        var payload = ReportingGovernancePersistenceJson.SerializeRestatement(request);
+        var retained = ReportingGovernancePersistenceJson.DeserializeRestatement(payload);
+
+        Action validate = () => ReportingGovernanceCanonicalValidation.ValidateRestatementRequest(
+            retained,
+            requireAuditTrail: false);
+
+        validate.Should().NotThrow();
+    }
+
     [Fact]
     public void RunPayload_DefaultImmutableCollections_RoundTripsAsCanonicalEmptyCollections()
     {

--- a/tests/Meridian.Tests/Storage/Reporting/ReportingGovernanceRepositoryTests.cs
+++ b/tests/Meridian.Tests/Storage/Reporting/ReportingGovernanceRepositoryTests.cs
@@ -16,7 +16,9 @@ using Xunit;
 namespace Meridian.Tests.Storage.Reporting;
 
 [Trait("Category", "Integration")]
-public sealed class ReportingGovernanceRepositoryTests : IClassFixture<ReportingGovernanceDatabaseFixture>
+public sealed class ReportingGovernanceRepositoryTests :
+    IClassFixture<ReportingGovernanceDatabaseFixture>,
+    IAsyncLifetime
 {
     private readonly ReportingGovernanceDatabaseFixture _database;
 
@@ -24,6 +26,10 @@ public sealed class ReportingGovernanceRepositoryTests : IClassFixture<Reporting
     {
         _database = database;
     }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public Task DisposeAsync() => _database.ResetAsync();
 
     [ReportingDatabaseFact]
     public async Task Lifecycle_PersistsTenantBoundStateAndImmutableAuditAcrossRepositoryInstances()
@@ -829,7 +835,7 @@ public sealed class ReportingGovernanceDatabaseFixture : IAsyncLifetime
         Options = new ReportingArtifactStoreOptions
         {
             ConnectionString = _server.ConnectionString,
-            Schema = PostgresTestSchema.NewSchemaName("reporting_governance")
+            Schema = _server.CreateSchemaName("reporting_governance")
         };
 
         try
@@ -851,12 +857,24 @@ public sealed class ReportingGovernanceDatabaseFixture : IAsyncLifetime
             return;
         }
 
-        if (_server.UsesExternalConnection)
+        await _server.DisposeAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Recreates this class fixture's schema after every test method, including scenarios that
+    /// deliberately corrupt retained payloads or disable database guards.
+    /// </summary>
+    public async Task ResetAsync()
+    {
+        if (_server is null)
         {
-            await new ReportingMigrationRunner(Options).ResetSchemaAsync().ConfigureAwait(false);
+            throw new InvalidOperationException("The reporting governance fixture is not initialized.");
         }
 
-        await _server.DisposeAsync().ConfigureAwait(false);
+        var migrationRunner = new ReportingMigrationRunner(Options);
+        await migrationRunner.ResetSchemaAsync().ConfigureAwait(false);
+        await migrationRunner.EnsureMigratedAsync().ConfigureAwait(false);
+        Repository = new PostgresReportingGovernanceRepository(Options);
     }
 
     public async Task<long> CountAuditRowsAsync(

--- a/tests/Meridian.Tests/Storage/Reporting/ReportingReconciliationEvidenceStoreTests.cs
+++ b/tests/Meridian.Tests/Storage/Reporting/ReportingReconciliationEvidenceStoreTests.cs
@@ -22,7 +22,8 @@ namespace Meridian.Tests.Storage.Reporting;
 
 [Trait("Category", "Integration")]
 public sealed class ReportingReconciliationEvidenceStoreTests :
-    IClassFixture<ReportingGovernanceDatabaseFixture>
+    IClassFixture<ReportingGovernanceDatabaseFixture>,
+    IAsyncLifetime
 {
     private readonly ReportingGovernanceDatabaseFixture _database;
 
@@ -30,6 +31,10 @@ public sealed class ReportingReconciliationEvidenceStoreTests :
     {
         _database = database;
     }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public Task DisposeAsync() => _database.ResetAsync();
 
     [ReportingDatabaseFact]
     public async Task RetainAndRead_RoundTripsExactTextPayloadIdempotentlyAcrossStoreRestart()
@@ -244,6 +249,31 @@ public sealed class ReportingReconciliationEvidenceStoreTests :
         var breakQueue = Substitute.For<IReconciliationBreakQueueRepository>();
         breakQueue.GetAllAsync(Arg.Any<ReconciliationBreakQueueStatus?>(), Arg.Any<CancellationToken>())
             .Returns(Array.Empty<ReconciliationBreakQueueItem>());
+        var closeScope = new ReconciliationCloseScope(
+            fundId,
+            bookId,
+            periodId,
+            softClosed.EndDate);
+        var closeScopeCheckpoint = new ReconciliationCloseScopeCheckpoint(
+            closeScope,
+            [],
+            new string('c', 64));
+        var closeScopeLease = Substitute.For<IReconciliationCloseScopeLease>();
+        closeScopeLease.Scope.Returns(closeScope);
+        closeScopeLease.Items.Returns(Array.Empty<ReconciliationBreakQueueItem>());
+        closeScopeLease.CheckpointHashSha256.Returns(closeScopeCheckpoint.CheckpointHashSha256);
+        closeScopeLease.Generation.Returns(closeScopeCheckpoint.Generation);
+        closeScopeLease.CommitHardCloseAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        closeScopeLease.DisposeAsync().Returns(ValueTask.CompletedTask);
+        breakQueue.AcquireCloseScopeLeaseAsync(
+                Arg.Is<ReconciliationCloseScope>(candidate => candidate == closeScope),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(closeScopeLease));
+        breakQueue.RecoverHardClosedScopeCheckpointAsync(
+                Arg.Is<ReconciliationCloseScope>(candidate => candidate == closeScope),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(closeScopeCheckpoint));
         var bridge = new AccountingClosePostingWorkbenchBridge(
             runner,
             workbench,
@@ -453,7 +483,7 @@ public sealed class ReportingReconciliationEvidenceStoreTests :
         await using var command = connection.CreateCommand();
         command.CommandText =
             $"""
-            insert into \"{_database.Options.Schema}\".\"reporting_reconciliation_evidence\" (
+            insert into "{_database.Options.Schema}"."reporting_reconciliation_evidence" (
                 tenant_id, receipt_key_sha256, organization_id, company_id, fund_id, ledger_book_id,
                 accounting_period_id, accounting_basis, as_of_date, source_checkpoint_id,
                 source_checkpoint_hash, reconciliation_checkpoint_id, reconciliation_checkpoint_hash,

--- a/tests/Meridian.Tests/Storage/Reporting/ReportingReconciliationEvidenceStoreTests.cs
+++ b/tests/Meridian.Tests/Storage/Reporting/ReportingReconciliationEvidenceStoreTests.cs
@@ -183,29 +183,33 @@ public sealed class ReportingReconciliationEvidenceStoreTests :
                 "USD",
                 completedAt,
                 completedAt));
-        var periodReadCount = 0;
+        // Model the ledger authority's committed state instead of coupling the fixture to the
+        // bridge's number of defensive boundary reads.
+        var currentPeriod = softClosed;
         ledgerBookService.ListPeriodsAsync(
                 Arg.Any<LedgerPeriodQuery>(),
                 Arg.Any<CancellationToken>())
-            .Returns(_ => ++periodReadCount <= 3
-                ? new[] { softClosed }
-                : new[] { hardClosed });
+            .Returns(_ => new[] { currentPeriod });
         ledgerBookService.GetPeriodSummaryAsync(periodId, Arg.Any<CancellationToken>())
             .Returns(summary);
         ledgerBookService.ClosePeriodAsync(
                 periodId,
                 Arg.Any<CloseLedgerPeriodRequest>(),
                 Arg.Any<CancellationToken>())
-            .Returns(new LedgerPeriodCloseResultDto(
-                hardClosed,
-                summary,
-                new OperatorWorkItemDto(
-                    $"period-close:{periodId:D}",
-                    OperatorWorkItemKindDto.LedgerPeriodClose,
-                    "Period hard closed",
-                    "The reporting close completed.",
-                    OperatorWorkItemToneDto.Success,
-                    completedAt)));
+            .Returns(_ =>
+            {
+                currentPeriod = hardClosed;
+                return new LedgerPeriodCloseResultDto(
+                    hardClosed,
+                    summary,
+                    new OperatorWorkItemDto(
+                        $"period-close:{periodId:D}",
+                        OperatorWorkItemKindDto.LedgerPeriodClose,
+                        "Period hard closed",
+                        "The reporting close completed.",
+                        OperatorWorkItemToneDto.Success,
+                        completedAt));
+            });
 
         var workbench = Substitute.For<IManualJournalEntryWorkbenchService>();
         workbench.GetWorkbenchAsync(

--- a/tests/Meridian.Tests/Storage/Reporting/ReportingReconciliationEvidenceStoreTests.cs
+++ b/tests/Meridian.Tests/Storage/Reporting/ReportingReconciliationEvidenceStoreTests.cs
@@ -364,8 +364,10 @@ public sealed class ReportingReconciliationEvidenceStoreTests :
                     RequireBoundScope: true));
 
         var blocked = await certify.Should().ThrowAsync<ReportingRunReadinessBlockedException>();
-        blocked.Which.Message.Should().Contain(
-            "Final reporting requires retained proof that the accounting-close workflow committed");
+        blocked.Which.Readiness.BlockingReasons.Should().ContainSingle(reason =>
+            reason.Contains(
+                "Final reporting requires retained proof that the accounting-close workflow committed",
+                StringComparison.Ordinal));
     }
 
     private static ReportingReconciliationEvidenceReceipt NewReceipt()

--- a/tests/Meridian.Tests/Storage/Reporting/StatementReconciliationReportAuthorityStoreTests.cs
+++ b/tests/Meridian.Tests/Storage/Reporting/StatementReconciliationReportAuthorityStoreTests.cs
@@ -10,7 +10,8 @@ namespace Meridian.Tests.Storage.Reporting;
 
 [Trait("Category", "Integration")]
 public sealed class StatementReconciliationReportAuthorityStoreTests :
-    IClassFixture<ReportingArtifactDatabaseFixture>
+    IClassFixture<ReportingArtifactDatabaseFixture>,
+    IAsyncLifetime
 {
     private const string MigrationFileName =
         "013_reporting_statement_reconciliation_authority.sql";
@@ -22,6 +23,10 @@ public sealed class StatementReconciliationReportAuthorityStoreTests :
     {
         _database = database;
     }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public Task DisposeAsync() => _database.ResetAsync();
 
     [ReportingDatabaseFact]
     public async Task ImmutableDocument_ExactRetryIsIdempotentAndRetainsOneRevision()

--- a/tests/Meridian.Tests/Storage/ReportingOperationalStoreTests.cs
+++ b/tests/Meridian.Tests/Storage/ReportingOperationalStoreTests.cs
@@ -10,7 +10,9 @@ using Xunit;
 namespace Meridian.Tests.Storage.Reporting;
 
 [Trait("Category", "Integration")]
-public sealed class ReportingOperationalStoreTests : IClassFixture<ReportingArtifactDatabaseFixture>
+public sealed class ReportingOperationalStoreTests :
+    IClassFixture<ReportingArtifactDatabaseFixture>,
+    IAsyncLifetime
 {
     private static readonly DateTimeOffset FixedNow =
         new(2026, 7, 25, 12, 0, 0, TimeSpan.Zero);
@@ -21,6 +23,10 @@ public sealed class ReportingOperationalStoreTests : IClassFixture<ReportingArti
     {
         _database = database;
     }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public Task DisposeAsync() => _database.ResetAsync();
 
     [ReportingDatabaseFact]
     public async Task RunStore_IsTenantScopedAndExactRetriesAreIdempotent()
@@ -162,8 +168,8 @@ public sealed class ReportingOperationalStoreTests : IClassFixture<ReportingArti
                 update {{QualifiedRunTable}}
                 set manifest_payload = jsonb_set(
                     manifest_payload,
-                    '{templateId}',
-                    to_jsonb('tampered-template'::text))
+                    '{attemptCount}',
+                    to_jsonb(2::integer))
                 where tenant_id = @tenant_id
                   and run_id_key = @identity_key;
                 """,

--- a/tests/Meridian.Tests/TestSupport/PostgresTestSchemaTests.cs
+++ b/tests/Meridian.Tests/TestSupport/PostgresTestSchemaTests.cs
@@ -1,0 +1,139 @@
+using FluentAssertions;
+using Meridian.Tests.Storage;
+using Meridian.TestSupport;
+using Npgsql;
+
+namespace Meridian.Tests.TestSupport;
+
+public sealed class PostgresTestSchemaTests
+{
+    [LedgerDatabaseFact]
+    [Trait("Category", "Integration")]
+    public async Task EnvironmentScope_ExternalDatabase_DropsOwnedSchemaAndRestoresFallbackConfiguration()
+    {
+        var suffix = Guid.NewGuid().ToString("N");
+        var connectionVariable = $"MERIDIAN_TEST_CONNECTION_{suffix}";
+        var fallbackVariable = $"MERIDIAN_TEST_FALLBACK_{suffix}";
+        var schemaVariable = $"MERIDIAN_TEST_SCHEMA_{suffix}";
+        const string originalSchema = "caller_owned_schema";
+        await using var database = await PostgresTestServer.CreateAsync(
+            "MERIDIAN_LEDGER_CONNECTION_STRING");
+        Environment.SetEnvironmentVariable(fallbackVariable, database.ConnectionString);
+        Environment.SetEnvironmentVariable(schemaVariable, originalSchema);
+        PostgresTestSchemaEnvironmentScope? scope = null;
+
+        try
+        {
+            scope = await PostgresTestSchemaEnvironmentScope.CreateIfConfiguredAsync(
+                connectionVariable,
+                schemaVariable,
+                "scope_contract",
+                fallbackVariable);
+            scope.Should().NotBeNull();
+            var isolatedScope = scope!;
+            Environment.GetEnvironmentVariable(connectionVariable)
+                .Should().Be(database.ConnectionString);
+            Environment.GetEnvironmentVariable(schemaVariable).Should().Be(isolatedScope.Schema);
+
+            await using (var connection = new NpgsqlConnection(database.ConnectionString))
+            {
+                await connection.OpenAsync();
+                await using var create = connection.CreateCommand();
+                create.CommandText =
+                    $"CREATE SCHEMA \"{isolatedScope.Schema}\"; " +
+                    $"CREATE TABLE \"{isolatedScope.Schema}\".owned_probe(id integer PRIMARY KEY);";
+                await create.ExecuteNonQueryAsync();
+            }
+
+            await isolatedScope.DisposeAsync();
+
+            Environment.GetEnvironmentVariable(connectionVariable).Should().BeNull();
+            Environment.GetEnvironmentVariable(schemaVariable).Should().Be(originalSchema);
+            (await SchemaExistsAsync(database.ConnectionString, isolatedScope.Schema))
+                .Should().BeFalse();
+
+            // Repeated fixture cleanup must remain safe after the owned schema was removed.
+            await isolatedScope.DisposeAsync();
+        }
+        finally
+        {
+            if (scope is not null)
+            {
+                await scope.DisposeAsync();
+            }
+            Environment.SetEnvironmentVariable(connectionVariable, null);
+            Environment.SetEnvironmentVariable(fallbackVariable, null);
+            Environment.SetEnvironmentVariable(schemaVariable, null);
+        }
+    }
+
+    [Fact]
+    public async Task EnvironmentScope_MissingConnection_DoesNotPublishOrReplaceSchema()
+    {
+        var suffix = Guid.NewGuid().ToString("N");
+        var connectionVariable = $"MERIDIAN_TEST_CONNECTION_{suffix}";
+        var schemaVariable = $"MERIDIAN_TEST_SCHEMA_{suffix}";
+        const string originalSchema = "caller_owned_schema";
+        Environment.SetEnvironmentVariable(schemaVariable, originalSchema);
+
+        try
+        {
+            var scope = await PostgresTestSchemaEnvironmentScope.CreateIfConfiguredAsync(
+                connectionVariable,
+                schemaVariable,
+                "missing_connection");
+
+            scope.Should().BeNull();
+            Environment.GetEnvironmentVariable(schemaVariable).Should().Be(originalSchema);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(connectionVariable, null);
+            Environment.SetEnvironmentVariable(schemaVariable, null);
+        }
+    }
+
+    [Fact]
+    public void NewSchemaName_LongValidPrefix_StaysWithinPostgresIdentifierLimit()
+    {
+        var schema = PostgresTestSchema.NewSchemaName("reporting_source_structure");
+
+        schema.Should().HaveLength(PostgresTestSchema.MaxIdentifierLength);
+        schema.Should().MatchRegex("^[a-z0-9_]+$");
+        schema.Should().StartWith("reporting_source_structur_test_");
+    }
+
+    [Fact]
+    public void NewSchemaName_RepeatedCalls_RemainUniqueAfterPrefixTruncation()
+    {
+        var first = PostgresTestSchema.NewSchemaName("reporting_source_structure");
+        var second = PostgresTestSchema.NewSchemaName("reporting_source_structure");
+
+        second.Should().NotBe(first);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("1ledger")]
+    [InlineData("unsafe-prefix")]
+    [InlineData("MixedCase")]
+    public void NewSchemaName_UnsafePrefix_IsRejected(string prefix)
+    {
+        var act = () => PostgresTestSchema.NewSchemaName(prefix);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    private static async Task<bool> SchemaExistsAsync(
+        string connectionString,
+        string schema)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = @schema);";
+        command.Parameters.AddWithValue("schema", schema);
+        return (bool)(await command.ExecuteScalarAsync())!;
+    }
+}

--- a/tests/Meridian.Tests/TestSupport/ProviderCatalogTestLease.cs
+++ b/tests/Meridian.Tests/TestSupport/ProviderCatalogTestLease.cs
@@ -1,0 +1,54 @@
+using Meridian.Contracts.Api;
+using Meridian.Infrastructure.Adapters.Core;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Tests.TestSupport;
+
+/// <summary>
+/// Owns the process-wide provider catalog callback pair installed by one test host.
+/// Arbitrary predecessor callbacks are never restored because they may close over a disposed host.
+/// </summary>
+internal sealed class ProviderCatalogTestLease : IDisposable
+{
+    private readonly Func<IReadOnlyList<ProviderCatalogEntry>> _catalogProvider;
+    private readonly Func<string, ProviderCatalogEntry?> _catalogEntryProvider;
+    private bool _disposed;
+
+    private ProviderCatalogTestLease(
+        Func<IReadOnlyList<ProviderCatalogEntry>> catalogProvider,
+        Func<string, ProviderCatalogEntry?> catalogEntryProvider)
+    {
+        _catalogProvider = catalogProvider;
+        _catalogEntryProvider = catalogEntryProvider;
+    }
+
+    public static ProviderCatalogTestLease Capture(IServiceProvider services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        // ProviderRegistry installs the callbacks from its singleton factory. Resolve it before
+        // host start so the exact pair owned by this host can be captured deterministically.
+        _ = services.GetRequiredService<ProviderRegistry>();
+        var catalogProvider = ProviderCatalog.RuntimeCatalogProvider
+            ?? throw new InvalidOperationException("ProviderRegistry did not install a catalog callback.");
+        var catalogEntryProvider = ProviderCatalog.RuntimeCatalogEntryProvider
+            ?? throw new InvalidOperationException("ProviderRegistry did not install a catalog-entry callback.");
+        return new ProviderCatalogTestLease(catalogProvider, catalogEntryProvider);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        if (ReferenceEquals(ProviderCatalog.RuntimeCatalogProvider, _catalogProvider) &&
+            ReferenceEquals(ProviderCatalog.RuntimeCatalogEntryProvider, _catalogEntryProvider))
+        {
+            ProviderCatalog.RuntimeCatalogProvider = null;
+            ProviderCatalog.RuntimeCatalogEntryProvider = null;
+        }
+    }
+}

--- a/tests/Meridian.Tests/Ui/DemoTenantProvisionerTests.cs
+++ b/tests/Meridian.Tests/Ui/DemoTenantProvisionerTests.cs
@@ -26,10 +26,15 @@ public sealed class DemoTenantProvisionerTests
         report.StrategyRunLoaded.Should().BeTrue();
         report.Warnings.Should().BeEmpty();
 
-        var seededBreaks = await breaks.GetAllAsync();
+        var seededBreaks = await breaks.GetAllAsync(new Meridian.Contracts.Workstation.ReconciliationBreakQueueScope(
+            DemoTenantBlueprint.TenantId,
+            DemoTenantBlueprint.CompanyId));
         seededBreaks.Should().HaveCount(DemoTenantBlueprint.BreakDefinitions.Count);
         seededBreaks.Select(item => item.BreakId).Should().BeEquivalentTo(
             DemoTenantBlueprint.BreakDefinitions.Select(definition => definition.Id));
+        seededBreaks.Should().OnlyContain(item =>
+            item.TenantId == DemoTenantBlueprint.TenantId &&
+            item.CompanyId == DemoTenantBlueprint.CompanyId);
 
         var run = await strategyStore.GetRunByIdAsync(DemoTenantBlueprint.StrategyRunId);
         run.Should().NotBeNull();

--- a/tests/Meridian.Tests/Ui/ReportingDeploymentReadinessPostgresIntegrationTests.cs
+++ b/tests/Meridian.Tests/Ui/ReportingDeploymentReadinessPostgresIntegrationTests.cs
@@ -4,12 +4,14 @@ using System.Text.Json;
 using FluentAssertions;
 using Meridian.Application.Composition;
 using Meridian.Application.FundStructure;
+using Meridian.Application.SecurityMaster;
 using Meridian.Contracts.FundStructure;
 using Meridian.Contracts.Ledger;
 using Meridian.Contracts.Services;
 using Meridian.Contracts.Tenancy;
 using Meridian.Contracts.Workstation;
 using Meridian.Entities.FundStructure;
+using Meridian.FinancialOperations.Reconciliation;
 using Meridian.Identity.Auth;
 using Meridian.Ledger;
 using Meridian.PortfolioRecords.FundAccounts;
@@ -21,7 +23,6 @@ using Meridian.Storage.Ledger;
 using Meridian.Storage.Reporting;
 using Meridian.TestSupport;
 using Meridian.Tests.Application.Composition;
-using Meridian.Tests.Storage.FundAccounts;
 using Meridian.Tests.Storage.Reporting;
 using Meridian.Ui.Shared.Endpoints;
 using Meridian.Ui.Shared.Services;
@@ -44,7 +45,7 @@ public sealed class ReportingDeploymentReadinessPostgresIntegrationTests
         await using var database =
             await PostgresTestServer.CreateAsync("MERIDIAN_REPORTING_CONNECTION_STRING");
 
-        var reportingSchema = PostgresTestSchema.NewSchemaName("reporting_readiness");
+        var reportingSchema = database.CreateSchemaName("reporting_readiness");
         var reportingOptions = new ReportingArtifactStoreOptions
         {
             ConnectionString = database.ConnectionString,
@@ -53,19 +54,19 @@ public sealed class ReportingDeploymentReadinessPostgresIntegrationTests
         var ledgerOptions = new LedgerJournalStoreOptions
         {
             ConnectionString = database.ConnectionString,
-            SchemaName = PostgresTestSchema.NewSchemaName("reporting_source_ledger"),
+            SchemaName = database.CreateSchemaName("reporting_source_ledger"),
             RequireGovernedPostingCommand = true,
             RequireExpectedVersion = true
         };
         var fundAccountOptions = new FundAccountStoreOptions
         {
             ConnectionString = database.ConnectionString,
-            Schema = PostgresTestSchema.NewSchemaName("reporting_source_accounts")
+            Schema = database.CreateSchemaName("reporting_source_accounts")
         };
         var fundStructureOptions = new FundStructureStoreOptions
         {
             ConnectionString = database.ConnectionString,
-            Schema = PostgresTestSchema.NewSchemaName("reporting_source_structure")
+            Schema = database.CreateSchemaName("reporting_source_structure")
         };
 
         using var environment = new EnvironmentVariableScope("ASPNETCORE_ENVIRONMENT", "Production");
@@ -130,6 +131,11 @@ public sealed class ReportingDeploymentReadinessPostgresIntegrationTests
             builder.Services.DeclareMeridianDeploymentPosture(
                 MeridianDeploymentPosture.ProductionApi);
             builder.Services.AddSingleton(new Meridian.Application.UI.ConfigStore(configPath));
+            builder.Services.AddSingleton<StorageOptions>(new StorageOptions { RootPath = dataRoot });
+            builder.Services.AddStatementReconciliationServices(dataRoot);
+            builder.Services.AddSingleton<NullSecurityMasterQueryService>();
+            builder.Services.AddSingleton<Meridian.Contracts.SecurityMaster.ISecurityMasterQueryService>(sp =>
+                sp.GetRequiredService<NullSecurityMasterQueryService>());
             RegisterPostgresLedgerPresentationSources(
                 builder.Services,
                 ledgerOptions,
@@ -268,21 +274,6 @@ public sealed class ReportingDeploymentReadinessPostgresIntegrationTests
         }
         finally
         {
-            if (database.UsesExternalConnection)
-            {
-                await new ReportingMigrationRunner(reportingOptions)
-                    .ResetSchemaAsync();
-                await FundAccountDatabaseFixture.DropSchemaAsync(
-                    database.ConnectionString,
-                    ledgerOptions.SchemaName);
-                await FundAccountDatabaseFixture.DropSchemaAsync(
-                    database.ConnectionString,
-                    fundAccountOptions.Schema);
-                await FundAccountDatabaseFixture.DropSchemaAsync(
-                    database.ConnectionString,
-                    fundStructureOptions.Schema);
-            }
-
             Directory.Delete(root, recursive: true);
         }
     }

--- a/tests/Meridian.Tests/Ui/ReportingDeploymentReadinessPostgresIntegrationTests.cs
+++ b/tests/Meridian.Tests/Ui/ReportingDeploymentReadinessPostgresIntegrationTests.cs
@@ -218,6 +218,10 @@ public sealed class ReportingDeploymentReadinessPostgresIntegrationTests
             beforeWorkerStart.Components
                 .Single(static component => component.ComponentId == "release-consistency")
                 .IsReady.Should().BeTrue();
+            app.Services.GetRequiredService<IReportingDeploymentReadinessService>()
+                .GetScheduleWorkerCycleBlockingReasons()
+                .Should().ContainSingle(reason =>
+                    reason.Contains("secure distribution worker", StringComparison.Ordinal));
 
             app.Use(async (context, next) =>
             {
@@ -233,6 +237,9 @@ public sealed class ReportingDeploymentReadinessPostgresIntegrationTests
             app.MapWorkstationEndpoints(
                 new JsonSerializerOptions(JsonSerializerDefaults.Web));
             await app.StartAsync();
+            await WaitUntilAsync(
+                () => app.Services.GetRequiredService<ReportingScheduleWorkerReadinessState>().IsReady
+                      && app.Services.GetRequiredService<ReportingDeliveryWorkerReadinessState>().IsReady);
 
             var capability = app.Services
                 .GetRequiredService<IReportingDeploymentReadinessService>()
@@ -275,6 +282,17 @@ public sealed class ReportingDeploymentReadinessPostgresIntegrationTests
         finally
         {
             Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> predicate)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        while (!predicate())
+        {
+            // BackgroundService.StartAsync returns after dispatching ExecuteAsync; the readiness
+            // receipt is the production observable for completion of each first worker cycle.
+            await Task.Delay(TimeSpan.FromMilliseconds(10), timeout.Token);
         }
     }
 

--- a/tests/Meridian.Tests/Ui/ReportingDeploymentReadinessServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/ReportingDeploymentReadinessServiceTests.cs
@@ -656,6 +656,112 @@ public sealed class ReportingDeploymentReadinessServiceTests
     }
 
     [Fact]
+    public async Task ScheduleWorkerCycleBlockers_InitialDeliveryBootstrapExemptsOnlyPeerLiveness()
+    {
+        var deliveryReadiness = new ReportingDeliveryWorkerReadinessState();
+        var capability = WorkerBootstrapCapability(deliveryReady: false);
+        var firstCycle = new TaskCompletionSource<ReportingScheduledHandoffBridgeResult>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var scheduleService = new ReportingScheduleService(
+            Substitute.For<IReportingOrchestrationService>(),
+            (Meridian.Reporting.IReportingScheduleStore?)null);
+        using var worker = new ReportingSecureDistributionHostedService(
+            scheduleService,
+            static (_, _, _) => Task.FromResult("unused-job"),
+            NullLogger<ReportingSecureDistributionHostedService>.Instance,
+            readiness: deliveryReadiness,
+            enqueueReleasedHandoffsAsync: _ => firstCycle.Task);
+
+        deliveryReadiness.IsInitialStartInProgress.Should().BeFalse();
+        ReportingDeploymentReadinessService
+            .ResolveScheduleWorkerCycleBlockingReasons(capability)
+            .Should().ContainSingle()
+            .Which.Should().Be(DeliveryWorkerBlockedSummary);
+
+        using var startup = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await worker.StartAsync(startup.Token);
+        try
+        {
+            deliveryReadiness.IsInitialStartInProgress.Should().BeTrue(
+                "StartAsync must expose the bootstrap window before the scheduler starts");
+            ReportingDeploymentReadinessService
+                .ResolveScheduleWorkerCycleBlockingReasons(
+                    capability,
+                    allowDeliveryWorkerInitialBootstrap:
+                        deliveryReadiness.IsInitialStartInProgress)
+                .Should().BeEmpty();
+        }
+        finally
+        {
+            firstCycle.TrySetResult(new ReportingScheduledHandoffBridgeResult(
+                Attempted: 0,
+                Enqueued: 0,
+                AwaitingRelease: 0,
+                Failed: 0,
+                NextCursor: null));
+            using var shutdown = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await worker.StopAsync(shutdown.Token);
+        }
+
+        deliveryReadiness.IsInitialStartInProgress.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ScheduleWorkerCycleBlockers_StaleOrFailedDeliveryAfterStartRemainsBlocked()
+    {
+        var completedAt = new DateTimeOffset(2026, 8, 4, 10, 0, 0, TimeSpan.Zero);
+        var staleReadiness = new ReportingDeliveryWorkerReadinessState();
+        staleReadiness.MarkStarting();
+        staleReadiness.MarkReady(completedAt);
+        var staleCapability = WorkerBootstrapCapability(
+            deliveryReady: staleReadiness.IsHealthy(
+                completedAt.AddMinutes(4),
+                TimeSpan.FromMinutes(3)));
+
+        staleReadiness.IsInitialStartInProgress.Should().BeFalse();
+        ReportingDeploymentReadinessService
+            .ResolveScheduleWorkerCycleBlockingReasons(
+                staleCapability,
+                allowDeliveryWorkerInitialBootstrap:
+                    staleReadiness.IsInitialStartInProgress)
+            .Should().ContainSingle()
+            .Which.Should().Be(DeliveryWorkerBlockedSummary);
+
+        var failedReadiness = new ReportingDeliveryWorkerReadinessState();
+        failedReadiness.MarkStarting();
+        failedReadiness.MarkCycleFailed();
+        failedReadiness.MarkStarting();
+
+        failedReadiness.IsInitialStartInProgress.Should().BeFalse(
+            "a worker restart must not recreate its one-time bootstrap exemption");
+        ReportingDeploymentReadinessService
+            .ResolveScheduleWorkerCycleBlockingReasons(
+                WorkerBootstrapCapability(deliveryReady: false),
+                allowDeliveryWorkerInitialBootstrap:
+                    failedReadiness.IsInitialStartInProgress)
+            .Should().ContainSingle()
+            .Which.Should().Be(DeliveryWorkerBlockedSummary);
+    }
+
+    [Fact]
+    public void ScheduleWorkerCycleBlockers_MissingDeliveryComponentFailsClosed()
+    {
+        var deliveryReadiness = new ReportingDeliveryWorkerReadinessState();
+        deliveryReadiness.MarkStarting();
+
+        ReportingDeploymentReadinessService
+            .ResolveScheduleWorkerCycleBlockingReasons(
+                WorkerBootstrapCapability(
+                    deliveryReady: false,
+                    includeDeliveryComponent: false),
+                allowDeliveryWorkerInitialBootstrap:
+                    deliveryReadiness.IsInitialStartInProgress)
+            .Should().ContainSingle()
+            .Which.Should().Be(
+                "Reporting deployment readiness omitted the delivery-worker component.");
+    }
+
+    [Fact]
     public void ScheduleWorkerCycleBlockers_PreserveUnrepresentedAndInconsistentFailures()
     {
         var schedulingSummary =
@@ -682,7 +788,12 @@ public sealed class ReportingDeploymentReadinessServiceTests
                     "governance",
                     "Governance",
                     IsReady: false,
-                    "Governance component is not ready.")
+                    "Governance component is not ready."),
+                new ReportingDeploymentComponentDto(
+                    "delivery-worker",
+                    "Delivery worker",
+                    IsReady: true,
+                    "The secure distribution worker is ready.")
             ],
             BlockingReasons:
             [
@@ -1019,6 +1130,55 @@ public sealed class ReportingDeploymentReadinessServiceTests
                 .StatementReconciliationAuthorityCompatibilityMarker
         ]
     };
+
+    private const string SchedulingWorkerBlockedSummary =
+        "The server-owned reporting schedule worker is missing, stopped, stale, failed its latest cycle, or has invalid configuration.";
+
+    private const string DeliveryWorkerBlockedSummary =
+        "The server-owned secure distribution worker is missing, stopped, stale, failed its latest cycle, or has invalid configuration.";
+
+    private static ReportingDeploymentCapabilityDto WorkerBootstrapCapability(
+        bool deliveryReady,
+        bool includeDeliveryComponent = true)
+    {
+        var components = new List<ReportingDeploymentComponentDto>
+        {
+            new(
+                "scheduling-worker",
+                "Scheduling worker",
+                IsReady: false,
+                SchedulingWorkerBlockedSummary)
+        };
+        var blockers = new List<string> { SchedulingWorkerBlockedSummary };
+        if (includeDeliveryComponent)
+        {
+            components.Add(new ReportingDeploymentComponentDto(
+                "delivery-worker",
+                "Delivery worker",
+                deliveryReady,
+                deliveryReady
+                    ? "The secure distribution worker is ready."
+                    : DeliveryWorkerBlockedSummary));
+            if (!deliveryReady)
+            {
+                blockers.Add(DeliveryWorkerBlockedSummary);
+            }
+        }
+
+        return new ReportingDeploymentCapabilityDto(
+            IsReady: false,
+            DurableGovernance: true,
+            DurableArtifacts: true,
+            DurableReconciliationEvidence: true,
+            DurableRuns: true,
+            DurableScheduling: true,
+            DurableDelivery: true,
+            RecipientDestinationsConfigured: true,
+            ClientDocumentsConfigured: true,
+            MigrationsManaged: true,
+            Components: components,
+            BlockingReasons: blockers);
+    }
 
     private static StatementReconciliationReportWorkflowService CreateDurableStatementWorkflow(
         IStatementReconciliationReportAuthorityStore authority,

--- a/tests/Meridian.Tests/Ui/ReportingDeploymentReadinessServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/ReportingDeploymentReadinessServiceTests.cs
@@ -707,6 +707,49 @@ public sealed class ReportingDeploymentReadinessServiceTests
     }
 
     [Fact]
+    public async Task DeliveryWorker_CanceledInitialStart_ClearsBootstrapExemptionOnStop()
+    {
+        var deliveryReadiness = new ReportingDeliveryWorkerReadinessState();
+        var cycleInvocationCount = 0;
+        var scheduleService = new ReportingScheduleService(
+            Substitute.For<IReportingOrchestrationService>(),
+            (Meridian.Reporting.IReportingScheduleStore?)null);
+        using var worker = new ReportingSecureDistributionHostedService(
+            scheduleService,
+            static (_, _, _) => Task.FromResult("unused-job"),
+            NullLogger<ReportingSecureDistributionHostedService>.Instance,
+            readiness: deliveryReadiness,
+            enqueueReleasedHandoffsAsync: _ =>
+            {
+                Interlocked.Increment(ref cycleInvocationCount);
+                return Task.FromResult(new ReportingScheduledHandoffBridgeResult(
+                    Attempted: 0,
+                    Enqueued: 0,
+                    AwaitingRelease: 0,
+                    Failed: 0,
+                    NextCursor: null));
+            });
+        using var canceledStart = new CancellationTokenSource();
+        canceledStart.Cancel();
+
+        await worker.StartAsync(canceledStart.Token);
+        Volatile.Read(ref cycleInvocationCount).Should().Be(0);
+        deliveryReadiness.IsInitialStartInProgress.Should().BeTrue();
+
+        await worker.StopAsync(CancellationToken.None);
+
+        deliveryReadiness.IsInitialStartInProgress.Should().BeFalse();
+        deliveryReadiness.IsReady.Should().BeFalse();
+        ReportingDeploymentReadinessService
+            .ResolveScheduleWorkerCycleBlockingReasons(
+                WorkerBootstrapCapability(deliveryReady: false),
+                allowDeliveryWorkerInitialBootstrap:
+                    deliveryReadiness.IsInitialStartInProgress)
+            .Should().ContainSingle()
+            .Which.Should().Be(DeliveryWorkerBlockedSummary);
+    }
+
+    [Fact]
     public void ScheduleWorkerCycleBlockers_StaleOrFailedDeliveryAfterStartRemainsBlocked()
     {
         var completedAt = new DateTimeOffset(2026, 8, 4, 10, 0, 0, TimeSpan.Zero);

--- a/tests/Meridian.Tests/Ui/WorkstationServiceCollectionExtensionsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationServiceCollectionExtensionsTests.cs
@@ -5,6 +5,7 @@ using Meridian.Contracts.FundStructure;
 using Meridian.Contracts.Services;
 using Meridian.Contracts.Tenancy;
 using Meridian.Contracts.Workstation;
+using Meridian.DataIntegration.Credentials;
 using Meridian.Execution.Services;
 using Meridian.FinancialOperations.PrivateCapital;
 using Meridian.Identity;
@@ -15,6 +16,7 @@ using Meridian.Storage.AssetOperations;
 using Meridian.Storage.Ledger;
 using Meridian.Storage.Reporting;
 using Meridian.Ui.Shared.Services;
+using Meridian.Ui.Shared.Endpoints;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -30,6 +32,44 @@ namespace Meridian.Tests.Ui;
 [Collection("Sequential")]
 public sealed class WorkstationServiceCollectionExtensionsTests
 {
+    [Fact]
+    public void AddUiSharedServices_DefaultProviderCatalog_ResolvesEveryProviderAndAliasExactlyOnce()
+    {
+        using var quietProductionEnvironment =
+            new Meridian.Tests.Application.Composition.ProductionEnvironmentQuietScope();
+        using var environment = new Meridian.Tests.Application.Composition.EnvironmentVariableScope(
+            "ASPNETCORE_ENVIRONMENT",
+            "Test");
+        using var inMemoryGovernance = new Meridian.Tests.Application.Composition.EnvironmentVariableScope(
+            "MERIDIAN_USE_INMEMORY_GOVERNANCE",
+            "true");
+        var expectedHandlers = DefaultProviderSetupHandlers.Create();
+        var services = CreateMinimalWorkstationServices();
+
+        services.AddUiSharedServices();
+
+        using var provider = services.BuildServiceProvider();
+        var registry = provider.GetRequiredService<IProviderSetupRegistry>();
+        registry.Handlers
+            .Select(static handler => handler.Descriptor.ProviderId)
+            .Should()
+            .Equal(expectedHandlers.Select(static handler => handler.Descriptor.ProviderId));
+
+        foreach (var expectedHandler in expectedHandlers)
+        {
+            var expectedProviderId = expectedHandler.Descriptor.ProviderId;
+            var supportedLookups = expectedHandler.Descriptor.Aliases
+                .Prepend(expectedProviderId);
+
+            foreach (var lookup in supportedLookups)
+            {
+                registry.Find(lookup)?.Descriptor.ProviderId
+                    .Should()
+                    .Be(expectedProviderId, $"'{lookup}' must resolve to its advertised provider setup handler");
+            }
+        }
+    }
+
     [Fact]
     public void ReportingAuthoritativeSource_NonPostgresDependencies_ShouldNotClaimDurableConfiguration()
     {

--- a/tests/coverlet.runsettings
+++ b/tests/coverlet.runsettings
@@ -4,7 +4,7 @@
     <DataCollectors>
       <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
-          <Format>cobertura,opencover</Format>
+          <Format>cobertura</Format>
           <ExcludeByFile>**/Migrations/**/*.cs,**/*.Designer.cs</ExcludeByFile>
           <Include>[Meridian]*,[Meridian.FSharp]*,[Meridian.Contracts]*</Include>
           <Exclude>[*Tests]*,[*Benchmarks]*</Exclude>

--- a/tests/scripts/test_production_certification_workflow.py
+++ b/tests/scripts/test_production_certification_workflow.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "production-certification.yml"
+COVERLET_SETTINGS_PATH = REPO_ROOT / "tests" / "coverlet.runsettings"
 LIVE_PROVIDER_TESTS = (
     REPO_ROOT / "tests" / "Meridian.Tests" / "Integration" / "YahooFinancePcgPreferredIntegrationTests.cs",
     REPO_ROOT / "tests" / "Meridian.Tests" / "Integration" / "ConfigurableTickerDataCollectionTests.cs",
@@ -14,6 +15,7 @@ class ProductionCertificationWorkflowTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        cls.coverlet_settings = COVERLET_SETTINGS_PATH.read_text(encoding="utf-8")
 
     def test_runs_on_release_tags_schedule_and_manual_dispatch(self) -> None:
         self.assertIn("workflow_dispatch:", self.workflow)
@@ -28,6 +30,13 @@ class ProductionCertificationWorkflowTests(unittest.TestCase):
         self.assertIn("--settings tests/coverlet.runsettings", self.workflow)
         self.assertIn('"Category=Integration&Category!=LiveProvider"', self.workflow)
         self.assertIn('"Category=Integration"', self.workflow)
+
+        # Coverlet 10 rejects DeterministicReport with its OpenCover reporter.
+        # Cobertura is the repository's consumed coverage format, so keep the
+        # certification collector deterministic and limited to that reporter.
+        self.assertIn("<Format>cobertura</Format>", self.coverlet_settings)
+        self.assertNotIn("opencover", self.coverlet_settings.casefold())
+        self.assertIn("<DeterministicReport>true</DeterministicReport>", self.coverlet_settings)
 
     def test_live_provider_tests_are_explicitly_owned_by_the_exclusion_category(self) -> None:
         for test_path in LIVE_PROVIDER_TESTS:


### PR DESCRIPTION
## Summary  - give every PostgreSQL-backed test class private schema ownership and deterministic `DROP SCHEMA ... CASCADE` cleanup - isolate destructive reporting, demo, and pilot host lifecycles while restoring process-wide environment and provider-catalog state exactly - replace collection reference-equality assertions with structural assertions - burn down genuine endpoint, provider registration, Security Master provider authority, reporting governance/readiness, fund-structure migration, operations-continuity, storage, and authorization failures exposed after isolation - refresh owning source documentation and generated source/TODO artifacts  ## Validation  - `C:\Program Files\Git\bin\bash.exe scripts/ci.sh` — passed on final implementation commit `ee8183e2b` (all maintained .NET/browser/docs/workflow lanes; 577 repository script tests) - endpoint namespace — 569 passed, 0 failed, 0 skipped - F# suite — 436 passed, 0 failed - harness lifecycle/composition regressions — 21 passed, 0 failed - reporting readiness/provider authority regressions — 94 passed, 0 failed - local certification filter (`Category=Integration&Category!=LiveProvider`) — 601 passed, 0 failed, 180 skipped because this workstation has no Docker/configured PostgreSQL - local Direct Lending integration slice — 0 failed, 7 skipped for the same local PostgreSQL limitation - coverlet smoke — 1 passed and emitted Cobertura output without the deterministic OpenCover-format failure  ## Hosted burn-down evidence  Production Certification run [#10](https://github.com/rodoHasArrived/Meridian-main/actions/runs/30947807924) on the initial isolation commit improved the deterministic PostgreSQL lane from **541 failed / 218 passed / 759 total** to **29 failed / 752 passed / 781 total**, with **zero skips**. Those 29 genuine failures were then repaired on this branch:  - 14 reporting-governance immutable collection serialization failures - 11 Fund Structure endpoint migration failures - Security Master provider-bound lookup fallback - Operations Continuity ledger/security fixture state - reporting delivery/schedule worker startup ordering and fail-closed readiness - hard-close fixture state mutation  The final authoritative Production Certification workflow is being dispatched for `ee8183e2b`. Its PostgreSQL 17 lanes reject both failures and skips; final artifact counts will be added after completion.  ## Remediation order  This implements the documented order: class/schema isolation, destructive-test isolation, assertion correction, then genuine failure burn-down.

<!-- phase:PR7 -->