### PR TITLE
W9-SAFETY-007: kill-switch activation sweeps the open book; registry scoped to in_progress

### DIFF
--- a/docs/architecture/diagrams/meridian-development-roadmap.mmd
+++ b/docs/architecture/diagrams/meridian-development-roadmap.mmd
@@ -46,7 +46,7 @@ flowchart LR
   W9_ALPACA_004 --> W9_REPORT_005
   W9_NAV_006["W9-NAV-006\nW9 - ready_for_acceptance / green"]
   W9_REPORT_005 --> W9_NAV_006
-  W9_SAFETY_007["W9-SAFETY-007\nW9 - planned / green"]
+  W9_SAFETY_007["W9-SAFETY-007\nW9 - in_progress / green"]
   W9_NAV_006 --> W9_SAFETY_007
   W9_GOV_008["W9-GOV-008\nW9 - planned / green"]
   W9_SAFETY_007 --> W9_GOV_008

--- a/docs/roadmap/data/roadmap-items.yml
+++ b/docs/roadmap/data/roadmap-items.yml
@@ -1101,11 +1101,11 @@ items:
       - Trading
       - Settings
     owner_lane: Execution and Fund Accounts
-    status: planned
+    status: in_progress
     health: green
     priority: high
-    evidence_posture: planned_evidence
-    current_summary: Rank 7 of the 2026-07 first-order improvement slate. Safety surfaces must never overpromise; the kill switch must actually cancel all open orders and halt routing, pre-trade rules must cover fat-finger, max-notional, and price-collar checks, and WPF safety buttons must be wired to the real shared controls or visibly demoted.
+    evidence_posture: in_progress
+    current_summary: Source-verified 2026-08-10 and substantially further along than the 2026-07-21 premise, with the remaining gaps now named precisely. Already implemented - the durable execution circuit breaker (versioned atomic snapshot, pending-trip file, operator endpoint) blocks order submission through the operator-controls gate the OMS consults, manual overrides are supported kinds with durable state, breaker activation and override events append to the execution audit trail, the OMS exposes a concurrent CancelAllAsync sweep behind the governed cancel-all endpoint, and the mandatory CompositeRiskValidator enforces drawdown-guardrail, order-rate, position-limit, gross-exposure, symbol-concentration, and max-order-notional rules (with escalation banding and fail-closed handling of unmeasurable orders) fed live from RiskRuleRuntimeService. The 2026-08-10 change closes the criterion-one coupling gap - opening the breaker now issues the kill-switch cancel-all sweep after the durable breaker flip, with completed and failed sweep outcomes audited separately from the activation, proven at the endpoint seam. Remaining before acceptance - fat-finger quantity and price-deviation rules and a price-collar rule do not yet exist in the mandatory validator (the reference-price seam already exists as IPortfolioExposureProvider.TryGetExecutablePrice, and new rules follow the OrderNotionalRule pattern with thresholds surfaced through RiskRuleRuntimeService state and config endpoints); and the WPF and browser safety-control sweep (every button wired to the shared execution-control service or explicitly demoted) has not been audited.
     exit_criteria:
       - Kill-switch activation cancels all open orders across gateways, blocks new order submission, and persists breaker state fail-closed across restart.
       - Pre-trade risk includes fat-finger quantity and price-deviation, max-notional, and price-collar rules enforced by the single mandatory production risk validator.
@@ -1116,7 +1116,18 @@ items:
       - SRC-RISK
       - SRC-WPF
       - SRC-UI-SHARED
-    last_reviewed: 2026-07-21
+    evidence:
+      - type: source
+        path: src/Meridian.Execution/Services/ExecutionOperatorControlService.cs
+      - type: source
+        path: src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs
+      - type: source
+        path: src/Meridian.Ui.Shared/Services/RiskRuleRuntimeService.cs
+      - type: source
+        path: src/Meridian.Risk/CompositeRiskValidator.cs
+      - type: test
+        path: tests/Meridian.Tests/Ui/ExecutionGovernanceEndpointsTests.cs
+    last_reviewed: 2026-08-10
 
   - id: W9-GOV-008
     title: Route-level authorization, fail-closed tenancy, and hash-chained accounting audit

--- a/docs/roadmap/generated/MANIFEST.json
+++ b/docs/roadmap/generated/MANIFEST.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "docs/roadmap/data/roadmap-items.yml",
-      "sha256": "d4744a1acd7e2ec31bad4fe1eb932b301b5817bc41ce59e5a60cbd2dcf053486"
+      "sha256": "2dc63dace28c0886ceeca8ea17718d82a9fbcbd2d70328f782c6e5989c253ee5"
     },
     {
       "path": "docs/roadmap/data/stage-gates.yml",
@@ -32,15 +32,15 @@
   "outputs": [
     {
       "path": "docs/roadmap/generated/ROADMAP_SUMMARY.md",
-      "sha256": "a62894297f14abc32b336c6da099469a442aa124ebee727eece8168c7d77a51a"
+      "sha256": "dd4c5e8947f3ebcd38c026018d984708f70acd1231299fdcfe5155ddf66e67ed"
     },
     {
       "path": "docs/roadmap/generated/roadmap-register.md",
-      "sha256": "33d2aeddc2bed83e042a502d70e1c092d698a8f40b2c99c38ef97d1413579060"
+      "sha256": "f98337738d3194f4656c6c515390785df4fbdac7e9381d97fa674cd2dc2ffe6c"
     },
     {
       "path": "docs/status/ROADMAP_SUMMARY.md",
-      "sha256": "a62894297f14abc32b336c6da099469a442aa124ebee727eece8168c7d77a51a"
+      "sha256": "dd4c5e8947f3ebcd38c026018d984708f70acd1231299fdcfe5155ddf66e67ed"
     }
   ],
   "schema": {

--- a/docs/roadmap/generated/ROADMAP_SUMMARY.md
+++ b/docs/roadmap/generated/ROADMAP_SUMMARY.md
@@ -46,7 +46,7 @@ Snapshot date: 2026-08-10
 | W9-ALPACA-004 | Alpaca fill streaming into order and ledger state | ready_for_acceptance | green | high | Execution and Fund Accounts |
 | W9-REPORT-005 | Client-grade PDF/XLSX exports and partners-capital statement | ready_for_acceptance | green | high | Accounting and Ledger |
 | W9-NAV-006 | Unitized NAV and real fee, waterfall, and capital-call economics | ready_for_acceptance | green | high | Accounting and Ledger |
-| W9-SAFETY-007 | Kill-switch cancel-all and fat-finger, notional, and collar rules | planned | green | high | Execution and Fund Accounts |
+| W9-SAFETY-007 | Kill-switch cancel-all and fat-finger, notional, and collar rules | in_progress | green | high | Execution and Fund Accounts |
 | W9-GOV-008 | Route-level authorization, fail-closed tenancy, and hash-chained accounting audit | planned | green | high | Platform Security and Governance |
 | W9-INGEST-009 | Institutional file ingestion (camt.053/BAI2) and sided reconciliation matcher | planned | green | high | Accounting and Ledger |
 | W9-ASSET-010 | Asset Accounting Event Spine and atomic lot posting | done | green | critical | Accounting and Ledger |

--- a/docs/roadmap/generated/roadmap-register.md
+++ b/docs/roadmap/generated/roadmap-register.md
@@ -736,16 +736,16 @@ Implementation verified complete 2026-08-10; the calculation surface the 2026-07
 | Field | Value |
 | --- | --- |
 | Wave | W9 |
-| Status | planned |
+| Status | in_progress |
 | Health | green |
 | Priority | high |
 | Owner lane | Execution and Fund Accounts |
-| Evidence posture | planned_evidence |
-| Last reviewed | 2026-07-21 |
+| Evidence posture | in_progress |
+| Last reviewed | 2026-08-10 |
 
 ### Current Summary
 
-Rank 7 of the 2026-07 first-order improvement slate. Safety surfaces must never overpromise; the kill switch must actually cancel all open orders and halt routing, pre-trade rules must cover fat-finger, max-notional, and price-collar checks, and WPF safety buttons must be wired to the real shared controls or visibly demoted.
+Source-verified 2026-08-10 and substantially further along than the 2026-07-21 premise, with the remaining gaps now named precisely. Already implemented - the durable execution circuit breaker (versioned atomic snapshot, pending-trip file, operator endpoint) blocks order submission through the operator-controls gate the OMS consults, manual overrides are supported kinds with durable state, breaker activation and override events append to the execution audit trail, the OMS exposes a concurrent CancelAllAsync sweep behind the governed cancel-all endpoint, and the mandatory CompositeRiskValidator enforces drawdown-guardrail, order-rate, position-limit, gross-exposure, symbol-concentration, and max-order-notional rules (with escalation banding and fail-closed handling of unmeasurable orders) fed live from RiskRuleRuntimeService. The 2026-08-10 change closes the criterion-one coupling gap - opening the breaker now issues the kill-switch cancel-all sweep after the durable breaker flip, with completed and failed sweep outcomes audited separately from the activation, proven at the endpoint seam. Remaining before acceptance - fat-finger quantity and price-deviation rules and a price-collar rule do not yet exist in the mandatory validator (the reference-price seam already exists as IPortfolioExposureProvider.TryGetExecutablePrice, and new rules follow the OrderNotionalRule pattern with thresholds surfaced through RiskRuleRuntimeService state and config endpoints); and the WPF and browser safety-control sweep (every button wired to the shared execution-control service or explicitly demoted) has not been audited.
 
 ### Exit Criteria
 

--- a/docs/status/ROADMAP_SUMMARY.md
+++ b/docs/status/ROADMAP_SUMMARY.md
@@ -46,7 +46,7 @@ Snapshot date: 2026-08-10
 | W9-ALPACA-004 | Alpaca fill streaming into order and ledger state | ready_for_acceptance | green | high | Execution and Fund Accounts |
 | W9-REPORT-005 | Client-grade PDF/XLSX exports and partners-capital statement | ready_for_acceptance | green | high | Accounting and Ledger |
 | W9-NAV-006 | Unitized NAV and real fee, waterfall, and capital-call economics | ready_for_acceptance | green | high | Accounting and Ledger |
-| W9-SAFETY-007 | Kill-switch cancel-all and fat-finger, notional, and collar rules | planned | green | high | Execution and Fund Accounts |
+| W9-SAFETY-007 | Kill-switch cancel-all and fat-finger, notional, and collar rules | in_progress | green | high | Execution and Fund Accounts |
 | W9-GOV-008 | Route-level authorization, fail-closed tenancy, and hash-chained accounting audit | planned | green | high | Platform Security and Governance |
 | W9-INGEST-009 | Institutional file ingestion (camt.053/BAI2) and sided reconciliation matcher | planned | green | high | Accounting and Ledger |
 | W9-ASSET-010 | Asset Accounting Event Spine and atomic lot posting | done | green | critical | Accounting and Ledger |

--- a/docs/status/coverage-report.md
+++ b/docs/status/coverage-report.md
@@ -5,17 +5,17 @@
 
 ## Overall Coverage
 
-**2743 / 8779** items documented (**31.2%**) &mdash; Grade: **F**
+**2745 / 8779** items documented (**31.3%**) &mdash; Grade: **F**
 
 ```text
-[======--------------] 31.2%
+[======--------------] 31.3%
 ```
 
 ## Coverage by Category
 
 | Category | Documented | Total | Coverage | Grade |
 | ---------- | ----------- | ------- | ---------- | ------- |
-| Public Classes / Interfaces | 2646 | 8297 | 31.9% | F |
+| Public Classes / Interfaces | 2648 | 8297 | 31.9% | F |
 | API Endpoints | 85 | 329 | 25.8% | F |
 | Configuration Options | 1 | 142 | 0.7% | F |
 | Provider Implementations | 0 | 0 | 100.0% | A |
@@ -23,7 +23,7 @@
 
 ## Undocumented Items
 
-### Public Classes / Interfaces (5651 undocumented)
+### Public Classes / Interfaces (5649 undocumented)
 
 | Item | Location |
 | ------ | ---------- |
@@ -77,7 +77,7 @@
 | `MeridianDataProvenanceDeclaration` | `src/Meridian.Application/Composition/MeridianDeploymentPosture.cs:33` |
 | `MeridianDeploymentPostureServiceCollectionExtensions` | `src/Meridian.Application/Composition/MeridianDeploymentPosture.cs:34` |
 | `PersistenceStatusSnapshot` | `src/Meridian.Application/Composition/PersistenceConfigurationStatus.cs:11` |
-| ... and 5601 more | |
+| ... and 5599 more | |
 
 ### API Endpoints (244 undocumented)
 
@@ -193,7 +193,7 @@
 
 ## Recommendations
 
-1. **Public Classes / Interfaces**: 5651 undocumented types. Consider generating API docs with DocFX (`docfx docfx.json`) to cover the long tail of public types automatically.
+1. **Public Classes / Interfaces**: 5649 undocumented types. Consider generating API docs with DocFX (`docfx docfx.json`) to cover the long tail of public types automatically.
 2. **API Endpoints**: 244 endpoint(s) missing from `docs/reference/api-reference.md`. Run the endpoint audit and update the API reference table.
 3. **Configuration Options**: 141 config key(s) not found in `docs/generated/configuration-schema.md`. Re-run the configuration schema generator to synchronise.
 

--- a/docs/status/program-state-summary.json
+++ b/docs/status/program-state-summary.json
@@ -347,13 +347,13 @@
       "Wave": "W9",
       "Title": "Kill-switch cancel-all and fat-finger, notional, and collar rules",
       "Workspaces": "Trading; Settings",
-      "Status": "planned",
+      "Status": "in_progress",
       "Health": "green",
       "Priority": "high",
       "Owner Lane": "Execution and Fund Accounts",
-      "Evidence Posture": "planned_evidence",
-      "Evidence": "",
-      "Last Reviewed": "2026-07-21"
+      "Evidence Posture": "in_progress",
+      "Evidence": "src/Meridian.Execution/Services/ExecutionOperatorControlService.cs; src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs; src/Meridian.Ui.Shared/Services/RiskRuleRuntimeService.cs; src/Meridian.Risk/CompositeRiskValidator.cs; tests/Meridian.Tests/Ui/ExecutionGovernanceEndpointsTests.cs",
+      "Last Reviewed": "2026-08-10"
     },
     {
       "ID": "W9-GOV-008",

--- a/docs/status/program-state-summary.md
+++ b/docs/status/program-state-summary.md
@@ -30,7 +30,7 @@ Snapshot date: 2026-08-10
 | W9-ALPACA-004 | W9 | Alpaca fill streaming into order and ledger state | Trading | ready_for_acceptance | green | high | Execution and Fund Accounts | implementation_complete | 2026-08-10 |
 | W9-REPORT-005 | W9 | Client-grade PDF/XLSX exports and partners-capital statement | Reporting; Accounting | ready_for_acceptance | green | high | Accounting and Ledger | implementation_complete | 2026-08-10 |
 | W9-NAV-006 | W9 | Unitized NAV and real fee, waterfall, and capital-call economics | Accounting; Portfolio | ready_for_acceptance | green | high | Accounting and Ledger | implementation_complete | 2026-08-10 |
-| W9-SAFETY-007 | W9 | Kill-switch cancel-all and fat-finger, notional, and collar rules | Trading; Settings | planned | green | high | Execution and Fund Accounts | planned_evidence | 2026-07-21 |
+| W9-SAFETY-007 | W9 | Kill-switch cancel-all and fat-finger, notional, and collar rules | Trading; Settings | in_progress | green | high | Execution and Fund Accounts | in_progress | 2026-08-10 |
 | W9-GOV-008 | W9 | Route-level authorization, fail-closed tenancy, and hash-chained accounting audit | Settings; Accounting | planned | green | high | Platform Security and Governance | planned_evidence | 2026-07-21 |
 | W9-INGEST-009 | W9 | Institutional file ingestion (camt.053/BAI2) and sided reconciliation matcher | Accounting; Data | planned | green | high | Accounting and Ledger | planned_evidence | 2026-07-21 |
 | W9-ASSET-010 | W9 | Asset Accounting Event Spine and atomic lot posting | Accounting; Portfolio; Reporting | done | green | critical | Accounting and Ledger | complete | 2026-07-28 |

--- a/src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs
@@ -1,13 +1,13 @@
 using System.Text.Json;
 using Meridian.Contracts.Api;
-using Meridian.Identity;
-using Meridian.Identity.Auth;
-using Meridian.PortfolioRecords.Accounts;
 using Meridian.Contracts.Workstation;
 using Meridian.Execution.Interfaces;
 using Meridian.Execution.Models;
 using Meridian.Execution.Sdk;
 using Meridian.Execution.Services;
+using Meridian.Identity;
+using Meridian.Identity.Auth;
+using Meridian.PortfolioRecords.Accounts;
 using Meridian.Ui.Shared.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -428,6 +428,57 @@ public static class ExecutionEndpoints
             var snapshot = await controls
                 .SetCircuitBreakerAsync(request.IsOpen, request.Reason, actor, request.CorrelationId, context.RequestAborted)
                 .ConfigureAwait(false);
+
+            // Opening the breaker is the kill switch: beyond blocking new submissions it must
+            // sweep the open book, or resting orders keep filling while routing is "halted".
+            // The cancel sweep runs after the durable breaker flip so a crash between the two
+            // restarts into the halted state, and its outcome is audited separately from the
+            // activation so a failed sweep is visible rather than silently absorbed.
+            if (request.IsOpen && context.RequestServices.GetService<IOrderManager>() is { } oms)
+            {
+                var auditTrail = context.RequestServices.GetService<ExecutionAuditTrailService>();
+                var openCount = oms.GetOpenOrders().Count;
+                try
+                {
+                    await oms.CancelAllAsync(context.RequestAborted).ConfigureAwait(false);
+                    GetLogger(context.RequestServices).LogInformation(
+                        "Circuit breaker opened by {Actor}; cancel-all issued for {Count} open order(s)",
+                        actor, openCount);
+                    if (auditTrail is not null)
+                    {
+                        await auditTrail.RecordAsync(
+                                "controls",
+                                "CircuitBreakerCancelAll",
+                                "Completed",
+                                actor: actor,
+                                correlationId: request.CorrelationId,
+                                message: $"Kill-switch cancel-all issued for {openCount} open order(s).",
+                                ct: CancellationToken.None)
+                            .ConfigureAwait(false);
+                    }
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    GetLogger(context.RequestServices).LogError(
+                        ex,
+                        "Circuit breaker opened by {Actor} but the cancel-all sweep failed; open orders may remain working",
+                        actor);
+                    if (auditTrail is not null)
+                    {
+                        await auditTrail.RecordAsync(
+                                "controls",
+                                "CircuitBreakerCancelAll",
+                                "Failed",
+                                actor: actor,
+                                correlationId: request.CorrelationId,
+                                message: $"Kill-switch cancel-all failed with {openCount} open order(s); manual cancellation is required.",
+                                reason: ex.Message,
+                                ct: CancellationToken.None)
+                            .ConfigureAwait(false);
+                    }
+                }
+            }
+
             return Results.Json(snapshot, jsonOptions);
         })
         .WithName("UpdateExecutionCircuitBreaker")

--- a/tests/Meridian.Tests/Ui/ExecutionGovernanceEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/ExecutionGovernanceEndpointsTests.cs
@@ -3,15 +3,15 @@ using System.Text;
 using System.Text.Json;
 using FluentAssertions;
 using Meridian.Contracts.FundStructure;
-using Meridian.Identity.Auth;
 using Meridian.Contracts.Workstation;
 using Meridian.Execution;
 using Meridian.Execution.Models;
 using Meridian.Execution.Sdk;
 using Meridian.Execution.Services;
+using Meridian.Identity;
+using Meridian.Identity.Auth;
 using Meridian.Infrastructure.Adapters.Alpaca;
 using Meridian.Infrastructure.Adapters.Robinhood;
-using Meridian.Identity;
 using Meridian.PortfolioRecords.Accounts;
 using Meridian.Ui.Shared.Endpoints;
 using Meridian.Ui.Shared.Services;
@@ -21,6 +21,7 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 using Xunit;
 
 namespace Meridian.Tests.Ui;
@@ -34,6 +35,8 @@ public sealed class ExecutionGovernanceEndpointsTests
     public async Task ControlsEndpoints_UpdateCircuitBreakerAndExposeAuditTrail()
     {
         var tempRoot = CreateTempRoot();
+        var oms = Substitute.For<IOrderManager>();
+        oms.GetOpenOrders().Returns(Array.Empty<OrderState>());
 
         await using var app = await CreateAppAsync(services =>
         {
@@ -41,6 +44,7 @@ public sealed class ExecutionGovernanceEndpointsTests
             services.AddSingleton(new ExecutionOperatorControlOptions(Path.Combine(tempRoot, "controls")));
             services.AddSingleton<ExecutionAuditTrailService>();
             services.AddSingleton<ExecutionOperatorControlService>();
+            services.AddSingleton(oms);
         });
 
         var client = app.GetTestClient();
@@ -51,6 +55,8 @@ public sealed class ExecutionGovernanceEndpointsTests
             JsonContent(new { isOpen = true, reason = "manual halt" }));
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await oms.Received(1).CancelAllAsync(Arg.Any<CancellationToken>());
 
         var controlsResponse = await client.GetAsync("/api/execution/controls");
         controlsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -67,6 +73,10 @@ public sealed class ExecutionGovernanceEndpointsTests
         auditEntries!.Should().Contain(entry =>
             entry.Action == "CircuitBreakerOpened" &&
             entry.Actor == "ops-user");
+        auditEntries.Should().Contain(entry =>
+            entry.Action == "CircuitBreakerCancelAll" &&
+            entry.Outcome == "Completed",
+            because: "opening the breaker is the kill switch and must sweep the open book with an audited outcome");
     }
 
     [Fact]


### PR DESCRIPTION
<!-- phase:PR7 -->

## Summary

First slice of roadmap row `W9-SAFETY-007` (kill-switch cancel-all and fat-finger/notional/collar rules), closing the criterion-1 coupling gap and truthing the registry row up from its stale 2026-07-21 premise.

**The verified state:** far more exists than the row claimed — the durable execution circuit breaker (versioned atomic snapshot, pending-trip file, operator endpoint) already blocks submissions via the operator-controls gate, breaker/override events already append to the execution audit trail, the OMS already exposes a concurrent `CancelAllAsync` sweep, and the mandatory `CompositeRiskValidator` already enforces drawdown, order-rate, position-limit, gross-exposure, symbol-concentration, and max-order-notional rules with escalation banding and fail-closed unmeasurable-order handling.

**The genuine gap fixed here:** breaker activation and the cancel sweep were two separate operator actions — opening the breaker halted *new* submissions while resting orders kept working at the broker. The circuit-breaker endpoint now issues the kill-switch `CancelAllAsync` sweep immediately after the durable breaker flip (so a crash between the two still restarts halted), with `Completed` and `Failed` sweep outcomes audited separately from the activation — a failed sweep is operator-visible, never silently absorbed. Proven at the endpoint seam with a substituted order manager and audit-trail assertions.

**Registry:** `W9-SAFETY-007` → `in_progress` (deliberately not `ready_for_acceptance`) with a precise map of what remains: fat-finger quantity/price-deviation and price-collar rules in the mandatory validator (the reference-price seam already exists as `IPortfolioExposureProvider.TryGetExecutablePrice`; new rules follow the `OrderNotionalRule` pattern with thresholds in `RiskRuleRuntimeService`), and the WPF/browser safety-control wiring sweep.

## Reason

`W9-SAFETY-007` is rank 7 of the accepted 2026-07 first-order improvement slate — the next planned row with ranks 1–6 at `ready_for_acceptance`. The same verify-before-building pass used on the previous three rows showed this one is a genuine partial: one small, high-severity coupling gap worth fixing immediately (a "halted" book that keeps filling is exactly the overpromising safety surface the row warns about), and two well-scoped remaining work packages recorded honestly rather than half-built.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit tests were added or updated (`ExecutionGovernanceEndpointsTests` 10/10, including the new breaker→cancel-all coupling and audit assertions)
- [x] Relevant integration tests were added or updated (`ExecutionWriteEndpointsTests` 47/47 re-run against the modified endpoint file)
- [ ] GitHub Actions `quality-gate` passed (pending on this PR)

Also run locally: host build (0 errors), `dotnet format --verify-no-changes` on both touched files, `validate-roadmap-registry.py`, `render-roadmap-docs.py` + `render-roadmap-diagrams.py` + `run-docs-automation.py --profile core` (drift-clean), `check_program_state_consistency.py`, `check_status_doc_staleness.py`, `check_status_delivery_claims.py`, and `tools/roadmap/enforce_phase_scope.py --pr-body "<!-- phase:PR7 -->"` against the committed diff — all green.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

Check every governance file modified:

- [x] No governance files changed
- [ ] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dJYhoE4EaACFai47L2pv8

---
_Generated by [Claude Code](https://claude.ai/code/session_017dJYhoE4EaACFai47L2pv8)_