### PR TITLE
Fail closed on concentration limits when aggregate NAV is exhausted

### DIFF
--- a/src/Meridian.FSharp/Risk/RiskRules.fs
+++ b/src/Meridian.FSharp/Risk/RiskRules.fs
@@ -65,7 +65,8 @@ let grossExposureLimit (ctx: RiskContext) : RiskDecision =
 /// percentage of portfolio value. Direction-aware: reducing orders lower the projected
 /// concentration, and an order that strictly reduces the symbol's exposure is always
 /// permitted so an oversized position can be unwound incrementally while still above the
-/// cap. Requires a positive portfolio value to be meaningful.
+/// cap. A measured nonpositive portfolio value fails closed for orders that do
+/// not strictly reduce exposure: an exhausted book has no NAV left to allocate.
 let symbolConcentration (ctx: RiskContext) : RiskDecision =
     match ctx.PortfolioValue, ctx.MaxSymbolConcentrationPercent with
     | Some portfolioValue, Some maxPercent when portfolioValue > 0m && maxPercent > 0m ->
@@ -74,6 +75,13 @@ let symbolConcentration (ctx: RiskContext) : RiskDecision =
         let projectedPercent = (projected / portfolioValue) * 100m
         if projectedPercent > maxPercent && projected >= currentSymbolAbs then
             Reject (sprintf "Concentration limit: %s at %.2f%% of portfolio value exceeds %.2f%% cap" ctx.Request.Symbol (float projectedPercent) (float maxPercent))
+        else
+            Approve
+    | Some portfolioValue, Some maxPercent when portfolioValue <= 0m && maxPercent > 0m ->
+        let currentSymbolAbs = ctx.SymbolExposure |> Option.defaultValue 0m
+        let projected = projectedSymbolAbsoluteExposure ctx
+        if projected >= currentSymbolAbs then
+            Reject (sprintf "Concentration limit: %s cannot increase exposure while portfolio value is exhausted" ctx.Request.Symbol)
         else
             Approve
     | _ -> Approve

--- a/tests/Meridian.FSharp.Tests/RiskPolicyTests.fs
+++ b/tests/Meridian.FSharp.Tests/RiskPolicyTests.fs
@@ -197,8 +197,16 @@ let ``Symbol concentration rejects breach of the portfolio-value cap`` () =
     result.Reasons[0].Contains("Concentration limit") |> should equal true
 
 [<Fact>]
-let ``Symbol concentration approves without a positive portfolio value`` () =
+let ``Symbol concentration rejects increased exposure without a positive portfolio value`` () =
     let ctx = createPortfolioContext (createOrder OrderSide.Buy 100m) (Nullable 20_000m) (Nullable 20_000m) (Nullable 0m) (Nullable 10_000m) (Nullable()) (Nullable 25m) (Nullable()) (Nullable())
+    let result = RiskInterop.EvaluateSymbolConcentration(ctx)
+
+    result.Approved |> should equal false
+    result.Reasons[0].Contains("portfolio value is exhausted") |> should equal true
+
+[<Fact>]
+let ``Symbol concentration permits reduced exposure without a positive portfolio value`` () =
+    let ctx = createPortfolioContextSigned (createOrder OrderSide.Sell 100m) (Nullable 20_000m) (Nullable 20_000m) (Nullable 20_000m) (Nullable -10_000m) (Nullable 10_000m) (Nullable -10_000m) (Nullable()) (Nullable 25m) (Nullable()) (Nullable())
     let result = RiskInterop.EvaluateSymbolConcentration(ctx)
 
     result.Approved |> should equal true

--- a/tests/Meridian.Tests/Risk/PortfolioRiskRulesTests.cs
+++ b/tests/Meridian.Tests/Risk/PortfolioRiskRulesTests.cs
@@ -190,7 +190,7 @@ public sealed class PortfolioRiskRulesTests
     }
 
     [Fact]
-    public async Task Concentration_WithZeroPortfolioValue_Approves()
+    public async Task Concentration_WithZeroPortfolioValue_RejectsIncreasedExposure()
     {
         var rule = new SymbolConcentrationRule(
             Provider(grossExposure: 0m, portfolioValue: 0m),
@@ -199,7 +199,8 @@ public sealed class PortfolioRiskRulesTests
 
         var result = await rule.EvaluateAsync(CreateOrder(limitPrice: 100m));
 
-        result.IsApproved.Should().BeTrue();
+        result.IsApproved.Should().BeFalse();
+        result.RejectReason.Should().Contain("portfolio value is exhausted");
     }
 
     // --- OrderNotionalRule ---


### PR DESCRIPTION
### Motivation
- A measured zero or negative aggregate portfolio value caused the symbol-concentration policy to short-circuit to `Approve`, creating a pre-trade risk-control bypass when the registry sum was exhausted.
- The intent is to keep concentration limits effective for an insolvent aggregated registry while still permitting strictly de-risking orders so an exhausted book can be unwound.

### Description
- Change F# concentration kernel `symbolConcentration` to treat a measured nonpositive `PortfolioValue` as a fail-closed condition for orders that would maintain or increase symbol exposure, while preserving approval for strictly exposure-reducing orders (`src/Meridian.FSharp/Risk/RiskRules.fs`).
- Replace the unsafe zero-NAV approval expectations with focused regression tests in F# that assert rejection for risk-increasing orders and allowance for de-risking orders (`tests/Meridian.FSharp.Tests/RiskPolicyTests.fs`).
- Update the C# rule-level test to assert a risk-increasing order is rejected when portfolio value is zero (`tests/Meridian.Tests/Risk/PortfolioRiskRulesTests.cs`).

### Testing
- Ran `git diff --check` to ensure no whitespace/patch issues (passed).
- Attempted focused `dotnet test` runs for the touched F# and C# tests, but `dotnet` is not available in this environment so those tests were not executed here (must be run in CI/GitHub Actions or a dev machine with the .NET SDK).
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary`, which reported pre-existing repository-wide documentation hash-drift errors unrelated to this change; these are pre-existing and not caused by the patch.
- CI / authoritative integration tests remain the responsibility of GitHub Actions; the branch and tests should be validated there (`bash scripts/ci.sh` / full `Meridian CI / quality-gate`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e75996a6c8320b8f4b5f3a587ecc8)