### PR TITLE
Route ComputeSha256 through the canonical Sha256Digest primitive

### DIFF
--- a/src/Meridian.Ledger/LedgerReportPackBuilder.cs
+++ b/src/Meridian.Ledger/LedgerReportPackBuilder.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Json;
 
 using static Meridian.Contracts.Ledger.LedgerCurrencyRounding;
+using Meridian.Contracts.Integrity;
 
 namespace Meridian.Ledger;
 
@@ -53,7 +54,7 @@ public static class LedgerReportPackBuilder
 
         var signature = new LedgerReportPackSignature(
             "SHA256",
-            ComputeSha256(payload),
+            Sha256Digest.ComputeUtf8(payload),
             request.GeneratedBy,
             request.GeneratedAtUtc);
 
@@ -170,13 +171,13 @@ public static class LedgerReportPackBuilder
         }
 
         var content = builder.ToString();
-        return new LedgerReportPackArtifact("tax-lot-realized-gains.csv", "text/csv", content, ComputeSha256(content));
+        return new LedgerReportPackArtifact("tax-lot-realized-gains.csv", "text/csv", content, Sha256Digest.ComputeUtf8(content));
     }
 
     private static LedgerReportPackArtifact CreateCsvArtifact(string name, IReadOnlyList<LedgerChartBalance> rows)
     {
         var content = BuildCsv(rows);
-        return new LedgerReportPackArtifact(name, "text/csv", content, ComputeSha256(content));
+        return new LedgerReportPackArtifact(name, "text/csv", content, Sha256Digest.ComputeUtf8(content));
     }
 
     private static LedgerReportPackArtifact CreateCashFlowArtifact(string name, LedgerCashFlowStatement? cashFlow)
@@ -207,7 +208,7 @@ public static class LedgerReportPackBuilder
         }
 
         var content = builder.ToString();
-        return new LedgerReportPackArtifact(name, "text/csv", content, ComputeSha256(content));
+        return new LedgerReportPackArtifact(name, "text/csv", content, Sha256Digest.ComputeUtf8(content));
     }
 
     private static void AppendCashFlowTotal(StringBuilder builder, string label, decimal amount)
@@ -273,7 +274,7 @@ public static class LedgerReportPackBuilder
         }
 
         var content = builder.ToString();
-        return new LedgerReportPackArtifact(name, "text/csv", content, ComputeSha256(content));
+        return new LedgerReportPackArtifact(name, "text/csv", content, Sha256Digest.ComputeUtf8(content));
     }
 
     private static LedgerReportPackArtifact CreateFinancialStatementsJsonArtifact(
@@ -308,7 +309,7 @@ public static class LedgerReportPackBuilder
         builder.AppendLine("}");
 
         var content = builder.ToString();
-        return new LedgerReportPackArtifact("financial-statements.json", "application/json", content, ComputeSha256(content));
+        return new LedgerReportPackArtifact("financial-statements.json", "application/json", content, Sha256Digest.ComputeUtf8(content));
     }
 
     private static void AppendRows(
@@ -384,7 +385,7 @@ public static class LedgerReportPackBuilder
         }
 
         var content = builder.ToString();
-        return new LedgerReportPackArtifact("manifest.csv", "text/csv", content, ComputeSha256(content));
+        return new LedgerReportPackArtifact("manifest.csv", "text/csv", content, Sha256Digest.ComputeUtf8(content));
     }
 
     private static IReadOnlyList<LedgerReportLineProvenance> BuildLineProvenance(
@@ -477,7 +478,7 @@ public static class LedgerReportPackBuilder
         }
 
         var content = builder.ToString();
-        return new LedgerReportPackArtifact("line-provenance.csv", "text/csv", content, ComputeSha256(content));
+        return new LedgerReportPackArtifact("line-provenance.csv", "text/csv", content, Sha256Digest.ComputeUtf8(content));
     }
 
     private static string BuildCsv(IReadOnlyList<LedgerChartBalance> rows)
@@ -545,12 +546,6 @@ public static class LedgerReportPackBuilder
 
     private static bool MatchesLineDimensions(LedgerLineDimensionSet? actual, LedgerLineDimensionSet? expected)
         => LedgerLineDimensionSetNormalizer.Matches(actual, expected);
-
-    private static string ComputeSha256(string value)
-    {
-        var bytes = Encoding.UTF8.GetBytes(value);
-        return Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
-    }
 
     private static string FormatDecimal(decimal value)
         => value.ToString("0.############################", CultureInfo.InvariantCulture);

--- a/src/Meridian.Ledger/LedgerScheduledReportExportPackageBuilder.cs
+++ b/src/Meridian.Ledger/LedgerScheduledReportExportPackageBuilder.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using System.Xml;
+using Meridian.Contracts.Integrity;
 
 namespace Meridian.Ledger;
 
@@ -195,11 +196,14 @@ public static class LedgerScheduledReportExportPackageBuilder
         return new LedgerReportPackArtifact("regulatory-summary.xml", "application/xml", content, ComputeSha256(content));
     }
 
+    // Both overloads delegate rather than being replaced at the call sites: this type declares
+    // two of them, so a name-only rewrite cannot tell which one a given call meant. The duplicated
+    // hashing is gone either way, which is the part that could drift.
     private static string ComputeSha256(string value)
-        => ComputeSha256(Encoding.UTF8.GetBytes(value));
+        => Sha256Digest.ComputeUtf8(value);
 
     private static string ComputeSha256(byte[] bytes)
-        => Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+        => Sha256Digest.Compute(bytes);
 
     private static string FormatDecimal(decimal value)
         => value.ToString("0.############################", CultureInfo.InvariantCulture);

--- a/src/Meridian.Reporting/ReportingCertifiedManifestValidation.cs
+++ b/src/Meridian.Reporting/ReportingCertifiedManifestValidation.cs
@@ -174,7 +174,7 @@ public static class ReportingCertifiedManifestValidation
             writer.WriteEndArray();
         }
 
-        return ComputeSha256(stream.ToArray());
+        return Sha256Digest.Compute(stream.ToArray());
     }
 
     public static string ComputeSnapshotHash(ReportingOutputManifest manifest)
@@ -227,7 +227,7 @@ public static class ReportingCertifiedManifestValidation
                 readinessHash = manifest.Readiness.EvidenceHash,
                 certifiedDatasetHash = ComputeCertifiedRowsHash(manifest.CertifiedDatasetRows)
             });
-        return ComputeSha256(Encoding.UTF8.GetBytes(payload));
+        return Sha256Digest.Compute(Encoding.UTF8.GetBytes(payload));
     }
 
     private static bool IsUtc(DateTimeOffset value) =>
@@ -248,6 +248,4 @@ public static class ReportingCertifiedManifestValidation
             _ => "Primary"
         };
 
-    private static string ComputeSha256(ReadOnlySpan<byte> value) =>
-        Convert.ToHexString(SHA256.HashData(value)).ToLowerInvariant();
 }

--- a/src/Meridian.Reporting/ReportingOrchestrationService.cs
+++ b/src/Meridian.Reporting/ReportingOrchestrationService.cs
@@ -670,7 +670,7 @@ public sealed class ReportingOrchestrationService : IReportingOrchestrationServi
             || !Sha256Digest.IsWellFormed(snapshot.ReconciliationCheckpointHash)
             || !Sha256Digest.IsWellFormed(parametersHash)
             || string.IsNullOrWhiteSpace(parametersJson)
-            || !string.Equals(ComputeSha256(parametersJson), parametersHash, StringComparison.OrdinalIgnoreCase)
+            || !string.Equals(Sha256Digest.ComputeUtf8(parametersJson), parametersHash, StringComparison.OrdinalIgnoreCase)
             || source.AsOfDate != contract.AsOfDate
             || parameters.AsOfDate != contract.AsOfDate
             || !string.Equals(source.AccountingBasis, expectedBasis, StringComparison.Ordinal)
@@ -1586,9 +1586,6 @@ public sealed class ReportingOrchestrationService : IReportingOrchestrationServi
 
     private static int ResolveRunAttemptOrdinal(ReportingOutputManifest manifest)
         => manifest.RunAttemptOrdinal is > 0 ? manifest.RunAttemptOrdinal.Value : 1;
-
-    private static string ComputeSha256(string value) =>
-        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value))).ToLowerInvariant();
 
     private sealed record ReportingRunVersionPlan(
         string RunSeriesId,

--- a/src/Meridian.Storage/Reporting/PostgresReportingArtifactCatalog.cs
+++ b/src/Meridian.Storage/Reporting/PostgresReportingArtifactCatalog.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using Meridian.Reporting;
 using Npgsql;
 using NpgsqlTypes;
+using Meridian.Contracts.Integrity;
 
 namespace Meridian.Storage.Reporting;
 
@@ -36,12 +37,12 @@ public sealed class PostgresReportingArtifactCatalog : IReportingArtifactCatalog
         ArgumentNullException.ThrowIfNull(package);
         var tenantId = ValidatePackage(package);
         var packagePayload = SerializePackage(package);
-        var packageHash = ComputeSha256(packagePayload);
+        var packageHash = Sha256Digest.ComputeUtf8(packagePayload);
         var artifactPayloads = package.Artifacts
             .Select(static artifact =>
             {
                 var payload = SerializeArtifact(artifact);
-                return new SerializedArtifact(artifact.ArtifactId, payload, ComputeSha256(payload));
+                return new SerializedArtifact(artifact.ArtifactId, payload, Sha256Digest.ComputeUtf8(payload));
             })
             .ToArray();
 
@@ -678,16 +679,13 @@ public sealed class PostgresReportingArtifactCatalog : IReportingArtifactCatalog
                 $"Retained {label} carries an invalid SHA-256 hash.");
         }
 
-        var actualHash = ComputeSha256(payload);
+        var actualHash = Sha256Digest.ComputeUtf8(payload);
         if (!string.Equals(declaredHash, actualHash, StringComparison.Ordinal))
         {
             throw new ReportingArtifactCatalogIntegrityException(
                 $"Retained {label} hash '{declaredHash}' does not match payload hash '{actualHash}'.");
         }
     }
-
-    private static string ComputeSha256(string payload) =>
-        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(payload))).ToLowerInvariant();
 
     private static void AddArtifactKeyParameters(
         NpgsqlCommand command,

--- a/src/Meridian.Storage/Reporting/PostgresReportingArtifactStore.cs
+++ b/src/Meridian.Storage/Reporting/PostgresReportingArtifactStore.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography;
 using Meridian.Reporting;
 using Npgsql;
 using NpgsqlTypes;
+using Meridian.Contracts.Integrity;
 
 namespace Meridian.Storage.Reporting;
 
@@ -167,7 +168,7 @@ public sealed class PostgresReportingArtifactStore : IReportingArtifactStore
         // Clone caller-owned memory before hashing or awaiting so mutations cannot change the bytes
         // between identity calculation and persistence.
         var content = request.Content.ToArray();
-        var contentHash = ComputeSha256(content);
+        var contentHash = Sha256Digest.Compute(content);
         return new PreparedArtifactWrite(
             new ReportingArtifactIdentity(tenantId, contentHash),
             content);
@@ -258,7 +259,7 @@ public sealed class PostgresReportingArtifactStore : IReportingArtifactStore
                 $"declared size {row.DeclaredByteSize} does not match retained size {row.PhysicalByteSize}");
         }
 
-        var actualHash = ComputeSha256(row.Content);
+        var actualHash = Sha256Digest.Compute(row.Content);
         if (!string.Equals(actualHash, identity.ContentHashSha256, StringComparison.Ordinal))
         {
             throw new ReportingArtifactIntegrityException(
@@ -303,9 +304,6 @@ public sealed class PostgresReportingArtifactStore : IReportingArtifactStore
 
         return normalized;
     }
-
-    private static string ComputeSha256(byte[] content) =>
-        Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant();
 
     private static DateTimeOffset ReadUtcTimestamp(NpgsqlDataReader reader, int ordinal) =>
         new(DateTime.SpecifyKind(reader.GetDateTime(ordinal), DateTimeKind.Utc));

--- a/src/Meridian.Storage/Reporting/PostgresReportingGovernanceRepository.cs
+++ b/src/Meridian.Storage/Reporting/PostgresReportingGovernanceRepository.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using Meridian.Reporting;
 using Npgsql;
 using NpgsqlTypes;
+using Meridian.Contracts.Integrity;
 
 namespace Meridian.Storage.Reporting;
 
@@ -345,7 +346,7 @@ public sealed class PostgresReportingGovernanceRepository : IReportingGovernance
             ValidateRunForWrite(run, expectedVersion: null);
 
             var payload = SerializeRun(run with { AuditTrail = [] });
-            var payloadHash = ComputeSha256(payload);
+            var payloadHash = Sha256Digest.ComputeUtf8(payload);
 
             try
             {
@@ -424,7 +425,7 @@ public sealed class PostgresReportingGovernanceRepository : IReportingGovernance
             }
 
             var payload = SerializeRun(run with { AuditTrail = [] });
-            var payloadHash = ComputeSha256(payload);
+            var payloadHash = Sha256Digest.ComputeUtf8(payload);
             await using var command = CreateCommand();
             command.CommandText =
                 $"""
@@ -550,7 +551,7 @@ public sealed class PostgresReportingGovernanceRepository : IReportingGovernance
             ValidateRestatementForWrite(tenantId, request, expectedVersion: null);
 
             var payload = SerializeRestatement(request with { AuditTrail = [] });
-            var payloadHash = ComputeSha256(payload);
+            var payloadHash = Sha256Digest.ComputeUtf8(payload);
 
             try
             {
@@ -605,7 +606,7 @@ public sealed class PostgresReportingGovernanceRepository : IReportingGovernance
             ValidateRestatementForWrite(tenantId, request, expectedVersion);
 
             var payload = SerializeRestatement(request with { AuditTrail = [] });
-            var payloadHash = ComputeSha256(payload);
+            var payloadHash = Sha256Digest.ComputeUtf8(payload);
             await using var command = CreateCommand();
             command.CommandText =
                 $"""
@@ -1060,7 +1061,7 @@ public sealed class PostgresReportingGovernanceRepository : IReportingGovernance
                     row.AggregateVersion,
                     row.StateFormatVersion,
                     row.StateHashSha256,
-                    StringComparer.Ordinal.Equals(ComputeSha256(row.StatePayload), row.StateHashSha256),
+                    StringComparer.Ordinal.Equals(Sha256Digest.ComputeUtf8(row.StatePayload), row.StateHashSha256),
                     exception.Message);
             }
         }
@@ -1156,7 +1157,7 @@ public sealed class PostgresReportingGovernanceRepository : IReportingGovernance
                     row.AggregateVersion,
                     row.StateFormatVersion,
                     row.StateHashSha256,
-                    StringComparer.Ordinal.Equals(ComputeSha256(row.StatePayload), row.StateHashSha256),
+                    StringComparer.Ordinal.Equals(Sha256Digest.ComputeUtf8(row.StatePayload), row.StateHashSha256),
                     exception.Message);
             }
         }
@@ -1417,7 +1418,7 @@ public sealed class PostgresReportingGovernanceRepository : IReportingGovernance
             AppendLegacyCanonical(canonical, entry.ToRestatementState is null ? null : (int)entry.ToRestatementState.Value);
             AppendLegacyCanonical(canonical, entry.Note);
             AppendLegacyCanonical(canonical, entry.PreviousHash);
-            return ComputeSha256(canonical.ToString());
+            return Sha256Digest.ComputeUtf8(canonical.ToString());
         }
 
         private static void AppendLegacyCanonical(StringBuilder target, object? value)
@@ -1484,7 +1485,7 @@ public sealed class PostgresReportingGovernanceRepository : IReportingGovernance
                 (object?)entry.PreviousHash ?? DBNull.Value);
             command.Parameters.AddWithValue("event_hash", NpgsqlDbType.Text, entry.Hash);
             command.Parameters.AddWithValue("event_payload", NpgsqlDbType.Text, payload);
-            command.Parameters.AddWithValue("payload_hash_sha256", NpgsqlDbType.Text, ComputeSha256(payload));
+            command.Parameters.AddWithValue("payload_hash_sha256", NpgsqlDbType.Text, Sha256Digest.ComputeUtf8(payload));
             command.Parameters.AddWithValue("hash_format_version", NpgsqlDbType.Smallint, CurrentFormatVersion);
             await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
@@ -1814,7 +1815,7 @@ public sealed class PostgresReportingGovernanceRepository : IReportingGovernance
 
         private static void VerifyPayloadChecksum(string kind, string id, string payload, string expectedHash)
         {
-            var actualHash = ComputeSha256(payload);
+            var actualHash = Sha256Digest.ComputeUtf8(payload);
             if (!StringComparer.Ordinal.Equals(actualHash, expectedHash))
             {
                 throw Integrity(kind, id, $"payload SHA-256 {actualHash} does not match retained checksum {expectedHash}");
@@ -1906,9 +1907,6 @@ public sealed class PostgresReportingGovernanceRepository : IReportingGovernance
                 throw Integrity("reporting governance audit event", id, "the retained event payload is invalid JSON", exception);
             }
         }
-
-        private static string ComputeSha256(string value) =>
-            Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value))).ToLowerInvariant();
 
         private static string NormalizeKey(string value, string parameterName)
         {

--- a/src/Meridian.Storage/Reporting/PostgresReportingReconciliationEvidenceStore.cs
+++ b/src/Meridian.Storage/Reporting/PostgresReportingReconciliationEvidenceStore.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using Meridian.Reporting;
 using Npgsql;
 using NpgsqlTypes;
+using Meridian.Contracts.Integrity;
 
 namespace Meridian.Storage.Reporting;
 
@@ -109,7 +110,7 @@ public sealed class PostgresReportingReconciliationEvidenceStore :
         var payload = JsonSerializer.Serialize(
             receipt,
             ReportingReconciliationEvidenceJsonContext.Default.ReportingReconciliationEvidenceReceipt);
-        var payloadHash = ComputeSha256(payload);
+        var payloadHash = Sha256Digest.ComputeUtf8(payload);
         await using var connection = new NpgsqlConnection(_options.ConnectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
@@ -599,7 +600,7 @@ public sealed class PostgresReportingReconciliationEvidenceStore :
         DateOnly asOfDate,
         string sourceCheckpointId,
         string sourceCheckpointHash) =>
-        ComputeSha256(string.Join('\n',
+        Sha256Digest.ComputeUtf8(string.Join('\n',
             NormalizeKey(tenantId, nameof(tenantId)),
             NormalizeKey(organizationId, nameof(organizationId)),
             NormalizeKey(companyId, nameof(companyId)),
@@ -616,15 +617,12 @@ public sealed class PostgresReportingReconciliationEvidenceStore :
     private static void VerifyPayloadHash(string payload, string declaredHash)
     {
         if (!ReportingReconciliationEvidenceValidation.IsLowercaseSha256(declaredHash)
-            || !string.Equals(declaredHash, ComputeSha256(payload), StringComparison.Ordinal))
+            || !string.Equals(declaredHash, Sha256Digest.ComputeUtf8(payload), StringComparison.Ordinal))
         {
             throw new ReportingArtifactCatalogIntegrityException(
                 "Retained reconciliation evidence payload hash verification failed.");
         }
     }
-
-    private static string ComputeSha256(string value) =>
-        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value))).ToLowerInvariant();
 
     private static string NormalizeKey(string? value, string parameterName)
     {

--- a/src/Meridian.Storage/Reporting/PostgresReportingRunStore.cs
+++ b/src/Meridian.Storage/Reporting/PostgresReportingRunStore.cs
@@ -1393,11 +1393,13 @@ internal static class ReportingOperationalStoreJson
         }
     }
 
+    // Delegating rather than rewriting call sites: this type declares both overloads and its
+    // callers qualify them, so which overload a call resolves to depends on the argument type.
     internal static string ComputeSha256(string value) =>
-        ComputeSha256(Encoding.UTF8.GetBytes(value));
+        Sha256Digest.ComputeUtf8(value);
 
     internal static string ComputeSha256(ReadOnlySpan<byte> value) =>
-        Convert.ToHexString(SHA256.HashData(value)).ToLowerInvariant();
+        Sha256Digest.Compute(value);
 
     private static void WriteCanonical(Utf8JsonWriter writer, JsonElement element)
     {

--- a/src/Meridian.Storage/Reporting/PostgresStatementReconciliationReportAuthorityStore.cs
+++ b/src/Meridian.Storage/Reporting/PostgresStatementReconciliationReportAuthorityStore.cs
@@ -248,7 +248,7 @@ public sealed class PostgresStatementReconciliationReportAuthorityStore :
         // Caller-owned memory may be mutated while persistence is awaiting I/O. Retain one exact
         // byte sequence for both the independently computed identity and the artifact-store write.
         var retainedContent = content.ToArray();
-        var expectedHash = ComputeSha256(retainedContent);
+        var expectedHash = Sha256Digest.Compute(retainedContent);
         var transactionalArtifactStore = RequireTransactionalArtifactStore();
 
         await using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
@@ -1008,9 +1008,6 @@ public sealed class PostgresStatementReconciliationReportAuthorityStore :
         return BinaryPrimitives.ReadInt64BigEndian(
             SHA256.HashData(Encoding.UTF8.GetBytes(canonicalIdentity)));
     }
-
-    private static string ComputeSha256(ReadOnlySpan<byte> content) =>
-        Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant();
 
     private static DateTimeOffset ReadUtcTimestamp(NpgsqlDataReader reader, int ordinal) =>
         new(DateTime.SpecifyKind(reader.GetDateTime(ordinal), DateTimeKind.Utc));

--- a/src/Meridian.Ui.Shared/Evidence/FileStatementReconciliationReportAuthorityStore.cs
+++ b/src/Meridian.Ui.Shared/Evidence/FileStatementReconciliationReportAuthorityStore.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Meridian.Core.IO;
 using Meridian.Reporting;
 using Meridian.Storage.Archival;
+using Meridian.Contracts.Integrity;
 
 namespace Meridian.Ui.Shared.Evidence;
 
@@ -100,7 +101,7 @@ public sealed class FileStatementReconciliationReportAuthorityStore
         var content = await File.ReadAllBytesAsync(path, cancellationToken).ConfigureAwait(false);
         var identity = new ReportingArtifactIdentity(
             normalizedScope.TenantId,
-            ComputeSha256(content));
+            Sha256Digest.Compute(content));
         var metadata = await ReadMetadataAsync(path, cancellationToken).ConfigureAwait(false);
         if (metadata is not null)
         {
@@ -147,7 +148,7 @@ public sealed class FileStatementReconciliationReportAuthorityStore
         var path = GetDocumentPath(document.Scope, document.DocumentKey);
         _pathGuard.EnsurePath(path);
         var content = await File.ReadAllBytesAsync(path, cancellationToken).ConfigureAwait(false);
-        var actualHash = ComputeSha256(content);
+        var actualHash = Sha256Digest.Compute(content);
         if (content.LongLength != document.ByteSize
             || !string.Equals(
                 actualHash,
@@ -180,7 +181,7 @@ public sealed class FileStatementReconciliationReportAuthorityStore
         var normalizedKey = NormalizeDocumentKey(documentKey);
         var path = GetDocumentPath(normalizedScope, normalizedKey);
         var bytes = content.ToArray();
-        var hash = ComputeSha256(bytes);
+        var hash = Sha256Digest.Compute(bytes);
         var now = DateTimeOffset.UtcNow;
         var existing = await GetDocumentAsync(normalizedScope, normalizedKey, cancellationToken)
             .ConfigureAwait(false);
@@ -505,9 +506,6 @@ public sealed class FileStatementReconciliationReportAuthorityStore
         || documentKey.StartsWith("artifacts/history/", StringComparison.Ordinal);
 
     private static string GetMetadataPath(string documentPath) => documentPath + MetadataSuffix;
-
-    private static string ComputeSha256(byte[] content) =>
-        Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant();
 
     private sealed record FileDocumentMetadata(
         string TenantId,

--- a/src/Meridian.Ui.Shared/Services/ProviderLedgerReconciliationService.Outcomes.cs
+++ b/src/Meridian.Ui.Shared/Services/ProviderLedgerReconciliationService.Outcomes.cs
@@ -19,6 +19,7 @@ using Meridian.Storage.Archival;
 using Meridian.Storage.SecurityMaster;
 using Meridian.Strategies.Services;
 using Microsoft.Extensions.Logging;
+using Meridian.Contracts.Integrity;
 
 namespace Meridian.Ui.Shared.Services;
 
@@ -39,7 +40,7 @@ public sealed partial class ProviderLedgerReconciliationService
             "{accountId}",
             summary.AccountId.ToString("D"),
             StringComparison.Ordinal);
-        var caseworkHash = ComputeSha256(string.Join("\n", casework.CaseIds.Order(StringComparer.Ordinal)));
+        var caseworkHash = Sha256Digest.ComputeUtf8(string.Join("\n", casework.CaseIds.Order(StringComparer.Ordinal)));
         var evidence = new List<OperationEvidenceReference>
         {
             new(
@@ -622,7 +623,7 @@ public sealed partial class ProviderLedgerReconciliationService
         AppendCanonical(builder, "defaultBreakOwner", NormalizeOwner(request.DefaultBreakOwner) ?? "fund-accounting");
         AppendCanonical(builder, "signedOffBreakCount", request.SignedOffBreakKeys?.Count ?? 0);
         AppendCanonical(builder, "signedOffBy", NormalizeOwner(request.SignedOffBy));
-        return ComputeSha256(builder.ToString());
+        return Sha256Digest.ComputeUtf8(builder.ToString());
     }
 
     private static string ComputeOperationInputHash(
@@ -818,7 +819,7 @@ public sealed partial class ProviderLedgerReconciliationService
         AppendCanonical(builder, "scope.periodStart", scope?.Period?.StartDate);
         AppendCanonical(builder, "scope.periodEnd", scope?.Period?.EndDate);
         AppendCanonical(builder, "scope.asOfDate", scope?.AsOfDate);
-        return ComputeSha256(builder.ToString());
+        return Sha256Digest.ComputeUtf8(builder.ToString());
     }
 
     private static void AppendCanonical(StringBuilder builder, string key, object? value)
@@ -852,9 +853,6 @@ public sealed partial class ProviderLedgerReconciliationService
             IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture) ?? "<null>",
             _ => value.ToString()?.Trim() ?? "<null>"
         };
-
-    private static string ComputeSha256(string value)
-        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value))).ToLowerInvariant();
 
     private async Task<ProviderLedgerReconciliationRunIntent?> ReadRunIntentAsync(
         Guid accountId,
@@ -986,7 +984,7 @@ public sealed partial class ProviderLedgerReconciliationService
             $"{intent.AttemptNumber:D4}.json");
 
     private string BuildOperationDirectory(Guid accountId, string operationId)
-        => Path.Combine(BuildAccountDirectory(accountId), "operations", ComputeSha256(operationId));
+        => Path.Combine(BuildAccountDirectory(accountId), "operations", Sha256Digest.ComputeUtf8(operationId));
 
     private static string ToFileUri(string path)
         => new Uri(Path.GetFullPath(path)).AbsoluteUri;

--- a/src/Meridian.Ui.Shared/Services/ProviderLedgerReconciliationService.cs
+++ b/src/Meridian.Ui.Shared/Services/ProviderLedgerReconciliationService.cs
@@ -135,7 +135,7 @@ public sealed partial class ProviderLedgerReconciliationService
 
         var operationId = NormalizeOperationId(request.OperationId);
         var requestHash = ComputeRequestHash(accountId, accessScope, request);
-        var operationLockKey = $"{accountId:N}:{ComputeSha256(operationId)}";
+        var operationLockKey = $"{accountId:N}:{Meridian.Contracts.Integrity.Sha256Digest.ComputeUtf8(operationId)}";
         var operationGate = OperationLocks.GetOrAdd(operationLockKey, static _ => new SemaphoreSlim(1, 1));
         await operationGate.WaitAsync(ct).ConfigureAwait(false);
         try
@@ -1981,7 +1981,7 @@ public sealed partial class ProviderLedgerReconciliationService
                 .Append('|');
         }
 
-        return ComputeSha256(builder.ToString());
+        return Meridian.Contracts.Integrity.Sha256Digest.ComputeUtf8(builder.ToString());
     }
 
     private static ReconciliationBreakCategory MapCorporateActionCandidateCategory(

--- a/src/Meridian.Ui.Shared/Services/ReportingArtifactVaultService.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingArtifactVaultService.cs
@@ -115,7 +115,7 @@ public sealed class ReportingArtifactVaultService
         {
             cancellationToken.ThrowIfCancellationRequested();
             var content = artifact.Content.ToArray();
-            var expectedHash = ComputeSha256(content);
+            var expectedHash = Sha256Digest.Compute(content);
             var expectedIdentity = new ReportingArtifactIdentity(request.Scope.TenantId, expectedHash);
             var write = await _artifactStore
                 .StoreAsync(new ReportingArtifactWriteRequest(request.Scope.TenantId, content), cancellationToken)
@@ -453,7 +453,7 @@ public sealed class ReportingArtifactVaultService
                 nameof(request));
         }
 
-        var renderedManifestHash = ComputeSha256(manifestArtifacts[0].Content.Span);
+        var renderedManifestHash = Sha256Digest.Compute(manifestArtifacts[0].Content.Span);
         if (!string.Equals(renderedManifestHash, request.ManifestHash, StringComparison.OrdinalIgnoreCase))
         {
             throw new ArgumentException(
@@ -683,7 +683,7 @@ public sealed class ReportingArtifactVaultService
                 $"catalog size {record.ByteLength} does not match retrieved size {read.Content.LongLength}");
         }
 
-        var actualHash = ComputeSha256(read.Content);
+        var actualHash = Sha256Digest.Compute(read.Content);
         if (!string.Equals(actualHash, record.Identity.ContentHashSha256, StringComparison.OrdinalIgnoreCase))
         {
             throw new ReportingArtifactIntegrityException(
@@ -832,6 +832,4 @@ public sealed class ReportingArtifactVaultService
         string.IsNullOrWhiteSpace(left) && string.IsNullOrWhiteSpace(right)
         || Same(left, right);
 
-    private static string ComputeSha256(ReadOnlySpan<byte> content) =>
-        Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant();
 }

--- a/src/Meridian.Ui.Shared/Services/ReportingCertifiedArtifactProducer.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingCertifiedArtifactProducer.cs
@@ -135,7 +135,7 @@ public sealed class DeterministicReportingCertifiedArtifactProducer : IReporting
                 declaration.FileName,
                 declaration.ContentType,
                 content.LongLength,
-                ComputeSha256(content)));
+                Sha256Digest.Compute(content)));
         }
 
         descriptors.Add(new ReportingRetainedManifestArtifactDescriptor(
@@ -245,7 +245,7 @@ public sealed class DeterministicReportingCertifiedArtifactProducer : IReporting
             || !Sha256Digest.IsWellFormed(document.CertifiedDatasetHashSha256)
             || !Sha256Digest.IsWellFormed(document.ParametersHash)
             || !string.Equals(
-                ComputeSha256(Encoding.UTF8.GetBytes(document.ParametersCanonicalJson)),
+                Sha256Digest.Compute(Encoding.UTF8.GetBytes(document.ParametersCanonicalJson)),
                 document.ParametersHash,
                 StringComparison.OrdinalIgnoreCase))
         {
@@ -464,7 +464,7 @@ public sealed class DeterministicReportingCertifiedArtifactProducer : IReporting
         foreach (var artifact in reportPack.Artifacts)
         {
             if (!string.Equals(
-                    ComputeSha256(artifact.GetBytes()),
+                    Sha256Digest.Compute(artifact.GetBytes()),
                     artifact.ChecksumSha256,
                     StringComparison.OrdinalIgnoreCase))
             {
@@ -479,7 +479,7 @@ public sealed class DeterministicReportingCertifiedArtifactProducer : IReporting
                 .OrderBy(static artifact => artifact.Name, StringComparer.Ordinal)
                 .Select(static artifact => $"{artifact.Name}:{artifact.ChecksumSha256}"));
         if (!string.Equals(
-                ComputeSha256(Utf8(signaturePayload)),
+                Sha256Digest.Compute(Utf8(signaturePayload)),
                 reportPack.Signature.PayloadChecksumSha256,
                 StringComparison.OrdinalIgnoreCase))
         {
@@ -976,7 +976,7 @@ public sealed class DeterministicReportingCertifiedArtifactProducer : IReporting
             }
             writer.WriteEndArray();
         }
-        return ComputeSha256(stream.ToArray());
+        return Sha256Digest.Compute(stream.ToArray());
     }
 
     private static void AppendCsvRow(StringBuilder builder, params string?[] values)
@@ -1053,6 +1053,4 @@ public sealed class DeterministicReportingCertifiedArtifactProducer : IReporting
         stream.Write(bytes, 0, bytes.Length);
     }
 
-    private static string ComputeSha256(ReadOnlySpan<byte> content) =>
-        Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant();
 }

--- a/src/Meridian.Ui.Shared/Services/ReportingGovernanceCoordinatorService.ArtifactAccess.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingGovernanceCoordinatorService.ArtifactAccess.cs
@@ -114,14 +114,11 @@ public sealed partial class ReportingGovernanceCoordinatorService
     private static string BuildPackageId(GovernedReportingRun run)
     {
         var canonical = $"{run.Scope.TenantId}\n{run.RunId}\n{run.Revision.ToString(CultureInfo.InvariantCulture)}";
-        return $"report-package-{ComputeSha256(Encoding.UTF8.GetBytes(canonical))}";
+        return $"report-package-{Sha256Digest.Compute(Encoding.UTF8.GetBytes(canonical))}";
     }
 
     private static string BuildSourceCheckpointEvidence(string checkpointId, string checkpointHash) =>
         $"reporting-source-checkpoint:{checkpointId}:{checkpointHash.ToLowerInvariant()}";
-
-    private static string ComputeSha256(ReadOnlySpan<byte> content) =>
-        Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant();
 
     private static bool SameOptional(string? left, string? right) =>
         string.IsNullOrWhiteSpace(left) && string.IsNullOrWhiteSpace(right)

--- a/src/Meridian.Ui.Shared/Services/ReportingGovernanceCoordinatorService.ArtifactValidation.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingGovernanceCoordinatorService.ArtifactValidation.cs
@@ -125,7 +125,7 @@ public sealed partial class ReportingGovernanceCoordinatorService
                 artifact.ArtifactId,
                 production.ManifestArtifactId,
                 StringComparison.Ordinal);
-            var contentHash = ComputeSha256(artifact.Content.Span);
+            var contentHash = Sha256Digest.Compute(artifact.Content.Span);
             if (!descriptors.TryGetValue(artifact.ArtifactId, out var descriptor)
                 || !string.Equals(descriptor.FileName, artifact.FileName, StringComparison.Ordinal)
                 || !string.Equals(descriptor.ContentType, artifact.ContentType, StringComparison.Ordinal)
@@ -265,7 +265,7 @@ public sealed partial class ReportingGovernanceCoordinatorService
     {
         var manifestArtifact = production.Artifacts.Single(artifact =>
             string.Equals(artifact.ArtifactId, production.ManifestArtifactId, StringComparison.Ordinal));
-        var manifestHash = ComputeSha256(manifestArtifact.Content.Span);
+        var manifestHash = Sha256Digest.Compute(manifestArtifact.Content.Span);
         var retentionRequest = new ReportingArtifactPackageRetentionRequest(
             BuildPackageId(run),
             run.RunId,
@@ -325,7 +325,7 @@ public sealed partial class ReportingGovernanceCoordinatorService
                 || record.ByteLength != download.Content.LongLength
                 || !string.Equals(
                     record.Identity.ContentHashSha256,
-                    ComputeSha256(download.Content),
+                    Sha256Digest.Compute(download.Content),
                     StringComparison.OrdinalIgnoreCase))
             {
                 throw new ReportingArtifactCatalogIntegrityException(

--- a/src/Meridian.Ui.Shared/Services/ReportingGovernanceCoordinatorService.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingGovernanceCoordinatorService.cs
@@ -535,7 +535,7 @@ public sealed partial class ReportingGovernanceCoordinatorService : IReportingGo
             .ConfigureAwait(false);
         var descriptor = BuildArtifactDescriptor(run, download.Artifact, declaration);
         if (download.Content.LongLength != descriptor.ByteLength
-            || !string.Equals(ComputeSha256(download.Content), descriptor.ContentHashSha256, StringComparison.Ordinal))
+            || !string.Equals(Sha256Digest.Compute(download.Content), descriptor.ContentHashSha256, StringComparison.Ordinal))
         {
             throw new ReportingArtifactCatalogIntegrityException(
                 $"Retained artifact '{run.RunId}/{declaration.ArtifactId}' failed download verification.");
@@ -1475,7 +1475,7 @@ public sealed partial class ReportingGovernanceCoordinatorService : IReportingGo
 
     private static string ComputeRetainedSnapshotHash(ReportingRetainedManifestDocument document) =>
         document.Snapshot.RequiresCertifiedLedgerPresentation
-            ? ComputeSha256(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new
+            ? Sha256Digest.Compute(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new
             {
                 template = new
                 {
@@ -1493,7 +1493,7 @@ public sealed partial class ReportingGovernanceCoordinatorService : IReportingGo
                 certifiedDatasetHash = document.CertifiedDatasetHashSha256,
                 requiresCertifiedLedgerPresentation = true
             })))
-            : ComputeSha256(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new
+            : Sha256Digest.Compute(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new
             {
                 template = new
                 {
@@ -1547,7 +1547,7 @@ public sealed partial class ReportingGovernanceCoordinatorService : IReportingGo
                 || retained.ByteLength != produced.Content.Length
                 || !string.Equals(
                     retained.Identity.ContentHashSha256,
-                    ComputeSha256(produced.Content.Span),
+                    Sha256Digest.Compute(produced.Content.Span),
                     StringComparison.OrdinalIgnoreCase))
             {
                 throw new ReportingArtifactCatalogIntegrityException(
@@ -1649,7 +1649,7 @@ public sealed partial class ReportingGovernanceCoordinatorService : IReportingGo
             var canonical = SerializeCanonicalRow(row);
             var key = row.TryGetValue("entryId", out var entryId) && !string.IsNullOrWhiteSpace(entryId)
                 ? $"ledger-line:{entryId.Trim()}"
-                : $"ledger-row:{ComputeSha256(Encoding.UTF8.GetBytes(canonical))}";
+                : $"ledger-row:{Sha256Digest.Compute(Encoding.UTF8.GetBytes(canonical))}";
             if (!indexed.TryAdd(key, canonical))
             {
                 throw new ReportingGovernanceException(

--- a/src/Meridian.Ui.Shared/Services/ReportingRunStore.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingRunStore.cs
@@ -605,7 +605,7 @@ public sealed class FileReportingRunStore : IReportingRunStore, INonProductionOn
             var archivedAtUtc = DateTimeOffset.UtcNow;
             var archivedPayloadHash = ComputeLegacyEntriesHash(state.Snapshot.LegacyRuns);
             var receipt = new ReportingLegacyArchiveReceipt(
-                ComputeSha256(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new
+                Sha256Digest.Compute(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new
                 {
                     kind = "run",
                     actor = recoveryAuthority.ActorPrincipalId!.Trim(),
@@ -768,8 +768,8 @@ public sealed class FileReportingRunStore : IReportingRunStore, INonProductionOn
             run.Manifest.OperationalScope?.OrganizationId,
             run.Manifest.OperationalScope?.CompanyId,
             rawPayload,
-            ComputeSha256(Encoding.UTF8.GetBytes(rawPayload)),
-            ComputeSha256(Encoding.UTF8.GetBytes(canonicalPayload)),
+            Sha256Digest.Compute(Encoding.UTF8.GetBytes(rawPayload)),
+            Sha256Digest.Compute(Encoding.UTF8.GetBytes(canonicalPayload)),
             LegacyRunRemediation);
     }
 
@@ -837,10 +837,10 @@ public sealed class FileReportingRunStore : IReportingRunStore, INonProductionOn
                 || !string.Equals(entry.Remediation, LegacyRunRemediation, StringComparison.Ordinal)
                 || !Sha256Digest.FixedEquals(
                     entry.RawPayloadHashSha256,
-                    ComputeSha256(Encoding.UTF8.GetBytes(entry.RawPayloadJson)))
+                    Sha256Digest.Compute(Encoding.UTF8.GetBytes(entry.RawPayloadJson)))
                 || !Sha256Digest.FixedEquals(
                     entry.CanonicalPayloadHashSha256,
-                    ComputeSha256(Encoding.UTF8.GetBytes(CanonicalizeJson(entry.RawPayloadJson)))))
+                    Sha256Digest.Compute(Encoding.UTF8.GetBytes(CanonicalizeJson(entry.RawPayloadJson)))))
             {
                 throw new InvalidDataException(
                     "Archived legacy reporting run inventory checksum or schema is invalid.");
@@ -911,7 +911,7 @@ public sealed class FileReportingRunStore : IReportingRunStore, INonProductionOn
     // (or absent → default) array member, and hashing it directly would throw. Normalizing here
     // keeps hashing robust and consistent with the save-side computation.
     private string ComputeManifestHash(ReportingOutputManifest manifest) =>
-        ComputeSha256(Encoding.UTF8.GetBytes(
+        Sha256Digest.Compute(Encoding.UTF8.GetBytes(
             JsonSerializer.Serialize(NormalizeManifestArrays(manifest), _jsonOptions)));
 
     // A manifest can carry default (uninitialized) ImmutableArray members — most commonly on the
@@ -936,15 +936,15 @@ public sealed class FileReportingRunStore : IReportingRunStore, INonProductionOn
         value.IsDefault ? ImmutableArray<T>.Empty : value;
 
     private string ComputePayloadHash(IReadOnlyList<ReportingRunSnapshot> runs) =>
-        ComputeSha256(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(runs, _jsonOptions)));
+        Sha256Digest.Compute(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(runs, _jsonOptions)));
 
     private string ComputeLegacyEntriesHash(IReadOnlyList<LegacyReportingRunEntry> entries) =>
-        ComputeSha256(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(entries, _jsonOptions)));
+        Sha256Digest.Compute(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(entries, _jsonOptions)));
 
     private string ComputeLegacyPayloadHash(
         IReadOnlyList<LegacyReportingRunEntry> entries,
         ReportingLegacyArchiveReceipt? archiveReceipt) =>
-        ComputeSha256(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new
+        Sha256Digest.Compute(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new
         {
             entries,
             archiveReceipt
@@ -1060,7 +1060,7 @@ public sealed class FileReportingRunStore : IReportingRunStore, INonProductionOn
             throw new InvalidDataException("Legacy reporting run archive receipt is invalid.");
         }
 
-        var expectedArchiveId = ComputeSha256(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new
+        var expectedArchiveId = Sha256Digest.Compute(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new
         {
             kind = "run",
             actor = receipt.ActorPrincipalId,
@@ -1180,9 +1180,6 @@ public sealed class FileReportingRunStore : IReportingRunStore, INonProductionOn
         string runId) =>
         string.Equals(manifest.OperationalScope?.TenantId, tenantId, StringComparison.Ordinal)
         && string.Equals(manifest.RunId, runId, StringComparison.OrdinalIgnoreCase);
-
-    private static string ComputeSha256(ReadOnlySpan<byte> bytes) =>
-        Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
 
     private string SnapshotPath => Path.Combine(_options.RootDirectory, SnapshotFileName);
 

--- a/src/Meridian.Ui.Shared/Services/ReportingScheduleService.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingScheduleService.cs
@@ -403,7 +403,7 @@ public sealed partial class FileReportingScheduleStore : IReportingScheduleStore
             var archivedAtUtc = DateTimeOffset.UtcNow;
             var archivedPayloadHash = ComputeCanonicalHash(state.Snapshot.LegacySchedules);
             var receipt = new ReportingLegacyArchiveReceipt(
-                ComputeSha256(JsonSerializer.Serialize(new
+                Sha256Digest.ComputeUtf8(JsonSerializer.Serialize(new
                 {
                     kind = "schedule",
                     actor = recoveryAuthority.ActorPrincipalId!.Trim(),
@@ -531,8 +531,8 @@ public sealed partial class FileReportingScheduleStore : IReportingScheduleStore
             NormalizeOptional(schedule.TenantId),
             NormalizeOptional(schedule.CompanyId),
             rawPayload,
-            ComputeSha256(rawPayload),
-            ComputeSha256(CanonicalizeJson(rawPayload)),
+            Sha256Digest.ComputeUtf8(rawPayload),
+            Sha256Digest.ComputeUtf8(CanonicalizeJson(rawPayload)),
             LegacyScheduleRemediation);
     }
 
@@ -617,10 +617,10 @@ public sealed partial class FileReportingScheduleStore : IReportingScheduleStore
                 || (string.IsNullOrWhiteSpace(entry.TenantId) != string.IsNullOrWhiteSpace(entry.CompanyId))
                 || string.IsNullOrWhiteSpace(entry.RawPayloadJson)
                 || !string.Equals(entry.Remediation, LegacyScheduleRemediation, StringComparison.Ordinal)
-                || !Sha256Digest.FixedEquals(entry.RawPayloadHashSha256, ComputeSha256(entry.RawPayloadJson))
+                || !Sha256Digest.FixedEquals(entry.RawPayloadHashSha256, Sha256Digest.ComputeUtf8(entry.RawPayloadJson))
                 || !Sha256Digest.FixedEquals(
                     entry.CanonicalPayloadHashSha256,
-                    ComputeSha256(CanonicalizeJson(entry.RawPayloadJson))))
+                    Sha256Digest.ComputeUtf8(CanonicalizeJson(entry.RawPayloadJson))))
             {
                 throw new InvalidDataException(
                     "Archived legacy reporting schedule inventory checksum or schema is invalid.");
@@ -901,7 +901,7 @@ public sealed partial class FileReportingScheduleStore : IReportingScheduleStore
             throw new InvalidDataException("Legacy reporting schedule archive receipt is invalid.");
         }
 
-        var expectedId = ComputeSha256(JsonSerializer.Serialize(new
+        var expectedId = Sha256Digest.ComputeUtf8(JsonSerializer.Serialize(new
         {
             kind = "schedule",
             actor = receipt.ActorPrincipalId,
@@ -919,7 +919,7 @@ public sealed partial class FileReportingScheduleStore : IReportingScheduleStore
         IReadOnlyList<ReportingScheduleEntry> schedules,
         IReadOnlyList<LegacyReportingScheduleEntry> legacySchedules,
         ReportingLegacyArchiveReceipt? archiveReceipt) =>
-        ComputeSha256(JsonSerializer.Serialize(new
+        Sha256Digest.ComputeUtf8(JsonSerializer.Serialize(new
         {
             schedules,
             legacySchedules,
@@ -927,10 +927,7 @@ public sealed partial class FileReportingScheduleStore : IReportingScheduleStore
         }, _jsonOptions));
 
     private string ComputeCanonicalHash<T>(T value) =>
-        ComputeSha256(JsonSerializer.Serialize(value, _jsonOptions));
-
-    private static string ComputeSha256(string value) =>
-        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value))).ToLowerInvariant();
+        Sha256Digest.ComputeUtf8(JsonSerializer.Serialize(value, _jsonOptions));
 
     private static string CanonicalizeJson(string rawJson)
     {

--- a/src/Meridian.Ui.Shared/Services/ReportingSecureDistributionApplicationService.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingSecureDistributionApplicationService.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using Meridian.Reporting;
+using Meridian.Contracts.Integrity;
 
 namespace Meridian.Ui.Shared.Services;
 
@@ -636,7 +637,7 @@ public sealed class ReportingSecureDistributionApplicationService :
         }
 
         var eventId = NormalizeRequired(command.ProviderEventId, nameof(command.ProviderEventId), 512);
-        var receiptId = ComputeSha256(string.Join(
+        var receiptId = Sha256Digest.ComputeUtf8(string.Join(
             "\u001f",
             job.JobId,
             job.TransportId.ToLowerInvariant(),
@@ -1894,6 +1895,4 @@ public sealed class ReportingSecureDistributionApplicationService :
     private static bool SameOptional(string? left, string? right) =>
         string.IsNullOrWhiteSpace(left) && string.IsNullOrWhiteSpace(right) || Same(left, right);
 
-    private static string ComputeSha256(string value) =>
-        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value))).ToLowerInvariant();
 }


### PR DESCRIPTION
## Summary

Next tranche of #2614. Removes the duplicated SHA-256 hashing behind `ComputeSha256` — 20 declarations across 18 files — by routing it to the `Sha256Digest` primitive that #2610 already built.

## `IsSha256` is already done, and checking that first changed this change

The issue lists `IsSha256` at 18 files and warns it had *already* split into two incompatible families. That was the reason to take it first — but it landed with #2610 as PR #2637. `Sha256Digest` owns the predicate now, and the three surviving `IsSha256` declarations are thin delegations that add real semantics:

| File | Adds |
| --- | --- |
| `AccountingPostingCandidateService.cs` | `.Trim()` before validating |
| `AssetAccountingEventSpineService.cs` | rejects an all-zero digest |
| `AssetAccountingEventDtos.cs` | rejects an all-zero digest |

Those are deliberate and stay. Verifying it before starting is what redirected this to the half that was actually left.

## What this does

`Sha256Digest` already exposes exactly the two shapes needed — `Compute(ReadOnlySpan<byte>)` and `ComputeUtf8(string)` — and all 20 `ComputeSha256` declarations were behaviourally identical to them: SHA-256 → hex → lowercase. **No divergence this time**; `Convert.ToHexStringLower` and `Convert.ToHexString(...).ToLowerInvariant()` produce the same string, so unlike `NormalizeOptional` in #2688 there was no latent behaviour split to preserve.

- **16 files with a single overload** — call sites rewritten to `Sha256Digest.Compute` / `.ComputeUtf8`, private copy deleted. This is the pattern #2637 established.
- **2 files declaring both overloads** (`LedgerScheduledReportExportPackageBuilder`, `PostgresReportingRunStore`) — a name-only rewrite cannot tell which overload a call meant, so these keep their overloads as one-line delegations. The duplicated hashing is gone either way, which is the part that could drift.

## Reason

Partial fix for #2614; not closing it. Remaining: `Normalize` (26), `NormalizeCurrency` (19), `FormatBytes` (12), and the domain-owned canonicalisers.

## A finding worth separating from this PR

Grepping for the **hashing itself** rather than for helper names finds **275 inline `SHA256.HashData` sites** outside the primitive, against the 18 the helper-name audit found. Concentrated in `Meridian.Ui.Shared` and `Meridian.Strategies`:

```
9  StatementReconciliationReportWorkflowService.cs
8  ReportingAccessGrantService.cs
7  FileEvidenceArtifactStore.cs
6  ReportPackDeliveryService.cs
5  ReportingGovernanceCanonicalValidation.cs
```

Consolidating named helpers does not touch any of it. That is a far larger surface than #2614 describes, and it is where the next `IsSha256`-style divergence would hide — an open-coded hash has no name to audit. Flagging rather than folding it in; happy to file it separately.

## Testing performed

- [ ] Relevant unit tests were added or updated — not applicable; `Sha256DigestTests` already covers the primitive (added by #2637), and this only redirects callers to it
- [ ] `bash scripts/ci.sh` completed successfully — **not run; no .NET SDK in this environment**
- [ ] GitHub Actions `quality-gate` passed — pending
- [ ] Relevant integration tests were added or updated — not applicable

> **Not compiled locally.** Checked by inspection instead:
> - **0 orphaned callers.** Reaching that required fixing three partial-class siblings whose declaration lived in another file — the same hazard as #2688, and the reason a name-based sweep needs a caller check afterwards.
> - **Brace balance unchanged from HEAD** in every touched file.
> - Both existing ratchets exit `0`; docs generators idempotent.

`ProviderLedgerReconciliationService.cs` would have gone one line over its cap from the added `using`, and has two call sites, so those are fully qualified and the import dropped. Same trade as the previous tranche, where a one-call-site file got qualified and a 48-call-site file got a justified cap bump.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtGupfUEyokEr8GmKSVVuq)_