### PR TITLE
W9-REPORT-005: bespoke partners-capital statement in governed client deliverables (supersedes #2525)

### DIFF
--- a/docs/architecture/diagrams/meridian-development-roadmap.mmd
+++ b/docs/architecture/diagrams/meridian-development-roadmap.mmd
@@ -42,7 +42,7 @@ flowchart LR
   W9_DEMO_002 --> W9_PAPER_003
   W9_ALPACA_004["W9-ALPACA-004\nW9 - ready_for_acceptance / green"]
   W9_PAPER_003 --> W9_ALPACA_004
-  W9_REPORT_005["W9-REPORT-005\nW9 - planned / green"]
+  W9_REPORT_005["W9-REPORT-005\nW9 - ready_for_acceptance / green"]
   W9_ALPACA_004 --> W9_REPORT_005
   W9_NAV_006["W9-NAV-006\nW9 - planned / green"]
   W9_REPORT_005 --> W9_NAV_006

--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -5036,6 +5036,7 @@ Meridian-main
 │   │   ├── MultiCurrencyJournalProjector.cs
 │   │   ├── MultiCurrencyLedgerTranslator.cs
 │   │   ├── NavPerUnitCalculator.cs
+│   │   ├── PartnersCapitalStatementLayout.cs
 │   │   ├── PartnershipInvestor.cs
 │   │   ├── PartnershipInvestorAccountingProjector.cs
 │   │   ├── PartnershipInvestorAllocation.cs
@@ -9317,6 +9318,8 @@ Meridian-main
 │   │   │   ├── LotConsumptionTests.cs
 │   │   │   ├── NavPerUnitAndEqualizationTests.cs
 │   │   │   ├── PartnersCapitalAllocationBreakoutTests.cs
+│   │   │   ├── PartnersCapitalBespokeRenderTests.cs
+│   │   │   ├── PartnersCapitalStatementLayoutTests.cs
 │   │   │   ├── PeriodCloseProjectorTests.cs
 │   │   │   ├── PeriodReopenTests.cs
 │   │   │   ├── PortfolioPricingRuleTests.cs

--- a/docs/roadmap/data/roadmap-items.yml
+++ b/docs/roadmap/data/roadmap-items.yml
@@ -1007,11 +1007,11 @@ items:
       - Reporting
       - Accounting
     owner_lane: Accounting and Ledger
-    status: planned
+    status: ready_for_acceptance
     health: green
     priority: high
-    evidence_posture: planned_evidence
-    current_summary: Rank 5 of the 2026-07 first-order improvement slate. Ops teams currently re-type every deliverable into Excel; governed report packs must export client-presentable PDF and XLSX artifacts, including a partners-capital statement, so the governed output is the deliverable rather than an input to manual reformatting.
+    evidence_posture: implementation_complete
+    current_summary: Implementation completed 2026-08-10. The phase-1 client-grade rendering lane had already merged - Meridian.Documents renders governed ledger report packs to deterministic client-presentable PDF (QuestPDF) and XLSX (ClosedXML) with fixed metadata and canonical zip ordering so re-rendering reproduces the bytes, the certified reporting path binds every primary document to an exact checkpoint-bound canonical ledger presentation and fails closed without one, and certified packages retain report-pack signatures and provenance manifests alongside the artifacts. This acceptance candidate completes the deferred presentation half by absorbing and validating the stalled bespoke partners-capital layout (supersedes PR 2525) against current main - PartnersCapitalStatementLayout classifies each capital account by partner role from stable ledger account names, computes ownership shares that foot to 100 percent while excluding non-partner equity, anchors the statement to the fund's ledger-backed net asset value with an explicit reconciliation flag, and never alters a ledger figure; the renderer emits a purpose-built PDF section (NAV context strip, role-labelled per-partner roll-forward, ownership column, reconciliation footnote) and a dedicated typed-numeric XLSX sheet with accounting/percent formats plus a NAV anchor block so operators can sum and pivot without retyping. Certification tests were updated to the bespoke sheet shape while keeping their governance intent - primary bytes must equal the canonical Documents renderer output and display-row rebuild fingerprints remain forbidden.
     exit_criteria:
       - Governed report packs export deterministic client-presentable PDF and XLSX artifacts with retained hash and provenance manifests.
       - A partners-capital statement covering opening balance, contributions, distributions, income/expense/gain allocations, fees, and closing balance renders per partner and per period from ledger-backed data.
@@ -1021,7 +1021,22 @@ items:
       - SRC-LEDGER
       - SRC-CONTRACTS
       - SRC-UI-SHARED
-    last_reviewed: 2026-07-21
+    evidence:
+      - type: source
+        path: src/Meridian.Ledger/PartnersCapitalStatementLayout.cs
+      - type: source
+        path: src/Meridian.Documents/FinancialReportDocumentRenderer.cs
+      - type: source
+        path: src/Meridian.Ui.Shared/Services/ReportingCertifiedArtifactProducer.cs
+      - type: source
+        path: src/Meridian.Ledger/LedgerScheduledReportExportPackageBuilder.cs
+      - type: test
+        path: tests/Meridian.Tests/Ledger/PartnersCapitalStatementLayoutTests.cs
+      - type: test
+        path: tests/Meridian.Tests/Ledger/PartnersCapitalBespokeRenderTests.cs
+      - type: test
+        path: tests/Meridian.Tests/Ui/ReportingRunCertificationServiceTests.cs
+    last_reviewed: 2026-08-10
 
   - id: W9-NAV-006
     title: Unitized NAV and real fee, waterfall, and capital-call economics

--- a/docs/roadmap/generated/MANIFEST.json
+++ b/docs/roadmap/generated/MANIFEST.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "docs/roadmap/data/roadmap-items.yml",
-      "sha256": "5188d77182bee81f9733d6b51fc8162d305d5811d909c77c1e3854ff8318b17f"
+      "sha256": "64afd17dde25507a8b22b1198abb2adee2ab693788aea811d9c69f88b6985f4f"
     },
     {
       "path": "docs/roadmap/data/stage-gates.yml",
@@ -32,15 +32,15 @@
   "outputs": [
     {
       "path": "docs/roadmap/generated/ROADMAP_SUMMARY.md",
-      "sha256": "a9127ff9e196bde46b6d9623f76ea0971f99d528f73fab3f1f8af0122734159b"
+      "sha256": "9bf8171d2dacbcd3d36cd08c7af6855386e76159b758e3dd33f6e4642b36e86c"
     },
     {
       "path": "docs/roadmap/generated/roadmap-register.md",
-      "sha256": "0a4531abef38fd782722f73ba2c8ec05e244c7f8ce8fe9e07a25e1d20da10721"
+      "sha256": "895d35abf303de31f115875b38019b4cfaaa8b231990d5ed6a33ead7abdc782a"
     },
     {
       "path": "docs/status/ROADMAP_SUMMARY.md",
-      "sha256": "a9127ff9e196bde46b6d9623f76ea0971f99d528f73fab3f1f8af0122734159b"
+      "sha256": "9bf8171d2dacbcd3d36cd08c7af6855386e76159b758e3dd33f6e4642b36e86c"
     }
   ],
   "schema": {

--- a/docs/roadmap/generated/ROADMAP_SUMMARY.md
+++ b/docs/roadmap/generated/ROADMAP_SUMMARY.md
@@ -44,7 +44,7 @@ Snapshot date: 2026-08-10
 | W9-DEMO-002 | One-command seeded demo with durable storage | ready_for_acceptance | green | critical | Workstation Shell and UX |
 | W9-PAPER-003 | Paper-trading realism with limit/stop matching and costs | ready_for_acceptance | green | critical | Execution and Fund Accounts |
 | W9-ALPACA-004 | Alpaca fill streaming into order and ledger state | ready_for_acceptance | green | high | Execution and Fund Accounts |
-| W9-REPORT-005 | Client-grade PDF/XLSX exports and partners-capital statement | planned | green | high | Accounting and Ledger |
+| W9-REPORT-005 | Client-grade PDF/XLSX exports and partners-capital statement | ready_for_acceptance | green | high | Accounting and Ledger |
 | W9-NAV-006 | Unitized NAV and real fee, waterfall, and capital-call economics | planned | green | high | Accounting and Ledger |
 | W9-SAFETY-007 | Kill-switch cancel-all and fat-finger, notional, and collar rules | planned | green | high | Execution and Fund Accounts |
 | W9-GOV-008 | Route-level authorization, fail-closed tenancy, and hash-chained accounting audit | planned | green | high | Platform Security and Governance |

--- a/docs/roadmap/generated/roadmap-register.md
+++ b/docs/roadmap/generated/roadmap-register.md
@@ -679,16 +679,16 @@ Implementation verified complete 2026-08-10; the 2026-07-21 premise that the ord
 | Field | Value |
 | --- | --- |
 | Wave | W9 |
-| Status | planned |
+| Status | ready_for_acceptance |
 | Health | green |
 | Priority | high |
 | Owner lane | Accounting and Ledger |
-| Evidence posture | planned_evidence |
-| Last reviewed | 2026-07-21 |
+| Evidence posture | implementation_complete |
+| Last reviewed | 2026-08-10 |
 
 ### Current Summary
 
-Rank 5 of the 2026-07 first-order improvement slate. Ops teams currently re-type every deliverable into Excel; governed report packs must export client-presentable PDF and XLSX artifacts, including a partners-capital statement, so the governed output is the deliverable rather than an input to manual reformatting.
+Implementation completed 2026-08-10. The phase-1 client-grade rendering lane had already merged - Meridian.Documents renders governed ledger report packs to deterministic client-presentable PDF (QuestPDF) and XLSX (ClosedXML) with fixed metadata and canonical zip ordering so re-rendering reproduces the bytes, the certified reporting path binds every primary document to an exact checkpoint-bound canonical ledger presentation and fails closed without one, and certified packages retain report-pack signatures and provenance manifests alongside the artifacts. This acceptance candidate completes the deferred presentation half by absorbing and validating the stalled bespoke partners-capital layout (supersedes PR 2525) against current main - PartnersCapitalStatementLayout classifies each capital account by partner role from stable ledger account names, computes ownership shares that foot to 100 percent while excluding non-partner equity, anchors the statement to the fund's ledger-backed net asset value with an explicit reconciliation flag, and never alters a ledger figure; the renderer emits a purpose-built PDF section (NAV context strip, role-labelled per-partner roll-forward, ownership column, reconciliation footnote) and a dedicated typed-numeric XLSX sheet with accounting/percent formats plus a NAV anchor block so operators can sum and pivot without retyping. Certification tests were updated to the bespoke sheet shape while keeping their governance intent - primary bytes must equal the canonical Documents renderer output and display-row rebuild fingerprints remain forbidden.
 
 ### Exit Criteria
 

--- a/docs/status/ROADMAP_SUMMARY.md
+++ b/docs/status/ROADMAP_SUMMARY.md
@@ -44,7 +44,7 @@ Snapshot date: 2026-08-10
 | W9-DEMO-002 | One-command seeded demo with durable storage | ready_for_acceptance | green | critical | Workstation Shell and UX |
 | W9-PAPER-003 | Paper-trading realism with limit/stop matching and costs | ready_for_acceptance | green | critical | Execution and Fund Accounts |
 | W9-ALPACA-004 | Alpaca fill streaming into order and ledger state | ready_for_acceptance | green | high | Execution and Fund Accounts |
-| W9-REPORT-005 | Client-grade PDF/XLSX exports and partners-capital statement | planned | green | high | Accounting and Ledger |
+| W9-REPORT-005 | Client-grade PDF/XLSX exports and partners-capital statement | ready_for_acceptance | green | high | Accounting and Ledger |
 | W9-NAV-006 | Unitized NAV and real fee, waterfall, and capital-call economics | planned | green | high | Accounting and Ledger |
 | W9-SAFETY-007 | Kill-switch cancel-all and fat-finger, notional, and collar rules | planned | green | high | Execution and Fund Accounts |
 | W9-GOV-008 | Route-level authorization, fail-closed tenancy, and hash-chained accounting audit | planned | green | high | Platform Security and Governance |

--- a/docs/status/coverage-report.md
+++ b/docs/status/coverage-report.md
@@ -5,7 +5,7 @@
 
 ## Overall Coverage
 
-**2741 / 8775** items documented (**31.2%**) &mdash; Grade: **F**
+**2742 / 8779** items documented (**31.2%**) &mdash; Grade: **F**
 
 ```text
 [======--------------] 31.2%
@@ -15,7 +15,7 @@
 
 | Category | Documented | Total | Coverage | Grade |
 | ---------- | ----------- | ------- | ---------- | ------- |
-| Public Classes / Interfaces | 2644 | 8293 | 31.9% | F |
+| Public Classes / Interfaces | 2645 | 8297 | 31.9% | F |
 | API Endpoints | 85 | 329 | 25.8% | F |
 | Configuration Options | 1 | 142 | 0.7% | F |
 | Provider Implementations | 0 | 0 | 100.0% | A |
@@ -23,7 +23,7 @@
 
 ## Undocumented Items
 
-### Public Classes / Interfaces (5649 undocumented)
+### Public Classes / Interfaces (5652 undocumented)
 
 | Item | Location |
 | ------ | ---------- |
@@ -77,7 +77,7 @@
 | `MeridianDataProvenanceDeclaration` | `src/Meridian.Application/Composition/MeridianDeploymentPosture.cs:33` |
 | `MeridianDeploymentPostureServiceCollectionExtensions` | `src/Meridian.Application/Composition/MeridianDeploymentPosture.cs:34` |
 | `PersistenceStatusSnapshot` | `src/Meridian.Application/Composition/PersistenceConfigurationStatus.cs:11` |
-| ... and 5599 more | |
+| ... and 5602 more | |
 
 ### API Endpoints (244 undocumented)
 
@@ -193,7 +193,7 @@
 
 ## Recommendations
 
-1. **Public Classes / Interfaces**: 5649 undocumented types. Consider generating API docs with DocFX (`docfx docfx.json`) to cover the long tail of public types automatically.
+1. **Public Classes / Interfaces**: 5652 undocumented types. Consider generating API docs with DocFX (`docfx docfx.json`) to cover the long tail of public types automatically.
 2. **API Endpoints**: 244 endpoint(s) missing from `docs/reference/api-reference.md`. Run the endpoint audit and update the API reference table.
 3. **Configuration Options**: 141 config key(s) not found in `docs/generated/configuration-schema.md`. Re-run the configuration schema generator to synchronise.
 

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 643,
-  "total_lines": 124816,
+  "total_lines": 124833,
   "orphaned_count": 255,
   "no_heading_count": 148,
   "stale_count": 0,
@@ -2594,7 +2594,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 10377,
+      "line_count": 10380,
       "has_heading": true,
       "todo_count": 8,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -5082,7 +5082,7 @@
     },
     {
       "path": "src/Meridian.Documents/README.md",
-      "line_count": 101,
+      "line_count": 107,
       "has_heading": true,
       "todo_count": 1,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -5202,7 +5202,7 @@
     },
     {
       "path": "src/Meridian.Ledger/README.md",
-      "line_count": 266,
+      "line_count": 274,
       "has_heading": true,
       "todo_count": 1,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 643 |
-| Total lines | 124,816 |
+| Total lines | 124,833 |
 | Average file size (lines) | 194.1 |
 | Orphaned files | 255 |
 | Files without headings | 148 |

--- a/docs/status/program-state-summary.json
+++ b/docs/status/program-state-summary.json
@@ -321,13 +321,13 @@
       "Wave": "W9",
       "Title": "Client-grade PDF/XLSX exports and partners-capital statement",
       "Workspaces": "Reporting; Accounting",
-      "Status": "planned",
+      "Status": "ready_for_acceptance",
       "Health": "green",
       "Priority": "high",
       "Owner Lane": "Accounting and Ledger",
-      "Evidence Posture": "planned_evidence",
-      "Evidence": "",
-      "Last Reviewed": "2026-07-21"
+      "Evidence Posture": "implementation_complete",
+      "Evidence": "src/Meridian.Ledger/PartnersCapitalStatementLayout.cs; src/Meridian.Documents/FinancialReportDocumentRenderer.cs; src/Meridian.Ui.Shared/Services/ReportingCertifiedArtifactProducer.cs; src/Meridian.Ledger/LedgerScheduledReportExportPackageBuilder.cs; tests/Meridian.Tests/Ledger/PartnersCapitalStatementLayoutTests.cs; tests/Meridian.Tests/Ledger/PartnersCapitalBespokeRenderTests.cs; tests/Meridian.Tests/Ui/ReportingRunCertificationServiceTests.cs",
+      "Last Reviewed": "2026-08-10"
     },
     {
       "ID": "W9-NAV-006",

--- a/docs/status/program-state-summary.md
+++ b/docs/status/program-state-summary.md
@@ -28,7 +28,7 @@ Snapshot date: 2026-08-10
 | W9-DEMO-002 | W9 | One-command seeded demo with durable storage | Data; Settings | ready_for_acceptance | green | critical | Workstation Shell and UX | implementation_complete | 2026-08-08 |
 | W9-PAPER-003 | W9 | Paper-trading realism with limit/stop matching and costs | Trading; Strategy | ready_for_acceptance | green | critical | Execution and Fund Accounts | implementation_complete | 2026-08-08 |
 | W9-ALPACA-004 | W9 | Alpaca fill streaming into order and ledger state | Trading | ready_for_acceptance | green | high | Execution and Fund Accounts | implementation_complete | 2026-08-10 |
-| W9-REPORT-005 | W9 | Client-grade PDF/XLSX exports and partners-capital statement | Reporting; Accounting | planned | green | high | Accounting and Ledger | planned_evidence | 2026-07-21 |
+| W9-REPORT-005 | W9 | Client-grade PDF/XLSX exports and partners-capital statement | Reporting; Accounting | ready_for_acceptance | green | high | Accounting and Ledger | implementation_complete | 2026-08-10 |
 | W9-NAV-006 | W9 | Unitized NAV and real fee, waterfall, and capital-call economics | Accounting; Portfolio | planned | green | high | Accounting and Ledger | planned_evidence | 2026-07-21 |
 | W9-SAFETY-007 | W9 | Kill-switch cancel-all and fat-finger, notional, and collar rules | Trading; Settings | planned | green | high | Execution and Fund Accounts | planned_evidence | 2026-07-21 |
 | W9-GOV-008 | W9 | Route-level authorization, fail-closed tenancy, and hash-chained accounting audit | Settings; Accounting | planned | green | high | Platform Security and Governance | planned_evidence | 2026-07-21 |

--- a/src/Meridian.Documents/FinancialReportDocumentRenderer.cs
+++ b/src/Meridian.Documents/FinancialReportDocumentRenderer.cs
@@ -170,7 +170,7 @@ public sealed class FinancialReportDocumentRenderer : ILedgerReportBinaryRendere
     private static readonly string[] PartnersCapitalPdfColumns =
     [
         "Partner", "Beginning", "Contributions", "Distributions",
-        "Income & Gains", "Expenses", "Fees", "Ending", "Ownership %"
+        "Income & Gains", "Expenses", "Fees", "Other", "Ending", "Ownership %"
     ];
 
     private static readonly string[] PartnersCapitalSheetColumns =
@@ -257,6 +257,7 @@ public sealed class FinancialReportDocumentRenderer : ILedgerReportBinaryRendere
         RenderPartnersCapitalNumber(grid, Money(line.IncomeGainAllocations), background, isTotal);
         RenderPartnersCapitalNumber(grid, Money(line.ExpenseAllocations), background, isTotal);
         RenderPartnersCapitalNumber(grid, Money(line.FeeAllocations), background, isTotal);
+        RenderPartnersCapitalNumber(grid, Money(line.OtherMovements), background, isTotal);
         RenderPartnersCapitalNumber(grid, Money(line.EndingCapital), background, isTotal);
         RenderPartnersCapitalNumber(grid, Percent(line.OwnershipPercent), background, isTotal);
     }

--- a/src/Meridian.Documents/FinancialReportDocumentRenderer.cs
+++ b/src/Meridian.Documents/FinancialReportDocumentRenderer.cs
@@ -24,6 +24,9 @@ public sealed class FinancialReportDocumentRenderer : ILedgerReportBinaryRendere
     {
         ArgumentNullException.ThrowIfNull(reportPack);
         var tables = LedgerReportPresentation.BuildTables(reportPack);
+        var partnersCapital = reportPack.Statements.PartnersCapital is null
+            ? null
+            : PartnersCapitalStatementLayoutBuilder.Build(reportPack);
         var request = reportPack.Request;
 
         var document = Document.Create(container =>
@@ -46,7 +49,17 @@ public sealed class FinancialReportDocumentRenderer : ILedgerReportBinaryRendere
                 {
                     column.Spacing(14);
                     foreach (var table in tables)
-                        RenderTable(column, table);
+                    {
+                        if (partnersCapital is not null
+                            && table.Title == LedgerReportPresentation.PartnersCapitalTableTitle)
+                        {
+                            RenderPartnersCapital(column, partnersCapital);
+                        }
+                        else
+                        {
+                            RenderTable(column, table);
+                        }
+                    }
                 });
 
                 page.Footer().Row(row =>
@@ -83,6 +96,9 @@ public sealed class FinancialReportDocumentRenderer : ILedgerReportBinaryRendere
     {
         ArgumentNullException.ThrowIfNull(reportPack);
         var tables = LedgerReportPresentation.BuildTables(reportPack);
+        var partnersCapital = reportPack.Statements.PartnersCapital is null
+            ? null
+            : PartnersCapitalStatementLayoutBuilder.Build(reportPack);
 
         byte[] rendered;
         using (var workbook = new XLWorkbook())
@@ -90,28 +106,15 @@ public sealed class FinancialReportDocumentRenderer : ILedgerReportBinaryRendere
             var usedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var table in tables)
             {
-                var sheet = workbook.Worksheets.Add(UniqueSheetName(table.Title, usedNames));
-                var headerRow = sheet.Row(1);
-                for (var column = 0; column < table.Headers.Count; column++)
+                if (partnersCapital is not null
+                    && table.Title == LedgerReportPresentation.PartnersCapitalTableTitle)
                 {
-                    var cell = sheet.Cell(1, column + 1);
-                    cell.Value = table.Headers[column];
-                    cell.Style.Font.Bold = true;
-                    cell.Style.Fill.BackgroundColor = XLColor.FromHtml("#0b7285");
-                    cell.Style.Font.FontColor = XLColor.White;
+                    WritePartnersCapitalSheet(workbook, partnersCapital, usedNames);
                 }
-
-                headerRow.Height = 18;
-                var rowNumber = 2;
-                foreach (var row in table.Rows)
+                else
                 {
-                    for (var column = 0; column < row.Count; column++)
-                        sheet.Cell(rowNumber, column + 1).Value = row[column];
-                    rowNumber++;
+                    WriteGenericSheet(workbook, table, usedNames);
                 }
-
-                sheet.Columns().AdjustToContents();
-                sheet.SheetView.FreezeRows(1);
             }
 
             workbook.Properties.Author = "Meridian";
@@ -163,6 +166,235 @@ public sealed class FinancialReportDocumentRenderer : ILedgerReportBinaryRendere
             }
         });
     }
+
+    private static readonly string[] PartnersCapitalPdfColumns =
+    [
+        "Partner", "Beginning", "Contributions", "Distributions",
+        "Income & Gains", "Expenses", "Fees", "Ending", "Ownership %"
+    ];
+
+    private static readonly string[] PartnersCapitalSheetColumns =
+    [
+        "Partner", "Role", "Beginning", "Contributions", "Distributions",
+        "Income & Gains", "Expenses", "Fees", "Allocated Result", "Other", "Ending", "Ownership %"
+    ];
+
+    private const string MoneyNumberFormat = "#,##0.00";
+    private const string PercentNumberFormat = "0.00%";
+
+    /// <summary>
+    /// Bespoke PDF layout for the statement of changes in partners' capital: a NAV (net-assets)
+    /// context strip, a role-labelled per-partner roll-forward with right-aligned figures and an
+    /// ownership-share column, a bold total row, and a ledger-backed reconciliation footnote. This
+    /// replaces the generic table layout for this one statement so the client deliverable reads like a
+    /// fund administrator's statement rather than a flat grid.
+    /// </summary>
+    private static void RenderPartnersCapital(ColumnDescriptor column, PartnersCapitalStatementLayout layout)
+    {
+        column.Item().Text(LedgerReportPresentation.PartnersCapitalTableTitle)
+            .FontSize(11).Bold().FontColor("#102a43");
+        column.Item().Text(
+                $"Net asset value {Money(layout.NetAssetValue)} {layout.BaseCurrency} · {layout.Lines.Count} capital accounts")
+            .FontSize(8).FontColor("#627d98");
+
+        column.Item().Table(grid =>
+        {
+            grid.ColumnsDefinition(columns =>
+            {
+                columns.RelativeColumn(2.2f);
+                for (var index = 1; index < PartnersCapitalPdfColumns.Length; index++)
+                    columns.RelativeColumn();
+            });
+
+            grid.Header(headerRow =>
+            {
+                // Partner heading left-aligned; every economic heading right-aligned to read as figures.
+                headerRow.Cell().Background("#d9e2ec").PaddingVertical(3).PaddingHorizontal(4)
+                    .Text(PartnersCapitalPdfColumns[0]).SemiBold().FontSize(8);
+                for (var index = 1; index < PartnersCapitalPdfColumns.Length; index++)
+                {
+                    headerRow.Cell().Background("#d9e2ec").AlignRight().PaddingVertical(3).PaddingHorizontal(4)
+                        .Text(PartnersCapitalPdfColumns[index]).SemiBold().FontSize(8);
+                }
+            });
+
+            var alternate = false;
+            foreach (var line in layout.Lines)
+            {
+                RenderPartnersCapitalRow(grid, line, alternate ? "#f0f4f8" : "#ffffff", isTotal: false);
+                alternate = !alternate;
+            }
+
+            RenderPartnersCapitalRow(grid, layout.Total, "#d9e2ec", isTotal: true);
+        });
+
+        var note = layout.TiesToNetAssets
+            ? $"Ending partners' capital of {Money(layout.Total.EndingCapital)} {layout.BaseCurrency} reconciles to the fund's ledger-backed net asset value."
+            : $"Reconciliation exception: ending partners' capital differs from net assets by {Money(layout.NetAssetVariance)} {layout.BaseCurrency}.";
+        column.Item().Text(note).FontSize(7).FontColor(layout.TiesToNetAssets ? "#627d98" : "#b91c1c");
+    }
+
+    private static void RenderPartnersCapitalRow(
+        TableDescriptor grid,
+        PartnersCapitalStatementLine line,
+        string background,
+        bool isTotal)
+    {
+        grid.Cell().Background(background).PaddingVertical(2).PaddingHorizontal(4).Column(cell =>
+        {
+            var name = cell.Item().Text(line.PartnerLabel).FontSize(8);
+            if (isTotal)
+                name.Bold();
+            else
+                name.SemiBold();
+            if (!isTotal)
+                cell.Item().Text(RoleLabel(line.Role)).FontSize(6).FontColor("#829ab1");
+        });
+
+        RenderPartnersCapitalNumber(grid, Money(line.BeginningCapital), background, isTotal);
+        RenderPartnersCapitalNumber(grid, Money(line.Contributions), background, isTotal);
+        RenderPartnersCapitalNumber(grid, Money(line.Distributions), background, isTotal);
+        RenderPartnersCapitalNumber(grid, Money(line.IncomeGainAllocations), background, isTotal);
+        RenderPartnersCapitalNumber(grid, Money(line.ExpenseAllocations), background, isTotal);
+        RenderPartnersCapitalNumber(grid, Money(line.FeeAllocations), background, isTotal);
+        RenderPartnersCapitalNumber(grid, Money(line.EndingCapital), background, isTotal);
+        RenderPartnersCapitalNumber(grid, Percent(line.OwnershipPercent), background, isTotal);
+    }
+
+    private static void RenderPartnersCapitalNumber(
+        TableDescriptor grid,
+        string value,
+        string background,
+        bool bold)
+    {
+        var text = grid.Cell().Background(background).AlignRight().PaddingVertical(2).PaddingHorizontal(4)
+            .Text(value).FontSize(8);
+        if (bold)
+            text.Bold();
+    }
+
+    private static void WriteGenericSheet(XLWorkbook workbook, LedgerReportTable table, HashSet<string> usedNames)
+    {
+        var sheet = workbook.Worksheets.Add(UniqueSheetName(table.Title, usedNames));
+        var headerRow = sheet.Row(1);
+        for (var column = 0; column < table.Headers.Count; column++)
+        {
+            var cell = sheet.Cell(1, column + 1);
+            cell.Value = table.Headers[column];
+            cell.Style.Font.Bold = true;
+            cell.Style.Fill.BackgroundColor = XLColor.FromHtml("#0b7285");
+            cell.Style.Font.FontColor = XLColor.White;
+        }
+
+        headerRow.Height = 18;
+        var rowNumber = 2;
+        foreach (var row in table.Rows)
+        {
+            for (var column = 0; column < row.Count; column++)
+                sheet.Cell(rowNumber, column + 1).Value = row[column];
+            rowNumber++;
+        }
+
+        sheet.Columns().AdjustToContents();
+        sheet.SheetView.FreezeRows(1);
+    }
+
+    /// <summary>
+    /// Bespoke XLSX sheet for the partners' capital statement. Unlike the generic sheet (whose every
+    /// cell is a pre-formatted string), the money and ownership cells are written as typed numeric
+    /// values with accounting/percent number formats, so an operator can SUM, pivot, and recompute the
+    /// statement without retyping. A NAV anchor block records the ledger-backed net asset value the
+    /// statement ties to.
+    /// </summary>
+    private static void WritePartnersCapitalSheet(
+        XLWorkbook workbook,
+        PartnersCapitalStatementLayout layout,
+        HashSet<string> usedNames)
+    {
+        var sheet = workbook.Worksheets.Add(UniqueSheetName("Partners' Capital", usedNames));
+
+        for (var column = 0; column < PartnersCapitalSheetColumns.Length; column++)
+        {
+            var cell = sheet.Cell(1, column + 1);
+            cell.Value = PartnersCapitalSheetColumns[column];
+            cell.Style.Font.Bold = true;
+            cell.Style.Fill.BackgroundColor = XLColor.FromHtml("#0b7285");
+            cell.Style.Font.FontColor = XLColor.White;
+        }
+
+        sheet.Row(1).Height = 18;
+
+        var rowNumber = 2;
+        foreach (var line in layout.Lines)
+        {
+            WritePartnersCapitalRow(sheet, rowNumber, line, RoleLabel(line.Role), bold: false);
+            rowNumber++;
+        }
+
+        var totalRowNumber = rowNumber;
+        WritePartnersCapitalRow(sheet, totalRowNumber, layout.Total, "Total", bold: true);
+
+        // Fund-economics anchor: the ledger-backed NAV the statement reconciles to, with an explicit
+        // tie flag, so the governed deliverable can prove the ending capital against net assets.
+        var navLabelRow = totalRowNumber + 2;
+        sheet.Cell(navLabelRow, 1).Value = "Net asset value (NAV base)";
+        sheet.Cell(navLabelRow, 1).Style.Font.Bold = true;
+        WriteMoneyCell(sheet.Cell(navLabelRow, 3), layout.NetAssetValue);
+
+        var tieRow = navLabelRow + 1;
+        sheet.Cell(tieRow, 1).Value = "Ending capital ties to NAV";
+        sheet.Cell(tieRow, 3).Value = layout.TiesToNetAssets
+            ? "Yes"
+            : $"No — variance {layout.NetAssetVariance.ToString(MoneyNumberFormat, CultureInfo.InvariantCulture)}";
+
+        sheet.Columns().AdjustToContents();
+        sheet.SheetView.FreezeRows(1);
+    }
+
+    private static void WritePartnersCapitalRow(
+        IXLWorksheet sheet,
+        int rowNumber,
+        PartnersCapitalStatementLine line,
+        string roleLabel,
+        bool bold)
+    {
+        sheet.Cell(rowNumber, 1).Value = line.PartnerLabel;
+        sheet.Cell(rowNumber, 2).Value = roleLabel;
+        WriteMoneyCell(sheet.Cell(rowNumber, 3), line.BeginningCapital);
+        WriteMoneyCell(sheet.Cell(rowNumber, 4), line.Contributions);
+        WriteMoneyCell(sheet.Cell(rowNumber, 5), line.Distributions);
+        WriteMoneyCell(sheet.Cell(rowNumber, 6), line.IncomeGainAllocations);
+        WriteMoneyCell(sheet.Cell(rowNumber, 7), line.ExpenseAllocations);
+        WriteMoneyCell(sheet.Cell(rowNumber, 8), line.FeeAllocations);
+        WriteMoneyCell(sheet.Cell(rowNumber, 9), line.AllocatedResult);
+        WriteMoneyCell(sheet.Cell(rowNumber, 10), line.OtherMovements);
+        WriteMoneyCell(sheet.Cell(rowNumber, 11), line.EndingCapital);
+
+        var ownership = sheet.Cell(rowNumber, 12);
+        ownership.Value = line.OwnershipPercent / 100m; // stored as a true fraction so Excel foots to 100%
+        ownership.Style.NumberFormat.Format = PercentNumberFormat;
+
+        if (bold)
+            sheet.Range(rowNumber, 1, rowNumber, PartnersCapitalSheetColumns.Length).Style.Font.Bold = true;
+    }
+
+    private static void WriteMoneyCell(IXLCell cell, decimal value)
+    {
+        cell.Value = value;
+        cell.Style.NumberFormat.Format = MoneyNumberFormat;
+    }
+
+    private static string RoleLabel(PartnersCapitalPartnerRole role) => role switch
+    {
+        PartnersCapitalPartnerRole.LimitedPartner => "Limited partner",
+        PartnersCapitalPartnerRole.GeneralPartner => "General partner",
+        PartnersCapitalPartnerRole.UndistributedResult => "Undistributed result",
+        _ => "Fund capital",
+    };
+
+    private static string Money(decimal value) => value.ToString(MoneyNumberFormat, CultureInfo.InvariantCulture);
+
+    private static string Percent(decimal value) => value.ToString("0.00", CultureInfo.InvariantCulture) + "%";
 
     private static string UniqueSheetName(string title, HashSet<string> used)
     {

--- a/src/Meridian.Documents/README.md
+++ b/src/Meridian.Documents/README.md
@@ -25,6 +25,12 @@ This module belongs to the Design Module layer. Keep changes within that ownersh
 - `FinancialReportDocumentRenderer.cs` - client-grade QuestPDF (PDF) + ClosedXML (XLSX) renderer that
   implements the ledger's `ILedgerReportBinaryRenderer` seam. Output is made deterministic (fixed
   document metadata/timestamps, canonical zip ordering) so re-rendering a pack reproduces the bytes.
+  The statement of changes in partners' capital renders through a bespoke layout (from the ledger's
+  `PartnersCapitalStatementLayout`) rather than the generic table: a fund-economics NAV context strip,
+  role-labelled per-partner rows, an ownership-share column, a bold total, and a reconciliation note in
+  the PDF, and a dedicated XLSX sheet whose money and ownership cells are typed numbers (accounting and
+  percent formats) so the deliverable can be summed and pivoted without retyping. Every other statement
+  keeps the generic tabular rendering.
 - `DocumentsServiceCollectionExtensions.cs` - `AddFinancialReportDocumentRenderer` composition helper
   that registers the renderer for the `ILedgerReportBinaryRenderer` seam. The workstation host calls
   it (see `WorkstationServiceCollectionExtensions`), flipping governed ledger exports off the

--- a/src/Meridian.Ledger/LedgerReportPresentation.cs
+++ b/src/Meridian.Ledger/LedgerReportPresentation.cs
@@ -14,6 +14,10 @@ public sealed record LedgerReportTable(
 /// </summary>
 public static class LedgerReportPresentation
 {
+    /// <summary>Title of the statement-of-changes-in-partners'-capital table, shared so a renderer can
+    /// substitute a bespoke layout for the generic table without matching a loose string.</summary>
+    public const string PartnersCapitalTableTitle = "Statement of Changes in Partners' Capital";
+
     public static IReadOnlyList<LedgerReportTable> BuildTables(LedgerFinancialReportPack reportPack)
     {
         ArgumentNullException.ThrowIfNull(reportPack);
@@ -135,7 +139,7 @@ public static class LedgerReportPresentation
         ]);
 
         return new LedgerReportTable(
-            "Statement of Changes in Partners' Capital",
+            PartnersCapitalTableTitle,
             ["Partner", "Beginning", "Contributions", "Distributions", "Income & Gains", "Expenses", "Fees", "Ending"],
             rows);
     }

--- a/src/Meridian.Ledger/PartnersCapitalStatementLayout.cs
+++ b/src/Meridian.Ledger/PartnersCapitalStatementLayout.cs
@@ -110,28 +110,36 @@ public static class PartnersCapitalStatementLayoutBuilder
     {
         ArgumentNullException.ThrowIfNull(statement);
 
-        // Ownership is a partner's share of total ending partners' capital. Dividing every line by
-        // the same total means the column foots to 100% (each line = lineEnding / totalEnding, and the
-        // line endings sum to the total by construction). A fully-distributed fund has no capital to
-        // apportion, so every share is zero.
-        var totalEnding = statement.EndingCapital;
+        // Classify each account once: role drives both the presentation label and whether the account
+        // participates in ownership.
+        var classified = statement.Accounts
+            .Select(account => (account, role: ClassifyRole(account.AccountName)))
+            .ToList();
 
-        var lines = statement.Accounts
-            .Select(account => new PartnersCapitalStatementLine(
-                PartnerLabel: string.IsNullOrWhiteSpace(account.InvestorId)
-                    ? account.AccountName
-                    : account.InvestorId,
-                Role: ClassifyRole(account.AccountName),
-                BeginningCapital: account.BeginningCapital,
-                Contributions: account.Contributions,
-                Distributions: account.Distributions,
-                IncomeGainAllocations: account.IncomeGainAllocations,
-                ExpenseAllocations: account.ExpenseAllocations,
-                FeeAllocations: account.FeeAllocations,
-                AllocatedResult: account.AllocatedResult,
-                OtherMovements: account.OtherMovements,
-                EndingCapital: account.EndingCapital,
-                OwnershipPercent: OwnershipShare(account.EndingCapital, totalEnding)))
+        // Ownership is a named partner's share of the capital held by named partners (LP + GP). Fund-level
+        // results not yet closed to a partner (undistributed net income) and undesignated fund capital are
+        // not partners: counting them let a partner exceed 100% while the undistributed line showed a
+        // negative share. They are excluded from both numerator and denominator and carry no ownership.
+        var partnerEndingCapital = classified
+            .Where(entry => IsNamedPartner(entry.role))
+            .Sum(entry => entry.account.EndingCapital);
+
+        var lines = classified
+            .Select(entry => new PartnersCapitalStatementLine(
+                PartnerLabel: PartnerLabelFor(entry.role, entry.account.InvestorId, entry.account.AccountName),
+                Role: entry.role,
+                BeginningCapital: entry.account.BeginningCapital,
+                Contributions: entry.account.Contributions,
+                Distributions: entry.account.Distributions,
+                IncomeGainAllocations: entry.account.IncomeGainAllocations,
+                ExpenseAllocations: entry.account.ExpenseAllocations,
+                FeeAllocations: entry.account.FeeAllocations,
+                AllocatedResult: entry.account.AllocatedResult,
+                OtherMovements: entry.account.OtherMovements,
+                EndingCapital: entry.account.EndingCapital,
+                OwnershipPercent: IsNamedPartner(entry.role)
+                    ? OwnershipShare(entry.account.EndingCapital, partnerEndingCapital)
+                    : 0m))
             .OrderBy(static line => line.Role)
             .ThenBy(static line => line.PartnerLabel, StringComparer.Ordinal)
             .ToList();
@@ -164,6 +172,19 @@ public static class PartnersCapitalStatementLayoutBuilder
 
     private static decimal OwnershipShare(decimal endingCapital, decimal totalEndingCapital)
         => totalEndingCapital == 0m ? 0m : endingCapital / totalEndingCapital * 100m;
+
+    // Only limited and general partners hold an ownership stake in the fund's capital.
+    private static bool IsNamedPartner(PartnersCapitalPartnerRole role)
+        => role is PartnersCapitalPartnerRole.LimitedPartner or PartnersCapitalPartnerRole.GeneralPartner;
+
+    // A limited-partner account carries a trustworthy investor identity, so it is labelled by that id.
+    // Every other role is labelled by its ledger account-name caption: the distribution-waterfall posting
+    // reuses the LP's investorId on the GP carried-interest line, so surfacing InvestorId for a non-LP
+    // role would print the LP's id as the general partner.
+    private static string PartnerLabelFor(PartnersCapitalPartnerRole role, string? investorId, string accountName)
+        => role == PartnersCapitalPartnerRole.LimitedPartner && !string.IsNullOrWhiteSpace(investorId)
+            ? investorId
+            : accountName;
 
     // Role is derived from the stable account names minted by LedgerAccounts. It is a caption only:
     // an unrecognized capital account falls back to GeneralCapital and its figures are untouched.

--- a/src/Meridian.Ledger/PartnersCapitalStatementLayout.cs
+++ b/src/Meridian.Ledger/PartnersCapitalStatementLayout.cs
@@ -1,0 +1,180 @@
+using Meridian.Contracts.Ledger;
+
+namespace Meridian.Ledger;
+
+/// <summary>
+/// The economic role a capital account plays in a partners' capital statement. This is a
+/// presentation label only — it groups and titles the roll-forward lines a fund administrator hands
+/// to investors and never alters any figure. Classification is derived from the ledger-owned account
+/// name produced by <see cref="LedgerAccounts"/>, so a mislabel can only change a caption, not a
+/// balance.
+/// </summary>
+public enum PartnersCapitalPartnerRole
+{
+    /// <summary>Limited-partner (investor) capital, e.g. <c>Investor Capital</c> accounts.</summary>
+    LimitedPartner,
+
+    /// <summary>General-partner economics, e.g. <c>Carried Interest Allocation</c> accounts.</summary>
+    GeneralPartner,
+
+    /// <summary>Period result not yet closed to a named partner (the undistributed net income line).</summary>
+    UndistributedResult,
+
+    /// <summary>Undesignated fund capital (a generic capital account or retained earnings).</summary>
+    GeneralCapital,
+}
+
+/// <summary>
+/// One bespoke-layout line of the statement of changes in partners' capital: a partner-oriented
+/// roll-forward carrying the income/expense/fee breakout plus the partner's ownership share of
+/// ending capital. Money fields stay typed (not pre-formatted) so a renderer can emit computable
+/// numeric cells rather than a text dump.
+/// </summary>
+public sealed record PartnersCapitalStatementLine(
+    string PartnerLabel,
+    PartnersCapitalPartnerRole Role,
+    decimal BeginningCapital,
+    decimal Contributions,
+    decimal Distributions,
+    decimal IncomeGainAllocations,
+    decimal ExpenseAllocations,
+    decimal FeeAllocations,
+    decimal AllocatedResult,
+    decimal OtherMovements,
+    decimal EndingCapital,
+    decimal OwnershipPercent);
+
+/// <summary>
+/// A bespoke, client-grade layout of the statement of changes in partners' capital. Unlike the
+/// generic <see cref="LedgerReportTable"/> projection, this model keeps money typed, classifies each
+/// account by partner role, computes each partner's ownership percentage of ending capital, and
+/// anchors the statement to the fund's ledger-backed net asset value (the unitized NAV base) with an
+/// explicit reconciliation flag. It is a pure projection over a
+/// <see cref="LedgerPartnersCapitalStatement"/> — it introduces no new ledger fact.
+/// </summary>
+public sealed record PartnersCapitalStatementLayout(
+    string FundId,
+    string PeriodId,
+    string BaseCurrency,
+    DateTimeOffset PeriodStart,
+    DateTimeOffset AsOf,
+    decimal NetAssetValue,
+    bool TiesToNetAssets,
+    IReadOnlyList<PartnersCapitalStatementLine> Lines,
+    PartnersCapitalStatementLine Total)
+{
+    /// <summary>Reconciliation gap between ending partners' capital and the fund's net asset value.</summary>
+    public decimal NetAssetVariance => Total.EndingCapital - NetAssetValue;
+}
+
+/// <summary>
+/// Builds a <see cref="PartnersCapitalStatementLayout"/> from ledger-backed statements. The layout is
+/// a deterministic function of its inputs so it renders to byte-stable governed artifacts.
+/// </summary>
+public static class PartnersCapitalStatementLayoutBuilder
+{
+    /// <summary>
+    /// Projects the partners' capital statement inside <paramref name="pack"/>, anchored to the same
+    /// pack's ledger-backed net assets (ending equity = total assets − total liabilities), which is
+    /// the unitized NAV base the statement reconciles to.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The pack carries no partners' capital statement to lay out.
+    /// </exception>
+    public static PartnersCapitalStatementLayout Build(LedgerFinancialReportPack pack)
+    {
+        ArgumentNullException.ThrowIfNull(pack);
+        var statement = pack.Statements.PartnersCapital
+            ?? throw new InvalidOperationException(
+                "Report pack has no partners' capital statement to lay out.");
+
+        return Build(
+            statement,
+            pack.Request.FundId,
+            pack.Request.PeriodId,
+            pack.Request.BaseCurrency,
+            pack.Statements.EndingEquity);
+    }
+
+    /// <summary>
+    /// Projects <paramref name="statement"/> into the bespoke layout, expressing each partner's
+    /// ownership share and anchoring the whole statement to <paramref name="netAssetValue"/> (the
+    /// fund's ledger-backed net asset value / NAV base).
+    /// </summary>
+    public static PartnersCapitalStatementLayout Build(
+        LedgerPartnersCapitalStatement statement,
+        string fundId,
+        string periodId,
+        string baseCurrency,
+        decimal netAssetValue)
+    {
+        ArgumentNullException.ThrowIfNull(statement);
+
+        // Ownership is a partner's share of total ending partners' capital. Dividing every line by
+        // the same total means the column foots to 100% (each line = lineEnding / totalEnding, and the
+        // line endings sum to the total by construction). A fully-distributed fund has no capital to
+        // apportion, so every share is zero.
+        var totalEnding = statement.EndingCapital;
+
+        var lines = statement.Accounts
+            .Select(account => new PartnersCapitalStatementLine(
+                PartnerLabel: string.IsNullOrWhiteSpace(account.InvestorId)
+                    ? account.AccountName
+                    : account.InvestorId,
+                Role: ClassifyRole(account.AccountName),
+                BeginningCapital: account.BeginningCapital,
+                Contributions: account.Contributions,
+                Distributions: account.Distributions,
+                IncomeGainAllocations: account.IncomeGainAllocations,
+                ExpenseAllocations: account.ExpenseAllocations,
+                FeeAllocations: account.FeeAllocations,
+                AllocatedResult: account.AllocatedResult,
+                OtherMovements: account.OtherMovements,
+                EndingCapital: account.EndingCapital,
+                OwnershipPercent: OwnershipShare(account.EndingCapital, totalEnding)))
+            .OrderBy(static line => line.Role)
+            .ThenBy(static line => line.PartnerLabel, StringComparer.Ordinal)
+            .ToList();
+
+        var total = new PartnersCapitalStatementLine(
+            PartnerLabel: "Total partners' capital",
+            Role: PartnersCapitalPartnerRole.GeneralCapital,
+            BeginningCapital: statement.BeginningCapital,
+            Contributions: statement.Contributions,
+            Distributions: statement.Distributions,
+            IncomeGainAllocations: statement.IncomeGainAllocations,
+            ExpenseAllocations: statement.ExpenseAllocations,
+            FeeAllocations: statement.FeeAllocations,
+            AllocatedResult: statement.AllocatedResult,
+            OtherMovements: statement.OtherMovements,
+            EndingCapital: statement.EndingCapital,
+            OwnershipPercent: lines.Sum(static line => line.OwnershipPercent));
+
+        return new PartnersCapitalStatementLayout(
+            FundId: fundId,
+            PeriodId: periodId,
+            BaseCurrency: baseCurrency,
+            PeriodStart: statement.PeriodStart,
+            AsOf: statement.AsOf,
+            NetAssetValue: netAssetValue,
+            TiesToNetAssets: Math.Abs(statement.EndingCapital - netAssetValue) <= LedgerToleranceConstants.Balance,
+            Lines: lines,
+            Total: total);
+    }
+
+    private static decimal OwnershipShare(decimal endingCapital, decimal totalEndingCapital)
+        => totalEndingCapital == 0m ? 0m : endingCapital / totalEndingCapital * 100m;
+
+    // Role is derived from the stable account names minted by LedgerAccounts. It is a caption only:
+    // an unrecognized capital account falls back to GeneralCapital and its figures are untouched.
+    private static PartnersCapitalPartnerRole ClassifyRole(string accountName)
+    {
+        if (accountName.Equals("Undistributed Net Income", StringComparison.Ordinal))
+            return PartnersCapitalPartnerRole.UndistributedResult;
+        if (accountName.Contains("Carried Interest", StringComparison.OrdinalIgnoreCase))
+            return PartnersCapitalPartnerRole.GeneralPartner;
+        if (accountName.Contains("Investor Capital", StringComparison.OrdinalIgnoreCase))
+            return PartnersCapitalPartnerRole.LimitedPartner;
+        return PartnersCapitalPartnerRole.GeneralCapital;
+    }
+}

--- a/src/Meridian.Ledger/README.md
+++ b/src/Meridian.Ledger/README.md
@@ -44,6 +44,14 @@ income/expense/fee drivers a fund accountant delivers rather than one lumped fig
 never disturbs the existing ending-capital reconciliation, and it flows through both the
 partners-capital CSV artifact and the shared `LedgerReportPresentation` table that drives the Xlsx/Pdf
 renderers.
+`PartnersCapitalStatementLayout` (built by `PartnersCapitalStatementLayoutBuilder`) is a bespoke,
+client-grade projection of that statement for the deliverable: it classifies each capital account by
+partner role (limited partner, general partner, undistributed result, or fund capital), computes each
+partner's ownership share of ending capital, and anchors the whole statement to the fund's
+ledger-backed net asset value (the unitized NAV base) with an explicit reconciliation flag. It keeps
+money typed (not pre-formatted) so `FinancialReportDocumentRenderer` can emit a purpose-built
+partners-capital PDF section and a typed-numeric XLSX sheet instead of the generic table. The
+projection is presentation only — it introduces no ledger fact and never changes a figure.
 `LedgerReportPackBuilder` emits those statements as CSV/JSON pack artifacts, and
 `LedgerScheduledReportExportPackageBuilder` now honors every declared `LedgerReportExportFormat`:
 Csv, Json, RegulatoryXml natively plus real binary Xlsx/Pdf through the

--- a/tests/Meridian.Tests/Ledger/PartnersCapitalBespokeRenderTests.cs
+++ b/tests/Meridian.Tests/Ledger/PartnersCapitalBespokeRenderTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+using ClosedXML.Excel;
+using FluentAssertions;
+using Meridian.Documents;
+using Meridian.Ledger;
+using Xunit;
+
+namespace Meridian.Tests.Ledger;
+
+/// <summary>
+/// Proves the client-grade renderer emits the bespoke partners' capital layout: a dedicated XLSX
+/// sheet whose money and ownership cells are typed numbers — so an operator can SUM/pivot without
+/// retyping, the exact program-review gap ("every cell is text") — plus a ledger-backed NAV anchor
+/// block, and a valid PDF. Both render deterministically for governed hash verification.
+/// </summary>
+public sealed class PartnersCapitalBespokeRenderTests
+{
+    [Fact]
+    public void Workbook_HasDedicatedPartnersCapitalSheet_WithTypedNumericCells()
+    {
+        var pack = LedgerReportPackTestData.BuildContributionPack();
+
+        var xlsx = new FinancialReportDocumentRenderer().RenderWorkbook(pack);
+
+        using var workbook = new XLWorkbook(new MemoryStream(xlsx));
+        workbook.Worksheets.Any(sheet => sheet.Name == "Partners' Capital").Should().BeTrue();
+        var sheet = workbook.Worksheet("Partners' Capital");
+
+        // Bespoke column set, distinct from the generic 8-column table.
+        sheet.Cell(1, 1).GetString().Should().Be("Partner");
+        sheet.Cell(1, 2).GetString().Should().Be("Role");
+
+        // Every data row's money cells are typed numbers with an accounting format — not text.
+        var beginning = sheet.Cell(2, 3);
+        beginning.DataType.Should().Be(XLDataType.Number);
+        beginning.Style.NumberFormat.Format.Should().Be("#,##0.00");
+        sheet.Cell(2, 11).DataType.Should().Be(XLDataType.Number);
+
+        // Ownership is a true percentage fraction so the column foots to 100% in Excel.
+        var ownership = sheet.Cell(2, 12);
+        ownership.DataType.Should().Be(XLDataType.Number);
+        ownership.Style.NumberFormat.Format.Should().Be("0.00%");
+    }
+
+    [Fact]
+    public void Workbook_PartnersCapitalSheet_CarriesLedgerBackedNavAnchor()
+    {
+        var pack = LedgerReportPackTestData.BuildContributionPack();
+
+        var xlsx = new FinancialReportDocumentRenderer().RenderWorkbook(pack);
+
+        using var workbook = new XLWorkbook(new MemoryStream(xlsx));
+        var cells = workbook.Worksheet("Partners' Capital").RangeUsed()!.CellsUsed().ToList();
+
+        cells.Should().Contain(cell => cell.GetString() == "Net asset value (NAV base)");
+        cells.Should().Contain(cell => cell.GetString() == "Ending capital ties to NAV");
+
+        // The NAV value is carried as a typed number equal to the pack's ledger-backed net assets.
+        var netAssets = (double)pack.Statements.EndingEquity;
+        cells.Should().Contain(cell => cell.DataType == XLDataType.Number && cell.GetDouble() == netAssets);
+    }
+
+    [Fact]
+    public void Renderer_BespokePath_IsDeterministicAndProducesValidPdf()
+    {
+        var pack = LedgerReportPackTestData.BuildContributionPack();
+        var renderer = new FinancialReportDocumentRenderer();
+
+        var firstPdf = renderer.RenderPdf(pack);
+        var secondPdf = renderer.RenderPdf(pack);
+        var firstXlsx = renderer.RenderWorkbook(pack);
+        var secondXlsx = renderer.RenderWorkbook(pack);
+
+        Encoding.ASCII.GetString(firstPdf, 0, 5).Should().Be("%PDF-");
+        firstPdf.Should().Equal(secondPdf);
+        firstXlsx.Should().Equal(secondXlsx);
+    }
+}

--- a/tests/Meridian.Tests/Ledger/PartnersCapitalStatementLayoutTests.cs
+++ b/tests/Meridian.Tests/Ledger/PartnersCapitalStatementLayoutTests.cs
@@ -57,26 +57,42 @@ public sealed class PartnersCapitalStatementLayoutTests
     }
 
     [Fact]
-    public void Build_OwnershipShares_FootToOneHundredPercent()
+    public void Build_Ownership_ExcludesNonPartnerEquityAndBoundsPartners()
     {
         var layout = PartnersCapitalStatementLayoutBuilder.Build(
             LedgerReportPackTestData.BuildContributionPack());
 
-        layout.Lines.Sum(line => line.OwnershipPercent).Should().BeApproximately(100m, 0.0001m);
+        // The undistributed net income line is a fund-level result, not a partner: it holds no ownership.
+        // (Before the fix its negative capital produced a negative "ownership" share.)
+        var undistributed = layout.Lines.Should()
+            .ContainSingle(line => line.Role == PartnersCapitalPartnerRole.UndistributedResult).Which;
+        undistributed.OwnershipPercent.Should().Be(0m);
+
+        // Named partners hold 100% between them and none is reported above 100%. (Before the fix the LP
+        // read ~102% because the negative undistributed line sat in the denominator.)
+        var lp = layout.Lines.Should()
+            .ContainSingle(line => line.Role == PartnersCapitalPartnerRole.LimitedPartner).Which;
+        lp.OwnershipPercent.Should().BeApproximately(100m, 0.0001m);
+        layout.Lines.Should().OnlyContain(line => line.OwnershipPercent <= 100m);
         layout.Total.OwnershipPercent.Should().BeApproximately(100m, 0.0001m);
     }
 
     [Fact]
-    public void Build_CarriedInterestAllocation_ClassifiedAsGeneralPartner()
+    public void Build_CarriedInterestAllocation_LabelledByCaptionNotTheLimitedPartnerId()
     {
+        // The distribution-waterfall factory posts the GP carried-interest line under the *LP's* investor
+        // id (BuildDistributionWaterfallDraft reuses its single investorId for both legs). Reproduce that
+        // by scoping the carry account to the LP id, then prove the layout never surfaces it as the GP.
+        const string lpId = "lp-1";
         var ledger = new Meridian.Ledger.Ledger();
         ledger.PostLines(new DateTimeOffset(2025, 6, 15, 0, 0, 0, TimeSpan.Zero), "opening contribution",
-            [(LedgerAccounts.Cash, 5_000_000m, 0m), (LedgerAccounts.InvestorCapitalFor("lp-1"), 0m, 5_000_000m)]);
+            [(LedgerAccounts.Cash, 5_000_000m, 0m), (LedgerAccounts.InvestorCapitalFor(lpId), 0m, 5_000_000m)]);
         ledger.PostLines(new DateTimeOffset(2026, 3, 31, 0, 0, 0, TimeSpan.Zero), "realized gain",
             [(LedgerAccounts.Cash, 1_000_000m, 0m), (LedgerAccounts.RealizedGainFor("fund-a"), 0m, 1_000_000m)]);
-        // Close part of the gain into the GP's carried-interest capital account.
+        // Close part of the gain into the carried-interest capital account, scoped to the LP id exactly
+        // as the waterfall factory posts it.
         ledger.PostLines(new DateTimeOffset(2026, 6, 30, 0, 0, 0, TimeSpan.Zero), "carry allocation",
-            [(LedgerAccounts.RealizedGainFor("fund-a"), 200_000m, 0m), (LedgerAccounts.CarriedInterestAllocationFor("gp-1"), 0m, 200_000m)]);
+            [(LedgerAccounts.RealizedGainFor("fund-a"), 200_000m, 0m), (LedgerAccounts.CarriedInterestAllocationFor(lpId), 0m, 200_000m)]);
 
         var statements = LedgerFinancialStatementBuilder.BuildForPeriod(ledger, PeriodStart, AsOf);
         var layout = PartnersCapitalStatementLayoutBuilder.Build(
@@ -84,8 +100,10 @@ public sealed class PartnersCapitalStatementLayoutTests
 
         var gp = layout.Lines.Should()
             .ContainSingle(line => line.Role == PartnersCapitalPartnerRole.GeneralPartner).Which;
-        gp.PartnerLabel.Should().Be("gp-1");
         gp.EndingCapital.Should().Be(200_000m);
+        // The GP row is labelled by its role caption, never the limited partner's investor id.
+        gp.PartnerLabel.Should().Be("Carried Interest Allocation");
+        gp.PartnerLabel.Should().NotBe(lpId);
         layout.Lines.Should().Contain(line => line.Role == PartnersCapitalPartnerRole.LimitedPartner);
         layout.TiesToNetAssets.Should().BeTrue();
     }

--- a/tests/Meridian.Tests/Ledger/PartnersCapitalStatementLayoutTests.cs
+++ b/tests/Meridian.Tests/Ledger/PartnersCapitalStatementLayoutTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Linq;
+
+using FluentAssertions;
+
+using Meridian.Ledger;
+
+using Xunit;
+
+namespace Meridian.Tests.Ledger;
+
+/// <summary>
+/// Coverage for the bespoke partners' capital statement layout projector: it classifies capital
+/// accounts by partner role, computes each partner's ownership share of ending capital, and anchors
+/// the statement to the fund's ledger-backed net asset value (the unitized NAV base) with an
+/// explicit reconciliation flag. The projection is presentation only — it never alters a figure.
+/// </summary>
+public sealed class PartnersCapitalStatementLayoutTests
+{
+    private static readonly DateTimeOffset PeriodStart = new(2025, 12, 31, 0, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset AsOf = new(2026, 12, 31, 0, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Build_FromContributionPack_ClassifiesLimitedPartnerAndAnchorsToNetAssets()
+    {
+        var pack = LedgerReportPackTestData.BuildContributionPack();
+        var statement = pack.Statements.PartnersCapital!;
+
+        var layout = PartnersCapitalStatementLayoutBuilder.Build(pack);
+
+        // Fund identity flows from the request.
+        layout.FundId.Should().Be(LedgerReportPackTestData.FundId);
+        layout.PeriodId.Should().Be(LedgerReportPackTestData.PeriodId);
+        layout.BaseCurrency.Should().Be("USD");
+
+        // The NAV anchor is the fund's ledger-backed net assets (ending equity), and the statement ties.
+        layout.NetAssetValue.Should().Be(pack.Statements.EndingEquity);
+        layout.Total.EndingCapital.Should().Be(statement.EndingCapital);
+        layout.TiesToNetAssets.Should().BeTrue();
+        layout.NetAssetVariance.Should().Be(0m);
+
+        // The investor-capital account is presented as a limited partner keyed by investor id.
+        var lp = layout.Lines.Should()
+            .ContainSingle(line => line.Role == PartnersCapitalPartnerRole.LimitedPartner).Which;
+        lp.PartnerLabel.Should().Be(LedgerReportPackTestData.InvestorId);
+        lp.Contributions.Should().Be(LedgerReportPackTestData.ContributionAmount);
+        lp.Distributions.Should().Be(LedgerReportPackTestData.DistributionAmount);
+
+        // The total line preserves the statement aggregate exactly (presentation never changes a figure).
+        layout.Total.BeginningCapital.Should().Be(statement.BeginningCapital);
+        layout.Total.Contributions.Should().Be(statement.Contributions);
+        layout.Total.Distributions.Should().Be(statement.Distributions);
+        layout.Total.IncomeGainAllocations.Should().Be(statement.IncomeGainAllocations);
+        layout.Total.ExpenseAllocations.Should().Be(statement.ExpenseAllocations);
+        layout.Total.FeeAllocations.Should().Be(statement.FeeAllocations);
+        layout.Total.EndingCapital.Should().Be(statement.EndingCapital);
+    }
+
+    [Fact]
+    public void Build_OwnershipShares_FootToOneHundredPercent()
+    {
+        var layout = PartnersCapitalStatementLayoutBuilder.Build(
+            LedgerReportPackTestData.BuildContributionPack());
+
+        layout.Lines.Sum(line => line.OwnershipPercent).Should().BeApproximately(100m, 0.0001m);
+        layout.Total.OwnershipPercent.Should().BeApproximately(100m, 0.0001m);
+    }
+
+    [Fact]
+    public void Build_CarriedInterestAllocation_ClassifiedAsGeneralPartner()
+    {
+        var ledger = new Meridian.Ledger.Ledger();
+        ledger.PostLines(new DateTimeOffset(2025, 6, 15, 0, 0, 0, TimeSpan.Zero), "opening contribution",
+            [(LedgerAccounts.Cash, 5_000_000m, 0m), (LedgerAccounts.InvestorCapitalFor("lp-1"), 0m, 5_000_000m)]);
+        ledger.PostLines(new DateTimeOffset(2026, 3, 31, 0, 0, 0, TimeSpan.Zero), "realized gain",
+            [(LedgerAccounts.Cash, 1_000_000m, 0m), (LedgerAccounts.RealizedGainFor("fund-a"), 0m, 1_000_000m)]);
+        // Close part of the gain into the GP's carried-interest capital account.
+        ledger.PostLines(new DateTimeOffset(2026, 6, 30, 0, 0, 0, TimeSpan.Zero), "carry allocation",
+            [(LedgerAccounts.RealizedGainFor("fund-a"), 200_000m, 0m), (LedgerAccounts.CarriedInterestAllocationFor("gp-1"), 0m, 200_000m)]);
+
+        var statements = LedgerFinancialStatementBuilder.BuildForPeriod(ledger, PeriodStart, AsOf);
+        var layout = PartnersCapitalStatementLayoutBuilder.Build(
+            statements.PartnersCapital!, "fund-a", "2026", "USD", statements.EndingEquity);
+
+        var gp = layout.Lines.Should()
+            .ContainSingle(line => line.Role == PartnersCapitalPartnerRole.GeneralPartner).Which;
+        gp.PartnerLabel.Should().Be("gp-1");
+        gp.EndingCapital.Should().Be(200_000m);
+        layout.Lines.Should().Contain(line => line.Role == PartnersCapitalPartnerRole.LimitedPartner);
+        layout.TiesToNetAssets.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Build_WithoutPartnersCapitalStatement_Throws()
+    {
+        var pack = LedgerReportPackTestData.BuildContributionPack();
+        var withoutPartnersCapital = pack with { Statements = pack.Statements with { PartnersCapital = null } };
+
+        var act = () => PartnersCapitalStatementLayoutBuilder.Build(withoutPartnersCapital);
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+}

--- a/tests/Meridian.Tests/Ui/ReportingRunCertificationServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/ReportingRunCertificationServiceTests.cs
@@ -1201,15 +1201,21 @@ public sealed class ReportingRunCertificationServiceTests
             XNamespace spreadsheet = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
             workbook.Descendants(spreadsheet + "sheet")
                 .Select(static element => element.Attribute("name")?.Value)
-                .Should().Contain(static name =>
-                    name != null
-                    && name.StartsWith("Statement of Changes in", StringComparison.Ordinal));
-            using var reader = new StreamReader(
-                archive.GetEntry("xl/sharedStrings.xml")!.Open(),
-                Encoding.UTF8);
-            var sharedStrings = await reader.ReadToEndAsync();
-            sharedStrings.Should().Contain("1,000,000.00");
-            sharedStrings.Should().Contain("250,000.00");
+                .Should().Contain(static name => name == "Partners' Capital",
+                    "the bespoke partners' capital layout renders as its own dedicated sheet");
+        }
+
+        // The bespoke sheet writes money as typed numeric cells rather than shared strings, so the
+        // canonical figures are asserted as cell values on the dedicated sheet.
+        using (var workbook = new ClosedXML.Excel.XLWorkbook(new MemoryStream(firstWorkbook)))
+        {
+            var partnersCapital = workbook.Worksheet("Partners' Capital");
+            var numericValues = partnersCapital.CellsUsed()
+                .Where(static cell => cell.DataType == ClosedXML.Excel.XLDataType.Number)
+                .Select(static cell => cell.GetDouble())
+                .ToList();
+            numericValues.Should().Contain(1_000_000d);
+            numericValues.Should().Contain(250_000d);
         }
     }
 
@@ -1469,8 +1475,12 @@ public sealed class ReportingRunCertificationServiceTests
         sharedStrings.Should().Contain("Income &amp; Gains");
         sharedStrings.Should().Contain("Expenses");
         sharedStrings.Should().Contain("Fees");
+        // Bespoke-layout canonical markers that a workbook rebuilt from certified display rows can
+        // never produce. The bespoke sheet legitimately carries an "Other" column, so only the
+        // display-row model's exact "Allocated" header remains a forbidden fingerprint.
+        sharedStrings.Should().Contain("Net asset value (NAV base)");
+        sharedStrings.Should().Contain("Ownership %");
         sharedStrings.Should().NotContain(">Allocated<");
-        sharedStrings.Should().NotContain(">Other<");
     }
 
     private static CertifiedPartnersCapitalProjection SamplePartnersCapital() => new(


### PR DESCRIPTION
<!-- phase:PR7 -->

## Summary

Completes roadmap row `W9-REPORT-005` (client-grade PDF/XLSX exports and partners-capital statement) and moves it to `ready_for_acceptance`. **Supersedes stalled PR #2525**, whose two commits are absorbed here verbatim (cherry-picked with authorship preserved) and validated against two weeks of main drift.

Phase 1 of this row — the deterministic client-grade PDF (QuestPDF) / XLSX (ClosedXML) renderer wired into the governed certified-reporting path with fail-closed canonical-presentation binding — had already merged. What remained was the deferred bespoke presentation of the flagship statement:

- **`PartnersCapitalStatementLayout` + builder** (`Meridian.Ledger`): pure presentation projection that classifies each capital account by partner role from stable ledger account names, computes ownership shares that foot to 100% (excluding non-partner equity from both numerator and denominator), and anchors the statement to the fund's ledger-backed NAV with an explicit reconciliation flag. Introduces no ledger fact, never changes a figure.
- **`FinancialReportDocumentRenderer`** (`Meridian.Documents`): the partners-capital statement renders through the bespoke layout — PDF gets a NAV context strip, role-labelled per-partner roll-forward, ownership column, and reconciliation footnote; XLSX gets a dedicated `Partners' Capital` sheet whose money/ownership cells are **typed numbers** with accounting/percent formats plus a NAV anchor block, so operators can SUM and pivot without retyping. All other statements keep the generic rendering; output stays byte-deterministic for governed hash verification.
- **Certification tests updated to the bespoke shape while preserving their governance intent** (the only changes beyond the absorbed commits): the client-package test asserts the dedicated sheet and verifies canonical figures as typed numeric cells; the standalone-document test keeps byte-equality with the canonical Documents renderer as the provenance proof, asserts bespoke-canonical markers a display-row rebuild cannot produce (NAV anchor, ownership column), and retains the display-row `"Allocated"` fingerprint as forbidden — the bespoke sheet legitimately carries an `Other` column, so that one fingerprint is retired.
- **Roadmap registry**: `W9-REPORT-005` → `ready_for_acceptance` with source/test evidence anchors; generated roadmap/status docs, diagram, and doc-health dashboards re-rendered in the same change.

Registry-staleness observation for a follow-up review (not changed here): `FundEconomicsJournalFactory` exists on main, suggesting `W9-NAV-006`'s posting kernels have at least partially landed while its row still reads `planned`.

## Reason

`W9-REPORT-005` is rank 5 of the accepted 2026-07 first-order improvement slate (DEC-PRIORITY-SLATE-001) and was the highest-ranked row not yet implementation-complete after ranks 1–4 reached `ready_for_acceptance`. The partners' capital statement is the deliverable fund admins hand to LPs and auditors; until this change it reached the client package as an untyped generic grid — the exact "re-type every deliverable into Excel" gap the row exists to close. PR #2525 solved this but stalled on 2026-07-27 with no substantive review findings (its only comments are bot notices) and went stale against main.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit tests were added or updated (`PartnersCapitalStatementLayoutTests`, `PartnersCapitalBespokeRenderTests`; certification assertions adapted)
- [x] Relevant integration tests were added or updated (106/106 across certification, partners-capital, documents-renderer, and export suites locally)
- [ ] GitHub Actions `quality-gate` passed (pending on this PR)

Also run locally: host build (0 warnings/0 errors), `dotnet format --verify-no-changes` on all touched files, `validate-roadmap-registry.py`, `render-roadmap-docs.py` + `render-roadmap-diagrams.py` + `run-docs-automation.py --profile core` (drift-clean), `check_program_state_consistency.py`, `check_status_doc_staleness.py`, `check_status_delivery_claims.py`, and `tools/roadmap/enforce_phase_scope.py --pr-body "<!-- phase:PR7 -->"` — all green.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

Check every governance file modified:

- [x] No governance files changed
- [ ] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dJYhoE4EaACFai47L2pv8

---
_Generated by [Claude Code](https://claude.ai/code/session_017dJYhoE4EaACFai47L2pv8)_