### PR TITLE
Fix Secret Scan multi-allowlist compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: .gitleaks.toml
+          GITLEAKS_VERSION: "8.25.1"
 
   browser-workstation:
     name: verify-fast (browser workstation)

--- a/tests/scripts/test_ci_workflow_contract.py
+++ b/tests/scripts/test_ci_workflow_contract.py
@@ -31,6 +31,7 @@ class CiWorkflowContractTests(unittest.TestCase):
 
         self.assertNotIn("if: github.event_name != 'pull_request'", secret_block)
         self.assertIn("gitleaks/gitleaks-action@v3", secret_block)
+        self.assertIn('GITLEAKS_VERSION: "8.25.1"', secret_block)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- pin the Secret Scan job to Gitleaks 8.25.1, the first patch release that both supports Meridian's plural global `[[allowlists]]` configuration and fixes evaluation across multiple allowlists
- retain the existing path-scoped catalog and test-fixture exclusions without widening them
- lock the compatible scanner version in the CI workflow contract test

## Root cause

Scheduled run [31558603360](https://github.com/rodoHasArrived/Meridian-main/actions/runs/31558603360) used the action's bundled Gitleaks 8.24.3 and scanned full history. That CLI predates plural global `[[allowlists]]`, so it silently ignored Meridian's scoped exceptions and reported 420 `generic-api-key` false positives:

- 419 deterministic generated schema fingerprints in `database/manifest/catalog.json`
- one deterministic `correlation-42` test fixture

Commit `304bb8df339ff990957fd76423167913dcaf9100` introduced neither class.

## Validation

- Gitleaks 8.24.3 full-history reproduction: 5,822 commits / 632.74 MB scanned; 420 findings
- Gitleaks 8.25.1 full-history validation: same 5,822 commits / 632.74 MB scanned; no leaks found
- positive control outside the scoped allowlists: one synthetic `generic-api-key` finding, proving the detector remains active
- `python3 -m unittest tests/scripts/test_ci_workflow_contract.py`: 2 passed
- `bash scripts/ci.sh --lane verify-workflows`: passed; 759 script tests passed with only registered quarantines
- `bash scripts/ci.sh`: could not start because this environment does not provide `dotnet`; hosted GitHub Actions remains authoritative

This PR changes a protected governance file and therefore requires human review. It is intentionally draft and must not be merged without approval.