### PR TITLE
Write persisted OAuth tokens owner-only

### DIFF
--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -8750,6 +8750,7 @@ Meridian-main
 │   │   │   │   ├── ConfigSchemaIntegrationTests.cs
 │   │   │   │   ├── ConfigurationUnificationTests.cs
 │   │   │   │   ├── ConfigValidatorCliTests.cs
+│   │   │   │   ├── OAuthTokenPersistencePermissionTests.cs
 │   │   │   │   ├── ProviderCredentialResolverTests.cs
 │   │   │   │   └── ProviderCredentialStoreTests.cs
 │   │   │   ├── Coordination

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 643,
-  "total_lines": 124865,
+  "total_lines": 124866,
   "orphaned_count": 255,
   "no_heading_count": 148,
   "stale_count": 0,
@@ -2594,7 +2594,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 10395,
+      "line_count": 10396,
       "has_heading": true,
       "todo_count": 8,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 643 |
-| Total lines | 124,865 |
+| Total lines | 124,866 |
 | Average file size (lines) | 194.2 |
 | Orphaned files | 255 |
 | Files without headings | 148 |

--- a/src/Meridian.Application/Config/Credentials/OAuthTokenRefreshService.cs
+++ b/src/Meridian.Application/Config/Credentials/OAuthTokenRefreshService.cs
@@ -326,12 +326,47 @@ public sealed class OAuthTokenRefreshService : IAsyncDisposable
         return TokenStatus.Valid;
     }
 
+    private const UnixFileMode OwnerOnlyFileMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+
+    // A token file written before this change carries the umask default, and rewriting it only
+    // happens on the next refresh - which may be hours away, or never if the tokens are still
+    // valid. Tighten on read so an existing install is protected from startup rather than from
+    // whenever the next write happens to occur.
+    private void RestrictExistingTokenFile()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        try
+        {
+            var mode = File.GetUnixFileMode(_tokenPersistencePath);
+            if ((mode & ~OwnerOnlyFileMode) == UnixFileMode.None)
+            {
+                return;
+            }
+
+            File.SetUnixFileMode(_tokenPersistencePath, OwnerOnlyFileMode);
+            _log.Warning(
+                "Persisted OAuth tokens at {TokenPath} were reachable beyond their owner ({ExposedMode}); tightened to owner-only. Treat the stored access and refresh tokens as disclosed and revoke them.",
+                _tokenPersistencePath,
+                mode & ~OwnerOnlyFileMode);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+        {
+            _log.Warning(ex, "Could not verify permissions on persisted OAuth tokens at {TokenPath}", _tokenPersistencePath);
+        }
+    }
+
     private void LoadPersistedTokens()
     {
         try
         {
             if (!File.Exists(_tokenPersistencePath))
                 return;
+
+            RestrictExistingTokenFile();
 
             var json = File.ReadAllText(_tokenPersistencePath);
             var tokens = JsonSerializer.Deserialize<Dictionary<string, OAuthToken>>(json);
@@ -363,7 +398,10 @@ public sealed class OAuthTokenRefreshService : IAsyncDisposable
             var tokens = _tokens.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
             var json = JsonSerializer.Serialize(tokens, new JsonSerializerOptions { WriteIndented = true });
 
-            await AtomicFileWriter.WriteAsync(_tokenPersistencePath, json, ct);
+            // Access and refresh tokens are bearer secrets held in cleartext here, so unlike the
+            // provider vault there is no encryption behind the file mode - the mode is the whole
+            // of the protection. Owner-only from creation, never chmod'ed after the bytes land.
+            await AtomicFileWriter.WriteAsync(_tokenPersistencePath, json, OwnerOnlyFileMode, ct);
             _log.Debug("Persisted OAuth tokens for {Count} providers", tokens.Count);
         }
         catch (Exception ex)

--- a/src/Meridian.Storage/Archival/AtomicFileWriter.cs
+++ b/src/Meridian.Storage/Archival/AtomicFileWriter.cs
@@ -70,9 +70,25 @@ public static partial class AtomicFileWriter
     /// Atomically writes content to a file.
     /// Uses a temporary file with rename to ensure atomicity.
     /// </summary>
+    public static Task WriteAsync(
+        string destinationPath,
+        string content,
+        CancellationToken ct = default)
+        => WriteAsync(destinationPath, content, unixCreateMode: null, ct);
+
+    /// <summary>
+    /// Atomically writes text content to a file, creating it with an explicit Unix permission mode.
+    /// </summary>
+    /// <remarks>
+    /// Text counterpart of the <see cref="byte"/>-array overload, with the same contract: the mode
+    /// is applied at creation rather than chmod'ed afterwards, and it suppresses the copy of the
+    /// destination's security metadata so an existing over-permissive file cannot re-widen its
+    /// replacement. Ignored on Windows, where ACLs rather than mode bits govern.
+    /// </remarks>
     public static async Task WriteAsync(
         string destinationPath,
         string content,
+        UnixFileMode? unixCreateMode,
         CancellationToken ct = default)
     {
         var directory = Path.GetDirectoryName(destinationPath);
@@ -87,13 +103,20 @@ public static partial class AtomicFileWriter
         try
         {
             // Write to temp file (no BOM: readers token-split the raw content, e.g. checksum sidecars)
-            await File.WriteAllTextAsync(tempPath, content, Utf8NoBom, ct);
+            if (unixCreateMode is { } mode && !OperatingSystem.IsWindows())
+            {
+                await WriteAllBytesWithModeAsync(tempPath, Utf8NoBom.GetBytes(content), mode, ct);
+            }
+            else
+            {
+                await File.WriteAllTextAsync(tempPath, content, Utf8NoBom, ct);
+            }
 
             // Sync the temp file to disk while it is still writable, before copying any
             // (possibly read-only) security metadata from the destination onto it.
             await SyncFileAsync(tempPath, ct);
 
-            if (destinationExists)
+            if (destinationExists && unixCreateMode is null)
             {
                 CopySecurityMetadata(destinationPath, tempPath);
             }

--- a/tests/Meridian.Tests/Application/Config/OAuthTokenPersistencePermissionTests.cs
+++ b/tests/Meridian.Tests/Application/Config/OAuthTokenPersistencePermissionTests.cs
@@ -1,0 +1,101 @@
+using FluentAssertions;
+using Meridian.Application.Config.Credentials;
+using Meridian.DataIntegration.Credentials;
+using Xunit;
+
+namespace Meridian.Tests.Application.Config;
+
+/// <summary>
+/// `.mdc/oauth_tokens.json` holds access and refresh tokens in cleartext. Unlike the provider
+/// credential vault there is no encryption behind it, so on Unix the file mode is the entirety of
+/// the protection. These pin that it is owner-only from creation, and repaired if an earlier
+/// release left it readable.
+/// </summary>
+public sealed class OAuthTokenPersistencePermissionTests : IDisposable
+{
+    private const UnixFileMode OwnerOnly = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+    private const UnixFileMode WorldReadable =
+        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead;
+
+    private readonly string _root;
+
+    public OAuthTokenPersistencePermissionTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "meridian-tests", "oauth-tokens", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    private string TokenPath => Path.Combine(_root, ".mdc", "oauth_tokens.json");
+
+    private static OAuthToken SampleToken() => new(
+        AccessToken: "access-secret",
+        TokenType: "Bearer",
+        ExpiresAt: DateTimeOffset.UtcNow.AddHours(1),
+        RefreshToken: "refresh-secret");
+
+    [Fact]
+    public async Task StoreTokenAsync_WritesTheTokenFileOwnerOnly()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        await using var service = new OAuthTokenRefreshService(_root);
+
+        await service.StoreTokenAsync("alpaca", SampleToken());
+
+        File.Exists(TokenPath).Should().BeTrue();
+        File.GetUnixFileMode(TokenPath).Should().Be(
+            OwnerOnly,
+            "the tokens are stored in cleartext, so the file mode is the only thing protecting them");
+    }
+
+    // Rewriting only happens on the next refresh, which may be hours away or never while the tokens
+    // remain valid. Repair therefore has to happen on load, not on write.
+    [Fact]
+    public async Task Construction_TightensATokenFileLeftReadableByAnEarlierRelease()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        await using (var seed = new OAuthTokenRefreshService(_root))
+        {
+            await seed.StoreTokenAsync("alpaca", SampleToken());
+        }
+
+        File.SetUnixFileMode(TokenPath, WorldReadable);
+
+        await using var reopened = new OAuthTokenRefreshService(_root);
+
+        File.GetUnixFileMode(TokenPath).Should().Be(OwnerOnly);
+        reopened.GetToken("alpaca").Should().NotBeNull("tightening permissions must not cost the tokens");
+        reopened.GetToken("alpaca")!.AccessToken.Should().Be("access-secret");
+    }
+
+    [Fact]
+    public async Task RewritingAnAlreadyTightenedFileKeepsItOwnerOnly()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        await using var service = new OAuthTokenRefreshService(_root);
+        await service.StoreTokenAsync("alpaca", SampleToken());
+
+        await service.StoreTokenAsync("polygon", SampleToken());
+
+        File.GetUnixFileMode(TokenPath).Should().Be(OwnerOnly);
+    }
+}

--- a/tests/Meridian.Tests/Storage/AtomicFileWriterTests.cs
+++ b/tests/Meridian.Tests/Storage/AtomicFileWriterTests.cs
@@ -352,8 +352,9 @@ public sealed class AtomicFileWriterTests : TempDirectoryTestBase
         await AtomicFileWriter.WriteAsync(
             path, "Hello 世界", UnixFileMode.UserRead | UnixFileMode.UserWrite);
 
+        // Byte-exact against a BOM-free encode: this pins both "no BOM" and the content in one
+        // assertion, where a prefix check would only rule out the three bytes it names.
         var bytes = await File.ReadAllBytesAsync(path);
-        bytes.Should().NotStartWith(new byte[] { 0xEF, 0xBB, 0xBF });
-        (await File.ReadAllTextAsync(path, Encoding.UTF8)).Should().Be("Hello 世界");
+        bytes.Should().Equal(Encoding.UTF8.GetBytes("Hello 世界"));
     }
 }

--- a/tests/Meridian.Tests/Storage/AtomicFileWriterTests.cs
+++ b/tests/Meridian.Tests/Storage/AtomicFileWriterTests.cs
@@ -301,4 +301,59 @@ public sealed class AtomicFileWriterTests : TempDirectoryTestBase
 
         File.GetUnixFileMode(path).Should().Be(UnixFileMode.UserRead | UnixFileMode.UserWrite);
     }
+
+    [Fact]
+    public async Task WriteAsync_String_AppliesRequestedUnixCreateMode()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var path = Path.Combine(TestDataRoot, "secret.json");
+
+        await AtomicFileWriter.WriteAsync(
+            path, "{\"token\":\"secret\"}", UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        File.GetUnixFileMode(path).Should().Be(UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        (await File.ReadAllTextAsync(path)).Should().Be("{\"token\":\"secret\"}");
+    }
+
+    [Fact]
+    public async Task WriteAsync_String_ExplicitModeOverridesAnExistingWiderMode()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var path = Path.Combine(TestDataRoot, "widened.json");
+        await File.WriteAllTextAsync(path, "old");
+        File.SetUnixFileMode(
+            path, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+
+        await AtomicFileWriter.WriteAsync(path, "new", UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        File.GetUnixFileMode(path).Should().Be(UnixFileMode.UserRead | UnixFileMode.UserWrite);
+    }
+
+    // The text overload writes through a byte path when a mode is requested; a BOM there would
+    // corrupt readers that token-split the raw content, so encoding must not change with the mode.
+    [Fact]
+    public async Task WriteAsync_String_WithModeStillWritesUtf8WithoutABom()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var path = Path.Combine(TestDataRoot, "nobom.txt");
+
+        await AtomicFileWriter.WriteAsync(
+            path, "Hello 世界", UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        var bytes = await File.ReadAllBytesAsync(path);
+        bytes.Should().NotStartWith(new byte[] { 0xEF, 0xBB, 0xBF });
+        (await File.ReadAllTextAsync(path, Encoding.UTF8)).Should().Be("Hello 世界");
+    }
 }


### PR DESCRIPTION
## Summary

`.mdc/oauth_tokens.json` holds OAuth **access and refresh tokens in cleartext**, in the same directory as the provider credential vault, and was written at the umask default — `0644` on a typical Linux host. Any local account could read live bearer credentials for every connected provider.

This is the exposure I found while fixing the vault key in #2677 and deliberately scoped out of that PR as belonging to a different service. The `AtomicFileWriter` seam #2677 added is what makes this a small change, so it's the natural follow-on.

Two differences from the vault key make this **worse**, not equivalent:

- The vault is ciphertext, so its key file was the thing needing protection. Here there is no encryption at all — the file mode is the entirety of the protection.
- A vault key is only useful alongside the vault it opens. An access token is useful on its own, to anyone, against a live third-party API.

Changes:

- **`AtomicFileWriter`** gains the text counterpart of the `byte[]` mode overload from #2677, same contract: applied at creation via `FileStreamOptions.UnixCreateMode` rather than chmod'ed afterwards, and suppressing the destination's security-metadata copy so replacing an over-permissive file cannot restore its mode. The existing three-argument overload delegates with no mode and is unchanged.
- **`OAuthTokenRefreshService`** writes the token file `0600`, and tightens it **on load** as well as on write. Rewriting only happens on the next refresh — hours away, or never while the tokens remain valid — so repairing on write alone would leave an existing install exposed indefinitely. The warning names the tokens as disclosed and says to revoke them, because unlike a local vault key they can be replayed remotely.

**Deliberately not changed:** `credential_status.json`, written to the same directory by `CredentialTestingService`. `StoredCredentialStatus` carries a provider name, timestamps, a status enum, and a failure count — no secret material. Tightening it would be applying the pattern rather than fixing an exposure.

**Known inconsistency this does not resolve:** whichever service creates `.mdc` first decides its mode, and only `FileProviderCredentialStore` narrows it. The file's own mode protects the tokens either way, but that directory would be better with a single owner than with two services each deciding.

## Reason

Advances #2649 (PRD-002, P0 release-blocker), whose scope covers credential persistence. **Does not close it** — the OS keyring / KMS mechanism, rotation, and two-account isolation all remain, as recorded in the issue.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Six tests, all guarded to skip on Windows where ACLs rather than mode bits govern:

`OAuthTokenPersistencePermissionTests` (new) — `StoreTokenAsync` writes the file owner-only; a file left world-readable by an earlier release is tightened at construction **and the tokens still load**; and rewriting an already-tightened file keeps it owner-only.

`AtomicFileWriterTests` — the text overload applies the requested mode; an explicit mode overrides an existing wider one; and it still writes UTF-8 **without a BOM** when a mode is given, since supplying a mode routes through a byte path and a BOM there would corrupt readers that token-split raw content.

`dotnet` is unavailable in this container, so the .NET lane runs on a hosted runner via `Targeted Test`. Local gates run here: file-size ratchet OK, `git diff --check` clean, source-README validation clean, and generated docs regenerated to convergence.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtGupfUEyokEr8GmKSVVuq)_