### PR TITLE
Create the provider credential vault key with owner-only permissions

### DIFF
--- a/src/Meridian.DataIntegration/Credentials/FileProviderCredentialStore.cs
+++ b/src/Meridian.DataIntegration/Credentials/FileProviderCredentialStore.cs
@@ -605,7 +605,7 @@ public sealed class FileProviderCredentialStore : IProviderCredentialStore
 
     private async Task WriteVaultAsync(ProviderCredentialVault vault, CancellationToken ct)
     {
-        Directory.CreateDirectory(_directoryPath);
+        EnsureVaultDirectory();
         vault.Version = VaultVersion;
         vault.UpdatedAt = DateTimeOffset.UtcNow;
 
@@ -697,18 +697,72 @@ public sealed class FileProviderCredentialStore : IProviderCredentialStore
         return plainBytes;
     }
 
+    // The AES-GCM key lives in the same directory as the ciphertext it opens, so on Unix the file
+    // mode is the only thing separating the two: a reader who can open the vault can open the key
+    // beside it. Owner-only is therefore a correctness requirement of the encryption, not
+    // defence in depth.
+    private const UnixFileMode OwnerOnlyFileMode =
+        UnixFileMode.UserRead | UnixFileMode.UserWrite;
+
+    private const UnixFileMode OwnerOnlyDirectoryMode =
+        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
+
     private async Task<byte[]> GetOrCreateLocalKeyAsync(CancellationToken ct)
     {
-        Directory.CreateDirectory(_directoryPath);
+        EnsureVaultDirectory();
         if (File.Exists(_keyPath))
         {
+            RestrictExistingKeyFile(_keyPath);
             return await File.ReadAllBytesAsync(_keyPath, ct).ConfigureAwait(false);
         }
 
         var key = RandomNumberGenerator.GetBytes(32);
-        await AtomicFileWriter.WriteAsync(_keyPath, key, ct).ConfigureAwait(false);
+        await AtomicFileWriter.WriteAsync(_keyPath, key, OwnerOnlyFileMode, ct).ConfigureAwait(false);
         TrySetHidden(_keyPath);
         return key;
+    }
+
+    // Only a directory this store creates is narrowed. An existing .mdc is left as the deployment
+    // configured it - it is shared with other credential state, and silently removing access a
+    // running install depends on would be a worse failure than the one being prevented. The key
+    // file's own mode is what actually protects the key, and that is enforced either way.
+    private void EnsureVaultDirectory()
+    {
+        if (OperatingSystem.IsWindows() || Directory.Exists(_directoryPath))
+        {
+            Directory.CreateDirectory(_directoryPath);
+            return;
+        }
+
+        Directory.CreateDirectory(_directoryPath, OwnerOnlyDirectoryMode);
+    }
+
+    private static void RestrictExistingKeyFile(string path)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        try
+        {
+            var mode = File.GetUnixFileMode(path);
+            var exposed = mode & ~OwnerOnlyFileMode;
+            if (exposed == UnixFileMode.None)
+            {
+                return;
+            }
+
+            File.SetUnixFileMode(path, OwnerOnlyFileMode);
+            Log.Warning(
+                "Provider credential vault key at {KeyPath} was reachable beyond its owner ({ExposedMode}); tightened to owner-only. The key should be treated as disclosed and provider credentials rotated.",
+                path,
+                exposed);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+        {
+            Log.Warning(ex, "Could not verify permissions on the provider credential vault key at {KeyPath}", path);
+        }
     }
 
     private static void TrySetHidden(string path)

--- a/src/Meridian.Storage/Archival/AtomicFileWriter.cs
+++ b/src/Meridian.Storage/Archival/AtomicFileWriter.cs
@@ -118,9 +118,28 @@ public static partial class AtomicFileWriter
     /// <summary>
     /// Atomically writes binary content to a file.
     /// </summary>
+    public static Task WriteAsync(
+        string destinationPath,
+        byte[] content,
+        CancellationToken ct = default)
+        => WriteAsync(destinationPath, content, unixCreateMode: null, ct);
+
+    /// <summary>
+    /// Atomically writes binary content to a file, creating it with an explicit Unix permission
+    /// mode.
+    /// </summary>
+    /// <remarks>
+    /// For secrets the mode has to be in place from the instant the file exists: chmod-after-write
+    /// leaves the content readable for the width of the write, and the temp file this method
+    /// renames is real, on-disk, and holding the same bytes. <paramref name="unixCreateMode"/> is
+    /// therefore applied at creation rather than afterwards, and suppresses the usual copy of the
+    /// destination's security metadata so an existing over-permissive file cannot re-widen the
+    /// replacement. Ignored on Windows, where ACLs rather than mode bits govern.
+    /// </remarks>
     public static async Task WriteAsync(
         string destinationPath,
         byte[] content,
+        UnixFileMode? unixCreateMode,
         CancellationToken ct = default)
     {
         var directory = Path.GetDirectoryName(destinationPath);
@@ -135,13 +154,20 @@ public static partial class AtomicFileWriter
         try
         {
             // Write to temp file
-            await File.WriteAllBytesAsync(tempPath, content, ct);
+            if (unixCreateMode is { } mode && !OperatingSystem.IsWindows())
+            {
+                await WriteAllBytesWithModeAsync(tempPath, content, mode, ct);
+            }
+            else
+            {
+                await File.WriteAllBytesAsync(tempPath, content, ct);
+            }
 
             // Sync the temp file to disk while it is still writable, before copying any
             // (possibly read-only) security metadata from the destination onto it.
             await SyncFileAsync(tempPath, ct);
 
-            if (destinationExists)
+            if (destinationExists && unixCreateMode is null)
             {
                 CopySecurityMetadata(destinationPath, tempPath);
             }
@@ -542,6 +568,28 @@ public static partial class AtomicFileWriter
         var directory = Path.GetDirectoryName(destinationPath) ?? ".";
         var fileName = Path.GetFileName(destinationPath);
         return Path.Combine(directory, $".{fileName}.{Guid.NewGuid():N}.tmp");
+    }
+
+    // FileStreamOptions.UnixCreateMode passes the mode to open(2), so the file is never visible at
+    // the umask default first. File.WriteAllBytesAsync offers no equivalent, which is why this
+    // exists rather than a chmod after the fact.
+    private static async Task WriteAllBytesWithModeAsync(
+        string path,
+        byte[] content,
+        UnixFileMode mode,
+        CancellationToken ct)
+    {
+        var options = new FileStreamOptions
+        {
+            Mode = FileMode.CreateNew,
+            Access = FileAccess.Write,
+            Share = FileShare.None,
+            Options = FileOptions.Asynchronous,
+            UnixCreateMode = mode,
+        };
+
+        await using var stream = new FileStream(path, options);
+        await stream.WriteAsync(content, ct);
     }
 
     private static void CopySecurityMetadata(string sourcePath, string targetPath)

--- a/tests/Meridian.Tests/Application/Config/ProviderCredentialStoreTests.cs
+++ b/tests/Meridian.Tests/Application/Config/ProviderCredentialStoreTests.cs
@@ -525,6 +525,75 @@ public sealed class ProviderCredentialStoreTests : IDisposable
         auditText.Should().NotContain("finnhub-secret");
     }
 
+    // The vault key sits in the same directory as the vault it decrypts, so on Unix the key file's
+    // mode is the whole of the protection: a reader who can open one can open the other. These
+    // cover that the mode is right at creation and repaired if a deployment already widened it.
+
+    [Fact]
+    public async Task SaveAsync_CreatesTheVaultKeyOwnerOnly()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var store = new FileProviderCredentialStore(_root);
+
+        await store.SaveAsync(new ProviderCredentialSaveRequest(
+            "finnhub",
+            new Dictionary<string, string?> { ["ApiKey"] = "finnhub-secret" }));
+
+        var keyPath = Path.Combine(_root, ".mdc", "provider-credentials.key");
+        File.Exists(keyPath).Should().BeTrue();
+        File.GetUnixFileMode(keyPath)
+            .Should().Be(UnixFileMode.UserRead | UnixFileMode.UserWrite,
+                "the key is the only thing standing between the vault file and its plaintext");
+    }
+
+    [Fact]
+    public async Task SaveAsync_CreatesTheVaultDirectoryOwnerOnly()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var store = new FileProviderCredentialStore(_root);
+
+        await store.SaveAsync(new ProviderCredentialSaveRequest(
+            "finnhub",
+            new Dictionary<string, string?> { ["ApiKey"] = "finnhub-secret" }));
+
+        File.GetUnixFileMode(Path.Combine(_root, ".mdc"))
+            .Should().Be(UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+    }
+
+    [Fact]
+    public async Task ReadForProviderAsync_TightensAKeyLeftReadableByAnEarlierRelease()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var store = new FileProviderCredentialStore(_root);
+        await store.SaveAsync(new ProviderCredentialSaveRequest(
+            "finnhub",
+            new Dictionary<string, string?> { ["ApiKey"] = "finnhub-secret" }));
+
+        // Reproduce what a pre-fix install left on disk: the umask default, world-readable.
+        var keyPath = Path.Combine(_root, ".mdc", "provider-credentials.key");
+        File.SetUnixFileMode(
+            keyPath,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+
+        var read = await new FileProviderCredentialStore(_root).ReadForProviderAsync("finnhub");
+
+        File.GetUnixFileMode(keyPath).Should().Be(UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        read.Should().NotBeNull();
+        read!.Get("ApiKey").Should().Be("finnhub-secret", "tightening permissions must not break decryption");
+    }
+
     private sealed class EnvironmentScope : IDisposable
     {
         private readonly string _name;

--- a/tests/Meridian.Tests/Storage/AtomicFileWriterTests.cs
+++ b/tests/Meridian.Tests/Storage/AtomicFileWriterTests.cs
@@ -243,4 +243,62 @@ public sealed class AtomicFileWriterTests : TempDirectoryTestBase
         File.Exists(path).Should().BeTrue();
         (await File.ReadAllBytesAsync(path)).Should().BeEmpty();
     }
+
+    [Fact]
+    public async Task WriteAsync_Bytes_AppliesRequestedUnixCreateMode()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var path = Path.Combine(TestDataRoot, "secret.bin");
+
+        var content = new byte[] { 1, 2, 3 };
+
+        await AtomicFileWriter.WriteAsync(
+            path, content, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        File.GetUnixFileMode(path).Should().Be(UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        (await File.ReadAllBytesAsync(path)).Should().Equal(content);
+    }
+
+    // Without an explicit mode the destination's permissions win, so replacing an over-permissive
+    // secret would silently restore the mode that made it over-permissive. An explicit mode has to
+    // override the destination rather than inherit from it.
+    [Fact]
+    public async Task WriteAsync_Bytes_ExplicitModeOverridesAnExistingWiderMode()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var path = Path.Combine(TestDataRoot, "widened.bin");
+        await File.WriteAllBytesAsync(path, new byte[] { 9 });
+        File.SetUnixFileMode(
+            path, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+
+        await AtomicFileWriter.WriteAsync(
+            path, new byte[] { 1, 2, 3 }, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        File.GetUnixFileMode(path).Should().Be(UnixFileMode.UserRead | UnixFileMode.UserWrite);
+    }
+
+    [Fact]
+    public async Task WriteAsync_Bytes_WithoutModeStillPreservesExistingPermissions()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var path = Path.Combine(TestDataRoot, "inherited.bin");
+        await File.WriteAllBytesAsync(path, new byte[] { 9 });
+        File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        await AtomicFileWriter.WriteAsync(path, new byte[] { 1, 2, 3 });
+
+        File.GetUnixFileMode(path).Should().Be(UnixFileMode.UserRead | UnixFileMode.UserWrite);
+    }
 }


### PR DESCRIPTION
## Summary

On non-Windows hosts the provider credential vault is AES-GCM encrypted under a 256-bit key that `FileProviderCredentialStore` writes to `.mdc/provider-credentials.key` — the same directory as `provider-credentials.vault`, which that key decrypts.

The key was written through `AtomicFileWriter`, which applies the destination's permissions **only when the destination already exists** (`if (destinationExists) CopySecurityMetadata(...)`). A key file has no destination on first write, so it landed at the umask default — `0644` on a typical Linux host. The only narrowing attempted was `FileAttributes.Hidden`, which is a no-op on Unix.

Any local account that could read the vault could therefore also read the key sitting beside it. Encrypting the vault bought nothing against that reader.

Three changes:

- **`AtomicFileWriter`** gains a `byte[]` overload taking an explicit `UnixFileMode`, applied via `FileStreamOptions.UnixCreateMode` so the mode reaches `open(2)` rather than being chmod'ed afterwards — a key written first and narrowed second is readable for the width of the write, and the temp file this method renames holds the real bytes. Passing a mode also suppresses the copy of the destination's security metadata; without that, replacing an over-permissive key would restore the very mode being corrected. The existing three-argument overload delegates with no mode and is behaviourally unchanged.
- **`FileProviderCredentialStore`** creates the key `0600`, and on reading a key that predates this change tightens it and warns that the key should be treated as disclosed and credentials rotated. Repair rather than refuse is deliberate — failing closed would brick every Linux install that already has a `0644` key, a worse outcome than the exposure it would announce.
- **A `.mdc` directory this store creates** is now `0700`. An existing one is left as the deployment configured it: it also holds credential state written by other services, and silently removing access a running install depends on is not a change to make as a side effect. The key file's own mode is what protects the key, and that is enforced either way.

The vault, backup, and audit files keep their current permissions. The vault is ciphertext and the audit holds only masked previews, so their exposure was bounded by the key's — which is the thing being fixed.

## Reason

Advances #2649 (PRD-002, P0 release-blocker), whose scope explicitly includes protecting non-Windows vault keys. **It does not close the issue** — the tracker also requires an OS keyring or KMS-backed mechanism, which is a design decision rather than a permissions fix, plus rotation and two-account-isolation evidence. Filed against the tracker row rather than as its own issue because it is squarely inside that row's stated scope.

One related exposure found and deliberately **not** fixed here: `OAuthTokenRefreshService` writes `.mdc/oauth_tokens.json` and `CredentialTestingService` writes `.mdc/credential_status.json`, both at the umask default. Those are a different service's files; folding them in would widen this change past the defect it describes. Worth a follow-up.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Six tests added, all guarded to skip on Windows where DPAPI applies and no key file exists:

`AtomicFileWriterTests` — the requested mode is applied on create; an explicit mode overrides an existing wider mode (the regression that would silently re-widen a corrected key); and omitting the mode still preserves existing permissions, so the current callers' behaviour is pinned.

`ProviderCredentialStoreTests` — `SaveAsync` creates the key owner-only; `SaveAsync` creates `.mdc` owner-only; and a key left world-readable by an earlier release is tightened on next read **and still decrypts**, so the repair cannot cost access to the vault.

`dotnet` is not available in this container, so the .NET lane was run on a hosted runner via the `Targeted Test` workflow rather than locally. Local gates run here: file-size ratchet OK, `git diff --check` clean.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtGupfUEyokEr8GmKSVVuq)_