### PR TITLE
Measure OCC option orders at contract notional

### DIFF
--- a/src/Meridian.Risk/Rules/OrderNotionalResolver.cs
+++ b/src/Meridian.Risk/Rules/OrderNotionalResolver.cs
@@ -105,7 +105,8 @@ internal static class OrderNotionalResolver
         OrderRequest request,
         PortfolioExposureSnapshot snapshot,
         Func<string, decimal?>? referencePriceLookup,
-        Func<string, OrderSide, decimal?>? sideAwarePriceLookup)
+        Func<string, OrderSide, decimal?>? sideAwarePriceLookup,
+        bool inferredOccOption)
     {
         // Broker-native notional sizing still wins: it is what the gateway routes.
         if (BrokerNotionalMetadata.TryRead(request.Metadata, request.Quantity) is { } brokerNotional)
@@ -151,7 +152,9 @@ internal static class OrderNotionalResolver
                 return null;
             }
 
-            var multiplier = ResolveMultiplier(leg.OptionContract ?? request.OptionContract);
+            var multiplier = inferredOccOption
+                ? DefaultContractMultiplier
+                : ResolveMultiplier(leg.OptionContract ?? request.OptionContract);
             total += Math.Abs(request.Quantity) * Math.Abs(leg.RatioQuantity) * price * multiplier;
             priced = true;
         }
@@ -191,11 +194,19 @@ internal static class OrderNotionalResolver
         // Broker adapters may infer an option from its compact OCC symbol even when a
         // caller omitted OptionContract. Risk must classify that same route as a
         // derivative or it will measure premium-only notional without the 100x multiplier.
+        var inferredOccOption = request.Legs is not { Count: > 0 } &&
+            request.OptionContract is null &&
+            IsOccOptionSymbol(request.Symbol);
         if (request.Legs is { Count: > 0 } ||
             request.OptionContract is not null ||
-            IsOccOptionSymbol(request.Symbol))
+            inferredOccOption)
         {
-            return ResolveDerivative(request, snapshot, referencePriceLookup, sideAwarePriceLookup);
+            return ResolveDerivative(
+                request,
+                snapshot,
+                referencePriceLookup,
+                sideAwarePriceLookup,
+                inferredOccOption);
         }
 
         // Broker-native notional sizing (Alpaca metadata "notional"/"alpaca:notional")

--- a/src/Meridian.Risk/Rules/OrderNotionalResolver.cs
+++ b/src/Meridian.Risk/Rules/OrderNotionalResolver.cs
@@ -188,7 +188,12 @@ internal static class OrderNotionalResolver
         // else, scaled by the contract multiplier — no Greeks, no VaR, just the notional
         // the contracts actually represent. A multi-leg order's top-level price is the net
         // debit/credit of the combination, so each leg is valued on its own instead.
-        if (request.Legs is { Count: > 0 } || request.OptionContract is not null)
+        // Broker adapters may infer an option from its compact OCC symbol even when a
+        // caller omitted OptionContract. Risk must classify that same route as a
+        // derivative or it will measure premium-only notional without the 100x multiplier.
+        if (request.Legs is { Count: > 0 } ||
+            request.OptionContract is not null ||
+            IsOccOptionSymbol(request.Symbol))
         {
             return ResolveDerivative(request, snapshot, referencePriceLookup, sideAwarePriceLookup);
         }
@@ -235,6 +240,12 @@ internal static class OrderNotionalResolver
 
         return referencePrice is { } price and > 0m ? Math.Abs(request.Quantity) * price : null;
     }
+
+    private static bool IsOccOptionSymbol(string symbol) =>
+        Meridian.Contracts.SecurityMaster.SecurityIdentifierNormalizer.TryValidateFormat(
+            Meridian.Contracts.SecurityMaster.SecurityIdentifierKind.OccOptionSymbol,
+            symbol,
+            out _);
 
     /// <summary>
     /// Signed order notional: positive for buys, negative for sells, so direction-aware

--- a/tests/Meridian.Tests/Risk/PortfolioRiskRulesTests.cs
+++ b/tests/Meridian.Tests/Risk/PortfolioRiskRulesTests.cs
@@ -464,7 +464,12 @@ public sealed class PortfolioRiskRulesTests
         // measure 100 contracts x $5 premium x 100, not treat them as $500 of shares.
         var order = CreateOrder(symbol: "AAPL261218C00250000", quantity: 100m);
 
-        (await rule.EvaluateAsync(order)).IsApproved.Should().BeFalse();
+        var result = await rule.EvaluateAsync(order);
+
+        result.IsApproved.Should().BeFalse();
+        result.RejectReason.Should().Be(
+            "Order notional limit: 50000.00 exceeds 20000.00 ceiling",
+            "100 OCC contracts at a $5 premium must use the standard 100x multiplier");
     }
 
     [Fact]

--- a/tests/Meridian.Tests/Risk/PortfolioRiskRulesTests.cs
+++ b/tests/Meridian.Tests/Risk/PortfolioRiskRulesTests.cs
@@ -451,6 +451,23 @@ public sealed class PortfolioRiskRulesTests
     }
 
     [Fact]
+    public async Task OrderNotional_OccOptionOrderWithoutContractIdentity_AssumesTheStandardContractSize()
+    {
+        var rule = new OrderNotionalRule(
+            Provider(symbols: [new SymbolExposure("AAPL261218C00250000", 50_000m, 100m, 5m)]),
+            () => 20_000m,
+            () => null,
+            NullLogger<OrderNotionalRule>.Instance);
+
+        // Broker adapters can classify a compact OCC symbol as an option even when the
+        // request omitted OptionContract. Risk must make the same classification and
+        // measure 100 contracts x $5 premium x 100, not treat them as $500 of shares.
+        var order = CreateOrder(symbol: "AAPL261218C00250000", quantity: 100m);
+
+        (await rule.EvaluateAsync(order)).IsApproved.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task OrderNotional_MultiLegOrder_SumsEveryLegRatherThanNetting()
     {
         var rule = new OrderNotionalRule(


### PR DESCRIPTION
### Motivation
- Fix an under-measurement where option orders that omit `OptionContract`/`Legs` but use a compact OCC symbol were being valued as equity (premium-only) and could bypass pre-trade risk ceilings.

### Description
- Treat strict compact OCC-format option symbols as derivatives during notional resolution by detecting them with `SecurityIdentifierNormalizer.TryValidateFormat` and routing through the existing derivative valuation path in `OrderNotionalResolver.Resolve`.
- Add a private helper `IsOccOptionSymbol(string)` that wraps the `TryValidateFormat` call and use it alongside the existing `Legs`/`OptionContract` checks.
- Add a regression test `OrderNotional_OccOptionOrderWithoutContractIdentity_AssumesTheStandardContractSize` to `PortfolioRiskRulesTests` that asserts a 100-contract order at a $5 premium is measured with the standard contract multiplier (100x) and thus fails a tight notional ceiling.
- Small test fixture adjustment to construct the `Provider(...)` symbol exposures as an array where needed for the new test.

### Testing
- Ran `git diff --check` which passed.
- Ran `python build/scripts/docs/validate-source-readmes.py --summary` which passed with 0 errors and 0 warnings.
- Attempted `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~PortfolioRiskRulesTests"`, but the environment does not provide `dotnet`, so the unit tests could not be executed locally.
- Ran `python build/scripts/docs/validate-doc-hashes.py --summary` and `bash scripts/ci.sh` in this environment; `validate-doc-hashes` reported pre-existing repository-wide README/source hash-drift findings and `scripts/ci.sh` could not complete because `dotnet` is unavailable here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e7a4c9df083209c4c318cdbd28126)