### PR TITLE
Improve journal editing and frontend reliability

### DIFF
--- a/docs/source/generated/source-hash-manifest.json
+++ b/docs/source/generated/source-hash-manifest.json
@@ -268,8 +268,8 @@
       "id": "SRC-UI-DASHBOARD",
       "path": "src/Meridian.Ui/dashboard",
       "readme": "src/Meridian.Ui/dashboard/README.md",
-      "readme_hash": "bd79b6e1e3665022036bee1c22de4dc390b4fbb8b015ea6d06dd47f8a63f77cc",
-      "source_hash": "2d7d59ef8d7cf6ff1395d3a7644b70d96bae0ac279528d71a31a7e4ad7640d90"
+      "readme_hash": "103a2fe37df8f506021e0d81cd3cbbd917fd701573898accbd4612a262970f53",
+      "source_hash": "a7921847f040341ad4e72514c5186f8b6da5e1b6cc6799fa8df81e47c0254586"
     },
     {
       "id": "SRC-UI-SERVICES",

--- a/src/Meridian.Backtesting.Sdk/BacktestResult.cs
+++ b/src/Meridian.Backtesting.Sdk/BacktestResult.cs
@@ -18,6 +18,15 @@ public sealed record SymbolAttribution(
 /// posts them through cash. <see cref="GrossPnl"/> is <see cref="NetPnl"/> with those frictions
 /// added back — the hypothetical friction-free result.
 /// </remarks>
+/// <param name="TotalReturn">Fraction of initial capital (0.15 = +15%), not percent units.</param>
+/// <param name="AnnualizedReturn">Fraction of initial capital (0.15 = +15%), not percent units.</param>
+/// <param name="MaxDrawdown">Absolute currency amount of the worst peak-to-trough decline.</param>
+/// <param name="MaxDrawdownPercent">
+/// Despite the name, this is a FRACTION of peak equity (0.15 = a 15% drawdown), not percent
+/// units. Every producer must agree: <c>BacktestMetricsEngine</c>, <c>WalkForwardService</c>,
+/// and <c>LiveRunMetricsTracker</c> all emit fractions, and the workstation multiplies by 100
+/// at render time. Emitting percent units here reads as a 100x drawdown downstream.
+/// </param>
 public sealed record BacktestMetrics(
     decimal InitialCapital,
     decimal FinalEquity,

--- a/src/Meridian.Strategies/GlobalUsings.cs
+++ b/src/Meridian.Strategies/GlobalUsings.cs
@@ -1,3 +1,4 @@
+global using System.Runtime.CompilerServices;
 global using Meridian.Backtesting.Sdk;
 global using Meridian.Execution.Interfaces;
 global using Meridian.Execution.Sdk;
@@ -5,3 +6,4 @@ global using Meridian.Infrastructure.Contracts;
 global using Meridian.Strategies.Interfaces;
 global using Meridian.Strategies.Models;
 global using Microsoft.Extensions.Logging;
+[assembly: InternalsVisibleTo("Meridian.Tests")]

--- a/src/Meridian.Strategies/Live/LiveRunMetricsTracker.cs
+++ b/src/Meridian.Strategies/Live/LiveRunMetricsTracker.cs
@@ -22,7 +22,8 @@ internal sealed class LiveRunMetricsTracker
     private decimal _previousEquity;
     private decimal _peakEquity;
     private decimal _maxDrawdown;
-    private decimal _maxDrawdownPercent;
+    /// <summary>Fraction of peak equity (0.15 = a 15% drawdown), matching <see cref="BacktestMetrics.MaxDrawdownPercent"/>.</summary>
+    private decimal _maxDrawdownFraction;
     private double _sumReturns;
     private double _sumSquaredReturns;
     private double _sumSquaredDownsideReturns;
@@ -93,7 +94,7 @@ internal sealed class LiveRunMetricsTracker
         if (drawdown > _maxDrawdown)
         {
             _maxDrawdown = drawdown;
-            _maxDrawdownPercent = _peakEquity > 0m ? drawdown / _peakEquity * 100m : 0m;
+            _maxDrawdownFraction = _peakEquity > 0m ? drawdown / _peakEquity : 0m;
         }
 
         _snapshots.Add(new PortfolioSnapshot(
@@ -136,7 +137,7 @@ internal sealed class LiveRunMetricsTracker
             sortino = downsideDev > 0 ? mean / downsideDev * Math.Sqrt(252) : 0;
         }
 
-        var calmar = _maxDrawdownPercent > 0m ? (double)(annualizedReturn / (_maxDrawdownPercent / 100m)) : 0;
+        var calmar = _maxDrawdownFraction > 0m ? (double)(annualizedReturn / _maxDrawdownFraction) : 0;
 
         var metrics = new BacktestMetrics(
             InitialCapital: _initialEquity,
@@ -149,7 +150,7 @@ internal sealed class LiveRunMetricsTracker
             SortinoRatio: sortino,
             CalmarRatio: calmar,
             MaxDrawdown: _maxDrawdown,
-            MaxDrawdownPercent: _maxDrawdownPercent,
+            MaxDrawdownPercent: _maxDrawdownFraction,
             MaxDrawdownRecoveryDays: 0,
             ProfitFactor: 0,
             WinRate: 0,

--- a/src/Meridian.Ui/dashboard/README.md
+++ b/src/Meridian.Ui/dashboard/README.md
@@ -1075,7 +1075,14 @@ ledger-book mutation checks, authenticated tenant/company scoping, and approval 
 server-owned. Browser route `fundProfileId` and `ledgerBookId` values now flow into the shared
 manual journal workbench query and are preserved on save, validate, submit, evidence attachment,
 and lifecycle transition requests so scoped Accounting work cannot silently fall back to fund-level
-manual JE drafts. The same workstream renders the shared
+manual JE drafts. The journal composer adds a sticky health and command bar, keyboard-oriented
+line navigation with insert and duplicate actions, debounced governed draft autosave, and a scoped
+local recovery snapshot for changes that have not reached the server. Recovery state is explicitly
+labelled as non-authoritative and can be discarded back to the loaded server draft. Validation
+issues retain their shared target identifiers and navigate operators to the affected header or line,
+while the selected-line inspector edits the existing line entity, allocation, tax-lot, Security
+Master, and shared journal dimension fields without moving accounting rules into React. The same
+workstream renders the shared
 private-capital activity projection as fund-event rows, capital-account aggregates, signed net
 activity, ordered capital-account subledger movements with running net activity, posted fund-event
 counts, ledger-impact readiness, published report-output counts, report-output readiness

--- a/src/Meridian.Ui/dashboard/src/lib/api-errors.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/api-errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createApiErrorFromResponseBody, describeApiError, isApiError } from "@/lib/api-errors";
+import { createApiErrorFromResponseBody, describeApiError, isAbortError, isApiError } from "@/lib/api-errors";
 
 describe("api-errors", () => {
   it("parses validation errors into structured operator-facing details", () => {
@@ -104,5 +104,36 @@ describe("api-errors", () => {
         "The active role cannot read trading readiness."
       ]
     });
+  });
+});
+
+describe("isAbortError", () => {
+  it("recognises the DOMException form browsers reject with", () => {
+    expect(isAbortError(new DOMException("The operation was aborted.", "AbortError"))).toBe(true);
+  });
+
+  it("recognises the plain Error form jsdom and fetch polyfills reject with", () => {
+    const error = new Error("The operation was aborted.");
+    error.name = "AbortError";
+    expect(isAbortError(error)).toBe(true);
+  });
+
+  it("recognises a real AbortController signal rejection", () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    expect(isAbortError(controller.signal.reason)).toBe(true);
+  });
+
+  it("does not treat genuine failures as aborts merely because they mention aborting", () => {
+    expect(isAbortError(new Error("Upload aborted by the remote host"))).toBe(false);
+    expect(isAbortError(new DOMException("Aborted the transaction", "InvalidStateError"))).toBe(false);
+  });
+
+  it("returns false for non-error values", () => {
+    expect(isAbortError(null)).toBe(false);
+    expect(isAbortError(undefined)).toBe(false);
+    expect(isAbortError("AbortError")).toBe(false);
+    expect(isAbortError({ name: "AbortError" })).toBe(false);
   });
 });

--- a/src/Meridian.Ui/dashboard/src/lib/api-errors.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/api-errors.ts
@@ -73,6 +73,24 @@ export function isApiError(error: unknown): error is ApiError {
   return error instanceof ApiError;
 }
 
+/**
+ * True when a rejected request was aborted rather than genuinely failing.
+ *
+ * Callers use this to stay silent on teardown/navigation instead of showing the
+ * operator an error banner. Both arms are required: `AbortController.abort()`
+ * rejects with a `DOMException` in browsers, but the same abort surfaces as a
+ * plain `Error` named "AbortError" under jsdom and some fetch polyfills, so a
+ * `DOMException`-only check misreports those as real failures.
+ *
+ * Matches on `name` only — never on message text, which would swallow genuine
+ * errors that merely mention aborting.
+ */
+export function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException
+    ? error.name === "AbortError"
+    : error instanceof Error && error.name === "AbortError";
+}
+
 export function describeApiError(error: unknown, fallback: string): ApiErrorDisplay {
   if (!isApiError(error)) {
     if (error instanceof Error && error.message.trim()) {

--- a/src/Meridian.Ui/dashboard/src/lib/format.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/format.test.ts
@@ -6,6 +6,7 @@ import {
   formatNumber,
   formatPercent,
   formatPrefixedCurrency,
+  formatRatioAsPercent,
   formatSignedCurrency,
   pluralizeCount
 } from "@/lib/format";
@@ -36,6 +37,25 @@ describe("formatPercent", () => {
 
   it("renders the fallback for non-finite values", () => {
     expect(formatPercent(null, { fallback: "Not measured" })).toBe("Not measured");
+  });
+});
+
+describe("formatRatioAsPercent", () => {
+  it("scales fraction-unit values into percent display", () => {
+    expect(formatRatioAsPercent(0.425)).toBe("42.5%");
+    expect(formatRatioAsPercent(1)).toBe("100%");
+    expect(formatRatioAsPercent(0)).toBe("0%");
+  });
+
+  it("differs from formatPercent by exactly 100x for the same input", () => {
+    expect(formatPercent(0.425)).toBe("0.43%");
+    expect(formatRatioAsPercent(0.425)).toBe("42.5%");
+  });
+
+  it("honours fraction digit bounds and the fallback", () => {
+    expect(formatRatioAsPercent(0.12345, { maximumFractionDigits: 1 })).toBe("12.3%");
+    expect(formatRatioAsPercent(null, { fallback: "Unavailable" })).toBe("Unavailable");
+    expect(formatRatioAsPercent(Number.NaN, { fallback: "Unavailable" })).toBe("Unavailable");
   });
 });
 

--- a/src/Meridian.Ui/dashboard/src/lib/format.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/format.ts
@@ -44,6 +44,15 @@ export function formatNumber(value: NullableNumber, options: NumberFormatOptions
   return value.toLocaleString(FORMAT_LOCALE, { minimumFractionDigits, maximumFractionDigits });
 }
 
+// PERCENT UNITS: the workstation carries percent-like values in two different units,
+// and picking the wrong helper is a silent 100x error in financial output. Read the
+// producing field before choosing:
+//   - `formatPercent`        takes PERCENT units  (42.5 -> "42.5%")
+//   - `formatRatioAsPercent` takes FRACTION units (0.425 -> "42.5%")
+// A `…Percent` suffix on a field name is NOT reliable evidence of its unit — see
+// `maxDrawdownPercent`, which arrives as a fraction from the walk-forward path and
+// as percent units from the live-metrics path.
+
 /** Percent display for values already expressed in percent units, e.g. 42.5 -> "42.5%". */
 export function formatPercent(value: NullableNumber, options: NumberFormatOptions = {}): string {
   const { fallback = DEFAULT_FALLBACK } = options;
@@ -52,6 +61,16 @@ export function formatPercent(value: NullableNumber, options: NumberFormatOption
   }
 
   return `${formatNumber(value, options)}%`;
+}
+
+/** Percent display for values expressed as a fraction of 1, e.g. 0.425 -> "42.5%". */
+export function formatRatioAsPercent(value: NullableNumber, options: NumberFormatOptions = {}): string {
+  const { fallback = DEFAULT_FALLBACK } = options;
+  if (!isRenderable(value)) {
+    return fallback;
+  }
+
+  return formatPercent(value * 100, options);
 }
 
 /** Symbol-style currency via Intl, e.g. "$1,234.56"; unknown codes render as "CODE 1,234.56". */

--- a/src/Meridian.Ui/dashboard/src/lib/price-alerts/service.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/price-alerts/service.ts
@@ -1,6 +1,7 @@
 import { createContext, createElement, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useQuotesStream } from "@/hooks/use-quotes-stream";
 import { getLiveQuotesSnapshot } from "@/lib/api";
+import { isAbortError } from "@/lib/api-errors";
 import type { QuotesSnapshotItem, QuotesSnapshotResponse } from "@/types";
 import { describeCondition, shouldTrigger } from "./evaluator";
 import {
@@ -395,10 +396,6 @@ function readPermission(): NotificationPermission | "unsupported" {
     return "unsupported";
   }
   return Notification.permission;
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof Error && (error.name === "AbortError" || /abort/i.test(error.message));
 }
 
 function formatPrice(value: number): string {

--- a/src/Meridian.Ui/dashboard/src/screens/accounting-screen.journal-entries.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/accounting-screen.journal-entries.view-model.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   useManualJournalEntryWorkbenchViewModel,
 } from "@/screens/accounting-screen.view-model";
@@ -767,6 +767,39 @@ const manualJournalWorkbench: ManualJournalEntryWorkbench = {
   }
 };
 
+function createJournalServices(
+  overrides: Partial<ManualJournalEntryWorkbenchServices> = {}
+): ManualJournalEntryWorkbenchServices {
+  return {
+    getWorkbench: vi.fn().mockResolvedValue(manualJournalWorkbench),
+    searchSecurities: vi.fn().mockResolvedValue([]),
+    saveDraft: vi.fn((request) => Promise.resolve({
+      ...request.draft,
+      version: request.draft.version + 1,
+      updatedAtUtc: "2026-06-30T00:01:00Z"
+    })),
+    validateDraft: vi.fn((request) => Promise.resolve(request.draft)),
+    submitApproval: vi.fn((request) => Promise.resolve({
+      ...manualJournalDraft,
+      journalEntryId: request.journalEntryId,
+      status: "Submitted" as const,
+      version: request.version + 1
+    })),
+    attachEvidence: vi.fn().mockResolvedValue(manualJournalDraft),
+    applyLifecycleAction: vi.fn(),
+    ...overrides
+  };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  window.localStorage.clear();
+});
+
 describe("accounting-screen journal-entry view model", () => {
   it("keeps editing unavailable when the governed workbench cannot load", async () => {
     const services = {
@@ -1433,6 +1466,97 @@ describe("accounting-screen journal-entry view model", () => {
       ledgerBookId: "book-route",
       action: "Approve"
     }));
+  });
+
+  it("autosaves editable changes and reports saved health after the debounce", async () => {
+    const services = createJournalServices();
+    const { result } = renderHook(() => useManualJournalEntryWorkbenchViewModel(true, services));
+    await waitFor(() => expect(result.current.available).toBe(true));
+
+    vi.useFakeTimers();
+    act(() => result.current.updateHeader("memo", "Autosaved close adjustment"));
+    expect(result.current.saveState).toBe("unsaved");
+    expect(result.current.saveStatusLabel).toBe("Unsaved changes");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_200);
+    });
+
+    expect(services.saveDraft).toHaveBeenCalledWith(expect.objectContaining({
+      correlationId: "manual-je-autosave",
+      draft: expect.objectContaining({ memo: "Autosaved close adjustment" })
+    }));
+    expect(result.current.saveState).toBe("saved");
+    expect(result.current.draft.version).toBe(2);
+  });
+
+  it("recovers an unsaved local snapshot and can discard it for the server draft", async () => {
+    vi.useFakeTimers();
+    const services = createJournalServices();
+    const first = renderHook(() => useManualJournalEntryWorkbenchViewModel(true, services));
+    await vi.waitFor(() => expect(first.result.current.available).toBe(true));
+
+    act(() => first.result.current.updateHeader("memo", "Recovered operator memo"));
+    expect(first.result.current.saveState).toBe("unsaved");
+    first.unmount();
+
+    const second = renderHook(() => useManualJournalEntryWorkbenchViewModel(true, services));
+    await vi.waitFor(() => expect(second.result.current.saveState).toBe("recovered"));
+    expect(second.result.current.draft.memo).toBe("Recovered operator memo");
+    expect(second.result.current.recoveryStatusText).toContain("Recovered unsaved changes");
+
+    act(() => second.result.current.discardRecoveredDraft());
+    expect(second.result.current.saveState).toBe("saved");
+    expect(second.result.current.draft.memo).toBe("Manual close adjustment");
+  });
+
+  it("duplicates and inserts lines while keeping selected dimensions editable", async () => {
+    const services = createJournalServices();
+    const { result } = renderHook(() => useManualJournalEntryWorkbenchViewModel(true, services));
+    await waitFor(() => expect(result.current.available).toBe(true));
+
+    let duplicateId: string | null = null;
+    act(() => {
+      duplicateId = result.current.duplicateLine("line-debit");
+    });
+    expect(duplicateId).toBeTruthy();
+    expect(result.current.draft.lines).toHaveLength(3);
+    expect(result.current.draft.lines[1]).toMatchObject({
+      lineId: duplicateId,
+      side: "Debit",
+      amount: 100,
+      accountPath: "Assets:Cash",
+      description: "Cash debit (copy)"
+    });
+
+    let insertedId = "";
+    act(() => {
+      insertedId = result.current.insertLineAfter(duplicateId!, "Credit");
+      result.current.updateLine(duplicateId!, {
+        entityId: "entity-line",
+        fundAllocationId: "allocation-1",
+        taxLotId: "lot-1"
+      });
+      result.current.updateDraftDimensions({
+        strategyId: "strategy-1",
+        portfolioId: "portfolio-1",
+        costCenterId: "cost-center-1"
+      });
+    });
+
+    expect(result.current.selectedLineId).toBe(insertedId);
+    expect(result.current.draft.lines).toHaveLength(4);
+    expect(result.current.draft.lines.find((line) => line.lineId === duplicateId)).toMatchObject({
+      entityId: "entity-line",
+      fundAllocationId: "allocation-1",
+      taxLotId: "lot-1"
+    });
+    expect(result.current.draft.dimensions).toMatchObject({
+      strategyId: "strategy-1",
+      portfolioId: "portfolio-1",
+      costCenterId: "cost-center-1"
+    });
+    expect(result.current.validationIsCurrent).toBe(false);
   });
 
 

--- a/src/Meridian.Ui/dashboard/src/screens/accounting-screen.journal-entries.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/accounting-screen.journal-entries.view-model.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   applyManualJournalEntryLifecycleAction,
   attachManualJournalEntryEvidence,
@@ -79,6 +79,8 @@ const defaultManualJournalEntryWorkbenchServices: ManualJournalEntryWorkbenchSer
   applyLifecycleAction: (request) => applyManualJournalEntryLifecycleAction(request)
 };
 
+const MANUAL_JOURNAL_AUTOSAVE_DELAY_MS = 1_200;
+
 export function useManualJournalEntryWorkbenchViewModel(
   active: boolean,
   services: ManualJournalEntryWorkbenchServices = defaultManualJournalEntryWorkbenchServices,
@@ -103,7 +105,18 @@ export function useManualJournalEntryWorkbenchViewModel(
   const [lifecycleStatusText, setLifecycleStatusText] = useState<string | null>(null);
   const [lifecycleCorrectionDrafts, setLifecycleCorrectionDrafts] = useState<ManualJournalEntryDraft[]>([]);
   const [validatedDraftSignature, setValidatedDraftSignature] = useState<string | null>(null);
+  const [savedDraftSignature, setSavedDraftSignature] = useState<string | null>(null);
+  const [saveState, setSaveState] = useState<ManualJournalEntryWorkbenchViewModel["saveState"]>("saved");
+  const [lastSavedAtUtc, setLastSavedAtUtc] = useState<string | null>(null);
+  const [recoveryStatusText, setRecoveryStatusText] = useState<string | null>(null);
+  const [recoveryBaseline, setRecoveryBaseline] = useState<ManualJournalEntryDraft | null>(null);
+  const draftRef = useRef(draft);
+  const saveBusyRef = useRef(false);
   const query = useMemo(() => parseManualJournalEntryWorkbenchQuery(search), [search]);
+
+  useEffect(() => {
+    draftRef.current = draft;
+  }, [draft]);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -117,8 +130,17 @@ export function useManualJournalEntryWorkbenchViewModel(
         next,
         query
       );
-      setDraft(selected);
-      setSelectedLineId(selected.lines[0]?.lineId ?? "line-1");
+      const recovered = readManualJournalRecoverySnapshot(selected);
+      const openedDraft = recovered?.draft ?? selected;
+      setDraft(openedDraft);
+      setSelectedLineId(openedDraft.lines[0]?.lineId ?? "line-1");
+      setSavedDraftSignature(buildManualJournalEditableSignature(selected));
+      setLastSavedAtUtc(selected.updatedAtUtc);
+      setRecoveryBaseline(recovered ? selected : null);
+      setRecoveryStatusText(recovered
+        ? `Recovered unsaved changes captured ${formatDateTimeLabel(recovered.capturedAtUtc)}.`
+        : null);
+      setSaveState(recovered ? "recovered" : "saved");
     } catch (err) {
       setError(describeApiError(err, "Manual journal entry workbench could not load."));
     } finally {
@@ -144,10 +166,22 @@ export function useManualJournalEntryWorkbenchViewModel(
     [workbench]
   );
 
-  const applyServerDraft = useCallback((next: ManualJournalEntryDraft, validationIsCurrent = false) => {
+  const applyServerDraft = useCallback((
+    next: ManualJournalEntryDraft,
+    validationIsCurrent = false,
+    persisted = true
+  ) => {
     setDraft(next);
     setValidatedDraftSignature(validationIsCurrent ? buildManualJournalValidationSignature(next) : null);
     setSelectedLineId(next.lines[0]?.lineId ?? selectedLineId);
+    if (persisted) {
+      setSavedDraftSignature(buildManualJournalEditableSignature(next));
+      setLastSavedAtUtc(next.updatedAtUtc);
+      setSaveState("saved");
+      setRecoveryBaseline(null);
+      setRecoveryStatusText(null);
+      clearManualJournalRecoverySnapshot(next);
+    }
     setWorkbench((current) => current
       ? {
         ...current,
@@ -163,6 +197,12 @@ export function useManualJournalEntryWorkbenchViewModel(
     setSelectedLineId(result.journalEntry.lines[0]?.lineId ?? selectedLineId);
     setLifecycleCorrectionDrafts(generated);
     setLifecycleStatusText(`${result.transition.action} recorded: ${result.transition.fromStatus} -> ${result.transition.toStatus}`);
+    setSavedDraftSignature(buildManualJournalEditableSignature(result.journalEntry));
+    setLastSavedAtUtc(result.journalEntry.updatedAtUtc);
+    setSaveState("saved");
+    setRecoveryBaseline(null);
+    setRecoveryStatusText(null);
+    clearManualJournalRecoverySnapshot(result.journalEntry);
     setWorkbench((current) => {
       if (!current) {
         return current;
@@ -179,16 +219,30 @@ export function useManualJournalEntryWorkbenchViewModel(
 
   const updateHeader = useCallback<ManualJournalEntryWorkbenchViewModel["updateHeader"]>((field, value) => {
     setValidatedDraftSignature(null);
+    setSaveState("unsaved");
     setDraft((current) => ({ ...current, [field]: value }));
   }, []);
 
   const updateLine = useCallback<ManualJournalEntryWorkbenchViewModel["updateLine"]>((lineId, patch) => {
     setValidatedDraftSignature(null);
+    setSaveState("unsaved");
     setDraft((current) => ({
       ...withManualJournalTotals({
         ...current,
         lines: current.lines.map((line) => line.lineId === lineId ? { ...line, ...patch } : line)
       })
+    }));
+  }, []);
+
+  const updateDraftDimensions = useCallback<ManualJournalEntryWorkbenchViewModel["updateDraftDimensions"]>((patch) => {
+    setValidatedDraftSignature(null);
+    setSaveState("unsaved");
+    setDraft((current) => ({
+      ...current,
+      dimensions: {
+        ...(current.dimensions ?? {}),
+        ...patch
+      }
     }));
   }, []);
 
@@ -231,9 +285,55 @@ export function useManualJournalEntryWorkbenchViewModel(
   const addLine = useCallback((side: AccountingTemplateLineSide) => {
     const line = createManualJournalEntryLine(side, draft.currency, accountOptions[0]?.value ?? "");
     setValidatedDraftSignature(null);
+    setSaveState("unsaved");
     setDraft((current) => withManualJournalTotals({ ...current, lines: [...current.lines, line] }));
     setSelectedLineId(line.lineId);
   }, [accountOptions, draft.currency]);
+
+  const insertLineAfter = useCallback<ManualJournalEntryWorkbenchViewModel["insertLineAfter"]>((lineId, side) => {
+    const currentDraft = draftRef.current;
+    const sourceIndex = currentDraft.lines.findIndex((line) => line.lineId === lineId);
+    const source = sourceIndex >= 0 ? currentDraft.lines[sourceIndex] : null;
+    const line = createManualJournalEntryLine(
+      side ?? source?.side ?? "Debit",
+      currentDraft.currency,
+      source?.accountPath ?? accountOptions[0]?.value ?? ""
+    );
+    setValidatedDraftSignature(null);
+    setSaveState("unsaved");
+    setDraft((current) => {
+      const index = current.lines.findIndex((item) => item.lineId === lineId);
+      const insertionIndex = index >= 0 ? index + 1 : current.lines.length;
+      const lines = [...current.lines];
+      lines.splice(insertionIndex, 0, line);
+      return withManualJournalTotals({ ...current, lines });
+    });
+    setSelectedLineId(line.lineId);
+    return line.lineId;
+  }, [accountOptions]);
+
+  const duplicateLine = useCallback<ManualJournalEntryWorkbenchViewModel["duplicateLine"]>((lineId) => {
+    const source = draftRef.current.lines.find((line) => line.lineId === lineId);
+    if (!source) {
+      return null;
+    }
+
+    const duplicate = {
+      ...source,
+      lineId: newClientId(),
+      description: source.description ? `${source.description} (copy)` : null
+    };
+    setValidatedDraftSignature(null);
+    setSaveState("unsaved");
+    setDraft((current) => {
+      const index = current.lines.findIndex((line) => line.lineId === lineId);
+      const lines = [...current.lines];
+      lines.splice(index >= 0 ? index + 1 : current.lines.length, 0, duplicate);
+      return withManualJournalTotals({ ...current, lines });
+    });
+    setSelectedLineId(duplicate.lineId);
+    return duplicate.lineId;
+  }, []);
 
   const removeLine = useCallback<ManualJournalEntryWorkbenchViewModel["removeLine"]>((lineId) => {
     setDraft((current) => {
@@ -242,6 +342,7 @@ export function useManualJournalEntryWorkbenchViewModel(
       }
 
       setValidatedDraftSignature(null);
+      setSaveState("unsaved");
       const nextLines = current.lines.filter((line) => line.lineId !== lineId);
       if (selectedLineId === lineId) {
         setSelectedLineId(nextLines[0]?.lineId ?? "line-1");
@@ -309,6 +410,7 @@ export function useManualJournalEntryWorkbenchViewModel(
       }
 
       setValidatedDraftSignature(null);
+      setSaveState("unsaved");
       const retainedUris = new Set(nextAttachments.map((item) => item.uri));
       return {
         ...current,
@@ -324,10 +426,21 @@ export function useManualJournalEntryWorkbenchViewModel(
       return;
     }
 
+    const current = draftRef.current;
+    if (savedDraftSignature !== null
+      && buildManualJournalEditableSignature(current) !== savedDraftSignature) {
+      writeManualJournalRecoverySnapshot(current);
+    }
+
     setDraft(selected);
     setValidatedDraftSignature(null);
+    setSavedDraftSignature(buildManualJournalEditableSignature(selected));
+    setLastSavedAtUtc(selected.updatedAtUtc);
+    setSaveState("saved");
+    setRecoveryBaseline(null);
+    setRecoveryStatusText(null);
     setSelectedLineId(selected.lines[0]?.lineId ?? selectedLineId);
-  }, [selectedLineId, workbench?.drafts]);
+  }, [savedDraftSignature, selectedLineId, workbench?.drafts]);
 
   const validate = useCallback(async () => {
     setValidateBusy(true);
@@ -340,7 +453,7 @@ export function useManualJournalEntryWorkbenchViewModel(
         correlationId: "manual-je-validate",
         ledgerBookId: draftForValidation.ledgerBookId ?? query.ledgerBookId ?? null
       });
-      applyServerDraft(validatedDraft, true);
+      applyServerDraft(validatedDraft, true, false);
     } catch (err) {
       setError(describeApiError(err, "Manual journal entry validation failed."));
     } finally {
@@ -348,23 +461,118 @@ export function useManualJournalEntryWorkbenchViewModel(
     }
   }, [applyServerDraft, draft, query.ledgerBookId, services]);
 
-  const save = useCallback(async () => {
+  const persistDraft = useCallback(async (
+    candidate: ManualJournalEntryDraft,
+    cause: "manual" | "autosave"
+  ) => {
+    if (saveBusyRef.current || !isManualJournalEditable(candidate.status)) {
+      return;
+    }
+
+    const draftForSave = withManualJournalTotals(candidate);
+    const candidateSignature = buildManualJournalEditableSignature(draftForSave);
+    saveBusyRef.current = true;
     setSaveBusy(true);
-    setError(null);
-    const draftForSave = withManualJournalTotals(draft);
+    setSaveState("saving");
+    if (cause === "manual") {
+      setError(null);
+    }
+
     try {
-      applyServerDraft(await services.saveDraft({
+      const saved = await services.saveDraft({
         draft: draftForSave,
         actor: "browser-user",
-        correlationId: "manual-je-save",
+        correlationId: cause === "autosave" ? "manual-je-autosave" : "manual-je-save",
         ledgerBookId: draftForSave.ledgerBookId ?? query.ledgerBookId ?? null
-      }));
+      });
+      const latest = draftRef.current;
+      if (buildManualJournalEditableSignature(latest) === candidateSignature) {
+        applyServerDraft(saved);
+      } else {
+        const rebased = withManualJournalTotals({
+          ...latest,
+          version: saved.version,
+          updatedAtUtc: saved.updatedAtUtc,
+          createdAtUtc: saved.createdAtUtc,
+          preparedBy: saved.preparedBy,
+          status: saved.status
+        });
+        setDraft(rebased);
+        setSavedDraftSignature(candidateSignature);
+        setLastSavedAtUtc(saved.updatedAtUtc);
+        setSaveState("unsaved");
+        writeManualJournalRecoverySnapshot(rebased);
+        setWorkbench((current) => current
+          ? {
+            ...current,
+            drafts: [rebased, ...current.drafts.filter((item) => item.journalEntryId !== rebased.journalEntryId)]
+          }
+          : current);
+      }
     } catch (err) {
-      setError(describeApiError(err, "Manual journal entry draft could not be saved."));
+      const errorDisplay = describeApiError(err, cause === "autosave"
+        ? "Manual journal autosave failed. Your changes remain available for recovery."
+        : "Manual journal entry draft could not be saved.");
+      setSaveState("error");
+      setRecoveryStatusText(errorDisplay.summary);
+      writeManualJournalRecoverySnapshot(draftRef.current);
+      if (cause === "manual") {
+        setError(errorDisplay);
+      }
     } finally {
+      saveBusyRef.current = false;
       setSaveBusy(false);
     }
-  }, [applyServerDraft, draft, query.ledgerBookId, services]);
+  }, [applyServerDraft, query.ledgerBookId, services]);
+
+  const save = useCallback(async () => {
+    await persistDraft(draftRef.current, "manual");
+  }, [persistDraft]);
+
+  const discardRecoveredDraft = useCallback(() => {
+    if (!recoveryBaseline) {
+      return;
+    }
+
+    const baseline = recoveryBaseline;
+    setDraft(baseline);
+    setSelectedLineId(baseline.lines[0]?.lineId ?? "line-1");
+    setValidatedDraftSignature(null);
+    setSavedDraftSignature(buildManualJournalEditableSignature(baseline));
+    setLastSavedAtUtc(baseline.updatedAtUtc);
+    setSaveState("saved");
+    setRecoveryBaseline(null);
+    setRecoveryStatusText(null);
+    clearManualJournalRecoverySnapshot(baseline);
+  }, [recoveryBaseline]);
+
+  const editableDraftSignature = useMemo(
+    () => buildManualJournalEditableSignature(draft),
+    [draft]
+  );
+
+  useEffect(() => {
+    if (!active || workbench === null || !isManualJournalEditable(draft.status)) {
+      return;
+    }
+
+    if (savedDraftSignature === null || editableDraftSignature === savedDraftSignature) {
+      return;
+    }
+
+    writeManualJournalRecoverySnapshot(draft);
+    if (saveState === "saving" || saveState === "error") {
+      return;
+    }
+    if (saveState !== "recovered") {
+      setSaveState("unsaved");
+    }
+    const timer = window.setTimeout(() => {
+      void persistDraft(draftRef.current, "autosave");
+    }, MANUAL_JOURNAL_AUTOSAVE_DELAY_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [active, draft, editableDraftSignature, persistDraft, saveState, savedDraftSignature, workbench]);
 
   const submit = useCallback(async () => {
     const draftForSubmit = withManualJournalTotals(draft);
@@ -432,7 +640,9 @@ export function useManualJournalEntryWorkbenchViewModel(
     label: issue.code,
     message: issue.message,
     detail: issue.suggestedAction ?? issue.targetId ?? "Review the journal entry.",
-    tone: issue.severity === "Critical" ? "danger" : issue.severity === "Warning" ? "warning" : "default"
+    tone: issue.severity === "Critical" ? "danger" : issue.severity === "Warning" ? "warning" : "default",
+    targetId: issue.targetId,
+    severity: issue.severity
   }));
   const getLineBadges = useCallback<ManualJournalEntryWorkbenchViewModel["getLineBadges"]>((lineId) => {
     const line = draft.lines.find((item) => item.lineId === lineId);
@@ -470,7 +680,27 @@ export function useManualJournalEntryWorkbenchViewModel(
     && validatedDraftSignature === buildManualJournalValidationSignature(balancedDraft);
   const submitDisabledReason = getManualJournalSubmitDisabledReason(balancedDraft, validationIsCurrent);
   const canSubmit = submitDisabledReason === null;
+  const blockingIssueCount = draft.validationIssues.filter((issue) => issue.severity === "Critical").length;
+  const warningIssueCount = draft.validationIssues.filter((issue) => issue.severity === "Warning").length;
   const balanceStatusLabel = Math.abs(balancedDraft.imbalance) === 0 ? "Balanced" : "Out by " + formatCurrency(Math.abs(balancedDraft.imbalance));
+  const saveStatusLabel = saveState === "saving"
+    ? "Saving draft"
+    : saveState === "unsaved"
+      ? "Unsaved changes"
+      : saveState === "error"
+        ? "Autosave failed - recovery copy retained"
+        : saveState === "recovered"
+          ? "Recovered unsaved changes"
+          : lastSavedAtUtc
+            ? `Saved ${formatDateTimeLabel(lastSavedAtUtc)}`
+            : "Draft saved";
+  const validationStatusLabel = validationIsCurrent
+    ? blockingIssueCount > 0
+      ? `${blockingIssueCount} blocking validation issue${blockingIssueCount === 1 ? "" : "s"}`
+      : warningIssueCount > 0
+        ? `Validated with ${warningIssueCount} warning${warningIssueCount === 1 ? "" : "s"}`
+        : "Validation current"
+    : "Validation required";
   const treasuryContextLabel = formatManualJournalTreasuryContext(draft);
   const privateCapitalActivity = useMemo(
     () => buildManualJournalPrivateCapitalActivityView(workbench?.privateCapitalActivity ?? null),
@@ -520,6 +750,12 @@ export function useManualJournalEntryWorkbenchViewModel(
     treasuryContextLabel,
     privateCapitalActivity,
     validationIssues,
+    blockingIssueCount,
+    warningIssueCount,
+    saveState,
+    saveStatusLabel,
+    validationStatusLabel,
+    recoveryStatusText,
     lifecycleCommands,
     lifecycleChecklist,
     lifecycleTransitions,
@@ -539,13 +775,17 @@ export function useManualJournalEntryWorkbenchViewModel(
     selectDraft,
     selectLine: setSelectedLineId,
     updateLine,
+    updateDraftDimensions,
     getLineBadges,
     updateSecuritySearchQuery: setSecuritySearchQuery,
     searchSecurityMaster,
     selectSecurity,
     clearSecurity,
     addLine,
+    insertLineAfter,
+    duplicateLine,
     removeLine,
+    discardRecoveredDraft,
     updateAttachmentDraft,
     addAttachment,
     removeAttachment,
@@ -562,6 +802,88 @@ function parseManualJournalEntryWorkbenchQuery(search: string): ManualJournalEnt
     fundProfileId: normalizeQueryValue(params.get("fundProfileId")),
     ledgerBookId: normalizeQueryValue(params.get("ledgerBookId"))
   };
+}
+
+interface ManualJournalRecoverySnapshot {
+  capturedAtUtc: string;
+  draft: ManualJournalEntryDraft;
+}
+
+function manualJournalRecoveryStorageKey(draft: ManualJournalEntryDraft): string {
+  const fundProfileId = draft.fundProfileId.trim() || "default-fund";
+  const ledgerBookId = draft.ledgerBookId?.trim() || "default-ledger-book";
+  return `meridian.manual-journal-recovery.v1:${fundProfileId}:${ledgerBookId}`;
+}
+
+function readManualJournalRecoverySnapshot(
+  serverDraft: ManualJournalEntryDraft
+): ManualJournalRecoverySnapshot | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(manualJournalRecoveryStorageKey(serverDraft));
+    if (!raw) {
+      return null;
+    }
+
+    const snapshot = JSON.parse(raw) as ManualJournalRecoverySnapshot;
+    if (!snapshot?.draft || !snapshot.capturedAtUtc || !isManualJournalEditable(snapshot.draft.status)) {
+      window.localStorage.removeItem(manualJournalRecoveryStorageKey(serverDraft));
+      return null;
+    }
+
+    if (snapshot.draft.fundProfileId !== serverDraft.fundProfileId ||
+        (snapshot.draft.ledgerBookId ?? null) !== (serverDraft.ledgerBookId ?? null)) {
+      return null;
+    }
+
+    if (snapshot.draft.journalEntryId === serverDraft.journalEntryId &&
+        snapshot.draft.version < serverDraft.version) {
+      window.localStorage.removeItem(manualJournalRecoveryStorageKey(serverDraft));
+      return null;
+    }
+
+    return buildManualJournalEditableSignature(snapshot.draft) === buildManualJournalEditableSignature(serverDraft)
+      ? null
+      : snapshot;
+  } catch {
+    window.localStorage.removeItem(manualJournalRecoveryStorageKey(serverDraft));
+    return null;
+  }
+}
+
+function writeManualJournalRecoverySnapshot(draft: ManualJournalEntryDraft): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    const snapshot: ManualJournalRecoverySnapshot = {
+      capturedAtUtc: new Date().toISOString(),
+      draft: withManualJournalTotals(draft)
+    };
+    window.localStorage.setItem(manualJournalRecoveryStorageKey(draft), JSON.stringify(snapshot));
+  } catch {
+    // Recovery storage is best effort; the governed server save remains authoritative.
+  }
+}
+
+function clearManualJournalRecoverySnapshot(draft: ManualJournalEntryDraft): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(manualJournalRecoveryStorageKey(draft));
+  } catch {
+    // A blocked storage API must not interfere with governed draft persistence.
+  }
+}
+
+function isManualJournalEditable(status: ManualJournalEntryDraft["status"]): boolean {
+  return status === "Draft" || status === "NeedsFix" || status === "Rejected";
 }
 
 function ensureManualJournalDraftScope(
@@ -1218,6 +1540,29 @@ function withManualJournalTotals(draft: ManualJournalEntryDraft): ManualJournalE
 
 function buildManualJournalValidationSignature(draft: ManualJournalEntryDraft): string {
   return JSON.stringify(withManualJournalTotals(draft));
+}
+
+function buildManualJournalEditableSignature(draft: ManualJournalEntryDraft): string {
+  return JSON.stringify({
+    journalEntryId: draft.journalEntryId,
+    fundProfileId: draft.fundProfileId,
+    ledgerBookId: draft.ledgerBookId ?? null,
+    accountingBasis: draft.accountingBasis,
+    accountingDate: draft.accountingDate,
+    periodId: draft.periodId ?? null,
+    entityId: draft.entityId ?? null,
+    fundNodeId: draft.fundNodeId ?? null,
+    currency: draft.currency,
+    memo: draft.memo,
+    lines: draft.lines,
+    evidenceLinks: draft.evidenceLinks,
+    evidenceAttachments: draft.evidenceAttachments ?? [],
+    entryType: draft.entryType,
+    treasuryContext: draft.treasuryContext ?? null,
+    dimensions: draft.dimensions ?? null,
+    tenantId: draft.tenantId ?? null,
+    companyId: draft.companyId ?? null
+  });
 }
 
 function getManualJournalSubmitDisabledReason(

--- a/src/Meridian.Ui/dashboard/src/screens/accounting-screen.journal-entry-enhancements.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/accounting-screen.journal-entry-enhancements.tsx
@@ -1,0 +1,178 @@
+import { Search, X } from "lucide-react";
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { TechnicalDetails } from "@/components/ui/technical-details";
+import { cn } from "@/lib/utils";
+import type { ManualJournalEntryWorkbenchViewModel } from "@/screens/accounting-screen.view-model";
+
+export function focusManualJournalCell(lineId: string, column: string): void {
+  const existing = document.getElementById(`manual-je-${column}-${lineId}`);
+  if (existing) {
+    existing.focus();
+    return;
+  }
+  window.requestAnimationFrame(() => document.getElementById(`manual-je-${column}-${lineId}`)?.focus());
+}
+
+export function handleManualJournalCellKeyDown(
+  event: ReactKeyboardEvent<HTMLElement>,
+  view: ManualJournalEntryWorkbenchViewModel,
+  lineId: string,
+  column: string,
+  side?: "Debit" | "Credit"
+): void {
+  if (event.ctrlKey && event.key === "Enter") {
+    event.preventDefault();
+    focusManualJournalCell(view.insertLineAfter(lineId, side), column);
+    return;
+  }
+
+  if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey ||
+      (event.key !== "ArrowDown" && event.key !== "ArrowUp" && event.key !== "Enter")) {
+    return;
+  }
+
+  const lineIndex = view.draft.lines.findIndex((line) => line.lineId === lineId);
+  const targetLine = view.draft.lines[lineIndex + (event.key === "ArrowUp" ? -1 : 1)];
+  if (!targetLine) {
+    return;
+  }
+
+  event.preventDefault();
+  view.selectLine(targetLine.lineId);
+  focusManualJournalCell(targetLine.lineId, column);
+}
+
+export function focusManualJournalValidationTarget(
+  view: ManualJournalEntryWorkbenchViewModel,
+  targetId?: string | null
+): void {
+  if (targetId && view.draft.lines.some((line) => line.lineId === targetId)) {
+    view.selectLine(targetId);
+    window.requestAnimationFrame(() => {
+      const target = document.getElementById(`manual-je-line-${targetId}`);
+      target?.focus();
+      target?.scrollIntoView?.({ block: "center", behavior: "smooth" });
+    });
+    return;
+  }
+
+  const target = targetId ? document.getElementById(`manual-je-header-${targetId}`) : null;
+  const fallback = document.getElementById("manual-je-validation-heading");
+  (target ?? fallback)?.focus();
+  (target ?? fallback)?.scrollIntoView?.({ block: "center", behavior: "smooth" });
+}
+
+export function ManualJournalHealthBar({
+  view,
+  hasInvalidAmountEdits,
+  invalidAmountReason
+}: {
+  view: ManualJournalEntryWorkbenchViewModel;
+  hasInvalidAmountEdits: boolean;
+  invalidAmountReason: string | null;
+}) {
+  return (
+    <div className="accounting-journal-health-bar" role="region" aria-label="Journal health and actions">
+      <div className="accounting-journal-health-summary">
+        <span className={cn("accounting-journal-health-item", `is-${view.saveState}`)} role="status"><span aria-hidden="true" />{view.saveStatusLabel}</span>
+        <span className={cn("accounting-journal-health-item", view.balanceStatusTone === "success" ? "is-saved" : "is-warning")}><span aria-hidden="true" />{view.balanceStatusLabel}</span>
+        <span className={cn("accounting-journal-health-item", view.validationIsCurrent && view.blockingIssueCount === 0 ? "is-saved" : "is-warning")}><span aria-hidden="true" />{view.validationStatusLabel}</span>
+        {view.blockingIssueCount > 0 ? <Button size="sm" variant="ghost" onClick={() => focusManualJournalValidationTarget(view, null)}>Show {view.blockingIssueCount} blocker{view.blockingIssueCount === 1 ? "" : "s"}</Button> : null}
+      </div>
+      <div className="accounting-journal-health-actions">
+        <Button size="sm" variant="outline" busy={view.saveBusy} disabled={hasInvalidAmountEdits} disabledReason={hasInvalidAmountEdits ? invalidAmountReason : null} onClick={() => void view.save()}>Save draft</Button>
+        <Button size="sm" variant="outline" busy={view.validateBusy} disabled={hasInvalidAmountEdits} disabledReason={hasInvalidAmountEdits ? invalidAmountReason : null} onClick={() => void view.validate()}>Validate</Button>
+        <Button size="sm" busy={view.submitBusy} disabled={!view.canSubmit || hasInvalidAmountEdits} disabledReason={hasInvalidAmountEdits ? invalidAmountReason : view.submitDisabledReason} onClick={() => void view.submit()}>Submit approval</Button>
+      </div>
+      {view.recoveryStatusText ? (
+        <div className="accounting-journal-recovery-status">
+          <p>{view.recoveryStatusText}</p>
+          {view.saveState === "recovered" ? <Button size="sm" variant="ghost" onClick={view.discardRecoveredDraft}>Discard recovered changes</Button> : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function ManualJournalValidationNavigator({ view }: { view: ManualJournalEntryWorkbenchViewModel }) {
+  return (
+    <div className="rounded-md border border-border/70 bg-secondary/20 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h4 id="manual-je-validation-heading" tabIndex={-1} className="text-sm font-semibold text-foreground">Validation navigator</h4>
+        <Badge variant={view.validationIsCurrent ? "success" : "warning"} dot>{view.validationIsCurrent ? "Current" : "Required"}</Badge>
+      </div>
+      <div className="mt-3 space-y-2">
+        {view.validationIssues.length > 0 ? view.validationIssues.map((issue) => (
+          <div key={issue.id} className={cn("rounded border px-3 py-2 text-sm", issue.tone === "danger" ? "border-danger/30 bg-danger/10 text-danger" : issue.tone === "warning" ? "border-warning/30 bg-warning/10 text-warning" : "border-border/70 bg-background/50 text-muted-foreground") }>
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div className="font-semibold">{issue.label}</div>
+              <Badge variant={issue.tone === "danger" ? "danger" : issue.tone === "warning" ? "warning" : "outline"}>{issue.severity ?? "Review"}</Badge>
+            </div>
+            <div className="mt-1">{issue.message}</div>
+            <div className="mt-1 text-xs">{issue.detail}</div>
+            <Button size="sm" variant="ghost" className="mt-2" onClick={() => focusManualJournalValidationTarget(view, issue.targetId)}>{issue.targetId ? "Go to affected field" : "Review journal"}</Button>
+          </div>
+        )) : <p className="rounded border border-border/70 bg-background/50 px-3 py-2 text-sm text-muted-foreground">{view.validationIsCurrent ? "Validation is current for this draft and no issues were returned." : "Validation has not completed for the current draft. Use Validate before approval submission."}</p>}
+      </div>
+    </div>
+  );
+}
+
+export function ManualJournalDimensionsInspector({ view }: { view: ManualJournalEntryWorkbenchViewModel }) {
+  const selectedLine = view.draft.lines.find((line) => line.lineId === view.selectedLineId) ?? view.draft.lines[0] ?? null;
+  const selectedAccountLabel = selectedLine ? view.accountOptions.find((option) => option.value === selectedLine.accountPath)?.label ?? "Not selected" : "Not selected";
+  return (
+    <div className="rounded-md border border-border/70 bg-secondary/20 p-3">
+      <h4 className="text-sm font-semibold text-foreground">Selected-line dimensions</h4>
+      {selectedLine ? (
+        <div className="mt-3 space-y-3 text-sm">
+          <dl className="grid gap-2">
+            <div><dt className="text-xs text-muted-foreground">GL account</dt><dd className="text-foreground">{selectedAccountLabel}</dd></div>
+            <div><dt className="text-xs text-muted-foreground">Security</dt><dd className="break-all text-foreground">{selectedLine.securityDisplayName || "No Security Master reference"}</dd></div>
+          </dl>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <DimensionField label="Line entity" value={selectedLine.entityId ?? ""} placeholder={view.draft.entityId || "Inherit journal entity"} onChange={(value) => view.updateLine(selectedLine.lineId, { entityId: value })} />
+            <DimensionField label="Fund allocation" value={selectedLine.fundAllocationId ?? ""} placeholder={view.draft.fundNodeId || "Optional"} onChange={(value) => view.updateLine(selectedLine.lineId, { fundAllocationId: value })} />
+            <DimensionField label="Tax lot" value={selectedLine.taxLotId ?? ""} placeholder="Optional tax-lot ID" onChange={(value) => view.updateLine(selectedLine.lineId, { taxLotId: value })} />
+            <DimensionField label="Strategy" value={view.draft.dimensions?.strategyId ?? ""} placeholder="Journal-level strategy" onChange={(value) => view.updateDraftDimensions({ strategyId: value })} />
+            <DimensionField label="Portfolio" value={view.draft.dimensions?.portfolioId ?? ""} placeholder="Journal-level portfolio" onChange={(value) => view.updateDraftDimensions({ portfolioId: value })} />
+            <DimensionField label="Cost center" value={view.draft.dimensions?.costCenterId ?? ""} placeholder="Journal-level cost center" onChange={(value) => view.updateDraftDimensions({ costCenterId: value })} />
+          </div>
+          <p className="text-xs text-muted-foreground">Blank line values inherit journal scope where available. Dimension edits invalidate the current validation and are autosaved as draft changes.</p>
+          <TechnicalDetails label="Line system details">
+            <dl className="grid gap-2 text-xs">
+              <div><dt className="text-muted-foreground">Line ID</dt><dd className="mt-1 break-all font-mono text-foreground">{selectedLine.lineId}</dd></div>
+              <div><dt className="text-muted-foreground">GL path</dt><dd className="mt-1 break-all font-mono text-foreground">{selectedLine.accountPath || "Not selected"}</dd></div>
+              <div><dt className="text-muted-foreground">Security ID</dt><dd className="mt-1 break-all font-mono text-foreground">{selectedLine.securityId || "Not selected"}</dd></div>
+            </dl>
+          </TechnicalDetails>
+          <div className="rounded border border-border/70 bg-background/50 p-2">
+            <label className="space-y-1 text-sm">
+              <span className="text-xs font-semibold uppercase text-muted-foreground">Security Master picker</span>
+              <div className="flex gap-2">
+                <input className="min-h-9 min-w-0 flex-1 rounded border border-border bg-background px-2" value={view.securitySearchQuery} placeholder="Ticker, ISIN, CUSIP, FIGI, name" onChange={(event) => view.updateSecuritySearchQuery(event.target.value)} />
+                <Button size="icon" variant="outline" busy={view.securitySearchBusy} aria-label="Search Security Master" onClick={() => void view.searchSecurityMaster()}><Search className="h-3.5 w-3.5" aria-hidden="true" /></Button>
+              </div>
+            </label>
+            <p role="status" className={cn("mt-2 text-xs", view.securitySearchErrorText ? "text-danger" : "text-muted-foreground")}>{view.securitySearchStatusText}</p>
+            <div className="mt-2 space-y-2">
+              {view.securitySearchResults.map((security) => <button key={security.securityId} type="button" className="w-full rounded border border-border/70 bg-secondary/30 px-3 py-2 text-left hover:border-primary/50 hover:bg-primary/10" onClick={() => view.selectSecurity(selectedLine.lineId, security)}><span className="block font-semibold text-foreground">{security.displayName}</span><span className="mt-1 block font-mono text-[11px] text-muted-foreground">{security.securityId} / {security.classification.assetClass} / {security.classification.primaryIdentifierValue}</span></button>)}
+            </div>
+            {selectedLine.securityId ? <Button className="mt-2" size="sm" variant="ghost" onClick={() => view.clearSecurity(selectedLine.lineId)}><X className="h-3.5 w-3.5" aria-hidden="true" />Clear security</Button> : null}
+          </div>
+        </div>
+      ) : <p className="mt-3 text-sm text-muted-foreground">Select a line to inspect attribution.</p>}
+    </div>
+  );
+}
+
+function DimensionField({ label, value, placeholder, onChange }: { label: string; value: string; placeholder: string; onChange: (value: string | null) => void }) {
+  return (
+    <label className="space-y-1">
+      <span className="text-xs font-semibold uppercase text-muted-foreground">{label}</span>
+      <input className="min-h-9 w-full rounded border border-border bg-background px-2 font-mono" value={value} placeholder={placeholder} onChange={(event) => onChange(event.target.value || null)} />
+    </label>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/screens/accounting-screen.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/accounting-screen.test.tsx
@@ -1554,6 +1554,7 @@ function findAppleSecuritySearchRow() {
 
 describe("AccountingScreen", () => {
   beforeEach(() => {
+    window.localStorage.clear();
     const searchSecurities = vi.mocked(api.searchSecurities);
     searchSecurities.mockReset();
     if (defaultSearchSecuritiesImplementation) {
@@ -3497,6 +3498,12 @@ describe("AccountingScreen", () => {
 
     expect(screen.getByRole("region", { name: "Accounting workbench context" })).toHaveTextContent("Journal Entry");
     expect(screen.getByRole("heading", { name: "Manual journal entry workbench" })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "Journal health and actions" })).toHaveTextContent("Balanced");
+    expect(screen.getByRole("region", { name: "Journal health and actions" })).toHaveTextContent("Validation required");
+    expect(screen.getByText(/Keyboard: Arrow Up or Down/)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Selected-line dimensions" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Line entity")).toHaveAttribute("placeholder", "entity-master");
+    expect(screen.getByLabelText("Strategy")).toBeInTheDocument();
     expect(screen.getByRole("region", { name: "Manual journal entry - balanced double-entry" })).toHaveTextContent("Totals");
     expect(screen.getByRole("heading", { name: "Balance impact preview" })).toBeInTheDocument();
     expect(screen.getByText("This draft increases the debit-normal account balance by $100.")).toBeInTheDocument();
@@ -3622,6 +3629,50 @@ describe("AccountingScreen", () => {
     expect(debitInput).toHaveValue(250.75);
     expect(debitInput).not.toHaveAttribute("aria-invalid");
     expect(screen.queryByText("Enter a valid amount.")).not.toBeInTheDocument();
+  });
+
+  it("supports keyboard line navigation, insertion, and duplication", async () => {
+    vi.mocked(api.getManualJournalEntryWorkbench).mockResolvedValueOnce(manualJournalWorkbench);
+
+    await renderAccountingScreen(data, "/accounting/journal-entries?fundProfileId=fund-alpha&ledgerBookId=book-alpha");
+
+    const firstDebit = screen.getByLabelText("Debit amount for line line-debit");
+    const secondDebit = screen.getByLabelText("Debit amount for line line-credit");
+    firstDebit.focus();
+    fireEvent.keyDown(firstDebit, { key: "ArrowDown" });
+    expect(secondDebit).toHaveFocus();
+
+    const accountCount = screen.getAllByLabelText(/^GL account for line/).length;
+    fireEvent.keyDown(secondDebit, { key: "Enter", ctrlKey: true });
+    expect(screen.getAllByLabelText(/^GL account for line/)).toHaveLength(accountCount + 1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Duplicate journal line line-debit" }));
+    expect(screen.getAllByLabelText(/^GL account for line/)).toHaveLength(accountCount + 2);
+    expect(screen.getByRole("region", { name: "Journal health and actions" })).toHaveTextContent("Unsaved changes");
+  });
+
+  it("navigates validation issues to their affected journal line", async () => {
+    const blockedDraft: ManualJournalEntryDraft = {
+      ...manualJournalDraft,
+      validationIssues: [{
+        code: "manual-je.account-missing",
+        severity: "Critical",
+        message: "GL account was not found.",
+        targetId: "line-debit",
+        suggestedAction: "Choose an active GL account."
+      }]
+    };
+    vi.mocked(api.getManualJournalEntryWorkbench).mockResolvedValueOnce({
+      ...manualJournalWorkbench,
+      drafts: [blockedDraft]
+    });
+
+    await renderAccountingScreen(data, "/accounting/journal-entries");
+
+    const health = screen.getByRole("region", { name: "Journal health and actions" });
+    expect(health).toHaveTextContent("1 blocker");
+    fireEvent.click(screen.getByRole("button", { name: "Go to affected field" }));
+    await waitFor(() => expect(document.getElementById("manual-je-line-line-debit")).toHaveFocus());
   });
 
   it("rejects unparseable journal amounts instead of silently posting them as zero", async () => {

--- a/src/Meridian.Ui/dashboard/src/screens/accounting-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/accounting-screen.tsx
@@ -1,4 +1,4 @@
-import { BookCheck, Landmark, Network, Paperclip, RefreshCcw, Search, ShieldCheck, UserCheck, WalletCards, X } from "lucide-react";
+import { BookCheck, Copy, Landmark, Network, Paperclip, RefreshCcw, Search, ShieldCheck, UserCheck, WalletCards, X } from "lucide-react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import "@/styles/accounting-screen.css";
@@ -50,6 +50,13 @@ import { CorporateActionsPanel } from "@/screens/accounting-screen.corporate-act
 import { AccountingCloseReportPackagePanel, AccountingWorkflowLaunchPanel, CloseCommandCenterPanel } from "@/screens/accounting-screen.close-cockpit-panels";
 import { SecuritySchedulesPanel } from "@/screens/accounting-screen.security-master-panels";
 import { CalibrationSummaryPanel } from "@/screens/accounting-screen.calibration-panel";
+import {
+  focusManualJournalCell,
+  handleManualJournalCellKeyDown,
+  ManualJournalDimensionsInspector,
+  ManualJournalHealthBar,
+  ManualJournalValidationNavigator
+} from "@/screens/accounting-screen.journal-entry-enhancements";
 import {
   InstrumentPassportPanel,
   ReferenceDataWorkbenchPanel,
@@ -4793,7 +4800,6 @@ function ManualJournalEntryWorkbenchPanel({ view }: { view: ManualJournalEntryWo
       handleAmountChange(lineId, side, input);
     }
   };
-
   if (!view.available) {
     return (
       <section className="workspace-section-band" aria-labelledby="manual-je-heading">
@@ -4820,7 +4826,6 @@ function ManualJournalEntryWorkbenchPanel({ view }: { view: ManualJournalEntryWo
     );
   }
 
-  const selectedLine = view.draft.lines.find((line) => line.lineId === view.selectedLineId) ?? view.draft.lines[0] ?? null;
   const nextLineSide = view.draft.totalDebits <= view.draft.totalCredits ? "Debit" : "Credit";
   const evidenceAttachments = view.draft.evidenceAttachments ?? [];
   const attachmentUris = new Set(evidenceAttachments.map((attachment) => attachment.uri));
@@ -4830,10 +4835,6 @@ function ManualJournalEntryWorkbenchPanel({ view }: { view: ManualJournalEntryWo
     ...evidenceAttachments.map((attachment) => attachment.uri),
     ...retainedEvidenceLinks
   ]).size;
-  const selectedAccountLabel = selectedLine
-    ? view.accountOptions.find((option) => option.value === selectedLine.accountPath)?.label ?? "Not selected"
-    : "Not selected";
-
   return (
     <section className="workspace-section-band" aria-labelledby="manual-je-heading">
       <div className="workspace-section-subheader">
@@ -4850,35 +4851,6 @@ function ManualJournalEntryWorkbenchPanel({ view }: { view: ManualJournalEntryWo
             <RefreshCcw className="h-3.5 w-3.5" aria-hidden="true" />
             Refresh
           </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            busy={view.validateBusy}
-            disabled={hasInvalidAmountEdits}
-            disabledReason={hasInvalidAmountEdits ? invalidAmountReason : null}
-            onClick={() => void view.validate()}
-          >
-            Validate
-          </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            busy={view.saveBusy}
-            disabled={hasInvalidAmountEdits}
-            disabledReason={hasInvalidAmountEdits ? invalidAmountReason : null}
-            onClick={() => void view.save()}
-          >
-            Save draft
-          </Button>
-          <Button
-            size="sm"
-            busy={view.submitBusy}
-            disabled={!view.canSubmit || hasInvalidAmountEdits}
-            disabledReason={hasInvalidAmountEdits ? invalidAmountReason : view.submitDisabledReason}
-            onClick={() => void view.submit()}
-          >
-            Submit approval
-          </Button>
         </div>
       </div>
 
@@ -4887,6 +4859,8 @@ function ManualJournalEntryWorkbenchPanel({ view }: { view: ManualJournalEntryWo
           {view.errorText}
         </div>
       ) : null}
+
+      <ManualJournalHealthBar view={view} hasInvalidAmountEdits={hasInvalidAmountEdits} invalidAmountReason={invalidAmountReason} />
 
       <div className="grid gap-4 xl:grid-cols-[minmax(14rem,0.28fr)_minmax(0,1fr)]">
         <div className="space-y-4">
@@ -4941,6 +4915,7 @@ function ManualJournalEntryWorkbenchPanel({ view }: { view: ManualJournalEntryWo
               <label>
                 <span>Date</span>
                 <input
+                  id="manual-je-header-accountingDate"
                   type="date"
                   value={view.draft.accountingDate}
                   onChange={(event) => view.updateHeader("accountingDate", event.target.value)}
@@ -4949,6 +4924,7 @@ function ManualJournalEntryWorkbenchPanel({ view }: { view: ManualJournalEntryWo
               <label>
                 <span>Prepared by</span>
                 <input
+                  id="manual-je-header-preparedBy"
                   readOnly
                   value={view.draft.preparedBy || "Current operator"}
                 />
@@ -4956,21 +4932,22 @@ function ManualJournalEntryWorkbenchPanel({ view }: { view: ManualJournalEntryWo
               <label className="md:col-span-2 xl:col-span-1">
                 <span>Memo</span>
                 <input
+                  id="manual-je-header-memo"
                   value={view.draft.memo}
                   onChange={(event) => view.updateHeader("memo", event.target.value)}
                 />
               </label>
               <label>
                 <span>Fund profile</span>
-                <input className="font-mono" value={view.draft.fundProfileId} onChange={(event) => view.updateHeader("fundProfileId", event.target.value)} />
+                <input id="manual-je-header-fundProfileId" className="font-mono" value={view.draft.fundProfileId} onChange={(event) => view.updateHeader("fundProfileId", event.target.value)} />
               </label>
               <label>
                 <span>Period</span>
-                <input className="font-mono" value={view.draft.periodId ?? ""} onChange={(event) => view.updateHeader("periodId", event.target.value)} />
+                <input id="manual-je-header-periodId" className="font-mono" value={view.draft.periodId ?? ""} onChange={(event) => view.updateHeader("periodId", event.target.value)} />
               </label>
               <label>
                 <span>Currency</span>
-                <input className="font-mono" value={view.draft.currency} onChange={(event) => view.updateHeader("currency", event.target.value.toUpperCase())} />
+                <input id="manual-je-header-currency" className="font-mono" value={view.draft.currency} onChange={(event) => view.updateHeader("currency", event.target.value.toUpperCase())} />
               </label>
             </div>
 
@@ -4985,6 +4962,10 @@ function ManualJournalEntryWorkbenchPanel({ view }: { view: ManualJournalEntryWo
                 <div><dt className="text-muted-foreground">Record version</dt><dd className="mt-1 font-mono text-foreground">{view.draft.version}</dd></div>
               </dl>
             </TechnicalDetails>
+
+            <p className="accounting-journal-keyboard-hint" id="manual-je-keyboard-hint">
+              Keyboard: Arrow Up or Down and Enter move within a column; Ctrl+Enter inserts a line beneath the current row.
+            </p>
 
             <div className="accounting-journal-table-wrap">
               <table className="accounting-journal-table">
@@ -5002,9 +4983,26 @@ function ManualJournalEntryWorkbenchPanel({ view }: { view: ManualJournalEntryWo
                     const badges = view.getLineBadges(line.lineId);
                     const isDebit = line.side === "Debit";
                     return (
-                      <tr key={line.lineId} className={cn(line.lineId === view.selectedLineId && "is-selected")}>
+                      <tr
+                        key={line.lineId}
+                        id={`manual-je-line-${line.lineId}`}
+                        className={cn(line.lineId === view.selectedLineId && "is-selected")}
+                        tabIndex={-1}
+                      >
                         <td>
-                          <select value={line.accountPath} onChange={(event) => view.updateLine(line.lineId, { accountPath: event.target.value })} onFocus={() => view.selectLine(line.lineId)} aria-label={`GL account for line ${line.lineId}`}>
+                          <select
+                            id={`manual-je-account-${line.lineId}`}
+                            value={line.accountPath}
+                            onChange={(event) => view.updateLine(line.lineId, { accountPath: event.target.value })}
+                            onFocus={() => view.selectLine(line.lineId)}
+                            onKeyDown={(event) => {
+                              if (event.ctrlKey && event.key === "Enter") {
+                                handleManualJournalCellKeyDown(event, view, line.lineId, "account", line.side);
+                              }
+                            }}
+                            aria-label={`GL account for line ${line.lineId}`}
+                            aria-describedby="manual-je-keyboard-hint"
+                          >
                             <option value="">Select GL account</option>
                             {view.accountOptions.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
                           </select>
@@ -5012,7 +5010,9 @@ function ManualJournalEntryWorkbenchPanel({ view }: { view: ManualJournalEntryWo
                         </td>
                         <td>
                           <input
+                            id={`manual-je-debit-${line.lineId}`}
                             aria-label={`Debit amount for line ${line.lineId}`}
+                            aria-describedby="manual-je-keyboard-hint"
                             className="text-right font-mono"
                             type="number"
                             value={amountDrafts[`${line.lineId}:Debit`] ?? (isDebit ? line.amount : 0)}
@@ -5020,14 +5020,17 @@ function ManualJournalEntryWorkbenchPanel({ view }: { view: ManualJournalEntryWo
                             onChange={(event) => handleAmountChange(line.lineId, "Debit", event.target)}
                             onBlur={(event) => handleAmountBlur(line.lineId, "Debit", event.target)}
                             onFocus={() => view.selectLine(line.lineId)}
+                            onKeyDown={(event) => handleManualJournalCellKeyDown(event, view, line.lineId, "debit", "Debit")}
                           />
                           {`${line.lineId}:Debit` in amountDrafts ? (
-                            <p className="mt-1 text-right text-[11px] text-danger" role="alert">Enter a valid amount.</p>
+                            <p id={`manual-je-debit-error-${line.lineId}`} className="mt-1 text-right text-[11px] text-danger" role="alert">Enter a valid amount.</p>
                           ) : null}
                         </td>
                         <td>
                           <input
+                            id={`manual-je-credit-${line.lineId}`}
                             aria-label={`Credit amount for line ${line.lineId}`}
+                            aria-describedby={`${line.lineId}:Credit` in amountDrafts ? `manual-je-keyboard-hint manual-je-credit-error-${line.lineId}` : "manual-je-keyboard-hint"}
                             className="text-right font-mono"
                             type="number"
                             value={amountDrafts[`${line.lineId}:Credit`] ?? (isDebit ? 0 : line.amount)}
@@ -5035,9 +5038,10 @@ function ManualJournalEntryWorkbenchPanel({ view }: { view: ManualJournalEntryWo
                             onChange={(event) => handleAmountChange(line.lineId, "Credit", event.target)}
                             onBlur={(event) => handleAmountBlur(line.lineId, "Credit", event.target)}
                             onFocus={() => view.selectLine(line.lineId)}
+                            onKeyDown={(event) => handleManualJournalCellKeyDown(event, view, line.lineId, "credit", "Credit")}
                           />
                           {`${line.lineId}:Credit` in amountDrafts ? (
-                            <p className="mt-1 text-right text-[11px] text-danger" role="alert">Enter a valid amount.</p>
+                            <p id={`manual-je-credit-error-${line.lineId}`} className="mt-1 text-right text-[11px] text-danger" role="alert">Enter a valid amount.</p>
                           ) : null}
                         </td>
                         <td>
@@ -5050,24 +5054,42 @@ function ManualJournalEntryWorkbenchPanel({ view }: { view: ManualJournalEntryWo
                             <span className="block truncate font-mono text-[11px] text-muted-foreground">{line.securityId || "No Security Master reference"}</span>
                           </button>
                           <input
+                            id={`manual-je-description-${line.lineId}`}
                             className="mt-2"
                             aria-label={`Description for line ${line.lineId}`}
+                            aria-describedby="manual-je-keyboard-hint"
                             value={line.description ?? ""}
                             onChange={(event) => view.updateLine(line.lineId, { description: event.target.value })}
                             onFocus={() => view.selectLine(line.lineId)}
+                            onKeyDown={(event) => handleManualJournalCellKeyDown(event, view, line.lineId, "description", line.side)}
                           />
                         </td>
                         <td>
-                          <Button
-                            size="icon"
-                            variant="ghost"
-                            aria-label={`Remove journal line ${line.lineId}`}
-                            disabled={view.draft.lines.length <= 2}
-                            disabledReason={view.draft.lines.length <= 2 ? "A balanced journal entry needs at least two lines." : null}
-                            onClick={() => view.removeLine(line.lineId)}
-                          >
-                            <X className="h-3.5 w-3.5" aria-hidden="true" />
-                          </Button>
+                          <div className="flex items-center gap-1">
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              aria-label={`Duplicate journal line ${line.lineId}`}
+                              onClick={() => {
+                                const duplicateId = view.duplicateLine(line.lineId);
+                                if (duplicateId) {
+                                  focusManualJournalCell(duplicateId, "account");
+                                }
+                              }}
+                            >
+                              <Copy className="h-3.5 w-3.5" aria-hidden="true" />
+                            </Button>
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              aria-label={`Remove journal line ${line.lineId}`}
+                              disabled={view.draft.lines.length <= 2}
+                              disabledReason={view.draft.lines.length <= 2 ? "A balanced journal entry needs at least two lines." : null}
+                              onClick={() => view.removeLine(line.lineId)}
+                            >
+                              <X className="h-3.5 w-3.5" aria-hidden="true" />
+                            </Button>
+                          </div>
                         </td>
                       </tr>
                     );
@@ -5323,85 +5345,8 @@ function ManualJournalEntryWorkbenchPanel({ view }: { view: ManualJournalEntryWo
           </div>
 
           <div className="grid gap-4 lg:grid-cols-[minmax(0,0.55fr)_minmax(0,0.45fr)]">
-            <div className="rounded-md border border-border/70 bg-secondary/20 p-3">
-                <div className="flex flex-wrap items-center justify-between gap-2">
-                  <h4 className="text-sm font-semibold text-foreground">Validation</h4>
-                  <Badge variant={view.validationIsCurrent ? "success" : "warning"} dot>
-                    {view.validationIsCurrent ? "Current" : "Required"}
-                  </Badge>
-                </div>
-                <div className="mt-3 space-y-2">
-                  {view.validationIssues.length > 0 ? view.validationIssues.map((issue) => (
-                    <div key={issue.id} className={cn("rounded border px-3 py-2 text-sm", issue.tone === "danger" ? "border-danger/30 bg-danger/10 text-danger" : issue.tone === "warning" ? "border-warning/30 bg-warning/10 text-warning" : "border-border/70 bg-background/50 text-muted-foreground")}>
-                      <div className="font-semibold">{issue.label}</div>
-                      <div className="mt-1">{issue.message}</div>
-                      <div className="mt-1 text-xs">{issue.detail}</div>
-                    </div>
-                  )) : (
-                    <p className="rounded border border-border/70 bg-background/50 px-3 py-2 text-sm text-muted-foreground">
-                      {view.validationIsCurrent
-                        ? "Validation is current for this draft and no issues were returned."
-                        : "Validation has not completed for the current draft. Use Validate before approval submission."}
-                    </p>
-                  )}
-                </div>
-            </div>
-            <div className="rounded-md border border-border/70 bg-secondary/20 p-3">
-                <h4 className="text-sm font-semibold text-foreground">Selected line</h4>
-                {selectedLine ? (
-                  <div className="mt-3 space-y-3 text-sm">
-                    <dl className="grid gap-2">
-                      <div><dt className="text-xs text-muted-foreground">GL account</dt><dd className="text-foreground">{selectedAccountLabel}</dd></div>
-                      <div><dt className="text-xs text-muted-foreground">Security</dt><dd className="break-all text-foreground">{selectedLine.securityDisplayName || "No Security Master reference"}</dd></div>
-                    </dl>
-                    <TechnicalDetails label="Line system details">
-                      <dl className="grid gap-2 text-xs">
-                        <div><dt className="text-muted-foreground">Line ID</dt><dd className="mt-1 break-all font-mono text-foreground">{selectedLine.lineId}</dd></div>
-                        <div><dt className="text-muted-foreground">GL path</dt><dd className="mt-1 break-all font-mono text-foreground">{selectedLine.accountPath || "Not selected"}</dd></div>
-                        <div><dt className="text-muted-foreground">Security ID</dt><dd className="mt-1 break-all font-mono text-foreground">{selectedLine.securityId || "Not selected"}</dd></div>
-                      </dl>
-                    </TechnicalDetails>
-                    <div className="rounded border border-border/70 bg-background/50 p-2">
-                      <label className="space-y-1 text-sm">
-                        <span className="text-xs font-semibold uppercase text-muted-foreground">Security Master picker</span>
-                        <div className="flex gap-2">
-                          <input
-                            className="min-h-9 min-w-0 flex-1 rounded border border-border bg-background px-2"
-                            value={view.securitySearchQuery}
-                            placeholder="Ticker, ISIN, CUSIP, FIGI, name"
-                            onChange={(event) => view.updateSecuritySearchQuery(event.target.value)}
-                          />
-                          <Button size="icon" variant="outline" busy={view.securitySearchBusy} aria-label="Search Security Master" onClick={() => void view.searchSecurityMaster()}>
-                            <Search className="h-3.5 w-3.5" aria-hidden="true" />
-                          </Button>
-                        </div>
-                      </label>
-                      <p role="status" className={cn("mt-2 text-xs", view.securitySearchErrorText ? "text-danger" : "text-muted-foreground")}>{view.securitySearchStatusText}</p>
-                      <div className="mt-2 space-y-2">
-                        {view.securitySearchResults.map((security) => (
-                          <button
-                            key={security.securityId}
-                            type="button"
-                            className="w-full rounded border border-border/70 bg-secondary/30 px-3 py-2 text-left hover:border-primary/50 hover:bg-primary/10"
-                            onClick={() => view.selectSecurity(selectedLine.lineId, security)}
-                          >
-                            <span className="block font-semibold text-foreground">{security.displayName}</span>
-                            <span className="mt-1 block font-mono text-[11px] text-muted-foreground">{security.securityId} / {security.classification.assetClass} / {security.classification.primaryIdentifierValue}</span>
-                          </button>
-                        ))}
-                      </div>
-                      {selectedLine.securityId ? (
-                        <Button className="mt-2" size="sm" variant="ghost" onClick={() => view.clearSecurity(selectedLine.lineId)}>
-                          <X className="h-3.5 w-3.5" aria-hidden="true" />
-                          Clear security
-                        </Button>
-                      ) : null}
-                    </div>
-                  </div>
-                ) : (
-                  <p className="mt-3 text-sm text-muted-foreground">Select a line to inspect attribution.</p>
-                )}
-            </div>
+            <ManualJournalValidationNavigator view={view} />
+            <ManualJournalDimensionsInspector view={view} />
           </div>
         </div>
       </div>

--- a/src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.ts
@@ -159,6 +159,7 @@ import type {
   JournalEntryLifecycleActionRequest,
   JournalEntryLifecycleActionResult,
   LockClosePeriodRequest,
+  LedgerDimensionSet,
   ManualJournalEntryDraft,
   ManualJournalEntryLine,
   ManualJournalEntryWorkbench,
@@ -346,6 +347,7 @@ export interface AccountingConfigurationIssueViewModel {
   message: string;
   detail: string;
   tone: "default" | "warning" | "danger";
+  targetId?: string | null; severity?: "Critical" | "Warning" | "Info";
 }
 
 export interface AccountingConfigurationAuditViewModel {
@@ -1895,9 +1897,7 @@ export type CapitalAccountWorkbenchFundEventCommandRowViewModel =
 export interface CapitalAccountWorkbenchViewModel {
   title: string;
   description: string;
-  available: boolean;
-  loading: boolean;
-  errorText: string | null;
+  available: boolean; loading: boolean; errorText: string | null;
   statusLabel: string;
   statusTone: AccountingToolingTone;
   statusReason: string;
@@ -1927,13 +1927,10 @@ export interface ManualJournalEntryWorkbenchViewModel {
   drafts: ManualJournalEntryDraft[];
   accountOptions: { value: string; label: string }[];
   selectedLineId: string;
-  securitySearchQuery: string;
-  securitySearchResults: SecurityMasterEntry[];
-  securitySearchBusy: boolean;
-  securitySearchErrorText: string | null;
+  securitySearchQuery: string; securitySearchResults: SecurityMasterEntry[];
+  securitySearchBusy: boolean; securitySearchErrorText: string | null;
   securitySearchStatusText: string;
-  attachmentDraft: ManualJournalEvidenceAttachmentDraft;
-  totalsLabel: string;
+  attachmentDraft: ManualJournalEvidenceAttachmentDraft; totalsLabel: string;
   totalDebitsLabel: string;
   totalCreditsLabel: string;
   imbalanceLabel: string;
@@ -1943,15 +1940,16 @@ export interface ManualJournalEntryWorkbenchViewModel {
   treasuryContextLabel: string;
   privateCapitalActivity: ManualJournalPrivateCapitalActivityViewModel;
   validationIssues: AccountingConfigurationIssueViewModel[];
+  blockingIssueCount: number; warningIssueCount: number;
+  saveState: "saved" | "unsaved" | "saving" | "error" | "recovered"; saveStatusLabel: string;
+  validationStatusLabel: string; recoveryStatusText: string | null;
   lifecycleCommands: ManualJournalLifecycleCommandViewModel[];
   lifecycleChecklist: ManualJournalLifecycleChecklistItemViewModel[];
   lifecycleTransitions: ManualJournalLifecycleTransitionViewModel[];
   lifecycleCorrectionRows: ManualJournalLifecycleCorrectionViewModel[];
   lifecycleStatusText: string | null;
   lifecycleBusyAction: JournalEntryLifecycleAction | null;
-  saveBusy: boolean;
-  validateBusy: boolean;
-  submitBusy: boolean;
+  saveBusy: boolean; validateBusy: boolean; submitBusy: boolean;
   attachEvidenceBusy: boolean;
   attachEvidenceStatusText: string | null;
   validationIsCurrent: boolean;
@@ -1961,14 +1959,16 @@ export interface ManualJournalEntryWorkbenchViewModel {
   updateHeader: (field: keyof Pick<ManualJournalEntryDraft, "memo" | "currency" | "fundProfileId" | "entityId" | "fundNodeId" | "periodId" | "accountingDate">, value: string) => void;
   selectDraft: (journalEntryId: string) => void;
   selectLine: (lineId: string) => void;
-  updateLine: (lineId: string, patch: Partial<ManualJournalEntryLine>) => void;
+  updateLine: (lineId: string, patch: Partial<ManualJournalEntryLine>) => void; updateDraftDimensions: (patch: Partial<LedgerDimensionSet>) => void;
   getLineBadges: (lineId: string) => ManualJournalLineValidationBadge[];
   updateSecuritySearchQuery: (query: string) => void;
   searchSecurityMaster: () => Promise<void>;
   selectSecurity: (lineId: string, security: SecurityMasterEntry) => void;
   clearSecurity: (lineId: string) => void;
   addLine: (side: AccountingTemplateLineSide) => void;
+  insertLineAfter: (lineId: string, side?: AccountingTemplateLineSide) => string; duplicateLine: (lineId: string) => string | null;
   removeLine: (lineId: string) => void;
+  discardRecoveredDraft: () => void;
   updateAttachmentDraft: (patch: Partial<ManualJournalEvidenceAttachmentDraft>) => void;
   addAttachment: () => Promise<void>;
   removeAttachment: (attachmentId: string) => void;

--- a/src/Meridian.Ui/dashboard/src/screens/covered-call-screen.formatters.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/covered-call-screen.formatters.ts
@@ -8,8 +8,14 @@ export function formatDecimal(value: number, digits: number): string {
   return value.toFixed(digits);
 }
 
-/** Input is already in percent units (42.5 -> "42.5%"). For fractions use `formatRatioAsPercent`. */
-export function formatPercent(value: number): string {
+/**
+ * Input is a fraction of 1 (0.425 -> "42.5%"), not percent units.
+ *
+ * Implied volatility and CAGR arrive from the covered-call API as fractions.
+ * Kept local rather than delegating to `@/lib/format` because these render
+ * ungrouped (`toFixed`); the shared helper adds thousands separators.
+ */
+export function formatRatioAsPercent(value: number): string {
   if (!Number.isFinite(value)) return "—";
   return `${(value * 100).toFixed(1)}%`;
 }

--- a/src/Meridian.Ui/dashboard/src/screens/covered-call-screen.formatters.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/covered-call-screen.formatters.ts
@@ -8,6 +8,7 @@ export function formatDecimal(value: number, digits: number): string {
   return value.toFixed(digits);
 }
 
+/** Input is already in percent units (42.5 -> "42.5%"). For fractions use `formatRatioAsPercent`. */
 export function formatPercent(value: number): string {
   if (!Number.isFinite(value)) return "—";
   return `${(value * 100).toFixed(1)}%`;

--- a/src/Meridian.Ui/dashboard/src/screens/covered-call-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/covered-call-screen.tsx
@@ -857,6 +857,7 @@ function HistoryPanel({ vm }: { vm: CoveredCallScreenViewModel }) {
   );
 }
 
+/** Input is a fraction of 1 (0.425 -> "42.50%"), not percent units. */
 function fmtPct(value: number): string {
   if (!Number.isFinite(value)) return "—";
   return `${(value * 100).toFixed(2)}%`;

--- a/src/Meridian.Ui/dashboard/src/screens/covered-call-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/covered-call-screen.view-model.ts
@@ -19,7 +19,7 @@ import {
   formatCount,
   formatDecimal,
   formatExitReason,
-  formatPercent,
+  formatRatioAsPercent,
   formatPrice,
   formatSignedMoney,
   formatUtcDateTime
@@ -1274,7 +1274,7 @@ function buildCoveredCallTradeTimelineDetail(
       { label: "Total net PnL", value: totalPnl },
       { label: "Holding days", value: formatCount(trade.holdingDays) },
       { label: "Multiplier", value: formatCount(trade.multiplier) },
-      { label: "Entry IV", value: trade.entryImpliedVolatility === null ? "—" : formatPercent(trade.entryImpliedVolatility) },
+      { label: "Entry IV", value: trade.entryImpliedVolatility === null ? "—" : formatRatioAsPercent(trade.entryImpliedVolatility) },
       { label: "Assignment", value: trade.wasAssigned ? "Assigned" : "Not assigned" }
     ],
     ariaLabel: `Selected covered-call trade ${index + 1}: ${underlyingSymbol} ${strikeLabel} call`
@@ -1424,7 +1424,7 @@ function buildChainPreviewDetail(
       { label: "DTE", value: formatCount(row.daysToExpiration) },
       { label: "Bid / Ask", value: `${formatPrice(row.bid)} / ${formatPrice(row.ask)}` },
       { label: "Delta", value: formatDecimal(row.delta, 2) },
-      { label: "Implied volatility", value: row.impliedVolatility === null ? "—" : formatPercent(row.impliedVolatility) },
+      { label: "Implied volatility", value: row.impliedVolatility === null ? "—" : formatRatioAsPercent(row.impliedVolatility) },
       { label: "Open interest", value: formatCount(row.openInterest) },
       { label: "Volume", value: formatCount(row.volume) }
     ],
@@ -1443,7 +1443,7 @@ export function buildCoveredCallHistoryRows(history: CoveredCallRunSummary[]): C
     const startedAtLabel = formatUtcDateTime(row.startedAt);
     const rangeLabel = `${row.from} to ${row.to}`;
     const statusBadgeVariant = statusBadgeVariantForHistory(row.status);
-    const cagrLabel = row.cagr === null ? "—" : formatPercent(row.cagr);
+    const cagrLabel = row.cagr === null ? "—" : formatRatioAsPercent(row.cagr);
     const sharpeRatioLabel = row.sharpeRatio === null ? "—" : formatDecimal(row.sharpeRatio, 2);
     const labelText = row.label?.trim() || "Unlabeled";
 

--- a/src/Meridian.Ui/dashboard/src/screens/evidence-workbench-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/evidence-workbench-screen.view-model.ts
@@ -10,7 +10,7 @@ import {
   reviewEvidenceVaultDocument,
   validateEvidencePacket
 } from "@/lib/api";
-import { describeApiError } from "@/lib/api-errors";
+import { describeApiError, isAbortError } from "@/lib/api-errors";
 import {
   formatDate,
   formatEvidenceDocumentAuthority,
@@ -1599,12 +1599,6 @@ function buildSlaAssessmentRow(assessment: EvidenceSlaAssessment): EvidenceSlaAs
 
 function buildEvidenceWorkbenchError(error: unknown, fallback: string): EvidenceWorkbenchErrorState {
   return describeApiError(error, fallback);
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof DOMException
-    ? error.name === "AbortError"
-    : error instanceof Error && error.name === "AbortError";
 }
 
 export function buildEvidenceLineagePanel(

--- a/src/Meridian.Ui/dashboard/src/screens/family-office-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/family-office-screen.view-model.ts
@@ -522,6 +522,7 @@ function entityDisplayName(entityStructure: FamilyOfficeEntityStructure, entityI
   return entityStructure.entities.find((entity) => entity.entityId === entityId)?.displayName ?? "Unmapped entity";
 }
 
+/** Input is already in percent units (42.5 -> "42.5%"). For fractions use `formatRatioAsPercent`. */
 function formatPercent(value: number): string {
   return Number.isInteger(value) ? `${value}%` : `${value.toFixed(1)}%`;
 }

--- a/src/Meridian.Ui/dashboard/src/screens/operations-continuity-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/operations-continuity-screen.view-model.ts
@@ -8,7 +8,7 @@ import {
   type ApiRequestOptions,
   type PrivateCapitalCloseCockpitQuery
 } from "@/lib/api";
-import { describeApiError } from "@/lib/api-errors";
+import { describeApiError, isAbortError } from "@/lib/api-errors";
 import { humanizeStatus } from "@/components/operations/status";
 import { normalizeLocalWorkstationRoute, workstationRouteWithQuery } from "@/lib/workspace";
 import {
@@ -3938,10 +3938,6 @@ function formatError(err: unknown, fallback: string): string {
   return display.summary || (err instanceof Error ? err.message : fallback);
 }
 
-function isAbortError(err: unknown): boolean {
-  return err instanceof DOMException && err.name === "AbortError";
-}
-
 function splitEnumLabel(value: string): string {
   return value
     .replace(/[-_]+/g, " ")
@@ -4019,6 +4015,7 @@ function formatCurrency(value: number | null | undefined, currency: string): str
   return formatCurrencyAmount(value, { currency });
 }
 
+/** Input is already in percent units (readiness scores are 0-100). For fractions use `formatRatioAsPercent`. */
 function formatPercent(value: number | null | undefined): string {
   return typeof value === "number" && Number.isFinite(value)
     ? `${Math.round(value)}%`

--- a/src/Meridian.Ui/dashboard/src/screens/portfolio-screen.presentation.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/portfolio-screen.presentation.ts
@@ -1,6 +1,6 @@
 import {
   formatNumber as formatNumberAmount,
-  formatPercent as formatPercentAmount,
+  formatRatioAsPercent as formatRatioAsPercentAmount,
   formatPrefixedCurrency,
   formatSignedCurrency as formatSignedCurrencyAmount,
   pluralizeCount
@@ -85,8 +85,9 @@ export function formatCurrencyPrecise(value: number): string {
   return formatPrefixedCurrency(value, { minimumFractionDigits: 2 });
 }
 
-export function formatPercent(value: number): string {
-  return formatPercentAmount(value * 100);
+/** Input is a fraction of 1 (0.425 -> "42.5%"), not percent units. */
+export function formatRatioAsPercent(value: number): string {
+  return formatRatioAsPercentAmount(value);
 }
 
 export function formatNumber(value: number): string {

--- a/src/Meridian.Ui/dashboard/src/screens/portfolio-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/portfolio-screen.view-model.ts
@@ -8,7 +8,7 @@ import {
   formatCurrencyPrecise,
   formatDateTime,
   formatNumber,
-  formatPercent,
+  formatRatioAsPercent,
   formatSignedCurrency,
   pnlFieldTone,
   pnlTone,
@@ -1115,7 +1115,7 @@ export function buildPortfolioRunDrillInSummary(
       {
         id: "drawdown",
         label: "Drawdown",
-        value: drawdown ? formatPercent(drawdown.maxDrawdownPercent) : "—",
+        value: drawdown ? formatRatioAsPercent(drawdown.maxDrawdownPercent) : "—",
         detail: drawdown
           ? `${formatCountLabel(drawdown.points.length, "equity point")}; recovery ${drawdown.maxDrawdownRecoveryDays} days; final equity ${formatCurrency(drawdown.finalEquity)}.`
           : "Equity curve and drawdown profile have not been loaded.",

--- a/src/Meridian.Ui/dashboard/src/screens/reporting-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/reporting-screen.view-model.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { runAnalysisExport } from "@/lib/api";
 import type { ApiRequestOptions } from "@/lib/api";
-import { describeApiError } from "@/lib/api-errors";
+import { describeApiError, isAbortError } from "@/lib/api-errors";
 import {
   EXPORT_API_ENDPOINTS,
   exportPreviewEndpoint,
@@ -2678,10 +2678,6 @@ export function buildExportStatusFailure(profileName: string, error: unknown): R
     warnings: detail.details,
     artifacts: []
   };
-}
-
-function isAbortError(error: unknown): boolean {
-  return (error instanceof DOMException || error instanceof Error) && error.name === "AbortError";
 }
 
 function buildExportResultFields(requestedProfileId: string, result: ExportAnalysisResult): ReportingDetailField[] {

--- a/src/Meridian.Ui/dashboard/src/screens/strategy-screen.formatters.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/strategy-screen.formatters.ts
@@ -82,6 +82,7 @@ export function formatCount(value: number | null | undefined): string {
   return value.toLocaleString();
 }
 
+/** Input is a fraction of 1 (0.425 -> "+42.50%"), not percent units. */
 export function formatSignedPercent(value: number | null | undefined): string {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     return "Unavailable";

--- a/src/Meridian.Ui/dashboard/src/screens/strategy-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/strategy-screen.view-model.ts
@@ -1546,7 +1546,14 @@ function formatDecimal(value: number | null | undefined, digits: number): string
   return value.toFixed(digits);
 }
 
-function formatPercent(value: number | null | undefined, digits: number): string {
+/**
+ * Input is a fraction of 1 (0.425 -> "42.5%"), not percent units.
+ *
+ * Kept local rather than delegating to `@/lib/format` because these promotion
+ * metrics render ungrouped (`toFixed`) — the shared helper adds thousands
+ * separators, which would change existing output.
+ */
+function formatRatioAsPercent(value: number | null | undefined, digits: number): string {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     return "Unavailable";
   }
@@ -1571,8 +1578,8 @@ export function buildPromotionEvaluationState(
     reason: promotionEval.reason.trim() || "Promotion evaluation returned no reason.",
     metricRows: [
       { id: "sharpe", label: "Sharpe", value: formatDecimal(promotionEval.sharpeRatio, 2) },
-      { id: "drawdown", label: "Max DD", value: formatPercent(promotionEval.maxDrawdownPercent, 1) },
-      { id: "return", label: "Return", value: formatPercent(promotionEval.totalReturn, 1) }
+      { id: "drawdown", label: "Max DD", value: formatRatioAsPercent(promotionEval.maxDrawdownPercent, 1) },
+      { id: "return", label: "Return", value: formatRatioAsPercent(promotionEval.totalReturn, 1) }
     ],
     blockingReasons,
     hasBlockingReasons: blockingReasons.length > 0,
@@ -2659,8 +2666,8 @@ function buildPromotionHistoryRow(
   const routeText = `${source} to ${target}`;
   const decisionText = formatPromotionDecision(record);
   const qualifyingSharpeText = formatNullableNumber(record.qualifyingSharpe, 3);
-  const qualifyingMaxDrawdownText = formatPercent(record.qualifyingMaxDrawdownPercent, 1);
-  const qualifyingTotalReturnText = formatPercent(record.qualifyingTotalReturn, 1);
+  const qualifyingMaxDrawdownText = formatRatioAsPercent(record.qualifyingMaxDrawdownPercent, 1);
+  const qualifyingTotalReturnText = formatRatioAsPercent(record.qualifyingTotalReturn, 1);
   const promotedAtText = formatText(record.promotedAt);
   const detailExpanded = record.promotionId === selectedPromotionId;
 
@@ -2711,8 +2718,8 @@ export function buildPromotionHistoryDetail(
       { label: "Target run", value: formatText(record.targetRunId ?? null) },
       { label: "Decision", value: decisionText },
       { label: "Sharpe", value: formatNullableNumber(record.qualifyingSharpe, 3) },
-      { label: "Max drawdown", value: formatPercent(record.qualifyingMaxDrawdownPercent, 1) },
-      { label: "Total return", value: formatPercent(record.qualifyingTotalReturn, 1) },
+      { label: "Max drawdown", value: formatRatioAsPercent(record.qualifyingMaxDrawdownPercent, 1) },
+      { label: "Total return", value: formatRatioAsPercent(record.qualifyingTotalReturn, 1) },
       { label: "Approved by", value: approvedBy },
       { label: "Audit ref", value: auditReference }
     ]

--- a/src/Meridian.Ui/dashboard/src/screens/watchlist-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/watchlist-screen.view-model.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ApiRequestOptions } from "@/lib/api";
-import { describeApiError, type ApiErrorDisplay } from "@/lib/api-errors";
+import { describeApiError, isAbortError, type ApiErrorDisplay } from "@/lib/api-errors";
 import { useQuotesStream } from "@/hooks/use-quotes-stream";
 import { formatRelativeAge as formatRelative } from "@/lib/time";
 import { WORKSTATION_ROUTE_CATALOG, workstationRouteWithQuery } from "@/lib/workspace";
@@ -1355,12 +1355,6 @@ function stableSymbolId(value: string): string {
 
 function formatCount(value: number): string {
   return value.toLocaleString();
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof DOMException
-    ? error.name === "AbortError"
-    : error instanceof Error && error.name === "AbortError";
 }
 
 function formatPrice(value: number | null | undefined): string {

--- a/src/Meridian.Ui/dashboard/src/styles/accounting-screen.css
+++ b/src/Meridian.Ui/dashboard/src/styles/accounting-screen.css
@@ -487,6 +487,104 @@
   padding: 0.75rem 1rem;
 }
 
+.accounting-journal-health-bar {
+  position: sticky;
+  top: 0.5rem;
+  z-index: 20;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.75rem 1rem;
+  border: 1px solid var(--ws-border-strong, #99a5b2);
+  border-radius: var(--radius-card, 2px);
+  background: color-mix(in srgb, var(--ws-surface, #ffffff) 94%, transparent);
+  box-shadow: 0 8px 24px rgba(31, 42, 55, 0.12);
+  padding: 0.75rem;
+  backdrop-filter: blur(10px);
+}
+
+.accounting-journal-health-summary,
+.accounting-journal-health-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.accounting-journal-health-actions {
+  justify-content: flex-end;
+}
+
+.accounting-journal-health-item {
+  display: inline-flex;
+  min-height: 2rem;
+  align-items: center;
+  gap: 0.45rem;
+  border: 1px solid var(--ws-border, #cbd3dc);
+  border-radius: 999px;
+  background: var(--ws-surface-subtle, #ebeff4);
+  padding: 0.25rem 0.65rem;
+  color: var(--ws-text, #22272e);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.accounting-journal-health-item > span[aria-hidden="true"] {
+  width: 0.5rem;
+  height: 0.5rem;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: var(--ws-text-muted, #59636f);
+}
+
+.accounting-journal-health-item.is-saved > span,
+.accounting-journal-health-item.is-recovered > span {
+  background: var(--state-positive, #18794e);
+}
+
+.accounting-journal-health-item.is-unsaved > span,
+.accounting-journal-health-item.is-saving > span,
+.accounting-journal-health-item.is-warning > span {
+  background: var(--state-warning, #9a6700);
+}
+
+.accounting-journal-health-item.is-error > span {
+  background: var(--state-danger, #b42318);
+}
+
+.accounting-journal-recovery-status {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  border-top: 1px solid var(--ws-border, #cbd3dc);
+  padding-top: 0.65rem;
+  color: var(--ws-text-muted, #59636f);
+  font-size: 0.8125rem;
+}
+
+.accounting-journal-keyboard-hint {
+  border: 1px solid var(--ws-border, #cbd3dc);
+  border-bottom: 0;
+  border-radius: var(--radius-card, 2px) var(--radius-card, 2px) 0 0;
+  background: var(--ws-surface-subtle, #ebeff4);
+  padding: 0.5rem 0.75rem;
+  color: var(--ws-text-muted, #59636f);
+  font-size: 0.75rem;
+}
+
+.accounting-journal-keyboard-hint + .accounting-journal-table-wrap {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+#manual-je-validation-heading:focus,
+.accounting-journal-table tr:focus {
+  outline: 2px solid var(--ws-accent, #2f6f8f);
+  outline-offset: 2px;
+}
+
 @media (max-width: 900px) {
   .accounting-reference-heading,
   .accounting-journal-footer {
@@ -502,6 +600,15 @@
   .accounting-balance-strip,
   .accounting-journal-header-grid {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .accounting-journal-health-bar {
+    position: static;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .accounting-journal-health-actions {
+    justify-content: flex-start;
   }
 
   .reconcile-pane + .reconcile-pane {

--- a/tests/Meridian.Tests/Strategies/LiveRunMetricsTrackerTests.cs
+++ b/tests/Meridian.Tests/Strategies/LiveRunMetricsTrackerTests.cs
@@ -1,0 +1,95 @@
+using FluentAssertions;
+using Meridian.Backtesting.Sdk;
+using Meridian.Strategies.Live;
+using MeridianLedger = Meridian.Ledger.Ledger;
+
+namespace Meridian.Tests.Strategies;
+
+/// <summary>
+/// Unit contract tests for <see cref="LiveRunMetricsTracker"/>.
+///
+/// <para>
+/// Regression guard: this tracker and <c>BacktestMetricsEngine</c> both populate the same
+/// <see cref="BacktestMetrics"/> record, so they must agree on units. The tracker previously
+/// wrote <c>MaxDrawdownPercent</c> in percent units (15.0) while the metrics engine wrote a
+/// fraction (0.15). Because the workstation multiplies by 100 at render time, live and paper
+/// runs displayed drawdown 100x too large.
+/// </para>
+/// </summary>
+public sealed class LiveRunMetricsTrackerTests
+{
+    private static readonly DateTimeOffset StartedAt = new(2024, 1, 2, 0, 0, 0, TimeSpan.Zero);
+
+    /// <summary>
+    /// Equity 1,000 -> 1,100 (peak) -> 950 (trough) -> 1,050.
+    /// Worst drawdown is 1,100 -> 950 = 150, i.e. 150/1100 ≈ 0.13636 as a fraction of peak.
+    /// </summary>
+    [Fact]
+    public void Build_MaxDrawdownPercent_IsAFractionOfPeakEquityNotPercentUnits()
+    {
+        var metrics = BuildMetricsFor([1_100m, 950m, 1_050m], initialEquity: 1_000m, finalEquity: 1_050m);
+
+        metrics.MaxDrawdown.Should().Be(150m, "the worst peak-to-trough decline is 1100 - 950");
+
+        metrics.MaxDrawdownPercent.Should().BeApproximately(150m / 1_100m, 1e-10m,
+            "MaxDrawdownPercent is a FRACTION of peak equity (~0.1364), matching BacktestMetricsEngine; " +
+            "emitting percent units (13.64) here renders as a 1364% drawdown in the workstation");
+
+        metrics.MaxDrawdownPercent.Should().BeLessThan(1m,
+            "a drawdown that never exceeded 100% of peak equity must stay below 1.0 in fraction units");
+    }
+
+    /// <summary>
+    /// Calmar is annualized return divided by max drawdown. Both operands must be in the same
+    /// units; the tracker previously compensated for its percent-unit drawdown by dividing by
+    /// 100 here, so changing the drawdown unit without changing this would break Calmar.
+    /// </summary>
+    [Fact]
+    public void Build_CalmarRatio_DividesAnnualizedReturnByTheSameFractionItReports()
+    {
+        var metrics = BuildMetricsFor([1_100m, 950m, 1_050m], initialEquity: 1_000m, finalEquity: 1_050m);
+
+        var expectedCalmar = (double)(metrics.AnnualizedReturn / metrics.MaxDrawdownPercent);
+
+        metrics.CalmarRatio.Should().BeApproximately(expectedCalmar, 1e-9,
+            "Calmar must be derived from the same drawdown fraction the tracker reports");
+    }
+
+    [Fact]
+    public void Build_WhenEquityOnlyRises_ReportsZeroDrawdownAndZeroCalmar()
+    {
+        var metrics = BuildMetricsFor([1_050m, 1_100m, 1_200m], initialEquity: 1_000m, finalEquity: 1_200m);
+
+        metrics.MaxDrawdown.Should().Be(0m);
+        metrics.MaxDrawdownPercent.Should().Be(0m);
+        metrics.CalmarRatio.Should().Be(0, "Calmar is undefined without a drawdown and is reported as zero");
+    }
+
+    private static BacktestMetrics BuildMetricsFor(
+        IReadOnlyList<decimal> dailyEquity,
+        decimal initialEquity,
+        decimal finalEquity)
+    {
+        var tracker = new LiveRunMetricsTracker(initialEquity, StartedAt);
+        var date = DateOnly.FromDateTime(StartedAt.UtcDateTime);
+
+        for (var i = 0; i < dailyEquity.Count; i++)
+        {
+            tracker.RecordDayEnd(
+                date.AddDays(i + 1),
+                cash: dailyEquity[i],
+                equity: dailyEquity[i],
+                positions: new Dictionary<string, Position>(),
+                accounts: new Dictionary<string, FinancialAccountSnapshot>());
+        }
+
+        var result = tracker.Build(
+            engineId: "BrokerPaper",
+            universe: new HashSet<string>(),
+            finalEquity: finalEquity,
+            ledger: new MeridianLedger(),
+            endedAt: StartedAt.AddDays(dailyEquity.Count));
+
+        return result.Metrics;
+    }
+}


### PR DESCRIPTION
## Summary

- add a sticky journal health and action bar with save, balance, validation, blocker, and recovery state
- add keyboard-first line navigation, insertion, duplication, autosave/recovery, actionable validation focus, and selected-line dimension editing
- centralize abort detection and distinguish fractional ratios from percent-unit values across browser workstation view models
- refresh focused tests, dashboard documentation, and the generated dashboard source hash

## Why

This makes manual journal entry work faster and more accessible while preventing navigation aborts from surfacing as operator failures and reducing silent 100x percentage-format errors.

## Validation

- post-rebase focused Vitest: 4 files, 117 tests passed
- post-rebase strict TypeScript: passed
- full dashboard suite: all 265 test files passed
- dashboard lint and production bundle build: passed
- .NET non-integration slices: 19/19 passed
- file-size ratchet, source README validation, and dashboard hash refresh: passed
- canonical local quality gate reached the final docs-render dirty-tree assertion; all preceding implementation gates passed, and GitHub Actions remains authoritative