### PR TITLE
Add a scope contract suite run against both FundStructure implementations

### DIFF
--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -8094,7 +8094,9 @@ Meridian-main
 │   │   └── ValidationTests.fs
 │   ├── Meridian.FundStructure.Tests
 │   │   ├── EnvironmentDesignerServiceTests.cs
+│   │   ├── FakeFundStructureStore.cs
 │   │   ├── FundStructurePolicyServiceTests.cs
+│   │   ├── FundStructureScopeContractTests.cs
 │   │   ├── FundStructureSetupWorkflowServiceTests.cs
 │   │   ├── GlobalUsings.SecurityMasterConcerns.cs
 │   │   ├── GovernanceSharedDataAccessServiceTests.cs

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 646,
-  "total_lines": 126628,
+  "total_lines": 126630,
   "orphaned_count": 255,
   "no_heading_count": 148,
   "stale_count": 0,
@@ -2610,7 +2610,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 10431,
+      "line_count": 10433,
       "has_heading": true,
       "todo_count": 8,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 646 |
-| Total lines | 126,628 |
+| Total lines | 126,630 |
 | Average file size (lines) | 196.0 |
 | Orphaned files | 255 |
 | Files without headings | 148 |

--- a/tests/Meridian.FundStructure.Tests/FakeFundStructureStore.cs
+++ b/tests/Meridian.FundStructure.Tests/FakeFundStructureStore.cs
@@ -130,7 +130,7 @@ public sealed class FakeFundStructureStore : IFundStructureStore
     {
         lock (_links)
         {
-            _links.RemoveAll(existing => existing.LinkId == dto.LinkId);
+            _links.RemoveAll(existing => existing.OwnershipLinkId == dto.OwnershipLinkId);
             _links.Add(dto);
         }
 

--- a/tests/Meridian.FundStructure.Tests/FakeFundStructureStore.cs
+++ b/tests/Meridian.FundStructure.Tests/FakeFundStructureStore.cs
@@ -1,0 +1,187 @@
+using System.Collections.Concurrent;
+using Meridian.Contracts.FundStructure;
+using Meridian.Storage.FundStructure;
+
+namespace Meridian.FundStructure.Tests;
+
+/// <summary>
+/// An in-memory <see cref="IFundStructureStore"/> so <c>PostgresFundStructureService</c> can be
+/// exercised without PostgreSQL.
+/// </summary>
+/// <remarks>
+/// The scoping rules this suite is about live in the *service*, not the store:
+/// <c>PostgresFundStructureStore</c> issues plain per-entity selects and does no cross-entity
+/// filtering, so swapping it for a dictionary changes nothing the tests assert on. Without this the
+/// Postgres half of the contract would skip wherever no database is available, which is most of the
+/// time — and a contract suite that only ever runs one side of the contract proves nothing about the
+/// other.
+/// </remarks>
+public sealed class FakeFundStructureStore : IFundStructureStore
+{
+    private readonly ConcurrentDictionary<Guid, OrganizationSummaryDto> _organizations = new();
+    private readonly ConcurrentDictionary<Guid, BusinessSummaryDto> _businesses = new();
+    private readonly ConcurrentDictionary<Guid, ClientSummaryDto> _clients = new();
+    private readonly ConcurrentDictionary<Guid, FundSummaryDto> _funds = new();
+    private readonly ConcurrentDictionary<Guid, SleeveSummaryDto> _sleeves = new();
+    private readonly ConcurrentDictionary<Guid, VehicleSummaryDto> _vehicles = new();
+    private readonly ConcurrentDictionary<Guid, LegalEntitySummaryDto> _entities = new();
+    private readonly ConcurrentDictionary<Guid, InvestmentPortfolioSummaryDto> _portfolios = new();
+    private readonly List<OwnershipLinkDto> _links = [];
+    private readonly List<FundStructureAssignmentDto> _assignments = [];
+    private readonly HashSet<Guid> _linkedAccountIds = [];
+
+    public Task UpsertOrganizationAsync(OrganizationSummaryDto dto, CancellationToken ct = default)
+    {
+        _organizations[dto.OrganizationId] = dto;
+        return Task.CompletedTask;
+    }
+
+    public Task<OrganizationSummaryDto?> GetOrganizationAsync(Guid organizationId, CancellationToken ct = default)
+        => Task.FromResult(_organizations.TryGetValue(organizationId, out var value) ? value : null);
+
+    public Task<IReadOnlyList<OrganizationSummaryDto>> GetAllOrganizationsAsync(CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<OrganizationSummaryDto>>([.. _organizations.Values]);
+
+    public Task UpsertBusinessAsync(BusinessSummaryDto dto, CancellationToken ct = default)
+    {
+        _businesses[dto.BusinessId] = dto;
+        return Task.CompletedTask;
+    }
+
+    public Task<BusinessSummaryDto?> GetBusinessAsync(Guid businessId, CancellationToken ct = default)
+        => Task.FromResult(_businesses.TryGetValue(businessId, out var value) ? value : null);
+
+    public Task<IReadOnlyList<BusinessSummaryDto>> GetAllBusinessesAsync(CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<BusinessSummaryDto>>([.. _businesses.Values]);
+
+    public Task UpsertClientAsync(ClientSummaryDto dto, CancellationToken ct = default)
+    {
+        _clients[dto.ClientId] = dto;
+        return Task.CompletedTask;
+    }
+
+    public Task<ClientSummaryDto?> GetClientAsync(Guid clientId, CancellationToken ct = default)
+        => Task.FromResult(_clients.TryGetValue(clientId, out var value) ? value : null);
+
+    public Task<IReadOnlyList<ClientSummaryDto>> GetAllClientsAsync(CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<ClientSummaryDto>>([.. _clients.Values]);
+
+    public Task UpsertFundAsync(FundSummaryDto dto, CancellationToken ct = default)
+    {
+        _funds[dto.FundId] = dto;
+        return Task.CompletedTask;
+    }
+
+    public Task<FundSummaryDto?> GetFundAsync(Guid fundId, CancellationToken ct = default)
+        => Task.FromResult(_funds.TryGetValue(fundId, out var value) ? value : null);
+
+    public Task<IReadOnlyList<FundSummaryDto>> GetAllFundsAsync(CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<FundSummaryDto>>([.. _funds.Values]);
+
+    public Task UpsertSleeveAsync(SleeveSummaryDto dto, CancellationToken ct = default)
+    {
+        _sleeves[dto.SleeveId] = dto;
+        return Task.CompletedTask;
+    }
+
+    public Task<SleeveSummaryDto?> GetSleeveAsync(Guid sleeveId, CancellationToken ct = default)
+        => Task.FromResult(_sleeves.TryGetValue(sleeveId, out var value) ? value : null);
+
+    public Task<IReadOnlyList<SleeveSummaryDto>> GetAllSleevesAsync(CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<SleeveSummaryDto>>([.. _sleeves.Values]);
+
+    public Task UpsertVehicleAsync(VehicleSummaryDto dto, CancellationToken ct = default)
+    {
+        _vehicles[dto.VehicleId] = dto;
+        return Task.CompletedTask;
+    }
+
+    public Task<VehicleSummaryDto?> GetVehicleAsync(Guid vehicleId, CancellationToken ct = default)
+        => Task.FromResult(_vehicles.TryGetValue(vehicleId, out var value) ? value : null);
+
+    public Task<IReadOnlyList<VehicleSummaryDto>> GetAllVehiclesAsync(CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<VehicleSummaryDto>>([.. _vehicles.Values]);
+
+    public Task UpsertLegalEntityAsync(LegalEntitySummaryDto dto, CancellationToken ct = default)
+    {
+        _entities[dto.EntityId] = dto;
+        return Task.CompletedTask;
+    }
+
+    public Task<LegalEntitySummaryDto?> GetLegalEntityAsync(Guid entityId, CancellationToken ct = default)
+        => Task.FromResult(_entities.TryGetValue(entityId, out var value) ? value : null);
+
+    public Task<IReadOnlyList<LegalEntitySummaryDto>> GetAllLegalEntitiesAsync(CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<LegalEntitySummaryDto>>([.. _entities.Values]);
+
+    public Task UpsertInvestmentPortfolioAsync(InvestmentPortfolioSummaryDto dto, CancellationToken ct = default)
+    {
+        _portfolios[dto.InvestmentPortfolioId] = dto;
+        return Task.CompletedTask;
+    }
+
+    public Task<InvestmentPortfolioSummaryDto?> GetInvestmentPortfolioAsync(Guid portfolioId, CancellationToken ct = default)
+        => Task.FromResult(_portfolios.TryGetValue(portfolioId, out var value) ? value : null);
+
+    public Task<IReadOnlyList<InvestmentPortfolioSummaryDto>> GetAllInvestmentPortfoliosAsync(CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<InvestmentPortfolioSummaryDto>>([.. _portfolios.Values]);
+
+    public Task UpsertOwnershipLinkAsync(OwnershipLinkDto dto, CancellationToken ct = default)
+    {
+        lock (_links)
+        {
+            _links.RemoveAll(existing => existing.LinkId == dto.LinkId);
+            _links.Add(dto);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<OwnershipLinkDto>> GetAllOwnershipLinksAsync(CancellationToken ct = default)
+    {
+        lock (_links)
+        {
+            return Task.FromResult<IReadOnlyList<OwnershipLinkDto>>([.. _links]);
+        }
+    }
+
+    public Task UpsertAssignmentAsync(FundStructureAssignmentDto dto, CancellationToken ct = default)
+    {
+        lock (_assignments)
+        {
+            _assignments.RemoveAll(existing => existing.AssignmentId == dto.AssignmentId);
+            _assignments.Add(dto);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<FundStructureAssignmentDto>> GetAllAssignmentsAsync(CancellationToken ct = default)
+    {
+        lock (_assignments)
+        {
+            return Task.FromResult<IReadOnlyList<FundStructureAssignmentDto>>([.. _assignments]);
+        }
+    }
+
+    public Task UpsertLinkedAccountIdAsync(Guid accountId, CancellationToken ct = default)
+    {
+        lock (_linkedAccountIds)
+        {
+            _linkedAccountIds.Add(accountId);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<Guid>> GetAllLinkedAccountIdsAsync(CancellationToken ct = default)
+    {
+        lock (_linkedAccountIds)
+        {
+            return Task.FromResult<IReadOnlyList<Guid>>([.. _linkedAccountIds]);
+        }
+    }
+
+    public Task<bool> IsEmptyAsync(CancellationToken ct = default)
+        => Task.FromResult(_organizations.IsEmpty && _businesses.IsEmpty && _clients.IsEmpty && _funds.IsEmpty);
+}

--- a/tests/Meridian.FundStructure.Tests/FundStructureScopeContractTests.cs
+++ b/tests/Meridian.FundStructure.Tests/FundStructureScopeContractTests.cs
@@ -1,0 +1,168 @@
+using Meridian.Application.FundStructure;
+using Meridian.Contracts.FundStructure;
+using Meridian.Contracts.Services;
+using Meridian.Entities.FundStructure;
+using Meridian.PortfolioRecords.FundAccounts;
+using Xunit;
+
+namespace Meridian.FundStructure.Tests;
+
+/// <summary>
+/// One contract, run against both <see cref="IFundStructureService"/> implementations.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both implementations ship. `StorageFeatureRegistration` selects Postgres or in-memory on whether
+/// a connection string is configured, and the WPF desktop workstation registers the in-memory one
+/// unconditionally — so these are two shipping products, not a production path and a test double.
+/// They also carry 25 same-named private helpers, of which six differ structurally.
+/// </para>
+/// <para>
+/// The specific question these tests exist to answer (#2612): the Postgres service's visible scope
+/// cascade begins at fund level, while the in-memory service additionally narrows businesses by
+/// organization and clients and funds by business. If Postgres does not apply that upper-level
+/// narrowing, an organization-scoped caller can see records belonging to another organization.
+/// These assertions state what both implementations must do, so the answer is a test result rather
+/// than an argument about which file to read.
+/// </para>
+/// </remarks>
+public abstract class FundStructureScopeContractTests
+{
+    private static readonly DateTimeOffset EffectiveFrom = new(2026, 01, 01, 0, 0, 0, TimeSpan.Zero);
+
+    protected abstract IFundStructureService CreateService();
+
+    /// <summary>Two organizations, each owning one business, one client, and one fund.</summary>
+    private sealed record Fixture(
+        Guid OrganizationA, Guid BusinessA, Guid ClientA, Guid FundA,
+        Guid OrganizationB, Guid BusinessB, Guid ClientB, Guid FundB);
+
+    private static async Task<Fixture> SeedAsync(IFundStructureService service)
+    {
+        var f = new Fixture(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(),
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid());
+
+        foreach (var (org, business, client, fund, tag) in new[]
+                 {
+                     (f.OrganizationA, f.BusinessA, f.ClientA, f.FundA, "A"),
+                     (f.OrganizationB, f.BusinessB, f.ClientB, f.FundB, "B"),
+                 })
+        {
+            await service.CreateOrganizationAsync(new CreateOrganizationRequest(
+                org, $"ORG-{tag}", $"Organization {tag}", "USD", EffectiveFrom, "contract-test"));
+
+            await service.CreateBusinessAsync(new CreateBusinessRequest(
+                business, org, BusinessKindDto.FundManager,
+                $"BUS-{tag}", $"Business {tag}", "USD", EffectiveFrom, "contract-test"));
+
+            await service.CreateClientAsync(new CreateClientRequest(
+                client, business, $"CLI-{tag}", $"Client {tag}", "USD", EffectiveFrom, "contract-test"));
+
+            await service.CreateFundAsync(new CreateFundRequest(
+                fund, $"FND-{tag}", $"Fund {tag}", "USD", EffectiveFrom, "contract-test",
+                Description: null, BusinessId: business));
+        }
+
+        return f;
+    }
+
+    [Fact]
+    public async Task OrganizationScopedQuery_ExcludesBusinessesOwnedByAnotherOrganization()
+    {
+        var service = CreateService();
+        var fixture = await SeedAsync(service);
+
+        var graph = await service.GetOrganizationStructureAsync(
+            new OrganizationStructureQuery(OrganizationId: fixture.OrganizationA));
+
+        var businessIds = graph.Businesses.Select(b => b.BusinessId).ToList();
+        Assert.Contains(fixture.BusinessA, businessIds);
+        // A caller scoped to one organization must not see a business owned by another.
+        Assert.DoesNotContain(fixture.BusinessB, businessIds);
+    }
+
+    [Fact]
+    public async Task OrganizationScopedQuery_ExcludesClientsOwnedByAnotherOrganization()
+    {
+        var service = CreateService();
+        var fixture = await SeedAsync(service);
+
+        var graph = await service.GetOrganizationStructureAsync(
+            new OrganizationStructureQuery(OrganizationId: fixture.OrganizationA));
+
+        // Clients belong to a business, which belongs to an organization, so the scope must cascade.
+        Assert.DoesNotContain(fixture.ClientB, graph.Clients.Select(c => c.ClientId).ToList());
+    }
+
+    [Fact]
+    public async Task OrganizationScopedQuery_ExcludesFundsOwnedByAnotherOrganization()
+    {
+        var service = CreateService();
+        var fixture = await SeedAsync(service);
+
+        var graph = await service.GetOrganizationStructureAsync(
+            new OrganizationStructureQuery(OrganizationId: fixture.OrganizationA));
+
+        // A fund attached to another organization's business is outside the requested scope.
+        Assert.DoesNotContain(fixture.FundB, graph.Funds.Select(x => x.FundId).ToList());
+    }
+
+    [Fact]
+    public async Task BusinessScopedQuery_ExcludesClientsOwnedByAnotherBusiness()
+    {
+        var service = CreateService();
+        var fixture = await SeedAsync(service);
+
+        var graph = await service.GetOrganizationStructureAsync(
+            new OrganizationStructureQuery(BusinessId: fixture.BusinessA));
+
+        var clientIds = graph.Clients.Select(c => c.ClientId).ToList();
+        Assert.Contains(fixture.ClientA, clientIds);
+        // A caller scoped to one business must not see another business's clients.
+        Assert.DoesNotContain(fixture.ClientB, clientIds);
+    }
+
+    [Fact]
+    public async Task UnscopedQuery_ReturnsBothOrganizations()
+    {
+        // Guards the assertions above: if the scoped queries returned nothing at all they would pass
+        // vacuously, so pin that the fixture really did produce two organizations' worth of records.
+        var service = CreateService();
+        var fixture = await SeedAsync(service);
+
+        var graph = await service.GetOrganizationStructureAsync(new OrganizationStructureQuery());
+
+        var organizationIds = graph.Organizations.Select(o => o.OrganizationId).ToList();
+        Assert.Contains(fixture.OrganizationA, organizationIds);
+        Assert.Contains(fixture.OrganizationB, organizationIds);
+        var allBusinessIds = graph.Businesses.Select(b => b.BusinessId).ToList();
+        Assert.Contains(fixture.BusinessA, allBusinessIds);
+        Assert.Contains(fixture.BusinessB, allBusinessIds);
+    }
+}
+
+/// <summary>The contract as enforced by the implementation the WPF desktop workstation ships.</summary>
+public sealed class InMemoryFundStructureScopeContractTests : FundStructureScopeContractTests
+{
+    protected override IFundStructureService CreateService()
+        => new InMemoryFundStructureService(new InMemoryFundAccountService());
+}
+
+/// <summary>
+/// The same contract as enforced by the implementation a Postgres-configured deployment ships.
+/// </summary>
+/// <remarks>
+/// Backed by <see cref="FakeFundStructureStore"/> rather than PostgreSQL. The rules under test are
+/// service-layer — <c>PostgresFundStructureStore</c> does no cross-entity filtering — so this
+/// exercises the real scoping code, and it runs everywhere instead of skipping wherever no database
+/// is available.
+/// </remarks>
+public sealed class PostgresFundStructureScopeContractTests : FundStructureScopeContractTests
+{
+    protected override IFundStructureService CreateService()
+        => new PostgresFundStructureService(
+            new FakeFundStructureStore(),
+            new InMemoryFundAccountService(),
+            new FundStructurePolicyService());
+}


### PR DESCRIPTION
## Summary

#2612 step 3 asks for one contract suite run against both `IFundStructureService` implementations. This adds it, aimed at one specific question rather than as a general audit.

⚠️ **This PR may legitimately go red, and that would be the point.** If `PostgresFundStructureScopeContractTests` fails, that is the answer to #2612's open question, not a broken test. See *Expected outcome* below.

## Measuring first changed what needed testing

Comparing the 25 same-named private helpers across the two files, normalising braces, parameter names, locals, and lambda parameters:

| | Count |
|---|---|
| same-named helpers | 25 |
| **alpha-equivalent — identical logic** | **19** |
| structurally different | 6 |

The 19 are verbatim copies modulo naming convention — one file verbose (`account`, `query`, `MatchesOptionalScope`), the other terse (`a`, `q`, `MatchOpt`). **`IsVisible`, `IsAccountInAccountingScope`, `IsAccountInAccountingBusinessScope`, `HasAccountingAccountScopeFilter`, and `MatchesDirectAccountingAccountFilters` are all in that bucket** — the core visibility predicates have not drifted.

My first pass measured 15 as divergent. That was wrong: it was counting brace style and parameter names. Recording it because an alarming number here would change how this issue gets prioritised, and the real number is much less alarming.

## The question that survives

The Postgres service's visible scope cascade begins at fund level (`PostgresFundStructureService.cs:706-722`). The in-memory service additionally narrows **businesses by organization, and clients and funds by business**. If Postgres does not apply that upper-level narrowing somewhere I did not find, an organization-scoped caller sees another organization's records.

`PostgresFundStructureStore` issues plain per-entity selects with no cross-entity filtering, so the SQL is not quietly doing it.

## Design note: why the Postgres half does not need a database

The obvious way to write this — a Postgres-backed fixture — would skip wherever no database is available, which is most CI runs. **A contract suite where one side never runs proves nothing about that side.**

The rules under test are service-layer, and `IFundStructureStore` is an interface, so `PostgresFundStructureService` runs against an in-memory store double (`FakeFundStructureStore`) and executes its *real* scoping code. Both halves run everywhere.

## What it asserts

Two organizations, each owning one business, one client, one fund:

- organization-scoped query excludes another organization's **business**
- …its **clients**
- …its **funds**
- business-scoped query excludes another business's **clients**
- unscoped query returns both organizations — a guard so the four above cannot pass vacuously by returning nothing at all

## Expected outcome

I have deliberately not predicted the result, and I cannot run it here (no .NET SDK).

- **Both green** — the upper-level narrowing exists on both paths, the concern is closed, and the suite becomes the regression guard that makes the extraction in #2612 safe.
- **Postgres red** — the visibility gap is real and demonstrated. The fix follows as its own change; I would rather land the test that proves a bug separately from the fix, so the failure is on record.

## Testing performed

- [x] Relevant unit tests were added or updated — this PR is the tests
- [ ] `bash scripts/ci.sh` completed successfully — **not run; no .NET SDK in this environment**
- [ ] GitHub Actions `quality-gate` passed — pending
- [ ] Relevant integration tests were added or updated — not applicable

Verified statically: namespaces resolve, braces balance, and `Meridian.Application` references both `Meridian.Storage` and `Meridian.PortfolioRecords`, so `IFundStructureStore` and `InMemoryFundAccountService` are visible transitively to this test project. Uses xUnit `Assert` rather than FluentAssertions, which this project does not reference — and adding a package would cut across central package management. Both ratchets exit `0`.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included — no production code is touched; this PR is tests plus a test double

## Governance changes

- [x] No governance files changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtGupfUEyokEr8GmKSVVuq)_