### PR TITLE
Fail-closed startup guard for factory-backed durables and ledger-driven report provenance

### DIFF
--- a/src/Meridian.Application/Composition/ProductionRegistrationGuardService.cs
+++ b/src/Meridian.Application/Composition/ProductionRegistrationGuardService.cs
@@ -8,9 +8,9 @@ namespace Meridian.Application.Composition;
 /// Final-graph production guard (ADR-019). The composition root inserts this as the first
 /// <see cref="IHostedService"/> so it runs before any other hosted service and re-validates the
 /// complete service collection — including registrations added after <c>AddMarketDataServices</c>
-/// — once the host starts. In production postures it additionally resolves non-keyed singleton
-/// factory descriptors so factory-hidden implementations are checked by their actual runtime
-/// type; any violation aborts startup with the full list of prohibited bindings.
+/// — once the host starts. It additionally resolves relevant non-keyed singleton factory
+/// descriptors so factory-hidden implementations are checked by their actual runtime type;
+/// any violation aborts startup with the full list of prohibited bindings.
 /// </summary>
 public sealed class ProductionRegistrationGuardService : IHostedService
 {
@@ -40,6 +40,11 @@ public sealed class ProductionRegistrationGuardService : IHostedService
                 ProductionServiceRegistrationPolicy.ValidateSupportedLocal(
                     _services,
                     requireDurableStores: !runsLabeled);
+                if (!runsLabeled)
+                {
+                    ProductionServiceRegistrationPolicy.ThrowIfNonDurableStoreBindings(
+                        CollectFactoryNonDurableStoreBindings(cancellationToken));
+                }
             }
 
             return Task.CompletedTask;
@@ -59,7 +64,7 @@ public sealed class ProductionRegistrationGuardService : IHostedService
     {
         // Keyed factory descriptors are excluded: their instances cannot be enumerated without
         // knowing every key, and the static descriptor pass still covers keyed implementation
-        // types. Eager resolution is intentional fail-fast for production postures only.
+        // types. Eager resolution is intentional fail-fast for production postures.
         var factorySingletonServiceTypes = _services
             .Where(descriptor => descriptor.Lifetime == ServiceLifetime.Singleton
                                  && !descriptor.IsKeyedService
@@ -96,6 +101,34 @@ public sealed class ProductionRegistrationGuardService : IHostedService
                 }
             }
         }
+    }
+
+    private string[] CollectFactoryNonDurableStoreBindings(CancellationToken cancellationToken)
+    {
+        var bindings = new SortedSet<string>(StringComparer.Ordinal);
+        var factoryDescriptors = _services
+            .Where(descriptor => descriptor.Lifetime == ServiceLifetime.Singleton
+                                 && !descriptor.IsKeyedService
+                                 && descriptor.ImplementationFactory is not null
+                                 && !descriptor.ServiceType.IsGenericTypeDefinition
+                                 && ProductionServiceRegistrationPolicy.IsDurableStoreServiceType(descriptor.ServiceType))
+            .ToArray();
+
+        foreach (var descriptor in factoryDescriptors)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            foreach (var instance in _provider.GetServices(descriptor.ServiceType))
+            {
+                var implementationType = instance?.GetType();
+                if (implementationType is not null
+                    && ProductionServiceRegistrationPolicy.IsNonProductionOnlyImplementation(implementationType))
+                {
+                    bindings.Add($"{descriptor.ServiceType.FullName} -> {implementationType.FullName}");
+                }
+            }
+        }
+
+        return bindings.ToArray();
     }
 }
 

--- a/src/Meridian.Application/Composition/ProductionServiceRegistrationPolicy.cs
+++ b/src/Meridian.Application/Composition/ProductionServiceRegistrationPolicy.cs
@@ -257,6 +257,11 @@ public static class ProductionServiceRegistrationPolicy
         }
 
         var bindings = CollectNonDurableStoreBindings(services);
+        ThrowIfNonDurableStoreBindings(bindings);
+    }
+
+    internal static void ThrowIfNonDurableStoreBindings(IReadOnlyCollection<string> bindings)
+    {
         if (bindings.Count == 0)
         {
             return;

--- a/src/Meridian.Ui.Shared/Services/FundOperationsWorkspaceReadService.cs
+++ b/src/Meridian.Ui.Shared/Services/FundOperationsWorkspaceReadService.cs
@@ -599,7 +599,9 @@ public sealed partial class FundOperationsWorkspaceReadService
             report,
             auditActor,
             ct).ConfigureAwait(false);
-        var derivedProvenanceToken = ReportPackProvenanceResolver.ResolveDerivedToken(runs);
+        var derivedProvenanceToken = _ledgerJournalStore is null
+            ? ReportPackProvenanceResolver.ResolveDerivedToken(runs)
+            : ReportPackProvenanceResolver.ResolveDerivedToken(ledgerBook.ConsolidatedJournalEntries());
         var validationIssues = _reportPackValidationService.Validate(new ReportPackValidationContext(
             ReportId: report.ReportId,
             AsOf: asOf,

--- a/src/Meridian.Ui.Shared/Services/GovernanceReportPackRepository.cs
+++ b/src/Meridian.Ui.Shared/Services/GovernanceReportPackRepository.cs
@@ -404,6 +404,7 @@ public sealed class FileGovernanceReportPackRepository : IGovernanceReportPackRe
 
         if (snapshot.Status is GovernanceReportPackStatusDto.Validated
             or GovernanceReportPackStatusDto.Approved
+            or GovernanceReportPackStatusDto.Published
             or GovernanceReportPackStatusDto.Exported
             or GovernanceReportPackStatusDto.Retained
             or GovernanceReportPackStatusDto.Restated)

--- a/src/Meridian.Ui.Shared/Services/ReportPackProvenanceResolver.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportPackProvenanceResolver.cs
@@ -1,13 +1,15 @@
 using Meridian.Contracts.Operations;
+using Meridian.Ledger;
 using Meridian.Strategies.Models;
 
 namespace Meridian.Ui.Shared.Services;
 
 /// <summary>
-/// W9-TRUTH-001: derives the data-provenance mark a report pack must carry from the strategy runs
-/// it cites. A pack that cites any simulated, seeded, or sample run inherits the strongest
-/// non-real provenance of its inputs, so the derived figure can never enter report-pack evidence
-/// without the blocking mark. Unknown tokens degrade to "simulated", never to real.
+/// W9-TRUTH-001: derives the data-provenance mark a report pack must carry from the inputs used to
+/// construct it: retained journal tags for durable-ledger reports, or strategy-run lineage for the
+/// legacy run-backed path. A pack inherits the strongest non-real provenance of its inputs, so the
+/// derived figure can never enter report-pack evidence without the blocking mark. Unknown tokens
+/// degrade to "simulated", never to real.
 /// </summary>
 public static class ReportPackProvenanceResolver
 {
@@ -24,6 +26,47 @@ public static class ReportPackProvenanceResolver
             }
 
             var declared = DataProvenanceExtensions.ParseTokenOrSimulated(run.DataProvenanceToken);
+            if (!declared.IsNonReal())
+            {
+                continue;
+            }
+
+            if (declared == DataProvenance.Simulated)
+            {
+                return declared.Token();
+            }
+
+            if (strongest is null || declared < strongest)
+            {
+                strongest = declared;
+            }
+        }
+
+        return strongest?.Token();
+    }
+
+    public static string? ResolveDerivedToken(IReadOnlyList<JournalEntry> journalEntries)
+    {
+        ArgumentNullException.ThrowIfNull(journalEntries);
+
+        return ResolveStrongestToken(journalEntries.Select(static entry =>
+            entry.Metadata.Tags is not null
+            && entry.Metadata.Tags.TryGetValue("dataProvenance", out var token)
+                ? token
+                : null));
+    }
+
+    private static string? ResolveStrongestToken(IEnumerable<string?> tokens)
+    {
+        DataProvenance? strongest = null;
+        foreach (var token in tokens)
+        {
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                continue;
+            }
+
+            var declared = DataProvenanceExtensions.ParseTokenOrSimulated(token);
             if (!declared.IsNonReal())
             {
                 continue;

--- a/tests/Meridian.Tests/Application/Composition/ProductionRegistrationGuardServiceTests.cs
+++ b/tests/Meridian.Tests/Application/Composition/ProductionRegistrationGuardServiceTests.cs
@@ -96,6 +96,23 @@ public sealed class ProductionRegistrationGuardServiceTests
     }
 
     [Fact]
+    public async Task StartAsync_LocalWorkstationPosture_RejectsFactoryHiddenInMemoryDurableBinding()
+    {
+        using var quietEnvironment = new ProductionEnvironmentQuietScope();
+        using var host = BuildHost(services =>
+        {
+            services.DeclareMeridianDeploymentPosture(MeridianDeploymentPosture.LocalWorkstation);
+            services.AddProductionRegistrationGuard();
+            services.AddSingleton<ITestStore>(_ => new InMemoryTestStore());
+        });
+
+        Func<Task> act = () => host.StartAsync();
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*requires durable money-path stores*ITestStore*InMemoryTestStore*");
+    }
+
+    [Fact]
     public async Task StartAsync_LocalWorkstationPosture_LabeledComposition_AcceptsInMemoryDurableBindings()
     {
         // The pinned non-real label is the sanctioned way to run fabricated local stores: the

--- a/tests/Meridian.Tests/Application/Services/FundOperationsWorkspaceReadServiceTests.cs
+++ b/tests/Meridian.Tests/Application/Services/FundOperationsWorkspaceReadServiceTests.cs
@@ -1613,6 +1613,13 @@ public sealed class FundOperationsWorkspaceReadServiceTests
             var exception = await act.Should().ThrowAsync<ArgumentException>();
             exception.Which.Message.Should().Contain("'seeded' data-provenance");
             exception.Which.Message.Should().Contain("cannot persist in the 'Validated' state");
+
+            var publishAct = () => repository.SaveAsync(
+                snapshot with { Status = GovernanceReportPackStatusDto.Published },
+                []);
+
+            var publishException = await publishAct.Should().ThrowAsync<ArgumentException>();
+            publishException.Which.Message.Should().Contain("cannot persist in the 'Published' state");
         }
         finally
         {

--- a/tests/Meridian.Tests/Ui/ReportPackProvenanceResolverTests.cs
+++ b/tests/Meridian.Tests/Ui/ReportPackProvenanceResolverTests.cs
@@ -1,0 +1,66 @@
+using FluentAssertions;
+using Meridian.Ledger;
+using Meridian.Ui.Shared.Services;
+
+namespace Meridian.Tests.Ui;
+
+public sealed class ReportPackProvenanceResolverTests
+{
+    [Fact]
+    public void ResolveDerivedToken_JournalEntries_UsesRetainedPostingProvenance()
+    {
+        var journalEntryId = Guid.NewGuid();
+        var timestamp = DateTimeOffset.UtcNow;
+        const string description = "seeded posting";
+        var entry = new JournalEntry(
+            journalEntryId,
+            timestamp,
+            description,
+            [
+                new LedgerEntry(
+                    Guid.NewGuid(), journalEntryId, timestamp,
+                    new LedgerAccount("Assets:Cash", LedgerAccountType.Asset),
+                    100m, 0m, description),
+                new LedgerEntry(
+                    Guid.NewGuid(), journalEntryId, timestamp,
+                    new LedgerAccount("Equity:Capital", LedgerAccountType.Equity),
+                    0m, 100m, description)
+            ],
+            new JournalEntryMetadata(Tags: new Dictionary<string, string>
+            {
+                ["dataProvenance"] = "SEEDED"
+            }));
+
+        var token = ReportPackProvenanceResolver.ResolveDerivedToken([entry]);
+
+        token.Should().Be("seeded");
+    }
+
+    [Fact]
+    public void ResolveDerivedToken_JournalEntries_IgnoresRealInputs()
+    {
+        var journalEntryId = Guid.NewGuid();
+        var timestamp = DateTimeOffset.UtcNow;
+        const string description = "real posting";
+        var entry = new JournalEntry(
+            journalEntryId,
+            timestamp,
+            description,
+            [
+                new LedgerEntry(
+                    Guid.NewGuid(), journalEntryId, timestamp,
+                    new LedgerAccount("Assets:Cash", LedgerAccountType.Asset),
+                    100m, 0m, description),
+                new LedgerEntry(
+                    Guid.NewGuid(), journalEntryId, timestamp,
+                    new LedgerAccount("Equity:Capital", LedgerAccountType.Equity),
+                    0m, 100m, description)
+            ],
+            new JournalEntryMetadata(Tags: new Dictionary<string, string>
+            {
+                ["dataProvenance"] = "real"
+            }));
+
+        ReportPackProvenanceResolver.ResolveDerivedToken([entry]).Should().BeNull();
+    }
+}


### PR DESCRIPTION
### Motivation

- Ensure the host cannot silently start with in-memory durable money-path bindings when running a supported local workstation posture unless a non-real provenance label is pinned. 
- Derive report-pack provenance from the actual inputs used to build the report so durable-ledger reports inherit retained posting provenance rather than a run list that may be unrelated. 
- Prevent any non-real provenance from being persisted into approvable/deliverable report-pack states, including `Published`.

### Description

- Extend `ProductionRegistrationGuardService` to inspect non-keyed singleton factory registrations at startup and reject factory-backed in-memory durable-store implementations when the local composition is unlabeled by a non-real provenance (`ProductionRegistrationGuardService.CollectFactoryNonDurableStoreBindings`).
- Add `ProductionServiceRegistrationPolicy.ThrowIfNonDurableStoreBindings` to centralize the fail-closed behavior for supported local posture checks and call it from the guard and existing validation flow.
- Change report-pack provenance derivation in `FundOperationsWorkspaceReadService` to use retained journal tags when a durable ledger store (`_ledgerJournalStore`) is configured and fall back to run-based derivation otherwise (`ReportPackProvenanceResolver.ResolveDerivedToken` overload accepting `JournalEntry` inputs).
- Make `ReportPackProvenanceResolver` resolve the strongest non-real token from retained `dataProvenance` journal tags and introduced a helper `ResolveStrongestToken` to centralize token reasoning.
- Add `Published` to the list of prohibited deliverable states in `GovernanceReportPackRepository.EnsureProvenanceMarkBlocksDeliverableStatus` so packs with non-real provenance cannot persist as `Published`.
- Add unit tests covering: factory-hidden in-memory durable rejection (`ProductionRegistrationGuardServiceTests`), ledger-driven provenance resolution (`ReportPackProvenanceResolverTests`), and the `Published` state refusal on marked report packs (updated `FundOperationsWorkspaceReadServiceTests`).

### Testing

- Added/updated unit tests: `tests/Meridian.Tests/Application/Composition/ProductionRegistrationGuardServiceTests.cs` (new factory-hidden in-memory case), `tests/Meridian.Tests/Ui/ReportPackProvenanceResolverTests.cs` (new ledger-driven provenance cases), and an assertion extension in `tests/Meridian.Tests/Application/Services/FundOperationsWorkspaceReadServiceTests.cs` verifying `Published` is refused for marked packs; these tests were compiled into the working tree.
- Static checks: `git diff --check` returned clean for the applied edits.
- Attempted to run targeted automation: `dotnet test --filter "FullyQualifiedName~ProductionRegistrationGuardServiceTests"` could not be executed in this environment because the `dotnet` SDK is not available (`dotnet: command not found`).
- CI script attempt: `bash scripts/ci.sh` ran but failed early at the .NET SDK verification step for the same reason; full automated test runs should be executed in CI (GitHub Actions) where the .NET toolchain is present.

Please run `bash scripts/ci.sh` or the repository's GitHub Actions `quality-gate` to validate the changes in the CI environment and report any failing tests; locally, run `dotnet test` for the updated test projects to confirm green status.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a3a507d4c832090be30ee6bfdfecb)