### PR TITLE
Preserve submitter identity across chained risk approvals

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/RiskEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/RiskEndpoints.cs
@@ -327,19 +327,29 @@ public static class RiskEndpoints
 
                 carriedTokens.Add(approved.EscalationId);
 
-                var metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                {
-                    [RiskEscalationQueueService.ApprovalMetadataKey] = RiskEscalationQueueService.JoinTokens(carriedTokens),
-                    ["actor"] = actor,
-                    ["correlationId"] = $"risk-escalation-{approved.EscalationId}"
-                };
+                var metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
                 if (approved.Request.Metadata is not null)
                 {
                     foreach (var (key, value) in approved.Request.Metadata)
                     {
-                        metadata.TryAdd(key, value);
+                        metadata[key] = value;
                     }
                 }
+
+                // The retained actor is the original submitter, not the approver releasing
+                // this particular escalation. Preserve it so any later rule in the same
+                // validation chain enforces segregation of duties against that submitter.
+                metadata[RiskEscalationQueueService.ApprovalMetadataKey] =
+                    RiskEscalationQueueService.JoinTokens(carriedTokens);
+                if (!string.IsNullOrWhiteSpace(approved.Actor))
+                {
+                    metadata["actor"] = approved.Actor;
+                }
+                else
+                {
+                    metadata.Remove("actor");
+                }
+                metadata["correlationId"] = $"risk-escalation-{approved.EscalationId}";
 
                 var releaseRequest = approved.Request with { Metadata = metadata };
                 try

--- a/tests/Meridian.Tests/Ui/RiskEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/RiskEndpointsTests.cs
@@ -9,6 +9,7 @@ using Meridian.Execution.Models;
 using Meridian.Execution.Sdk;
 using Meridian.Execution.Services;
 using Meridian.PortfolioRecords.Accounts;
+using Meridian.Risk;
 using Meridian.Ui.Shared.Endpoints;
 using Meridian.Ui.Shared.Services;
 using Microsoft.AspNetCore.Builder;
@@ -243,6 +244,83 @@ public sealed class RiskEndpointsTests
         var denyAfter = await client.PostAsync(
             $"/api/risk/escalations/{escalationId}/deny", JsonContent(new { reason = "too late" }));
         denyAfter.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task RiskEscalations_ChainedApprovalRetainsOriginalSubmitterForSegregationOfDuties()
+    {
+        await using var app = await CreateAppAsync(services =>
+        {
+            services.AddSingleton<PaperTradingPortfolio>(_ => new PaperTradingPortfolio(100_000m));
+            services.AddSingleton<IPortfolioState>(sp => sp.GetRequiredService<PaperTradingPortfolio>());
+            services.AddSingleton<IExecutionGateway>(_ => new Meridian.Execution.PaperTradingGateway(
+                NullLogger<Meridian.Execution.PaperTradingGateway>.Instance,
+                options: new Meridian.Execution.Adapters.PaperTradingGatewayOptions { AllowScaffoldMarketFills = true }));
+            services.AddSingleton(new RiskEscalationQueueService(
+                NullLogger<RiskEscalationQueueService>.Instance,
+                options: new RiskEscalationQueueOptions(
+                    Path.Combine(Path.GetTempPath(), "Meridian.Tests", $"escalations-{Guid.NewGuid():N}", "escalations.json"))));
+            services.AddSingleton<IRiskValidator>(sp => new Meridian.Risk.CompositeRiskValidator(
+                [
+                    new EscalatingRule("order-notional", "band A"),
+                    new EscalatingRule("desk-review", "band B")
+                ],
+                NullLogger<Meridian.Risk.CompositeRiskValidator>.Instance,
+                escalationQueue: sp.GetRequiredService<RiskEscalationQueueService>()));
+            services.AddSingleton<IOrderManager>(sp => new OrderManagementSystem(
+                sp.GetRequiredService<IExecutionGateway>(),
+                NullLogger<OrderManagementSystem>.Instance,
+                riskValidator: sp.GetRequiredService<IRiskValidator>(),
+                portfolioState: sp.GetRequiredService<PaperTradingPortfolio>()));
+        }, includeExecutionEndpoints: true);
+
+        var client = app.GetTestClient();
+        var submit = new HttpRequestMessage(HttpMethod.Post, "/api/execution/orders/submit")
+        {
+            Content = JsonContent(new
+            {
+                symbol = "AAPL",
+                side = 0,
+                type = 1,
+                timeInForce = 0,
+                quantity = 10,
+                limitPrice = 100m
+            })
+        };
+        submit.Headers.Add("X-Test-User", "submitter");
+
+        var parkedResponse = await client.SendAsync(submit);
+        parkedResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        var parked = JsonSerializer.Deserialize<OrderResult>(
+            await parkedResponse.Content.ReadAsStringAsync(), JsonOptions());
+
+        var approveFirst = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/api/risk/escalations/{parked!.EscalationId}/approve")
+        {
+            Content = JsonContent(new { reason = "first independent review" })
+        };
+        approveFirst.Headers.Add("X-Test-User", "risk-desk");
+        var firstApprovalResponse = await client.SendAsync(approveFirst);
+        firstApprovalResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var firstApproval = JsonSerializer.Deserialize<RiskEscalationApprovalResponse>(
+            await firstApprovalResponse.Content.ReadAsStringAsync(), JsonOptions());
+        firstApproval!.ReleaseResult!.RequiresApproval.Should().BeTrue("the second rule still requires its own decision");
+
+        var queue = app.Services.GetRequiredService<RiskEscalationQueueService>();
+        var second = queue.TryGet(firstApproval.ReleaseResult.EscalationId!);
+        second!.Actor.Should().Be("submitter", "an approver cannot replace the submitting actor during a chained release");
+
+        var selfApproveSecond = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/api/risk/escalations/{second.EscalationId}/approve")
+        {
+            Content = JsonContent(new { reason = "submitter must not approve a later exception" })
+        };
+        selfApproveSecond.Headers.Add("X-Test-User", "submitter");
+
+        (await client.SendAsync(selfApproveSecond)).StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 
     [Fact]
@@ -511,6 +589,14 @@ public sealed class RiskEndpointsTests
             PortfolioValue: 100_000m,
             SymbolExposures: new Dictionary<string, Meridian.Risk.SymbolExposure>(StringComparer.OrdinalIgnoreCase),
             AsOf: DateTimeOffset.UtcNow);
+    }
+
+    private sealed class EscalatingRule(string ruleName, string reason) : IRiskRule
+    {
+        public string RuleName => ruleName;
+
+        public Task<RiskValidationResult> EvaluateAsync(OrderRequest request, CancellationToken ct = default) =>
+            Task.FromResult(RiskValidationResult.Escalated(reason));
     }
 
     private sealed class StaticPositionTracker : IPositionTracker


### PR DESCRIPTION
### Motivation
- Fix an actor-confusion vulnerability in the multi-rule governed-approval flow where the release path overwrote the original submitting actor with the current approver, allowing self-approval of later escalations.
- Preserve segregation-of-duties by ensuring any later parked escalation continues to attribute the order to the original submitter.

### Description
- Adjusted the release metadata assembly in `src/Meridian.Ui.Shared/Endpoints/RiskEndpoints.cs` to preserve the original request metadata, continue carrying all approval tokens, and restore the trusted actor from the parked `approved` entry instead of stamping the current approver into `actor` (and remove `actor` metadata when no trusted actor exists). This keeps the approval tokens behavior but prevents actor replacement during chained releases.
- Changed metadata copy strategy to overwrite keys from the retained request first and then inject the approval token and correlation id from the released escalation so the original submitter remains authoritative for later SoD checks.
- Added an endpoint-level regression test in `tests/Meridian.Tests/Ui/RiskEndpointsTests.cs`: `RiskEscalations_ChainedApprovalRetainsOriginalSubmitterForSegregationOfDuties`, which exercises a two-rule escalation chain and asserts the second escalation is attributed to the original submitter and that the submitter cannot approve it.
- Added a small test helper rule `EscalatingRule` used by the new test to force escalations and exercise the chained approval path.

### Testing
- Ran `git diff --check` which passed with no whitespace/patch issues.
- Ran `python3 build/scripts/docs/validate-source-readmes.py --summary` which passed with `0` errors and `0` warnings.
- Added the regression test `RiskEscalations_ChainedApprovalRetainsOriginalSubmitterForSegregationOfDuties` and supporting helper in `tests/Meridian.Tests/Ui/RiskEndpointsTests.cs` (the test is present in the change set but could not be executed here because `dotnet` is not installed in this environment).
- Attempting `dotnet test` and `bash scripts/ci.sh` was blocked locally due to a missing .NET SDK; full CI (GitHub Actions) remains the authoritative run and should be used to validate the new test and overall suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e7264bfd883209f7eecf6a26ac9eb)