### PR TITLE
Fail-closed on unpriced uncapped orders

### DIFF
--- a/docs/source/generated/source-hash-manifest.json
+++ b/docs/source/generated/source-hash-manifest.json
@@ -240,8 +240,8 @@
       "id": "SRC-RISK",
       "path": "src/Meridian.Risk",
       "readme": "src/Meridian.Risk/README.md",
-      "readme_hash": "3b4d163b144dd88765b0b4e9d434d949811f0c57adeb18047cfa00a8e217a6a2",
-      "source_hash": "ef0b1cf435de0944258bf29fe7d0908f2b14aa89a139d4774882afd8f3b9254c"
+      "readme_hash": "332bd286efaedd2090cd75a03a417f57e7a2a9510fda98eb40c93db9db7f779b",
+      "source_hash": "7b5251dc885d9b6f33d8ed7344bd45544103bc22bc78af8dff0dee2dc60ce745"
     },
     {
       "id": "SRC-STORAGE",

--- a/src/Meridian.Risk/README.md
+++ b/src/Meridian.Risk/README.md
@@ -47,8 +47,9 @@ exposes one. Rule severity maps to a real outcome in `CompositeRiskValidator`:
 Portfolio-aware rules read a `PortfolioExposureSnapshot` per evaluation, so thresholds tuned
 through the UI runtime service apply immediately and enforcement always sees the same
 aggregated cross-run exposure the Portfolio workspace reports. Thresholds are operator-tuned
-(null means unconfigured and the rule approves); order notional resolves from the limit/stop
-price or the symbol's reference price and never guesses a price for unknown symbols.
+(null means unconfigured and the rule approves); capped buy limits resolve from their limit,
+while uncapped orders require a current symbol reference price. A configured rule rejects an
+order it cannot price rather than guessing or approving it unmeasured.
 
 ## Diagrams
 

--- a/src/Meridian.Risk/Rules/OrderNotionalResolver.cs
+++ b/src/Meridian.Risk/Rules/OrderNotionalResolver.cs
@@ -218,6 +218,14 @@ internal static class OrderNotionalResolver
         // $1 in a $100 symbol routes ~$100k. Neither may be valued at its own price alone.
         var pricePaidIsCapped = request.Side == OrderSide.Buy && request.LimitPrice is > 0m;
 
+        // A trigger or floor is not a safe fallback when the current market is unknown.
+        // Returning null makes every configured notional-based rail reject the order as
+        // unmeasurable instead of approving risk that can execute at an unbounded price.
+        if (!pricePaidIsCapped && marketPrice is null or <= 0m)
+        {
+            return null;
+        }
+
         if (referencePrice is null or <= 0m)
         {
             // No caller price: measure at the market. The portfolio may be flat in this

--- a/tests/Meridian.Tests/Risk/PortfolioRiskRulesTests.cs
+++ b/tests/Meridian.Tests/Risk/PortfolioRiskRulesTests.cs
@@ -351,6 +351,23 @@ public sealed class PortfolioRiskRulesTests
     }
 
     [Fact]
+    public async Task OrderNotional_BuyStopWithNoCurrentMarket_RejectsAsUnmeasurable()
+    {
+        var rule = new OrderNotionalRule(
+            Provider(),
+            () => 50_000m,
+            () => null,
+            NullLogger<OrderNotionalRule>.Instance);
+
+        var order = CreateOrder(quantity: 1_000m, type: OrderType.StopMarket) with { StopPrice = 1m };
+
+        var result = await rule.EvaluateAsync(order);
+
+        result.IsApproved.Should().BeFalse("a stop trigger does not cap the execution price");
+        result.RejectReason.Should().Contain("No current price");
+    }
+
+    [Fact]
     public async Task OrderNotional_RestingBuyLimit_KeepsItsOwnCap()
     {
         var rule = new OrderNotionalRule(
@@ -655,6 +672,22 @@ public sealed class PortfolioRiskRulesTests
             CreateOrder(quantity: 10_000m, limitPrice: 1m, side: OrderSide.Sell));
 
         result.IsApproved.Should().BeFalse("the executable value is 10,000 x the 100 market, not the 1 limit");
+    }
+
+    [Fact]
+    public async Task OrderNotional_SellLimitWithNoCurrentMarket_RejectsAsUnmeasurable()
+    {
+        var rule = new OrderNotionalRule(
+            Provider(),
+            () => 500_000m,
+            () => null,
+            NullLogger<OrderNotionalRule>.Instance);
+
+        var result = await rule.EvaluateAsync(
+            CreateOrder(quantity: 10_000m, limitPrice: 1m, side: OrderSide.Sell));
+
+        result.IsApproved.Should().BeFalse("a sell limit is a floor, not a cap on execution value");
+        result.RejectReason.Should().Contain("No current price");
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- Close a pre-trade risk bypass where stale or missing market marks allowed uncapped orders (buy stops, marketable sell limits, market orders in never-held symbols) to be valued at their submitted trigger/floor and thus bypass notional/gross/concentration controls.
- Preserve existing behavior for capped buy limits while ensuring any configured notional-based rule fails closed when the resolver cannot conservatively price an order.

### Description
- Change `OrderNotionalResolver.Resolve` so uncapped orders return `null` (unmeasurable) when no current market/reference price is available instead of falling back to the order's stop/limit price, causing configured rails to reject or escalate rather than approve understated risk (`src/Meridian.Risk/Rules/OrderNotionalResolver.cs`).
- Add regression tests that assert a buy stop without a current market and a sell limit without a current market are rejected as unmeasurable (`tests/Meridian.Tests/Risk/PortfolioRiskRulesTests.cs`).
- Update the risk module README to document the fail-closed requirement for uncapped orders and refresh the repository source-hash manifest for `SRC-RISK` (`src/Meridian.Risk/README.md` and `docs/source/generated/source-hash-manifest.json`).
- No change to the existing behavior that permits capped buy limits to be valued at their limit price.

### Testing
- `git diff --check` passed and repository doc manifest JSON parsed with `python3 -m json.tool` (passed). 
- Documentation hash refresh via `python3 build/scripts/docs/validate-doc-hashes.py --write-module SRC-RISK` succeeded and updated the manifest (passed).
- Added unit tests in `tests/Meridian.Tests/Risk/PortfolioRiskRulesTests.cs` to cover the new fail-closed cases; these tests could not be executed locally because the environment lacks the .NET SDK (`dotnet: command not found`).
- Local `bash scripts/ci.sh` was blocked by the same missing `dotnet` runtime; please run CI/GitHub Actions (`Meridian CI / quality-gate`) to execute the full .NET test suite and validate the change end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e7345501c8320b4832863519d85ab)