### PR TITLE
Fix the blocking-async detector's false positives and its blind spot

### DIFF
--- a/build/scripts/ai-repo-updater.py
+++ b/build/scripts/ai-repo-updater.py
@@ -90,7 +90,22 @@ UNSEALED_CLASS = re.compile(r"(?<!\bsealed\s)(?<!\babstract\s)(?<!\bstatic\s)\bc
 IMPLEMENTS_ADR = re.compile(r"\[ImplementsAdr\(")
 STRING_INTERPOLATION_LOG = re.compile(r'_logger\.Log\w+\(\$"')
 TASK_RUN_IO = re.compile(r"Task\.Run\(")
-BLOCKING_ASYNC = re.compile(r"\.(Result|Wait\(\))")
+# `\b` after Result keeps `.Results` (a collection property) from matching.
+BLOCKING_ASYNC = re.compile(r"\.(?:Result\b|Wait\(\))")
+# The receiver immediately before `.Result`: either a task-ish identifier or an
+# `Async(...)` call. Without this, a `Task.FromResult(...)` elsewhere on the line
+# vouches for an unrelated `.Result` (e.g. a record-struct member named Result).
+BLOCKING_ASYNC_RECEIVER = re.compile(r"(?:\w*[Tt]ask|Async\s*\([^()]*\))\s*(?:\.\w+\s*\(\s*\))*\.(?:Result\b|Wait\(\))")
+# Accessing .Result after an explicit completion check cannot deadlock.
+COMPLETED_TASK_GUARD = re.compile(r"\bIs(?:CompletedSuccessfully|Completed|Faulted|Canceled)\b")
+SYNC_OVER_ASYNC = re.compile(r"\.GetAwaiter\(\)\.GetResult\(\)")
+# Sync IDisposable bridging to async teardown — the accepted pattern, no alternative.
+DISPOSE_CONTEXT_METHOD = re.compile(r"^(?:Dispose|DisposeCore|DisposeAsyncCore|Close|Shutdown|Finalize)$")
+DISPOSE_CALLEE = re.compile(r"\b(?:DisposeAsync|DisposeCoreAsync|TerminateAsync)\s*\(")
+METHOD_SIGNATURE = re.compile(
+    r"^\s*(?:(?:public|private|protected|internal|static|virtual|override|sealed|partial|async|new|extern)\s+)*"
+    r"[\w<>,\[\]\?\.]+\s+(\w+)\s*\("
+)
 STRUCTURED_LOG = re.compile(r'_logger\.Log\w+\("[^"]*\{')
 HTTP_CLIENT_NEW = re.compile(r"new\s+HttpClient\s*\(")
 
@@ -249,6 +264,33 @@ def is_inside_string_literal(line: str, index: int) -> bool:
     return in_string
 
 
+def enclosing_method_name(lines: list[str], index: int, lookback: int = 40) -> str | None:
+    """Return the nearest method name at or above ``index``, or None if not found.
+
+    Regex-based rather than parsed, so it can mis-attribute inside deeply nested
+    local functions; callers should treat a miss as "unknown", not "not a method".
+    """
+    for k in range(index, max(-1, index - lookback), -1):
+        match = METHOD_SIGNATURE.match(lines[k])
+        if match:
+            return match.group(1)
+    return None
+
+
+def is_sync_dispose_bridge(lines: list[str], index: int) -> bool:
+    """True when a sync-over-async call is the accepted IDisposable-over-async bridge.
+
+    Two independent signals, because neither alone is sufficient: the enclosing
+    method catches non-Dispose-named callees inside ``Dispose()``, while the callee
+    check catches dispose callbacks in DI-registration lambdas where the enclosing
+    method scan finds no name.
+    """
+    if DISPOSE_CALLEE.search(lines[index]):
+        return True
+    enclosing = enclosing_method_name(lines, index)
+    return bool(enclosing and DISPOSE_CONTEXT_METHOD.match(enclosing))
+
+
 # ---------------------------------------------------------------------------
 # Analysers
 # ---------------------------------------------------------------------------
@@ -326,19 +368,55 @@ def audit_code(root: Path, report: AuditReport) -> None:  # noqa: C901
         # --- Check: blocking async (.Result / .Wait()) ---
         for i, line in enumerate(lines, 1):
             match = BLOCKING_ASYNC.search(line)
-            if match and "Task" in line:
-                stripped = line.strip()
-                if stripped.startswith("//") or stripped.startswith("*"):
-                    continue
-                if is_inside_string_literal(line, match.start()):
-                    continue
-                report.add(Finding(
-                    category="blocking-async",
-                    severity="critical",
-                    file=rel, line=i,
-                    message="Blocking async code (.Result or .Wait()) can cause deadlocks.",
-                    fix_hint="Use 'await' instead of .Result or .Wait().",
-                ))
+            if not match:
+                continue
+            stripped = line.strip()
+            if stripped.startswith("//") or stripped.startswith("*"):
+                continue
+            if is_inside_string_literal(line, match.start()):
+                continue
+            # Require the receiver itself to look like a task; a Task.FromResult
+            # elsewhere on the line is not evidence about this .Result.
+            if not BLOCKING_ASYNC_RECEIVER.search(line):
+                continue
+            # An explicit completion check upstream makes the access safe.
+            guard_window = lines[max(0, i - 5):i - 1]
+            if any(COMPLETED_TASK_GUARD.search(prev) for prev in guard_window):
+                continue
+            report.add(Finding(
+                category="blocking-async",
+                severity="critical",
+                file=rel, line=i,
+                message="Blocking async code (.Result or .Wait()) can cause deadlocks.",
+                fix_hint="Use 'await' instead of .Result or .Wait().",
+            ))
+
+        # --- Check: sync-over-async (.GetAwaiter().GetResult()) ---
+        for i, line in enumerate(lines, 1):
+            match = SYNC_OVER_ASYNC.search(line)
+            if not match:
+                continue
+            stripped = line.strip()
+            if stripped.startswith("//") or stripped.startswith("*"):
+                continue
+            if is_inside_string_literal(line, match.start()):
+                continue
+            if is_sync_dispose_bridge(lines, i - 1):
+                continue
+            # Task.Run(...).GetAwaiter().GetResult() burns a pool thread *and*
+            # blocks on it — unambiguously wrong, unlike a plain sync bridge.
+            blocking_task_run = bool(TASK_RUN_IO.search(line))
+            report.add(Finding(
+                category="sync-over-async",
+                severity="critical" if blocking_task_run else "warning",
+                file=rel, line=i,
+                message=(
+                    "Task.Run(...).GetAwaiter().GetResult() blocks a thread-pool thread on async work."
+                    if blocking_task_run
+                    else "Sync-over-async (.GetAwaiter().GetResult()) can deadlock and stalls the caller."
+                ),
+                fix_hint="Make the caller async and await instead of blocking.",
+            ))
 
         # --- Check: Task.Run for likely I/O ---
         for i, line in enumerate(lines, 1):

--- a/build/scripts/tests/test_ai_repo_updater_blocking_async.py
+++ b/build/scripts/tests/test_ai_repo_updater_blocking_async.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "ai-repo-updater.py"
+SPEC = importlib.util.spec_from_file_location("ai_repo_updater", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+updater = importlib.util.module_from_spec(SPEC)
+sys.modules["ai_repo_updater"] = updater
+SPEC.loader.exec_module(updater)
+
+
+def findings_for(source: str, category: str) -> list:
+    """Run audit_code over a single synthetic C# file and return matching findings."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root = Path(temp_dir)
+        src = root / "src" / "Sample"
+        src.mkdir(parents=True)
+        (src / "Sample.cs").write_text(source, encoding="utf-8")
+
+        report = updater.AuditReport()
+        updater.audit_code(root, report)
+        return [f for f in report.findings if f.category == category]
+
+
+class BlockingAsyncDetectorTests(unittest.TestCase):
+    """The detector previously reported only false positives; these pin the fixes."""
+
+    def test_results_collection_property_is_not_flagged(self) -> None:
+        # `.Results` is a collection, not Task.Result — the old regex lacked \b.
+        source = """
+public sealed class Gateway
+{
+    public async Task LoadAsync()
+    {
+        var optionDetails = await Task.WhenAll(optResult.Results.Select(async p => await FetchAsync(p)));
+    }
+}
+"""
+        self.assertEqual(findings_for(source, "blocking-async"), [])
+
+    def test_result_guarded_by_completion_check_is_not_flagged(self) -> None:
+        # Accessing .Result after IsCompletedSuccessfully cannot deadlock.
+        source = """
+public sealed class Runner
+{
+    public void Read(Task<int> resultTask)
+    {
+        if (resultTask.IsCompletedSuccessfully)
+        {
+            var result = resultTask.Result;
+        }
+    }
+}
+"""
+        self.assertEqual(findings_for(source, "blocking-async"), [])
+
+    def test_non_task_result_property_is_not_flagged(self) -> None:
+        # `Evaluate(...)` returns a record struct whose member is named Result.
+        # The old `"Task" in line` proxy let Task.FromResult vouch for it.
+        source = """
+public sealed class Throttle
+{
+    public Task<RiskValidationResult> EvaluateAsync(OrderRequest request)
+    {
+        return Task.FromResult(Evaluate(reserve: false).Result);
+    }
+}
+"""
+        self.assertEqual(findings_for(source, "blocking-async"), [])
+
+    def test_genuine_unguarded_task_result_is_flagged(self) -> None:
+        source = """
+public sealed class Runner
+{
+    public void Read(Task<int> pendingTask)
+    {
+        var value = pendingTask.Result;
+    }
+}
+"""
+        found = findings_for(source, "blocking-async")
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0].severity, "critical")
+
+    def test_task_wait_is_still_flagged(self) -> None:
+        source = """
+public sealed class Runner
+{
+    public void Read(Task pendingTask)
+    {
+        pendingTask.Wait();
+    }
+}
+"""
+        self.assertEqual(len(findings_for(source, "blocking-async")), 1)
+
+
+class SyncOverAsyncDetectorTests(unittest.TestCase):
+    """`.GetAwaiter().GetResult()` was invisible to the old regex entirely."""
+
+    def test_task_run_sync_over_async_is_critical(self) -> None:
+        source = """
+public sealed class StrategyFeatureModule
+{
+    private static object CreateEngine(IServiceProvider sp)
+    {
+        var config = Task.Run(() => configService.LoadConfigAsync()).GetAwaiter().GetResult();
+        return config;
+    }
+}
+"""
+        found = findings_for(source, "sync-over-async")
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0].severity, "critical")
+
+    def test_plain_sync_over_async_is_warning(self) -> None:
+        source = """
+public sealed class BacktestProxy
+{
+    public BacktestResult Run(Action onProgress)
+    {
+        return RunAsync(onProgress).GetAwaiter().GetResult();
+    }
+}
+"""
+        found = findings_for(source, "sync-over-async")
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0].severity, "warning")
+
+    # The next three isolate one half of the suppression rule each, so a
+    # regression in either half fails a distinct test instead of hiding.
+
+    def test_dispose_bridge_is_suppressed_by_both_signals(self) -> None:
+        source = """
+public sealed class Watcher
+{
+    public void Dispose()
+        => DisposeAsync().AsTask().GetAwaiter().GetResult();
+}
+"""
+        self.assertEqual(findings_for(source, "sync-over-async"), [])
+
+    def test_non_dispose_callee_inside_dispose_is_suppressed(self) -> None:
+        # Enclosing-method signal only: the callee is not named Dispose*.
+        source = """
+public sealed class ConnectionManager
+{
+    public void Dispose()
+    {
+        DisconnectAsync().GetAwaiter().GetResult();
+    }
+}
+"""
+        self.assertEqual(findings_for(source, "sync-over-async"), [])
+
+    def test_dispose_callback_in_lambda_is_suppressed(self) -> None:
+        # Callee signal only: inside a DI lambda, no enclosing method name.
+        source = """
+public static class BrokerageServiceRegistration
+{
+    public static void Register(IServiceCollection services)
+    {
+        services.AddSingleton(sp =>
+        {
+            lifetime.Register(() =>
+            {
+                store.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            });
+        });
+    }
+}
+"""
+        self.assertEqual(findings_for(source, "sync-over-async"), [])
+
+    def test_commented_and_string_occurrences_are_ignored(self) -> None:
+        source = '''
+public sealed class Docs
+{
+    // Never write RunAsync().GetAwaiter().GetResult() in new code.
+    public string Hint() => "call .GetAwaiter().GetResult() is forbidden";
+}
+'''
+        self.assertEqual(findings_for(source, "sync-over-async"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Meridian.Mcp/Tools/ConventionTools.cs
+++ b/src/Meridian.Mcp/Tools/ConventionTools.cs
@@ -29,6 +29,8 @@ public sealed class ConventionTools(RepoPathService repo)
         sb.AppendLine("| Anti-Pattern | Why |");
         sb.AppendLine("|--------------|-----|");
         sb.AppendLine("| Blocking task completion APIs | Deadlocks in async contexts |");
+        sb.AppendLine("| `.GetAwaiter().GetResult()` outside `Dispose` | Sync-over-async; deadlocks and stalls the caller |");
+        sb.AppendLine("| `Task.Run(...).GetAwaiter().GetResult()` | Burns a pool thread *and* blocks on it |");
         sb.AppendLine("| `Task.Run` for I/O-bound work | Wastes thread pool threads |");
         sb.AppendLine("| Direct `HttpClient` construction | Socket exhaustion, DNS caching issues |");
         sb.AppendLine("| String interpolation in logger | Loses structured log benefits |");
@@ -65,6 +67,8 @@ public sealed class ConventionTools(RepoPathService repo)
             ("Hardcoding credentials", "Security risk, inflexible deployment", "Use environment variables; never put keys in source or config files"),
             ("`Task.Run` for I/O-bound work", "Wastes thread pool threads, adds unnecessary overhead", "Use async/await with native async I/O APIs"),
             ("Blocking task completion APIs", "Causes deadlocks in synchronization-context environments", "Use `await` all the way up the call stack"),
+            ("`.GetAwaiter().GetResult()` outside a sync `Dispose` bridge", "Sync-over-async: deadlocks under a synchronization context and stalls the calling thread", "Make the caller async and `await`. Only acceptable when bridging sync `IDisposable` to `DisposeAsync`"),
+            ("`Task.Run(...).GetAwaiter().GetResult()`", "Burns a thread-pool thread to run the work, then blocks another waiting on it — worst of both", "Await the async method directly; never wrap-then-block"),
             ("Direct `HttpClient` instances", "Socket exhaustion, DNS staleness, connection pool thrash", "Inject `IHttpClientFactory` and use named/typed clients"),
             ("String interpolation in logger calls", "Loses structured log parameter names, prevents log filtering", "Use semantic parameters: `_logger.LogInfo(\"{Symbol} bars: {Count}\", sym, n)`"),
             ("Missing `CancellationToken`", "Prevents graceful shutdown, can hang on I/O indefinitely", "Add `CancellationToken ct = default` to every async method signature"),


### PR DESCRIPTION
## Summary

Fixes the `blocking-async` check in `build/scripts/ai-repo-updater.py`, which reported three criticals — all false positives — while missing the sync-over-async pattern that actually occurs in this tree.

The detector was `\.(Result|Wait\(\))` gated on `"Task" in line`. With no word boundary and no type awareness it matched:

| Site | What it actually matched |
|---|---|
| `RobinhoodBrokerageGateway.cs:442` | `optResult.Results` — a collection property, on a line already awaiting `Task.WhenAll` |
| `MeridianNativeBacktestStudioEngine.cs:211` | `resultTask.Result` guarded two lines above by `IsCompletedSuccessfully`; cannot deadlock |
| `OrderRateThrottle.cs:101` | `Evaluate(...).Result`, where `Result` is a positional member of the `readonly record struct` `RiskRuleReservationResult` — not a Task at all. Fired only because `Task.FromResult` sat elsewhere on the line |

The same regex structurally cannot match `.GetAwaiter().GetResult()` (the character before `Result` is `t`, not `.`), so 41 real sites were invisible — including six `Task.Run(...).GetAwaiter().GetResult()` calls in WPF DI factories and startup paths.

Changes to the detector:

- Add `\b` to `.Result` so `.Results` no longer matches.
- Replace the `"Task" in line` proxy with a check on the receiver immediately preceding `.Result`.
- Skip accesses guarded by an upstream completion check.
- Add a `sync-over-async` category for `.GetAwaiter().GetResult()`, suppressing the accepted sync-`IDisposable`-over-async bridge via two signals (enclosing method, and callee) because neither alone covers both `Dispose()` bodies and dispose callbacks in DI lambdas. Rated critical only for the `Task.Run` wrap-then-block form.

`ConventionTools.cs` now names the pattern the detector enforces, so the MCP-served guidance and the linter agree. That change is documentation-only — added rows in a string table.

Effect on a full audit run:

| Category | Before | After |
|---|---|---|
| `blocking-async` (critical) | 3 | 0 |
| `sync-over-async` (critical) | 0 | 6 |
| `sync-over-async` (warning) | 0 | 19 |
| all eleven other categories | — | unchanged |

16 of the 41 sync-over-async sites are suppressed as legitimate Dispose bridges. Total criticals move 17 → 20.

## Reason

An earlier attempt to work through "known issues" was planned against `archive/docs/assessments/AUDIT_REPORT.md` — a snapshot dated 2026-03-18 that is archived, ~5 months stale, and whose top-priority item (blocking `.Result` in `Meridian.Mcp/Tools/ConventionTools.cs`) no longer holds; that file contains no async code today.

Re-running the tool against current source showed why the stale report was misleading in the first place: its severity ranking cannot be trusted. Every `blocking-async` critical was a false positive, so any agent acting on the audit would burn effort on non-problems while the real pattern went unreported. Fixing the detector is higher leverage than fixing any single finding — it makes every future audit worth acting on.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

New `build/scripts/tests/test_ai_repo_updater_blocking_async.py` — 11 tests, all passing, following the existing `unittest` + `importlib` convention in that directory. **Five of them fail against the previous detector**, verified by running the suite against `HEAD`'s version of the script; the other six are regression guards for behavior that must be preserved. Three tests isolate one half of the Dispose-suppression rule each, so a regression in either half fails a distinct test rather than hiding behind the other.

Also verified: full `audit` re-run diffed category-by-category against a pre-change baseline, confirming only the three intended rows moved.

Not run, and why:

- `bash scripts/ci.sh` / `quality-gate` — not run locally; `dotnet` is not installed in this environment, so the `Meridian.Mcp` project could not be compiled. The C# change is additive string literals in an existing table with no new identifiers, but it is unverified by a compiler and should be confirmed by CI before merge.
- `build/scripts/tests/test_validate_budget.py` fails to import under `unittest discover` because `pytest` is not installed here. Pre-existing on `main`, unrelated to this change.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed


---
_Generated by [Claude Code](https://claude.ai/code/session_01SqdB3Ha7UBEwcKMhaZ2ufY)_