### PR TITLE
Improve browser workstation usability and accessibility

### DIFF
--- a/docs/source/generated/source-hash-manifest.json
+++ b/docs/source/generated/source-hash-manifest.json
@@ -268,8 +268,8 @@
       "id": "SRC-UI-DASHBOARD",
       "path": "src/Meridian.Ui/dashboard",
       "readme": "src/Meridian.Ui/dashboard/README.md",
-      "readme_hash": "3dc6f66b4ea47cce2e67d364ad8ce3f1efcc1099425bde59b5fa2345820d8862",
-      "source_hash": "28568e1c3568018122b8ade78be43599747d7791da466c4023f15fe848a91d6b"
+      "readme_hash": "bd79b6e1e3665022036bee1c22de4dc390b4fbb8b015ea6d06dd47f8a63f77cc",
+      "source_hash": "2d7d59ef8d7cf6ff1395d3a7644b70d96bae0ac279528d71a31a7e4ad7640d90"
     },
     {
       "id": "SRC-UI-SERVICES",

--- a/docs/source/generated/stale-docs.json
+++ b/docs/source/generated/stale-docs.json
@@ -11,7 +11,7 @@
     "version": "1.0.0"
   },
   "source_hash_manifest": "docs/source/generated/source-hash-manifest.json",
-  "stale_count": 25,
+  "stale_count": 24,
   "stale_modules": [
     {
       "module_id": "SRC-BACKTESTING",
@@ -24,18 +24,6 @@
       "recommended_actions": [
         "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
         "review README changes and rerender generated blocks if needed",
-        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
-      ]
-    },
-    {
-      "module_id": "SRC-BACKTESTING-SDK",
-      "path": "src/Meridian.Backtesting.Sdk",
-      "readme": "src/Meridian.Backtesting.Sdk/README.md",
-      "reasons": [
-        "source_hash_drift"
-      ],
-      "recommended_actions": [
-        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
         "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
       ]
     },
@@ -106,6 +94,18 @@
       ]
     },
     {
+      "module_id": "SRC-DESIGN-REPORTING",
+      "path": "src/Meridian.Reporting",
+      "readme": "src/Meridian.Reporting/README.md",
+      "reasons": [
+        "source_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
+      ]
+    },
+    {
       "module_id": "SRC-DOMAIN",
       "path": "src/Meridian.Domain",
       "readme": "src/Meridian.Domain/README.md",
@@ -146,33 +146,9 @@
       ]
     },
     {
-      "module_id": "SRC-FSHARP-DIRECTLENDING",
-      "path": "src/Meridian.FSharp.DirectLending.Aggregates",
-      "readme": "src/Meridian.FSharp.DirectLending.Aggregates/README.md",
-      "reasons": [
-        "source_hash_drift"
-      ],
-      "recommended_actions": [
-        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
-        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
-      ]
-    },
-    {
-      "module_id": "SRC-FSHARP-LEDGER",
-      "path": "src/Meridian.FSharp.Ledger",
-      "readme": "src/Meridian.FSharp.Ledger/README.md",
-      "reasons": [
-        "source_hash_drift"
-      ],
-      "recommended_actions": [
-        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
-        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
-      ]
-    },
-    {
-      "module_id": "SRC-FSHARP-TRADING",
-      "path": "src/Meridian.FSharp.Trading",
-      "readme": "src/Meridian.FSharp.Trading/README.md",
+      "module_id": "SRC-FSHARP",
+      "path": "src/Meridian.FSharp",
+      "readme": "src/Meridian.FSharp/README.md",
       "reasons": [
         "source_hash_drift"
       ],
@@ -246,6 +222,18 @@
       ]
     },
     {
+      "module_id": "SRC-PROVIDER-SDK",
+      "path": "src/Meridian.ProviderSdk",
+      "readme": "src/Meridian.ProviderSdk/README.md",
+      "reasons": [
+        "source_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
+      ]
+    },
+    {
       "module_id": "SRC-RISK",
       "path": "src/Meridian.Risk",
       "readme": "src/Meridian.Risk/README.md",
@@ -300,9 +288,9 @@
       ]
     },
     {
-      "module_id": "SRC-UI-DASHBOARD",
-      "path": "src/Meridian.Ui/dashboard",
-      "readme": "src/Meridian.Ui/dashboard/README.md",
+      "module_id": "SRC-UI-SERVICES",
+      "path": "src/Meridian.Ui.Services",
+      "readme": "src/Meridian.Ui.Services/README.md",
       "reasons": [
         "source_hash_drift",
         "readme_hash_drift"
@@ -314,16 +302,14 @@
       ]
     },
     {
-      "module_id": "SRC-UI-SERVICES",
-      "path": "src/Meridian.Ui.Services",
-      "readme": "src/Meridian.Ui.Services/README.md",
+      "module_id": "SRC-UI-SHARED",
+      "path": "src/Meridian.Ui.Shared",
+      "readme": "src/Meridian.Ui.Shared/README.md",
       "reasons": [
-        "source_hash_drift",
-        "readme_hash_drift"
+        "source_hash_drift"
       ],
       "recommended_actions": [
         "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
-        "review README changes and rerender generated blocks if needed",
         "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
       ]
     },

--- a/docs/source/generated/stale-docs.md
+++ b/docs/source/generated/stale-docs.md
@@ -8,33 +8,32 @@ do_not_edit: true
 
 This report marks registered source modules whose code or README hashes differ from the reviewed baseline.
 
-- Stale modules: 25
+- Stale modules: 24
 - Removed module hash entries: 0
 
 | Module | Path | README | Reason |
 | --- | --- | --- | --- |
 | `SRC-BACKTESTING` | `src/Meridian.Backtesting` | `src/Meridian.Backtesting/README.md` | `source_hash_drift`, `readme_hash_drift` |
-| `SRC-BACKTESTING-SDK` | `src/Meridian.Backtesting.Sdk` | `src/Meridian.Backtesting.Sdk/README.md` | `source_hash_drift` |
 | `SRC-CONTRACTS` | `src/Meridian.Contracts` | `src/Meridian.Contracts/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-DESIGN-DOCUMENTS` | `src/Meridian.Documents` | `src/Meridian.Documents/README.md` | `readme_hash_drift` |
 | `SRC-DESIGN-FINANCIAL-OPERATIONS` | `src/Meridian.FinancialOperations` | `src/Meridian.FinancialOperations/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-DESIGN-IDENTITY` | `src/Meridian.Identity` | `src/Meridian.Identity/README.md` | `source_hash_drift` |
 | `SRC-DESIGN-PLATFORM` | `src/Meridian.Platform` | `src/Meridian.Platform/README.md` | `source_hash_drift`, `readme_hash_drift` |
+| `SRC-DESIGN-REPORTING` | `src/Meridian.Reporting` | `src/Meridian.Reporting/README.md` | `source_hash_drift` |
 | `SRC-DOMAIN` | `src/Meridian.Domain` | `src/Meridian.Domain/README.md` | `source_hash_drift` |
 | `SRC-EXECUTION` | `src/Meridian.Execution` | `src/Meridian.Execution/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-EXECUTION-SDK` | `src/Meridian.Execution.Sdk` | `src/Meridian.Execution.Sdk/README.md` | `source_hash_drift`, `readme_hash_drift` |
-| `SRC-FSHARP-DIRECTLENDING` | `src/Meridian.FSharp.DirectLending.Aggregates` | `src/Meridian.FSharp.DirectLending.Aggregates/README.md` | `source_hash_drift` |
-| `SRC-FSHARP-LEDGER` | `src/Meridian.FSharp.Ledger` | `src/Meridian.FSharp.Ledger/README.md` | `source_hash_drift` |
-| `SRC-FSHARP-TRADING` | `src/Meridian.FSharp.Trading` | `src/Meridian.FSharp.Trading/README.md` | `source_hash_drift` |
+| `SRC-FSHARP` | `src/Meridian.FSharp` | `src/Meridian.FSharp/README.md` | `source_hash_drift` |
 | `SRC-HOST` | `src/Meridian` | `src/Meridian/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-IBAPI-SMOKESTUB` | `src/Meridian.IbApi.SmokeStub` | `src/Meridian.IbApi.SmokeStub/README.md` | `source_hash_drift` |
 | `SRC-INFRASTRUCTURE` | `src/Meridian.Infrastructure` | `src/Meridian.Infrastructure/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-LEDGER` | `src/Meridian.Ledger` | `src/Meridian.Ledger/README.md` | `source_hash_drift` |
 | `SRC-LIFECYCLE-SUPERVISOR` | `src/Meridian.LifecycleSupervisor` | `src/Meridian.LifecycleSupervisor/README.md` | `source_hash_drift` |
+| `SRC-PROVIDER-SDK` | `src/Meridian.ProviderSdk` | `src/Meridian.ProviderSdk/README.md` | `source_hash_drift` |
 | `SRC-RISK` | `src/Meridian.Risk` | `src/Meridian.Risk/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-STORAGE` | `src/Meridian.Storage` | `src/Meridian.Storage/README.md` | `source_hash_drift` |
 | `SRC-STRATEGIES` | `src/Meridian.Strategies` | `src/Meridian.Strategies/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-UI` | `src/Meridian.Ui` | `src/Meridian.Ui/README.md` | `source_hash_drift`, `readme_hash_drift` |
-| `SRC-UI-DASHBOARD` | `src/Meridian.Ui/dashboard` | `src/Meridian.Ui/dashboard/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-UI-SERVICES` | `src/Meridian.Ui.Services` | `src/Meridian.Ui.Services/README.md` | `source_hash_drift`, `readme_hash_drift` |
+| `SRC-UI-SHARED` | `src/Meridian.Ui.Shared` | `src/Meridian.Ui.Shared/README.md` | `source_hash_drift` |
 | `SRC-WPF` | `src/Meridian.Wpf` | `src/Meridian.Wpf/README.md` | `source_hash_drift`, `readme_hash_drift` |

--- a/docs/status/TODO.md
+++ b/docs/status/TODO.md
@@ -63,14 +63,14 @@ Total items: **230**
 | `src/Meridian.Ui.Shared/Services/ReportPackRunReadService.cs` | 2097 | `NOTE` | ❌ | Note: NormalizeOptional(target.Note), |
 | `src/Meridian.Ui.Shared/Services/StatementReconciliationCaseworkHandoffService.cs` | 138 | `NOTE` | ❌ | Note: request.Note, |
 | `src/Meridian.Ui.Shared/Services/StatementReconciliationCaseworkHandoffService.cs` | 297 | `NOTE` | ❌ | Note: "Clear the durable statement casework evidence-handoff obligation.", |
-| `src/Meridian.Ui/dashboard/src/app-shell.view-model.test.ts` | 376 | `NOTE` | ❌ | note: "Heartbeat delayed" |
-| `src/Meridian.Ui/dashboard/src/app-shell.view-model.test.ts` | 444 | `NOTE` | ❌ | note: "Credential verification failed." |
-| `src/Meridian.Ui/dashboard/src/app-shell.view-model.test.ts` | 841 | `NOTE` | ❌ | note: "Streaming quote path is healthy." |
-| `src/Meridian.Ui/dashboard/src/app-shell.view-model.test.ts` | 916 | `NOTE` | ❌ | note: "Streaming quote path is healthy." |
-| `src/Meridian.Ui/dashboard/src/app-shell.view-model.test.ts` | 1371 | `NOTE` | ❌ | note: "Paper endpoint returned intermittent quote gaps.", |
+| `src/Meridian.Ui/dashboard/src/app-shell.view-model.test.ts` | 387 | `NOTE` | ❌ | note: "Heartbeat delayed" |
+| `src/Meridian.Ui/dashboard/src/app-shell.view-model.test.ts` | 455 | `NOTE` | ❌ | note: "Credential verification failed." |
+| `src/Meridian.Ui/dashboard/src/app-shell.view-model.test.ts` | 852 | `NOTE` | ❌ | note: "Streaming quote path is healthy." |
+| `src/Meridian.Ui/dashboard/src/app-shell.view-model.test.ts` | 927 | `NOTE` | ❌ | note: "Streaming quote path is healthy." |
+| `src/Meridian.Ui/dashboard/src/app-shell.view-model.test.ts` | 1382 | `NOTE` | ❌ | note: "Paper endpoint returned intermittent quote gaps.", |
 | `src/Meridian.Ui/dashboard/src/app.test.tsx` | 223 | `NOTE` | ❌ | note: "Paper endpoint returned intermittent quote gaps.", |
-| `src/Meridian.Ui/dashboard/src/app.test.tsx` | 435 | `NOTE` | ❌ | note: "Credential check failed" |
-| `src/Meridian.Ui/dashboard/src/app.test.tsx` | 696 | `NOTE` | ❌ | note: "Paper endpoint returned intermittent quote gaps.", |
+| `src/Meridian.Ui/dashboard/src/app.test.tsx` | 437 | `NOTE` | ❌ | note: "Credential check failed" |
+| `src/Meridian.Ui/dashboard/src/app.test.tsx` | 698 | `NOTE` | ❌ | note: "Paper endpoint returned intermittent quote gaps.", |
 | `src/Meridian.Ui/dashboard/src/components/data/skeleton.tsx` | 5 | `NOTE` | ❌ | // NOTE: a second, Tailwind-based Skeleton family lives in `components/ui/skeleton.tsx` |
 | `src/Meridian.Ui/dashboard/src/components/meridian/security-details-tracker.test.tsx` | 23 | `NOTE` | ❌ | note: "Opening sleeve" |
 | `src/Meridian.Ui/dashboard/src/components/meridian/security-details-tracker.test.tsx` | 151 | `NOTE` | ❌ | note: "operator note" |

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,12 +1,12 @@
 {
-  "total_files": 640,
-  "total_lines": 118397,
+  "total_files": 641,
+  "total_lines": 120322,
   "orphaned_count": 255,
   "no_heading_count": 148,
   "stale_count": 0,
-  "todo_count": 220,
-  "average_lines": 185.0,
-  "health_score": 79,
+  "todo_count": 222,
+  "average_lines": 187.7,
+  "health_score": 80,
   "orphaned_files": [
     ".agents/skills/meridian-archive-organizer/SKILL.md",
     ".agents/skills/meridian-blueprint/SKILL.md",
@@ -2578,7 +2578,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 9676,
+      "line_count": 9702,
       "has_heading": true,
       "todo_count": 8,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -3546,7 +3546,7 @@
     },
     {
       "path": "docs/source/generated/stale-docs.md",
-      "line_count": 40,
+      "line_count": 39,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -5306,7 +5306,7 @@
     },
     {
       "path": "src/Meridian.Ui/dashboard/README.md",
-      "line_count": 1343,
+      "line_count": 1358,
       "has_heading": true,
       "todo_count": 4,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -19,9 +19,9 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 
 | Metric | Value |
 | -------- | ------- |
-| Total documentation files | 640 |
-| Total lines | 118,397 |
-| Average file size (lines) | 185.0 |
+| Total documentation files | 641 |
+| Total lines | 120,322 |
+| Average file size (lines) | 187.7 |
 | Orphaned files | 255 |
 | Files without headings | 148 |
 | Stale files (>90 days) | 0 |

--- a/src/Meridian.Ui/dashboard/README.md
+++ b/src/Meridian.Ui/dashboard/README.md
@@ -72,7 +72,8 @@ The contract standardizes:
 
 Current dense-row detail consumers covered by regression tests include Portfolio positions,
 Portfolio run evidence, Trading recent fills, Data backfill queue rows, Data export rows, and
-Security Master lots.
+Security Master lots. The Daily Control Tower finance queue uses the same table/inspector contract,
+including row selection, focus handoff, and Escape return behavior.
 
 The Data backfill workstream reads `/api/backfill/executions` as the durable remediation evidence
 source. Its remediation SLA queue keeps server-owned tier, deadline, status, provider, workflow,
@@ -1157,12 +1158,20 @@ metadata to the design-document root set: `Trading`, `Portfolio`, `Accounting`, 
 event labels also normalize retained source names before entering the visible evidence timeline.
 The browser workstation root (`/`) now opens the Daily Control Tower, a read-only shell projection
 of workflow continuity, trust posture, linked context, and timestamped evidence. Its landing model
+is a shell-level Home location rather than an eighth workspace: none of the seven root workspace
+items is marked current, and the operating-context copy identifies the Daily Control Tower instead
+of falling back to Trading. Before the combined finance queue is shown, operators choose an
+operating scope or explicitly opt into cross-scope review.
+The landing model
 now prioritizes the finance sequence Today, Exceptions, Close, Reconciliation, Ledger, Reports,
 Evidence, and Data Health before non-finance surfaces. Decision drivers emphasize the finance
 queue, trust posture, linked context, and evidence events before the queued work, so the first screen
 explains why the operator should act, who owns the issue, what output is affected, which action is
 next, and which retained evidence supports it. Scope, freshness, and provider-connectivity trust
 cards expose their remediation actions in the card that reports the warning.
+Queue evidence association is fail-closed on the stable item/evidence identifier. Similar route,
+workspace, severity, or list position never attaches an unrelated proof event; missing correlation
+is displayed as unavailable evidence and timestamp posture.
 Legacy `/overview` links redirect to that root while suffixed overview routes continue through the
 retained workspace alias path.
 The app shell exposes the active route as a named workbench landmark and marks that landmark busy
@@ -1171,6 +1180,12 @@ workspace with explicit loading posture.
 Shared workstation primitives render visual search context as read-only textboxes and shared tab
 strips move focus and the active tab stop with Arrow, Home, and End keys, so route-owned filters and
 inspector tabs do not need screen-local keyboard handling.
+The first-10-minutes coach mark offers task journeys for Financial Operations, Trading and
+Portfolio, Strategy and Research, and Administration. Journey progress is route-backed and retained
+in the existing versioned onboarding storage record; switching journeys preserves completed work.
+Supporting and metadata typography has a 12px floor in the dense setting. Global accessibility
+styles retain visible focus, selected/current state, status boundaries, and data-table structure in
+Windows forced-colors mode; reduced-motion mode suppresses non-essential animation and transitions.
 The app shell keeps cross-workspace ranking and disclosure chrome centralized, while workspace
 linked-context builders, workspace operator-focus candidate construction, workspace
 evidence-timeline projection, workflow-continuity trail definitions, trail selection, active-route

--- a/src/Meridian.Ui/dashboard/src/app-shell.onboarding.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/app-shell.onboarding.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   ONBOARDING_TOUR_STEPS,
+  ONBOARDING_JOURNEYS,
   buildOnboardingTourViewModel,
   resolveVisitedStepId
 } from "./app-shell.onboarding";
@@ -12,6 +13,7 @@ import {
   emptyOnboardingState,
   readOnboardingState,
   withCompletedStep,
+  withSelectedOnboardingJourney,
   writeOnboardingState,
   type OnboardingState
 } from "@/lib/onboarding";
@@ -29,7 +31,7 @@ describe("onboarding persistence", () => {
   beforeEach(() => localStorage.clear());
 
   it("returns an empty state when nothing is stored", () => {
-    expect(readOnboardingState()).toEqual({ version: 1, completedStepIds: [], dismissed: false });
+    expect(readOnboardingState()).toEqual({ version: 1, journeyId: "financial-operations", completedStepIds: [], dismissed: false });
   });
 
   it("round-trips and normalizes stored state", () => {
@@ -49,13 +51,20 @@ describe("onboarding persistence", () => {
     expect(withCompletedStep(base, "quote")).toBe(base);
     expect(withCompletedStep(base, "backtest").completedStepIds).toEqual(["quote", "backtest"]);
   });
+
+  it("selects a task journey without discarding progress", () => {
+    const base = state({ completedStepIds: ["financial-operations:import"] });
+    const next = withSelectedOnboardingJourney(base, "administration");
+    expect(next.journeyId).toBe("administration");
+    expect(next.completedStepIds).toEqual(base.completedStepIds);
+  });
 });
 
 describe("buildOnboardingTourViewModel", () => {
   it("marks the first incomplete step active and reports progress", () => {
     const vm = buildOnboardingTourViewModel({
-      pathname: "/data/quotes",
-      state: state({ completedStepIds: ["quote"] })
+      state: state({ completedStepIds: ["financial-operations:import"] }),
+      pathname: "/accounting/statement-import"
     });
     expect(vm.visible).toBe(true);
     expect(vm.completedCount).toBe(1);
@@ -64,7 +73,7 @@ describe("buildOnboardingTourViewModel", () => {
     expect(vm.steps[0].status).toBe("complete");
     expect(vm.steps[1].status).toBe("active");
     expect(vm.steps[2].status).toBe("upcoming");
-    expect(vm.steps.find((s) => s.id === "quote")?.isCurrentRoute).toBe(true);
+    expect(vm.steps.find((s) => s.id === "financial-operations:import")?.isCurrentRoute).toBe(true);
   });
 
   it("hides once every step is complete", () => {
@@ -84,8 +93,9 @@ describe("buildOnboardingTourViewModel", () => {
   });
 
   it("resolves the visited step id from a route, ignoring trailing slashes", () => {
-    expect(resolveVisitedStepId("/data/quotes")).toBe("quote");
-    expect(resolveVisitedStepId("/accounting/ledger/")).toBe("ledger");
+    expect(resolveVisitedStepId("/accounting/statement-import")).toBe("financial-operations:import");
+    expect(resolveVisitedStepId("/accounting/ledger/")).toBe("financial-operations:validate");
+    expect(resolveVisitedStepId("/data/quotes", "trading-portfolio")).toBe("trading-portfolio:quotes");
     expect(resolveVisitedStepId("/nowhere")).toBeNull();
   });
 });
@@ -116,11 +126,23 @@ describe("onboarding tour rendering", () => {
 
   it("auto-completes a step when its route is visited", async () => {
     const user = userEvent.setup();
-    render(<Harness initial="/data/quotes" />);
-    await waitFor(() => expect(readOnboardingState().completedStepIds).toContain("quote"));
+    render(<Harness initial="/accounting/statement-import" />);
+    await waitFor(() => expect(readOnboardingState().completedStepIds).toContain("financial-operations:import"));
     // Progress is visible once the operator opens the coach mark from the ring.
     await user.click(screen.getByRole("button", { name: /Getting started/ }));
     expect(screen.getByText(`1 / ${ONBOARDING_TOUR_STEPS.length} steps complete`)).toBeInTheDocument();
+  });
+
+  it("switches to a role-relevant journey and updates its guidance", async () => {
+    const user = userEvent.setup();
+    render(<Harness initial="/somewhere" />);
+    await user.click(screen.getByRole("button", { name: /Getting started/ }));
+
+    await user.selectOptions(screen.getByLabelText("Choose your task journey"), "administration");
+
+    expect(screen.getByText(ONBOARDING_JOURNEYS.find((journey) => journey.id === "administration")!.description))
+      .toBeInTheDocument();
+    expect(readOnboardingState().journeyId).toBe("administration");
   });
 
   it("stays docked to the header ring until the operator opens it", () => {

--- a/src/Meridian.Ui/dashboard/src/app-shell.onboarding.ts
+++ b/src/Meridian.Ui/dashboard/src/app-shell.onboarding.ts
@@ -1,5 +1,5 @@
 import { WORKSTATION_ROUTE_CATALOG, workstationRouteWithQuery } from "@/lib/workspace";
-import type { OnboardingState } from "@/lib/onboarding";
+import { DEFAULT_ONBOARDING_JOURNEY_ID, type OnboardingState } from "@/lib/onboarding";
 
 // Declarative "first 10 minutes" tour: a short (<=5), route-anchored path over
 // real screens. Each step is a genuine action the operator takes on the live UI;
@@ -17,40 +17,61 @@ export interface OnboardingStepDefinition {
   actionLabel: string;
 }
 
-export const ONBOARDING_TOUR_STEPS: readonly OnboardingStepDefinition[] = [
+export interface OnboardingJourneyDefinition {
+  id: string;
+  label: string;
+  description: string;
+  steps: readonly OnboardingStepDefinition[];
+}
+
+export const ONBOARDING_JOURNEYS: readonly OnboardingJourneyDefinition[] = [
   {
-    id: "quote",
-    title: "Watch a live quote",
-    description: "Open the quotes lane and watch a symbol stream in real time.",
-    href: workstationRouteWithQuery("dataQuotes", { symbol: "AAPL" }),
-    matchPath: WORKSTATION_ROUTE_CATALOG.dataQuotes,
-    actionLabel: "Open quotes"
+    id: DEFAULT_ONBOARDING_JOURNEY_ID,
+    label: "Financial operations",
+    description: "Move source records through validation, reconciliation, approval, and reporting.",
+    steps: [
+      { id: "financial-operations:import", title: "Import source records", description: "Bring a statement into the governed intake workflow.", href: WORKSTATION_ROUTE_CATALOG.accountingStatementImport, matchPath: WORKSTATION_ROUTE_CATALOG.accountingStatementImport, actionLabel: "Open statement import" },
+      { id: "financial-operations:validate", title: "Validate the ledger", description: "Trace balances and inspect the records behind them.", href: WORKSTATION_ROUTE_CATALOG.accountingLedger, matchPath: WORKSTATION_ROUTE_CATALOG.accountingLedger, actionLabel: "Open ledger" },
+      { id: "financial-operations:reconcile", title: "Reconcile breaks", description: "Match source activity and investigate unresolved differences.", href: WORKSTATION_ROUTE_CATALOG.accountingReconciliation, matchPath: WORKSTATION_ROUTE_CATALOG.accountingReconciliation, actionLabel: "Open reconciliation" },
+      { id: "financial-operations:approve", title: "Review approvals", description: "Resolve controlled decisions before downstream publication.", href: WORKSTATION_ROUTE_CATALOG.accountingApprovals, matchPath: WORKSTATION_ROUTE_CATALOG.accountingApprovals, actionLabel: "Open approvals" },
+      { id: "financial-operations:report", title: "Review report packs", description: "Validate the governed output and its supporting evidence.", href: WORKSTATION_ROUTE_CATALOG.reportingReportPacks, matchPath: WORKSTATION_ROUTE_CATALOG.reportingReportPacks, actionLabel: "Open report packs" }
+    ]
   },
   {
-    id: "backtest",
-    title: "Run a backtest",
-    description: "Take a strategy through the lab and see how it would have performed.",
-    href: WORKSTATION_ROUTE_CATALOG.strategyLab,
-    matchPath: WORKSTATION_ROUTE_CATALOG.strategyLab,
-    actionLabel: "Open strategy lab"
+    id: "trading-portfolio",
+    label: "Trading and portfolio",
+    description: "Establish data trust, review readiness, and follow activity into portfolio records.",
+    steps: [
+      { id: "trading-portfolio:quotes", title: "Check market data", description: "Confirm a live quote and the provider behind it.", href: workstationRouteWithQuery("dataQuotes", { symbol: "AAPL" }), matchPath: WORKSTATION_ROUTE_CATALOG.dataQuotes, actionLabel: "Open quotes" },
+      { id: "trading-portfolio:providers", title: "Review provider posture", description: "Check connectivity and data-quality evidence.", href: WORKSTATION_ROUTE_CATALOG.dataProviders, matchPath: WORKSTATION_ROUTE_CATALOG.dataProviders, actionLabel: "Open providers" },
+      { id: "trading-portfolio:trading", title: "Open the trading workspace", description: "Review current readiness and controlled actions.", href: WORKSTATION_ROUTE_CATALOG.trading, matchPath: WORKSTATION_ROUTE_CATALOG.trading, actionLabel: "Open trading" },
+      { id: "trading-portfolio:portfolio", title: "Trace portfolio impact", description: "Follow activity into positions and portfolio evidence.", href: WORKSTATION_ROUTE_CATALOG.portfolio, matchPath: WORKSTATION_ROUTE_CATALOG.portfolio, actionLabel: "Open portfolio" }
+    ]
   },
   {
-    id: "ledger",
-    title: "Trace P&L to the ledger",
-    description: "Follow a result into the accounting ledger — every number ties back.",
-    href: WORKSTATION_ROUTE_CATALOG.accountingLedger,
-    matchPath: WORKSTATION_ROUTE_CATALOG.accountingLedger,
-    actionLabel: "Open ledger"
+    id: "strategy-research",
+    label: "Strategy and research",
+    description: "Design, test, and promote a strategy through governed evidence gates.",
+    steps: [
+      { id: "strategy-research:design", title: "Design a strategy", description: "Start with a transparent, reviewable strategy definition.", href: WORKSTATION_ROUTE_CATALOG.strategyDesigner, matchPath: WORKSTATION_ROUTE_CATALOG.strategyDesigner, actionLabel: "Open designer" },
+      { id: "strategy-research:test", title: "Run the strategy lab", description: "Evaluate the strategy with reproducible inputs.", href: WORKSTATION_ROUTE_CATALOG.strategyLab, matchPath: WORKSTATION_ROUTE_CATALOG.strategyLab, actionLabel: "Open strategy lab" },
+      { id: "strategy-research:promote", title: "Review promotion gates", description: "Inspect evidence before advancing a strategy.", href: WORKSTATION_ROUTE_CATALOG.strategyPromotions, matchPath: WORKSTATION_ROUTE_CATALOG.strategyPromotions, actionLabel: "Open promotions" }
+    ]
   },
   {
-    id: "connect",
-    title: "Connect your first provider",
-    description: "Wire up a data provider to replace the sample feed with your own.",
-    href: WORKSTATION_ROUTE_CATALOG.dataProviders,
-    matchPath: WORKSTATION_ROUTE_CATALOG.dataProviders,
-    actionLabel: "Open providers"
+    id: "administration",
+    label: "Administration",
+    description: "Configure providers, access, accounting systems, and diagnostic recovery.",
+    steps: [
+      { id: "administration:providers", title: "Configure providers", description: "Connect and verify an operational data provider.", href: WORKSTATION_ROUTE_CATALOG.settingsProviders, matchPath: WORKSTATION_ROUTE_CATALOG.settingsProviders, actionLabel: "Open provider settings" },
+      { id: "administration:access", title: "Review access", description: "Inspect the controls governing operator access.", href: WORKSTATION_ROUTE_CATALOG.settingsAccess, matchPath: WORKSTATION_ROUTE_CATALOG.settingsAccess, actionLabel: "Open access settings" },
+      { id: "administration:accounting", title: "Connect accounting systems", description: "Configure the governed downstream accounting connection.", href: WORKSTATION_ROUTE_CATALOG.settingsAccountingSystems, matchPath: WORKSTATION_ROUTE_CATALOG.settingsAccountingSystems, actionLabel: "Open accounting systems" },
+      { id: "administration:diagnostics", title: "Learn recovery diagnostics", description: "Find actionable health and recovery evidence.", href: WORKSTATION_ROUTE_CATALOG.settingsDiagnostics, matchPath: WORKSTATION_ROUTE_CATALOG.settingsDiagnostics, actionLabel: "Open diagnostics" }
+    ]
   }
 ] as const;
+
+export const ONBOARDING_TOUR_STEPS: readonly OnboardingStepDefinition[] = ONBOARDING_JOURNEYS[0].steps;
 
 export type OnboardingStepStatus = "complete" | "active" | "upcoming";
 
@@ -80,6 +101,10 @@ export interface OnboardingTourViewModel {
   progressFraction: number;
   allComplete: boolean;
   dismissed: boolean;
+  journeys: readonly Pick<OnboardingJourneyDefinition, "id" | "label" | "description">[];
+  journeyId: string;
+  journeyLabel: string;
+  journeyDescription: string;
 }
 
 function normalizePath(pathname: string): string {
@@ -90,30 +115,32 @@ function normalizePath(pathname: string): string {
 }
 
 /** The step whose route matches the current location, or null. */
-export function resolveVisitedStepId(pathname: string): string | null {
+export function resolveVisitedStepId(pathname: string, journeyId = DEFAULT_ONBOARDING_JOURNEY_ID): string | null {
   const path = normalizePath(pathname);
-  return ONBOARDING_TOUR_STEPS.find((step) => step.matchPath === path)?.id ?? null;
+  return resolveOnboardingJourney(journeyId).steps.find((step) => step.matchPath === path)?.id ?? null;
 }
 
 export function buildOnboardingTourViewModel({
   pathname,
   state,
-  steps = ONBOARDING_TOUR_STEPS
+  steps
 }: {
   pathname: string;
   state: OnboardingState;
   steps?: readonly OnboardingStepDefinition[];
 }): OnboardingTourViewModel {
+  const journey = resolveOnboardingJourney(state.journeyId);
+  const selectedSteps = steps ?? journey.steps;
   const path = normalizePath(pathname);
   const completedSet = new Set(state.completedStepIds);
   const activeIndex = Math.max(
     0,
-    steps.findIndex((step) => !completedSet.has(step.id))
+    selectedSteps.findIndex((step) => !completedSet.has(step.id))
   );
-  const completedCount = steps.reduce((count, step) => (completedSet.has(step.id) ? count + 1 : count), 0);
-  const allComplete = completedCount === steps.length;
+  const completedCount = selectedSteps.reduce((count, step) => (completedSet.has(step.id) ? count + 1 : count), 0);
+  const allComplete = completedCount === selectedSteps.length;
 
-  const stepViewModels: OnboardingStepViewModel[] = steps.map((step, index) => {
+  const stepViewModels: OnboardingStepViewModel[] = selectedSteps.map((step, index) => {
     const complete = completedSet.has(step.id);
     const status: OnboardingStepStatus = complete ? "complete" : index === activeIndex ? "active" : "upcoming";
     return {
@@ -133,10 +160,18 @@ export function buildOnboardingTourViewModel({
     steps: stepViewModels,
     activeIndex,
     completedCount,
-    totalCount: steps.length,
-    progressLabel: `${completedCount} / ${steps.length}`,
-    progressFraction: steps.length === 0 ? 1 : completedCount / steps.length,
+    totalCount: selectedSteps.length,
+    progressLabel: `${completedCount} / ${selectedSteps.length}`,
+    progressFraction: selectedSteps.length === 0 ? 1 : completedCount / selectedSteps.length,
     allComplete,
-    dismissed: state.dismissed
+    dismissed: state.dismissed,
+    journeys: ONBOARDING_JOURNEYS.map(({ id, label, description }) => ({ id, label, description })),
+    journeyId: journey.id,
+    journeyLabel: journey.label,
+    journeyDescription: journey.description
   };
+}
+
+export function resolveOnboardingJourney(journeyId: string): OnboardingJourneyDefinition {
+  return ONBOARDING_JOURNEYS.find((journey) => journey.id === journeyId) ?? ONBOARDING_JOURNEYS[0];
 }

--- a/src/Meridian.Ui/dashboard/src/app-shell.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/app-shell.view-model.test.ts
@@ -6,6 +6,7 @@ import {
   buildCommandPaletteTriggerState,
   buildDevelopmentFixtureNoticeViewModel,
   normalizeWorkspace,
+  resolveAppShellLocation,
   resolveAppShellCommandPaletteShortcut,
   type AppShellWorkspacePayload
 } from "@/app-shell.view-model";
@@ -244,6 +245,14 @@ describe("app shell view model", () => {
     expect(normalizeWorkspace("/unknown")).toBe("trading");
   });
 
+  it("models the root as shell home without adding an eighth workspace", () => {
+    expect(resolveAppShellLocation("/")).toEqual({ kind: "home" });
+    expect(resolveAppShellLocation("/accounting/reconciliation")).toEqual({
+      kind: "workspace",
+      workspaceKey: "accounting"
+    });
+  });
+
   it("treats the root route as the Daily Control Tower shell focus", () => {
     const state = buildAppShellViewState({
       pathname: "/",
@@ -258,6 +267,8 @@ describe("app shell view model", () => {
       documentTitle: "Daily Control Tower - Meridian",
       fallbackElementId: "workbench-content"
     });
+    expect(state.location).toEqual({ kind: "home" });
+    expect(state.workflowContinuity.contextValue).toBe("Daily Control Tower / Today");
     expect(state.workflowContinuity.title).toBe("Daily Control Tower");
     expect(state.workflowContinuity.steps.map((step) => step.label)).toEqual([
       "Today",

--- a/src/Meridian.Ui/dashboard/src/app-shell.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/app-shell.view-model.ts
@@ -88,6 +88,7 @@ export type {
 
 export interface AppShellViewState {
   activeWorkspace: WorkspaceSummary;
+  location: AppShellLocation;
   statusPanel: ShellStatusPanel | null;
   canRenderRoutes: boolean;
   routeFocus: AppShellRouteFocusState;
@@ -95,6 +96,10 @@ export interface AppShellViewState {
   workflowContinuity: AppShellWorkflowContinuityViewModel;
   commandPaletteTrigger: AppShellCommandPaletteTriggerState;
 }
+
+export type AppShellLocation =
+  | { kind: "home" }
+  | { kind: "workspace"; workspaceKey: WorkspaceKey };
 
 export interface AppShellWorkspacePayload {
   session: SessionInfo | null;
@@ -142,6 +147,7 @@ export function buildAppShellViewState({
   payload
 }: BuildAppShellViewStateOptions): AppShellViewState {
   const activeWorkspace = getWorkspaceForPath(pathname);
+  const location = resolveAppShellLocation(pathname);
   const failedItems = buildShellFailureItems(workspaceErrors, workflowError);
   const hasAnyPayload = Boolean(
     payload.session
@@ -158,6 +164,7 @@ export function buildAppShellViewState({
 
   return {
     activeWorkspace,
+    location,
     statusPanel: buildShellStatusPanel({
       loading,
       error,
@@ -192,6 +199,13 @@ export function buildAppShellViewState({
     ),
     commandPaletteTrigger: buildCommandPaletteTriggerState(commandPaletteOpen)
   };
+}
+
+export function resolveAppShellLocation(pathname: string): AppShellLocation {
+  const normalized = pathname.split(/[?#]/, 1)[0]?.replace(/\/+$/, "") || "/";
+  return normalized === "/"
+    ? { kind: "home" }
+    : { kind: "workspace", workspaceKey: normalizeWorkspacePath(pathname) };
 }
 
 export function getWorkspaceForPath(pathname: string): WorkspaceSummary {

--- a/src/Meridian.Ui/dashboard/src/app-shell.workflow-continuity-view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/app-shell.workflow-continuity-view-model.ts
@@ -78,6 +78,7 @@ export function buildWorkflowContinuityViewModel(
     symbol: operatingContextScope?.symbol ?? operatingContextSymbol
   }, pathname);
   const subjectSymbol = operatingScope.subjectSymbol;
+  const isShellHome = pathname === "/";
   const currentRoute = `${pathname}${search}${hash}`;
   const routeResolution = resolveWorkflowContinuityRoute(pathname, hash);
   const trail = routeResolution.trail;
@@ -107,11 +108,12 @@ export function buildWorkflowContinuityViewModel(
     : routeResolution.mode === "choose-task"
       ? `No continuity step is selected for ${activeWorkspace.label}. Choose a task from the local workspace navigation; the current operating scope will be preserved.`
       : "The requested route is not part of a Meridian workspace. Open the Daily Control Tower to choose a task.";
+  const contextOwnerLabel = isShellHome ? "Daily Control Tower" : activeWorkspace.label;
   const contextValue = subjectSymbol
-    ? `${activeWorkspace.label} / ${subjectSymbol}`
+    ? `${contextOwnerLabel} / ${subjectSymbol}`
     : operatingScope.hasScope
-      ? `${activeWorkspace.label} / Scoped workflow`
-      : `${activeWorkspace.label} / ${activeStep?.label ?? "Choose a task"}`;
+      ? `${contextOwnerLabel} / Scoped workflow`
+      : `${contextOwnerLabel} / ${activeStep?.label ?? "Choose a task"}`;
   const nextActionLabel = routeResolution.mode === "matched"
     ? activeStep && nextStep && activeStep.id === nextStep.id
       ? `Stay on ${activeStep.label}`
@@ -156,8 +158,8 @@ export function buildWorkflowContinuityViewModel(
     clearSubjectAriaLabel: operatingScope.clearAriaLabel,
     operatingScope,
     routeLabel: currentRoute || "/",
-    stepsLabel: trail ? `${trail.title} workflow steps` : `${activeWorkspace.label} task workflow steps`,
-    ariaLabel: trail ? `${trail.title} continuity` : `${activeWorkspace.label} task choice`,
+    stepsLabel: trail ? `${trail.title} workflow steps` : `${contextOwnerLabel} task workflow steps`,
+    ariaLabel: trail ? `${trail.title} continuity` : `${contextOwnerLabel} task choice`,
     nextActionLabel,
     nextActionAriaLabel,
     nextActionHref,

--- a/src/Meridian.Ui/dashboard/src/app.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/app.test.tsx
@@ -364,12 +364,14 @@ describe("App", () => {
     });
     expect(confidence).toHaveTextContent("4 ranked items");
     expect(screen.queryByRole("region", { name: "Daily control tower decision drivers" })).not.toBeInTheDocument();
-    expect(screen.getByRole("table", { name: "Daily control tower finance queue" })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "Choose Control Tower scope" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Review all scopes" }));
+    expect(screen.getByRole("treegrid", { name: "Daily control tower finance queue" })).toBeInTheDocument();
     expect(screen.getAllByRole("link", {
       name: "Reporting: Report pack approval waiting. Monthly board pack still needs an operator sign-off. Open report packs."
     }).some((link) => link.getAttribute("href") === "/reporting/report-packs")).toBe(true);
 
-    const evidenceSummary = screen.getByRole("region", { name: "Report pack approval waiting Evidence summary" });
+    const evidenceSummary = screen.getByRole("region", { name: /Report pack approval waiting evidence summary/i });
     const moreEvidence = within(evidenceSummary).getByText("More evidence").closest("details");
     expect(moreEvidence).not.toHaveAttribute("open");
     await user.click(within(evidenceSummary).getByText("More evidence"));

--- a/src/Meridian.Ui/dashboard/src/components/meridian/onboarding-tour.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/onboarding-tour.tsx
@@ -11,6 +11,7 @@ import {
 import {
   readOnboardingState,
   withCompletedStep,
+  withSelectedOnboardingJourney,
   writeOnboardingState,
   type OnboardingState
 } from "@/lib/onboarding";
@@ -22,6 +23,7 @@ export interface OnboardingTourController {
   setExpanded: (expanded: boolean) => void;
   /** Permanently dismiss the tour. */
   dismiss: () => void;
+  selectJourney: (journeyId: string) => void;
 }
 
 /**
@@ -43,7 +45,7 @@ export function useOnboardingTour(): OnboardingTourController {
 
   // Visiting a step's route completes it — real actions, not a checklist.
   useEffect(() => {
-    const visitedStepId = resolveVisitedStepId(pathname);
+    const visitedStepId = resolveVisitedStepId(pathname, state.journeyId);
     if (!visitedStepId) {
       return;
     }
@@ -55,10 +57,14 @@ export function useOnboardingTour(): OnboardingTourController {
       writeOnboardingState(next);
       return next;
     });
-  }, [pathname]);
+  }, [pathname, state.journeyId]);
 
   const dismiss = useCallback(() => {
     persist({ ...state, dismissed: true });
+  }, [persist, state]);
+
+  const selectJourney = useCallback((journeyId: string) => {
+    persist(withSelectedOnboardingJourney(state, journeyId));
   }, [persist, state]);
 
   const viewModel = useMemo(
@@ -66,7 +72,7 @@ export function useOnboardingTour(): OnboardingTourController {
     [pathname, state]
   );
 
-  return { viewModel, expanded, setExpanded, dismiss };
+  return { viewModel, expanded, setExpanded, dismiss, selectJourney };
 }
 
 /** Header progress ring — visible until the operator graduates or dismisses. */
@@ -117,7 +123,7 @@ function ProgressRing({ fraction }: { fraction: number }) {
 
 /** Dismissible coach-mark card docked bottom-right, driven by the same controller. */
 export function OnboardingCoachMark({ controller }: { controller: OnboardingTourController }) {
-  const { viewModel, expanded, setExpanded, dismiss } = controller;
+  const { viewModel, expanded, setExpanded, dismiss, selectJourney } = controller;
   if (!viewModel.visible || !expanded) {
     return null;
   }
@@ -156,6 +162,23 @@ export function OnboardingCoachMark({ controller }: { controller: OnboardingTour
             <X className="h-4 w-4" aria-hidden="true" />
           </button>
         </div>
+      </div>
+
+      <div className="space-y-1 border-b border-border px-4 py-3">
+        <label htmlFor="onboarding-journey" className="text-xs font-medium text-foreground">
+          Choose your task journey
+        </label>
+        <select
+          id="onboarding-journey"
+          value={viewModel.journeyId}
+          onChange={(event) => selectJourney(event.target.value)}
+          className="min-h-8 w-full rounded-[2px] border border-border bg-background px-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+        >
+          {viewModel.journeys.map((journey) => (
+            <option key={journey.id} value={journey.id}>{journey.label}</option>
+          ))}
+        </select>
+        <p className="text-xs leading-5 text-muted-foreground">{viewModel.journeyDescription}</p>
       </div>
 
       <Stepper

--- a/src/Meridian.Ui/dashboard/src/components/meridian/workspace-nav.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/workspace-nav.test.tsx
@@ -5,6 +5,15 @@ import { WorkspaceNav } from "@/components/meridian/workspace-nav";
 import { renderWithRouter } from "@/test/render";
 
 describe("WorkspaceNav", () => {
+  it("keeps the Daily Control Tower outside the seven-workspace active state", () => {
+    renderWithRouter(<WorkspaceNav density="compact" />, { initialEntries: ["/"] });
+
+    expect(document.querySelectorAll(".operator-nav-item")).toHaveLength(7);
+    expect(document.querySelectorAll(".operator-nav-item.active")).toHaveLength(0);
+    expect(screen.queryByText("Available · Current")).not.toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: "Trading pages" })).not.toBeInTheDocument();
+  });
+
   it("renders the seven root workspaces through the design-system rail contract", () => {
     renderWithRouter(<WorkspaceNav />, { initialEntries: ["/trading"] });
 

--- a/src/Meridian.Ui/dashboard/src/components/meridian/workspace-nav.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/workspace-nav.tsx
@@ -39,7 +39,7 @@ export function WorkspaceNav({
   const location = useLocation();
   const viewModel = buildWorkspaceNavViewModel(location.pathname, undefined, location.search, operatingContextScope);
   const compact = density === "compact";
-  const activeWorkspaceKey = viewModel.items.find((item) => item.active)?.key ?? viewModel.items[0]?.key;
+  const activeWorkspaceKey = viewModel.activeWorkspaceKey ?? undefined;
   const { expandedWorkspaces, toggleWorkspace } = useWorkspaceExpansion(activeWorkspaceKey);
 
   return (

--- a/src/Meridian.Ui/dashboard/src/components/meridian/workspace-nav.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/workspace-nav.view-model.ts
@@ -59,6 +59,8 @@ export interface WorkspaceNavCurrentWorkspaceViewModel {
 }
 
 export interface WorkspaceNavViewModel {
+  isHome: boolean;
+  activeWorkspaceKey: WorkspaceKey | null;
   brandTitle: string;
   brandSubtitle: string;
   modelEyebrow: string;
@@ -142,13 +144,14 @@ export function buildWorkspaceNavViewModel(
   search = "",
   operatingContextScope: AppShellOperatingScopeInput | null = null
 ): WorkspaceNavViewModel {
+  const isHome = pathname === "/";
   const visibleWorkspaces = canonicalizeWorkspaceSummaries(workspaces);
   const currentWorkspace =
     visibleWorkspaces.find((workspace) => isWorkspacePathActive(pathname, workspace.key)) ?? visibleWorkspaces[0];
   const operatingScope = buildOperatingScopeFromSearch(search, operatingContextScope);
 
   const items = visibleWorkspaces.map<WorkspaceNavItemViewModel>((workspace) => {
-    const active = isWorkspacePathActive(pathname, workspace.key);
+    const active = !isHome && isWorkspacePathActive(pathname, workspace.key);
     const maturityTone = workspaceMaturityTone(workspace.maturity);
     const workspaceCanonicalRoute = workspacePath(workspace.key);
     const exactWorkspaceActive = isExactRouteActive(pathname, workspaceCanonicalRoute);
@@ -211,6 +214,8 @@ export function buildWorkspaceNavViewModel(
   const contextItems = buildContextItems(pathname, currentWorkspace.key, operatingScope, search);
 
   return {
+    isHome,
+    activeWorkspaceKey: isHome ? null : currentWorkspace.key,
     brandTitle: "Meridian",
     brandSubtitle: "Operator Workstation",
     modelEyebrow: "Operating model",

--- a/src/Meridian.Ui/dashboard/src/design-system-contract.test.ts
+++ b/src/Meridian.Ui/dashboard/src/design-system-contract.test.ts
@@ -6,6 +6,14 @@ function readDashboardStyles() {
   return readFileSync(resolve(process.cwd(), "src/styles/index.css"), "utf8");
 }
 
+function readDashboardStyleBundle() {
+  const stylesPath = resolve(process.cwd(), "src/styles");
+  return readdirSync(stylesPath)
+    .filter((file) => file.endsWith(".css"))
+    .map((file) => readFileSync(resolve(stylesPath, file), "utf8"))
+    .join("\n");
+}
+
 function readManualDarkHexToken(styles: string, token: string) {
   const darkScope = styles.match(/:root\[data-theme="dark"\]\s*\{([\s\S]*?)\n {2}\}/)?.[1];
   if (!darkScope) {
@@ -347,6 +355,17 @@ describe("dashboard design-system contract", () => {
     expect(styles).toContain("--cyan-focus: var(--ws-accent)");
     expect(styles).toContain(".focus-visible\\:ring-primary\\/40:focus-visible");
     expect(styles).toContain("--tw-ring-color: var(--cyan-focus)");
+  });
+
+  it("preserves legible metadata and explicit Windows forced-colors states", () => {
+    const styles = readDashboardStyles();
+    const styleBundle = readDashboardStyleBundle();
+
+    expect(styleBundle).not.toMatch(/font-size:\s*0\.(?:5625|59375|625)rem/);
+    expect(styles).toContain("@media (forced-colors: active)");
+    expect(styles).toContain('outline: 2px solid Highlight');
+    expect(styles).toContain('[aria-selected="true"]');
+    expect(styles).toContain("border-color: CanvasText");
   });
 
   it("uses the paper canvas background from the design-system documentation", () => {

--- a/src/Meridian.Ui/dashboard/src/lib/daily-control-tower.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/daily-control-tower.test.ts
@@ -155,4 +155,29 @@ describe("daily control tower model", () => {
     expect(row?.proofPassportItems.find((item) => item.label === "Report Usage")?.value).toBe("Reporting package or evidence");
     expect(row?.proofPassportItems.find((item) => item.label === "Audit Trail")?.value).toBe("2026-05-14T21:00:00.000Z");
   });
+
+  it("fails closed when an item has no exactly correlated evidence event", () => {
+    const shell = buildAppShellViewState({
+      pathname: "/",
+      loading: false,
+      error: null,
+      workspaceErrors: {},
+      payload
+    });
+    const leadingItemId = shell.workflowContinuity.operatorFocusItems[0]?.id;
+    const viewModel = {
+      ...shell.workflowContinuity,
+      evidenceTimelineItems: shell.workflowContinuity.evidenceTimelineItems.filter(
+        (item) => item.id !== leadingItemId
+      )
+    };
+
+    const row = buildDailyControlTowerModel(viewModel, shell.trustStrip).queueRows[0];
+
+    expect(row?.proof).toBeNull();
+    expect(row?.proofPassportItems.find((item) => item.label === "Freshness")?.value)
+      .toBe("No timestamped evidence");
+    expect(row?.proofPassportItems.find((item) => item.label === "Evidence Packet")?.value)
+      .toBe("No evidence packet linked");
+  });
 });

--- a/src/Meridian.Ui/dashboard/src/lib/daily-control-tower.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/daily-control-tower.ts
@@ -214,7 +214,7 @@ function buildProofPassportItems({
   const freshness = proof?.timestampLabel ?? "No timestamped evidence";
   const reconciliation = linkedContext?.statusLabel ?? viewModel.linkedContextPostureLabel;
   const approvals = approvalsLabelForTone(item.tone);
-  const evidencePacket = proof?.label ?? viewModel.decisionBrief.evidenceLabel ?? "No evidence packet linked";
+  const evidencePacket = proof?.label ?? "No evidence packet linked";
   const auditTrail = proof?.timestampIso ?? "Audit timestamp unavailable";
 
   return [
@@ -258,7 +258,7 @@ function buildProofPassportItems({
       id: "evidence-packet",
       label: "Evidence Packet",
       value: evidencePacket,
-      detail: proof?.ariaLabel ?? viewModel.evidenceTimelineSummary
+      detail: proof?.ariaLabel ?? "No correlated evidence packet is linked to this queue item."
     },
     {
       id: "audit-trail",
@@ -273,12 +273,10 @@ function findProofForItem(
   item: AppShellOperatorFocusItem,
   evidenceItems: AppShellEvidenceTimelineItem[]
 ): AppShellEvidenceTimelineItem | null {
-  return evidenceItems.find((proof) => proof.id === item.id)
-    ?? evidenceItems.find((proof) => routeFingerprint(proof.route) === routeFingerprint(item.route))
-    ?? evidenceItems.find((proof) => proof.workspaceLabel === item.workspaceLabel && proof.tone === item.tone)
-    ?? evidenceItems.find((proof) => proof.workspaceLabel === item.workspaceLabel)
-    ?? evidenceItems[0]
-    ?? null;
+  // Evidence association is deliberately fail-closed. Route, workspace, tone,
+  // and list position are presentation attributes, not durable correlation
+  // keys, so they must never be used to attach a different event to this row.
+  return evidenceItems.find((proof) => proof.id === item.id) ?? null;
 }
 
 function findLinkedContextForItem(

--- a/src/Meridian.Ui/dashboard/src/lib/onboarding.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/onboarding.ts
@@ -5,9 +5,12 @@ import { getLocalStorage } from "@/lib/theme";
 // the operator actually visits the corresponding route, so progress reflects
 // real actions on the real UI rather than a checklist they clicked through.
 export const ONBOARDING_STORAGE_KEY = "meridian.workstation.onboarding.v1";
+export const DEFAULT_ONBOARDING_JOURNEY_ID = "financial-operations";
 
 export interface OnboardingState {
   version: 1;
+  /** The task journey the operator chose for this tour. */
+  journeyId: string;
   /** Ids of tour steps the operator has completed (by visiting their route). */
   completedStepIds: string[];
   /** True once the operator dismisses the tour; hides the coach-mark and ring. */
@@ -15,7 +18,7 @@ export interface OnboardingState {
 }
 
 export function emptyOnboardingState(): OnboardingState {
-  return { version: 1, completedStepIds: [], dismissed: false };
+  return { version: 1, journeyId: DEFAULT_ONBOARDING_JOURNEY_ID, completedStepIds: [], dismissed: false };
 }
 
 function normalizeState(value: unknown): OnboardingState {
@@ -28,6 +31,9 @@ function normalizeState(value: unknown): OnboardingState {
     : [];
   return {
     version: 1,
+    journeyId: typeof source.journeyId === "string" && source.journeyId.length > 0
+      ? source.journeyId
+      : DEFAULT_ONBOARDING_JOURNEY_ID,
     completedStepIds,
     dismissed: source.dismissed === true
   };
@@ -56,4 +62,11 @@ export function withCompletedStep(state: OnboardingState, stepId: string): Onboa
     return state;
   }
   return { ...state, completedStepIds: [...state.completedStepIds, stepId] };
+}
+
+export function withSelectedOnboardingJourney(state: OnboardingState, journeyId: string): OnboardingState {
+  if (state.journeyId === journeyId) {
+    return state;
+  }
+  return { ...state, journeyId, dismissed: false };
 }

--- a/src/Meridian.Ui/dashboard/src/screens/daily-control-tower-screen.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/daily-control-tower-screen.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { screen, within } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
 import { buildAppShellViewState, type AppShellWorkspacePayload } from "@/app-shell.view-model";
@@ -89,7 +89,7 @@ function renderScreen({
   onEditOperatingScope = vi.fn(),
   onRefresh = vi.fn(),
   refreshing = false,
-  search = ""
+  search = "?symbol=MSFT"
 }: {
   onEditOperatingScope?: () => void;
   onRefresh?: () => void;
@@ -123,13 +123,13 @@ describe("DailyControlTowerScreen", () => {
       screen.getByRole("heading", { name: "What needs an operator decision now" })
     ).toBeInTheDocument();
 
-    // Each queue row exposes a selection control; the top-ranked row's evidence
-    // shows without any interaction.
+    // The shared dense table exposes the selected row and its controlled detail
+    // panel without adding a second, mouse-only selection control.
     expect(
-      screen.getByRole("button", { name: "Show evidence for Report pack approval waiting" })
-    ).toHaveAttribute("aria-pressed", "true");
+      screen.getByRole("row", { name: "Report pack approval waiting" })
+    ).toHaveAttribute("aria-selected", "true");
     expect(
-      screen.getByRole("region", { name: /Report pack approval waiting Evidence summary/ })
+      screen.getByRole("region", { name: /Report pack approval waiting evidence summary/i })
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Daily control tower confidence")).toHaveTextContent("3 ranked items");
     expect(screen.getByLabelText("Daily control tower confidence")).toHaveTextContent("Stale update");
@@ -143,7 +143,7 @@ describe("DailyControlTowerScreen", () => {
     const user = userEvent.setup();
     const onEditOperatingScope = vi.fn();
     const onRefresh = vi.fn();
-    renderScreen({ onEditOperatingScope, onRefresh });
+    renderScreen({ onEditOperatingScope, onRefresh, search: "" });
 
     const confidence = screen.getByRole("region", { name: "Daily control tower confidence" });
     expect(within(confidence).getByText("Connectivity")).toBeInTheDocument();
@@ -169,22 +169,54 @@ describe("DailyControlTowerScreen", () => {
     const user = userEvent.setup();
     renderScreen();
 
-    const brokerageButton = screen.getByRole("button", {
-      name: "Show evidence for Brokerage sync failed"
+    const brokerageRow = screen.getByRole("row", {
+      name: "Brokerage sync failed"
     });
-    expect(brokerageButton).toHaveAttribute("aria-pressed", "false");
+    expect(brokerageRow).not.toHaveAttribute("aria-selected", "true");
 
-    await user.click(brokerageButton);
+    await user.click(brokerageRow);
 
     // Selection moved without navigating away: the evidence region now reflects
     // the clicked row, and the pressed state follows it.
-    expect(brokerageButton).toHaveAttribute("aria-pressed", "true");
+    expect(brokerageRow).toHaveAttribute("aria-selected", "true");
     expect(
-      screen.getByRole("region", { name: /Brokerage sync failed Evidence summary/ })
+      screen.getByRole("region", { name: /Brokerage sync failed evidence summary/i })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Show evidence for Report pack approval waiting" })
-    ).toHaveAttribute("aria-pressed", "false");
+      screen.getByRole("row", { name: "Report pack approval waiting" })
+    ).not.toHaveAttribute("aria-selected", "true");
+  });
+
+  it("requires an explicit scope choice before showing the combined queue", async () => {
+    const user = userEvent.setup();
+    renderScreen({ search: "" });
+
+    expect(screen.getByRole("region", { name: "Choose Control Tower scope" })).toBeInTheDocument();
+    expect(screen.queryByRole("treegrid", { name: "Daily control tower finance queue" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Review all scopes" }));
+
+    expect(screen.getByRole("treegrid", { name: "Daily control tower finance queue" })).toBeInTheDocument();
+  });
+
+  it("supports keyboard selection and detail focus through the shared dense-row contract", async () => {
+    const user = userEvent.setup();
+    renderScreen();
+
+    const leadingRow = screen.getByRole("row", { name: "Report pack approval waiting" });
+    leadingRow.focus();
+    await user.keyboard("{ArrowDown}");
+
+    const providerRow = screen.getByRole("row", { name: "Alpaca provider warning" });
+    expect(providerRow).toHaveAttribute("aria-selected", "true");
+    providerRow.focus();
+    await user.keyboard("{Enter}");
+    await waitFor(() => {
+      expect(screen.getByRole("region", { name: /Alpaca provider warning evidence summary/i })).toHaveFocus();
+    });
+
+    await user.keyboard("{Escape}");
+    expect(screen.getByRole("row", { name: "Alpaca provider warning" })).toHaveFocus();
   });
 
   it("reveals secondary proof only when the operator expands more evidence", async () => {

--- a/src/Meridian.Ui/dashboard/src/screens/daily-control-tower-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/daily-control-tower-screen.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ArrowRight } from "lucide-react";
 import { Link } from "react-router-dom";
 import type { AppShellTrustStripState, AppShellWorkflowContinuityViewModel } from "@/app-shell.view-model";
@@ -7,6 +7,8 @@ import { TechnicalDetails } from "@/components/ui/technical-details";
 import { PanelSurface } from "@/components/ui/panel-surface";
 import { ScreenLayout } from "@/components/ui/screen-layout";
 import { KeyValueGrid } from "@/components/data/concrete";
+import { DenseRowDetailPanel } from "@/components/meridian/dense-row-detail-accessibility";
+import { DenseDataTable, type DenseDataTableColumn } from "@/components/meridian/ui-kit-primitives";
 import { OperationalTrustSummary, type OperationalTrustTone } from "@/components/meridian/operational-trust-summary";
 import { ReadinessPanel, SeverityBadge, WorkspaceSection } from "@/components/operations";
 import { buildDailyControlTowerModel } from "@/lib/daily-control-tower";
@@ -36,6 +38,7 @@ export function DailyControlTowerScreen({
   // leaving the tower. Falls back to the top-ranked row until one is chosen
   // (or when the chosen row leaves the queue on refresh).
   const [selectedQueueItemId, setSelectedQueueItemId] = useState<string | null>(null);
+  const [reviewAllScopes, setReviewAllScopes] = useState(false);
   const selectedQueueRow =
     model.queueRows.find((row) => row.item.id === selectedQueueItemId) ?? model.queueRows[0] ?? null;
   const freshnessEvidence = selectedQueueRow?.proofPassportItems.find((item) => item.id === "freshness");
@@ -44,13 +47,59 @@ export function DailyControlTowerScreen({
     freshnessEvidence?.detail
   );
   const providerTrust = trustStrip.items.find((item) => item.id === "providers") ?? null;
+  const evidencePanelId = "daily-control-tower-evidence-detail";
+  const queueVisible = viewModel.operatingScope.hasScope || reviewAllScopes;
   const trustTone: OperationalTrustTone = model.statusTone === "ready"
     ? "ready"
     : model.statusTone === "blocked"
       ? "blocked"
       : model.statusTone === "review"
         ? "review"
-        : "unknown";
+      : "unknown";
+
+  useEffect(() => {
+    if (selectedQueueItemId && !model.queueRows.some((row) => row.item.id === selectedQueueItemId)) {
+      setSelectedQueueItemId(null);
+    }
+  }, [model.queueRows, selectedQueueItemId]);
+
+  const queueColumns: DenseDataTableColumn<(typeof model.queueRows)[number]>[] = [
+    {
+      id: "item",
+      label: "Blocked item",
+      className: "min-w-[18rem]",
+      render: (row) => (
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-medium text-foreground">{row.item.label}</span>
+            <SeverityBadge status={badgeVariantToSeverityStatus(row.badgeVariant)} label={row.statusLabel} />
+          </div>
+          <p className="text-xs leading-5 text-muted-foreground">{row.item.detail}</p>
+        </div>
+      )
+    },
+    { id: "owner", label: "Owner", render: (row) => row.item.workspaceLabel },
+    { id: "output", label: "Affected output", render: (row) => row.outputLabel },
+    {
+      id: "action",
+      label: "Next action",
+      render: (row) => (
+        <Link
+          to={row.item.route}
+          className="inline-flex items-center gap-1 font-medium text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+          aria-label={row.item.ariaLabel}
+        >
+          <span>{row.item.actionLabel}</span>
+          <ArrowRight className="h-3 w-3" aria-hidden="true" />
+        </Link>
+      )
+    },
+    {
+      id: "evidence",
+      label: "Evidence",
+      render: (row) => row.proof?.label ?? "Evidence not linked"
+    }
+  ];
 
   return (
     <ScreenLayout
@@ -143,85 +192,59 @@ export function DailyControlTowerScreen({
         title="Finance queue"
         summary="Each row carries the evidence needed to move from source issue to downstream output."
       >
-        {model.queueRows.length > 0 ? (
-          <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_24rem]">
-            <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-border text-sm" aria-label="Daily control tower finance queue">
-                <thead className="bg-muted/35 text-left text-xs uppercase tracking-[0.08em] text-muted-foreground">
-                  <tr>
-                    <th scope="col" className="px-4 py-3 font-semibold">Blocked item</th>
-                    <th scope="col" className="px-4 py-3 font-semibold">Owner</th>
-                    <th scope="col" className="px-4 py-3 font-semibold">Affected output</th>
-                    <th scope="col" className="px-4 py-3 font-semibold">Next action</th>
-                    <th scope="col" className="px-4 py-3 font-semibold">Evidence</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-border">
-                  {model.queueRows.map((row) => {
-                    const isSelected = row.item.id === selectedQueueRow?.item.id;
-                    return (
-                    <tr
-                      key={row.item.id}
-                      className={isSelected ? "align-top bg-primary/5" : "align-top"}
-                      aria-current={isSelected ? "true" : undefined}
-                    >
-                      <td className="max-w-sm px-4 py-4">
-                        <div className="space-y-2">
-                          <div className="flex flex-wrap items-center gap-2">
-                            <button
-                              type="button"
-                              onClick={() => setSelectedQueueItemId(row.item.id)}
-                              aria-pressed={isSelected}
-                              aria-label={`Show evidence for ${row.item.label}`}
-                              className="text-left font-medium text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-                            >
-                              {row.item.label}
-                            </button>
-                            <SeverityBadge
-                              status={badgeVariantToSeverityStatus(row.badgeVariant)}
-                              label={row.statusLabel}
-                            />
-                          </div>
-                          <p className="text-xs leading-5 text-muted-foreground">{row.item.detail}</p>
-                        </div>
-                      </td>
-                      <td className="px-4 py-4 text-sm text-foreground">{row.item.workspaceLabel}</td>
-                      <td className="px-4 py-4 text-sm text-foreground">{row.outputLabel}</td>
-                      <td className="px-4 py-4">
-                        <Link
-                          to={row.item.route}
-                          className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-                          aria-label={row.item.ariaLabel}
-                        >
-                          <span>{row.item.actionLabel}</span>
-                          <ArrowRight className="h-3 w-3" aria-hidden="true" />
-                        </Link>
-                      </td>
-                      <td className="px-4 py-4 text-xs leading-5 text-muted-foreground">
-                        {row.proof?.label ?? row.proofPassportItems.find((item) => item.id === "freshness")?.value ?? "No evidence linked"}
-                      </td>
-                    </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
+        {!queueVisible ? (
+          <PanelSurface flat role="region" aria-label="Choose Control Tower scope" className="grid gap-4 p-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">Choose the scope for today’s queue</h3>
+              <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                Select a fund, account, provider, symbol, run, or date window to rank the most relevant decisions. You can still review the combined queue when cross-scope triage is required.
+              </p>
             </div>
+            <div className="flex flex-wrap gap-2">
+              {onEditOperatingScope ? (
+                <Button type="button" size="sm" onClick={onEditOperatingScope}>Set operating scope</Button>
+              ) : null}
+              <Button type="button" size="sm" variant="outline" onClick={() => setReviewAllScopes(true)}>
+                Review all scopes
+              </Button>
+            </div>
+          </PanelSurface>
+        ) : model.queueRows.length > 0 ? (
+          <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_24rem]">
+            <DenseDataTable
+              tableId="daily-control-tower-queue"
+              columns={queueColumns}
+              rows={model.queueRows}
+              getRowId={(row) => row.item.id}
+              getRowAriaLabel={(row) => `${row.item.label}. ${row.statusLabel}. ${row.item.detail}`}
+              getRowSelectAriaLabel={(row) => row.item.label}
+              getRowAriaControls={() => evidencePanelId}
+              getRowAriaExpanded={(row) => row.item.id === selectedQueueRow?.item.id}
+              getRowClassName={() => "align-top"}
+              onRowSelect={(row) => setSelectedQueueItemId(row.item.id)}
+              selectedRowId={selectedQueueRow?.item.id ?? null}
+              emptyText={model.emptyQueueText}
+              ariaLabel="Daily control tower finance queue"
+              maxVisibleRows={null}
+            />
             {selectedQueueRow ? (
-              <section
-                aria-label={`${selectedQueueRow.item.label} Evidence summary`}
+              <DenseRowDetailPanel
+                id={evidencePanelId}
+                ariaLabel={`${selectedQueueRow.item.label} evidence summary`}
+                selectedSourceLabel={selectedQueueRow.item.label}
                 className="space-y-3 border-l border-border bg-background/50 p-4"
               >
                 <div>
                   <p className="eyebrow-label">Selected queue evidence</p>
                   <h3 className="text-sm font-semibold text-foreground">{selectedQueueRow.item.label}</h3>
-                  <p className="mt-1 text-xs leading-5 text-muted-foreground">{selectedQueueRow.proofPassportSummary}</p>
+                  <p className="mt-1 text-sm leading-6 text-muted-foreground">{selectedQueueRow.proofPassportSummary}</p>
                 </div>
                 <dl className="grid gap-2">
                   {selectedQueueRow.proofPassportItems.slice(0, 4).map((passportItem) => (
                     <div key={passportItem.id} className="rounded border border-border bg-card p-2">
                       <dt className="eyebrow-label">{passportItem.label}</dt>
                       <dd className="mt-1 text-xs font-medium leading-5 text-foreground">{passportItem.value}</dd>
-                      <dd className="mt-1 text-[11px] leading-4 text-muted-foreground">{passportItem.detail}</dd>
+                      <dd className="mt-1 text-xs leading-5 text-muted-foreground">{passportItem.detail}</dd>
                     </div>
                   ))}
                 </dl>
@@ -235,13 +258,13 @@ export function DailyControlTowerScreen({
                         <div key={passportItem.id} className="rounded border border-border bg-card p-2">
                           <dt className="eyebrow-label">{passportItem.label}</dt>
                           <dd className="mt-1 text-xs font-medium leading-5 text-foreground">{passportItem.value}</dd>
-                          <dd className="mt-1 text-[11px] leading-4 text-muted-foreground">{passportItem.detail}</dd>
+                          <dd className="mt-1 text-xs leading-5 text-muted-foreground">{passportItem.detail}</dd>
                         </div>
                       ))}
                     </dl>
                   </TechnicalDetails>
                 ) : null}
-              </section>
+              </DenseRowDetailPanel>
             ) : null}
           </div>
         ) : (

--- a/src/Meridian.Ui/dashboard/src/styles/accounting-screen.css
+++ b/src/Meridian.Ui/dashboard/src/styles/accounting-screen.css
@@ -146,7 +146,7 @@
 
 .reconcile-pane-title {
   color: var(--ws-text-muted, #59636f);
-  font-size: 0.625rem;
+  font-size: 0.75rem;
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -180,7 +180,7 @@
   background: var(--ws-surface, #ffffff);
   padding: 0.375rem 0.75rem;
   color: var(--ws-text-muted, #59636f);
-  font-size: 0.5625rem;
+  font-size: 0.75rem;
   font-weight: 700;
   letter-spacing: 0.04em;
   text-align: left;

--- a/src/Meridian.Ui/dashboard/src/styles/app-shell.css
+++ b/src/Meridian.Ui/dashboard/src/styles/app-shell.css
@@ -177,7 +177,7 @@
   border-radius: var(--radius-chip, 2px);
   color: #8A929B;
   font-family: var(--font-data, "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace);
-  font-size: 0.625rem;
+  font-size: 0.75rem;
   white-space: nowrap;
 }
 
@@ -258,7 +258,7 @@
   background: #0F1216;
   color: #AEB7C0;
   font-family: var(--font-data, "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace);
-  font-size: 0.625rem;
+  font-size: 0.75rem;
   text-decoration: none;
   white-space: normal;
 }

--- a/src/Meridian.Ui/dashboard/src/styles/command-palette.css
+++ b/src/Meridian.Ui/dashboard/src/styles/command-palette.css
@@ -33,7 +33,7 @@
   background: var(--ws-surface-subtle, #F3F6F9);
   color: var(--ws-text-muted, #59636F);
   font-family: var(--font-data, "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace);
-  font-size: 0.625rem;
+  font-size: 0.75rem;
   letter-spacing: 0.04em;
   font-variant: all-small-caps;
   white-space: nowrap;
@@ -54,7 +54,7 @@
   gap: 0.75rem;
   padding: 0.375rem 0.25rem 0.25rem;
   font-family: var(--font-body, "Segoe UI Variable Text", "Segoe UI", system-ui, sans-serif);
-  font-size: 0.5625rem;
+  font-size: 0.75rem;
   font-weight: 600;
   font-variant: all-small-caps;
   letter-spacing: 0.08em;

--- a/src/Meridian.Ui/dashboard/src/styles/companion-pane.css
+++ b/src/Meridian.Ui/dashboard/src/styles/companion-pane.css
@@ -24,7 +24,7 @@
 
 .companion-pane-badge {
   font-family: "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace;
-  font-size: 0.625rem;
+  font-size: 0.75rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--ws-text-muted, #59636f);

--- a/src/Meridian.Ui/dashboard/src/styles/dense-row-detail-accessibility.css
+++ b/src/Meridian.Ui/dashboard/src/styles/dense-row-detail-accessibility.css
@@ -13,7 +13,7 @@
   background: #05101b;
   color: var(--fg-muted);
   font-family: "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace;
-  font-size: 0.59375rem;
+  font-size: 0.75rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
@@ -47,7 +47,7 @@
   background: rgba(47, 111, 143, 0.09);
   color: var(--cyan-primary);
   font-family: "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace;
-  font-size: 0.5625rem;
+  font-size: 0.75rem;
   font-weight: 700;
   line-height: 1;
   padding: 0.25rem 0.375rem;

--- a/src/Meridian.Ui/dashboard/src/styles/index.css
+++ b/src/Meridian.Ui/dashboard/src/styles/index.css
@@ -699,7 +699,7 @@
     background: var(--severity-info-bg);
     color: var(--severity-info-fg);
     font-family: "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace;
-    font-size: 0.5625rem;
+    font-size: 0.75rem;
     font-weight: 700;
     line-height: 1;
     padding: 0 0.375rem;
@@ -894,7 +894,7 @@
 
   .development-fixture-path-label {
     font-family: "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace;
-    font-size: 0.625rem;
+    font-size: 0.75rem;
     font-weight: 600;
     letter-spacing: 0.12em;
     text-transform: uppercase;
@@ -948,7 +948,7 @@
     border-radius: var(--radius-xs);
     background: rgba(242, 201, 76, 0.18);
     font-family: "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace;
-    font-size: 0.625rem;
+    font-size: 0.75rem;
     font-weight: 600;
     line-height: 1;
   }
@@ -1143,6 +1143,21 @@
 }
 
 @layer utilities {
+  /* Supporting and metadata copy stays legible at the workstation's dense
+     setting. This also covers legacy arbitrary-size utilities while those
+     screens migrate onto the semantic type scale. */
+  :where([class*="text-[9px]"], [class*="text-[10px]"], [class*="text-[11px]"], [class*="text-[0.625rem]"]) {
+    font-size: 0.75rem !important;
+  }
+
+  :where([style*="font-size: 9px"], [style*="font-size: 10px"], [style*="font-size: 11px"]) {
+    font-size: 0.75rem !important;
+  }
+
+  :where(.mds-sev, .mds-trust__label, .mds-gate__status, .mds-issue__gate, .act__label, .act__chevron) {
+    font-size: 0.75rem !important;
+  }
+
   .focus-visible\:ring-primary\/40:focus-visible,
   .focus-visible\:ring-primary\/35:focus-visible,
   .focus\:ring-primary\/40:focus,
@@ -1203,5 +1218,32 @@
     animation-iteration-count: 1 !important;
     scroll-behavior: auto !important;
     transition-duration: 0.01ms !important;
+  }
+}
+
+/* Windows High Contrast must preserve focus, selection, status, and table
+   boundaries without relying on Meridian's semantic color tokens. */
+@media (forced-colors: active) {
+  :where(a, button, input, select, textarea, summary, [tabindex]):focus-visible {
+    outline: 2px solid Highlight;
+    outline-offset: 2px;
+  }
+
+  :where([aria-current="page"], [aria-selected="true"], [aria-pressed="true"]) {
+    border-color: Highlight;
+    outline: 2px solid Highlight;
+    outline-offset: -2px;
+  }
+
+  :where(.mds-sev, .mds-badge, .status-badge, .operator-nav-status) {
+    border: 1px solid CanvasText;
+  }
+
+  :where(.dense-data-table, .dense-data-table th, .dense-data-table td, [data-dense-row-detail-panel="true"]) {
+    border-color: CanvasText;
+  }
+
+  :where(a) {
+    color: LinkText;
   }
 }

--- a/src/Meridian.Ui/dashboard/src/styles/ui-kit-primitives.css
+++ b/src/Meridian.Ui/dashboard/src/styles/ui-kit-primitives.css
@@ -32,7 +32,7 @@
   background: rgba(8, 16, 26, 0.92);
   color: var(--fg-muted);
   font-family: "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace;
-  font-size: 0.625rem;
+  font-size: 0.75rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   white-space: nowrap;
@@ -83,7 +83,7 @@
   padding: 0.625rem 0.75rem;
   color: var(--fg-muted);
   font-family: "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace;
-  font-size: 0.625rem;
+  font-size: 0.75rem;
   font-weight: 500;
   letter-spacing: 0.14em;
   text-transform: uppercase;

--- a/src/Meridian.Ui/dashboard/src/styles/workflow-continuity-dock.css
+++ b/src/Meridian.Ui/dashboard/src/styles/workflow-continuity-dock.css
@@ -45,7 +45,7 @@
   gap: 0.1875rem;
   color: var(--fg-muted);
   font-family: "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace;
-  font-size: 0.625rem;
+  font-size: 0.75rem;
 }
 
 .workflow-continuity-meta span {
@@ -93,7 +93,7 @@
 .workflow-continuity-scope-chip dt {
   color: var(--ws-text-muted, #59636F);
   font-family: "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace;
-  font-size: 0.5625rem;
+  font-size: 0.75rem;
   font-weight: 700;
   text-transform: uppercase;
 }
@@ -105,7 +105,7 @@
   white-space: nowrap;
   color: var(--ws-text);
   font-family: "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace;
-  font-size: 0.625rem;
+  font-size: 0.75rem;
   margin: 0;
 }
 
@@ -188,7 +188,7 @@
   color: var(--ws-text-muted);
   box-shadow: none;
   font-family: "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace;
-  font-size: 0.5625rem;
+  font-size: 0.75rem;
   font-weight: 700;
   line-height: 1;
   padding: 0.1875rem 0.3125rem;
@@ -212,7 +212,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--ws-text-muted);
-  font-size: 0.625rem;
+  font-size: 0.75rem;
   line-height: 1.3;
 }
 
@@ -223,14 +223,14 @@
   align-items: baseline;
   gap: 0.3125rem;
   color: var(--ws-text-muted);
-  font-size: 0.59375rem;
+  font-size: 0.75rem;
   line-height: 1.3;
 }
 
 .workflow-continuity-decision-reason span:first-child {
   color: var(--ws-text-muted, #59636F);
   font-family: "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace;
-  font-size: 0.5625rem;
+  font-size: 0.75rem;
   font-weight: 700;
   text-transform: uppercase;
 }
@@ -252,7 +252,7 @@
   background: var(--ws-surface-subtle, #F3F6F9);
   color: var(--ws-text-muted);
   font-family: "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace;
-  font-size: 0.5625rem;
+  font-size: 0.75rem;
   padding: 0.1875rem 0.375rem;
   text-transform: uppercase;
 }
@@ -344,7 +344,7 @@
   background: var(--ws-surface);
   color: var(--ws-text-muted);
   font-family: "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace;
-  font-size: 0.5625rem;
+  font-size: 0.75rem;
   font-weight: 600;
   line-height: 1;
   padding: 0.1875rem 0.3125rem;
@@ -435,7 +435,7 @@
 .workflow-continuity-expanded-flow span:first-child {
   color: var(--ws-text-muted, #59636F);
   font-family: "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace;
-  font-size: 0.5625rem;
+  font-size: 0.75rem;
   font-weight: 700;
   text-transform: uppercase;
 }

--- a/src/Meridian.Ui/dashboard/src/styles/workspace-nav.css
+++ b/src/Meridian.Ui/dashboard/src/styles/workspace-nav.css
@@ -48,7 +48,7 @@
 .operator-rail-section {
   padding: 0.625rem 0.625rem 0.3125rem;
   font-family: var(--font-body, "Segoe UI Variable Text", "Segoe UI", system-ui, sans-serif);
-  font-size: 0.625rem;
+  font-size: 0.75rem;
   font-weight: 600;
   font-variant: all-small-caps;
   letter-spacing: 0.04em;
@@ -71,7 +71,7 @@
 
 .operator-nav-scope span:first-child {
   font-family: var(--font-body, "Segoe UI Variable Text", "Segoe UI", system-ui, sans-serif);
-  font-size: 0.625rem;
+  font-size: 0.75rem;
   font-weight: 600;
   font-variant: all-small-caps;
   letter-spacing: 0.04em;
@@ -196,7 +196,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   font-family: var(--font-data, "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace);
-  font-size: 0.5625rem;
+  font-size: 0.75rem;
   color: var(--mds-nav-rail-text-muted, var(--ws-text-muted, #59636F));
 }
 
@@ -254,7 +254,7 @@
   overflow: hidden;
   color: var(--mds-nav-rail-text-muted, var(--ws-text-muted, #59636F));
   font-family: var(--font-body, "Segoe UI Variable Text", "Segoe UI", system-ui, sans-serif);
-  font-size: 0.625rem;
+  font-size: 0.75rem;
   font-weight: 600;
   font-variant: all-small-caps;
   letter-spacing: 0.04em;


### PR DESCRIPTION
## Summary - make `/` a true shell Home location so no root workspace is falsely marked active - gate the combined Daily Control Tower queue on an operating-scope choice and move triage onto the shared keyboard-accessible dense table/detail contract - fail evidence association closed on stable item ids instead of route/workspace/tone fallbacks - add task-oriented onboarding journeys for financial operations, trading/portfolio, strategy/research, and administration - establish a 12px supporting-text floor plus Windows forced-colors focus, selection, status, and table boundaries - refresh the dashboard source README and generated documentation hash reports  ## Validation - `npm run test -- --run` — passed, 265 files in 34 batches - `npm run typecheck:strict` — passed - `npm run lint` — passed with 92 existing warnings and 0 errors - `npm run build` — passed - rendered production smoke at `/workstation/` — passed; 7 root navigation labels, 1561 rendered characters, 147,908-byte screenshot, no page/console errors (fixture API 404s expected) - `dotnet test ... FullyQualifiedName~Meridian.Tests.Ui.WorkstationEndpointsTests` — passed, 346/346 - `python build/scripts/docs/check-codex-memory.py --summary` — passed - `git diff --check` — passed  ## Canonical CI note `C:\Program Files\Git\bin\bash.exe scripts/ci.sh` was attempted twice. The outer local runner timed out after 20 and 30 minutes without reporting a failing stage. The first timeout left parallel test children; after cleaning only those repo-owned processes, the slow WorkstationEndpoints lane passed independently (346/346 in 9m31s). GitHub Actions remains the integration authority for this PR.  ## Evidence limits The rendered smoke used the maintained fixture-backed API routes and proves production-asset rendering, navigation labels, DOM presence, console health, and screenshot generation. It does not certify live-backend permissions, persistence, production data, screen-reader announcements, 200% zoom/reflow, or Windows forced-colors rendering; those remain hosted/manual release checks.

<!-- phase:PR9 -->