### PR TITLE
Migrate seven renamed NormalizeOptional clones onto the shared primitive (#2614, partial)

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/Tiingo/TiingoSymbolSearchProvider.cs
+++ b/src/Meridian.Infrastructure/Adapters/Tiingo/TiingoSymbolSearchProvider.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Headers;
 using System.Text.Json.Serialization;
+using Meridian.Contracts.Text;
 using Meridian.Core.Subscriptions.Models;
 using Meridian.Infrastructure.Adapters.Core;
 using Meridian.Infrastructure.Contracts;
@@ -113,9 +114,9 @@ public sealed class TiingoSymbolSearchProvider : BaseSymbolSearchProvider
                     Symbol: symbol,
                     Name: name,
                     Exchange: FirstNonBlank(match.ExchangeCode, match.Exchange, match.ExchangeName),
-                    AssetType: Normalize(match.AssetType),
-                    Country: Normalize(match.CountryCode),
-                    Currency: Normalize(match.Currency),
+                    AssetType: TextPrimitives.NormalizeOptional(match.AssetType),
+                    Country: TextPrimitives.NormalizeOptional(match.CountryCode),
+                    Currency: TextPrimitives.NormalizeOptional(match.Currency),
                     Source: Name,
                     MatchScore: CalculateMatchScore(query, symbol, name, index));
             });
@@ -159,9 +160,6 @@ public sealed class TiingoSymbolSearchProvider : BaseSymbolSearchProvider
 
     private static string? FirstNonBlank(params string?[] values)
         => values.FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value))?.Trim();
-
-    private static string? Normalize(string? value)
-        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
     private sealed class TiingoSearchMatch
     {

--- a/src/Meridian.Infrastructure/Adapters/TwelveData/TwelveDataSymbolSearchProvider.cs
+++ b/src/Meridian.Infrastructure/Adapters/TwelveData/TwelveDataSymbolSearchProvider.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Meridian.Contracts.Text;
 using Meridian.Core.Subscriptions.Models;
 using Meridian.Infrastructure.Adapters.Core;
 using Meridian.Infrastructure.Contracts;
@@ -101,9 +102,9 @@ public sealed class TwelveDataSymbolSearchProvider : BaseSymbolSearchProvider
                     Symbol: symbol,
                     Name: name,
                     Exchange: exchange,
-                    AssetType: Normalize(match.InstrumentType),
+                    AssetType: TextPrimitives.NormalizeOptional(match.InstrumentType),
                     Country: MapCountry(match.Country),
-                    Currency: Normalize(match.Currency),
+                    Currency: TextPrimitives.NormalizeOptional(match.Currency),
                     Source: Name,
                     MatchScore: CalculateMatchScore(query, symbol, name, index));
             });
@@ -142,12 +143,9 @@ public sealed class TwelveDataSymbolSearchProvider : BaseSymbolSearchProvider
     private static string? FirstNonBlank(params string?[] values)
         => values.FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value))?.Trim();
 
-    private static string? Normalize(string? value)
-        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
-
     private static string? MapCountry(string? country)
     {
-        var normalized = Normalize(country);
+        var normalized = TextPrimitives.NormalizeOptional(country);
         if (normalized is null)
         {
             return null;

--- a/src/Meridian.Infrastructure/Reconciliation/StatementDurabilityInfrastructure.cs
+++ b/src/Meridian.Infrastructure/Reconciliation/StatementDurabilityInfrastructure.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using Meridian.Contracts.Text;
 using Meridian.Domain.Reconciliation;
 using Meridian.Storage.Archival;
 
@@ -694,11 +695,11 @@ public static class StatementBreakCaseworkFingerprint
             Action = update.Action.Trim(),
             CommandId = update.CommandId.Trim(),
             CorrelationId = update.CorrelationId.Trim(),
-            Reason = Normalize(update.Reason),
-            Disposition = Normalize(update.Disposition),
-            ApprovalActor = Normalize(update.ApprovalActor),
-            ApprovalReference = Normalize(update.ApprovalReference),
-            SupersedingBreakId = Normalize(update.SupersedingBreakId),
+            Reason = TextPrimitives.NormalizeOptional(update.Reason),
+            Disposition = TextPrimitives.NormalizeOptional(update.Disposition),
+            ApprovalActor = TextPrimitives.NormalizeOptional(update.ApprovalActor),
+            ApprovalReference = TextPrimitives.NormalizeOptional(update.ApprovalReference),
+            SupersedingBreakId = TextPrimitives.NormalizeOptional(update.SupersedingBreakId),
             EvidenceLinks = NormalizeEvidence(update.EvidenceLinks),
             OccurredAtUtc = update.OccurredAtUtc.ToUniversalTime()
         }, StatementLegacyCaseworkJsonContext.Default.StatementBreakCaseworkUpdate);
@@ -714,8 +715,6 @@ public static class StatementBreakCaseworkFingerprint
             .OrderBy(static value => value, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
-    private static string? Normalize(string? value)
-        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 }
 
 public static class StatementDurabilityHashing

--- a/src/Meridian.Storage/Ledger/AtomicTaxLotJournalFingerprint.cs
+++ b/src/Meridian.Storage/Ledger/AtomicTaxLotJournalFingerprint.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Meridian.Contracts.AssetOperations;
+using Meridian.Contracts.Text;
 using Meridian.Ledger;
 
 namespace Meridian.Storage.Ledger;
@@ -29,15 +30,15 @@ public static class AtomicTaxLotJournalFingerprint
             command.LedgerBookId,
             canonicalJournal,
             command.SourceEventId,
-            Normalize(command.IdempotencyKey),
+            TextPrimitives.NormalizeOptional(command.IdempotencyKey),
             command.ExpectedPeriodVersion,
             command.MutationKind,
             OrderEvidence(command.RetainedEvidence),
             command.AcquisitionLot,
             OrderSelections(command.DisposalSelections),
             command.CorrectsMutationBatchId,
-            Normalize(command.ReliefMethod),
-            Normalize(command.PolicyRevision));
+            TextPrimitives.NormalizeOptional(command.ReliefMethod),
+            TextPrimitives.NormalizeOptional(command.PolicyRevision));
 
         var element = JsonSerializer.SerializeToElement(payload, SerializerOptions);
         using var stream = new MemoryStream();
@@ -84,9 +85,6 @@ public static class AtomicTaxLotJournalFingerprint
             .ThenBy(static item => item.TaxLotRecordId)
             .ThenBy(static item => item.LotId, StringComparer.Ordinal)
             .ToArray();
-
-    private static string? Normalize(string? value)
-        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
     private static void WriteCanonicalJson(Utf8JsonWriter writer, JsonElement element)
     {

--- a/src/Meridian.Ui.Shared/Evidence/StatementReconciliationReportWorkflowService.cs
+++ b/src/Meridian.Ui.Shared/Evidence/StatementReconciliationReportWorkflowService.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Meridian.Contracts.Api;
+using Meridian.Contracts.Text;
 using Meridian.Contracts.Workstation;
 using Meridian.Domain.Reconciliation;
 using Meridian.FinancialOperations.Reconciliation;
@@ -1248,7 +1249,7 @@ public sealed partial class StatementReconciliationReportWorkflowService
             StatementReconciliationReportWorkflowStatusDto.InputRetained,
             Version: 1,
             command.TenantId.Trim(),
-            Normalize(command.CompanyId),
+            TextPrimitives.NormalizeOptional(command.CompanyId),
             command.Import.SourceInstitution.Trim(),
             command.Import.FundAccountId.Trim(),
             command.Import.ExternalAccountId.Trim(),
@@ -1465,7 +1466,7 @@ public sealed partial class StatementReconciliationReportWorkflowService
         var contentHash = Convert.ToHexString(SHA256.HashData(command.Import.Document.Content.Span));
         var identity = string.Join('|',
             command.TenantId.Trim(),
-            Normalize(command.CompanyId),
+            TextPrimitives.NormalizeOptional(command.CompanyId),
             CanonicalizeSemanticIdentity(command.Import.SourceInstitution),
             CanonicalizeSemanticIdentity(command.Import.FundAccountId),
             CanonicalizeSemanticIdentity(command.Import.ExternalAccountId),
@@ -1603,7 +1604,7 @@ public sealed partial class StatementReconciliationReportWorkflowService
     private static void EnsureScopeMatches(WorkflowSnapshot snapshot, string tenantId, string? companyId)
     {
         if (!string.Equals(snapshot.Workflow.TenantId, tenantId.Trim(), StringComparison.Ordinal)
-            || !string.Equals(snapshot.Workflow.CompanyId, Normalize(companyId), StringComparison.Ordinal))
+            || !string.Equals(snapshot.Workflow.CompanyId, TextPrimitives.NormalizeOptional(companyId), StringComparison.Ordinal))
             throw new UnauthorizedAccessException("Statement reconciliation report workflow belongs to another tenant or company scope.");
     }
 
@@ -1735,11 +1736,8 @@ public sealed partial class StatementReconciliationReportWorkflowService
            && retained.AccountingPeriodId == expected.AccountingPeriodId
            && retained.AsOfDate == expected.AsOfDate;
 
-    private static string? Normalize(string? value)
-        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
-
     private static string? CanonicalizeSemanticIdentity(string? value)
-        => Normalize(value)?.ToUpperInvariant();
+        => TextPrimitives.NormalizeOptional(value)?.ToUpperInvariant();
 
     private static bool SemanticIdentityEquals(string? left, string? right)
         => string.Equals(

--- a/src/Meridian.Ui.Shared/Services/PrivateCapitalFundEventCommandCenterService.cs
+++ b/src/Meridian.Ui.Shared/Services/PrivateCapitalFundEventCommandCenterService.cs
@@ -1,4 +1,5 @@
 using Meridian.Contracts.Ledger;
+using Meridian.Contracts.Text;
 
 namespace Meridian.Ui.Shared.Services;
 
@@ -34,7 +35,7 @@ public sealed class PrivateCapitalFundEventCommandCenterService : IPrivateCapita
     {
         ct.ThrowIfCancellationRequested();
 
-        var normalizedFundEventId = Normalize(fundEventId);
+        var normalizedFundEventId = TextPrimitives.NormalizeOptional(fundEventId);
         if (normalizedFundEventId is null)
         {
             return null;
@@ -414,13 +415,10 @@ public sealed class PrivateCapitalFundEventCommandCenterService : IPrivateCapita
             isReady ? "Ready" : "ReviewRequired",
             isReady,
             summary,
-            Normalize(route),
+            TextPrimitives.NormalizeOptional(route),
             evidenceLinks.Count,
             evidenceLinks,
             isReady ? [] : [requiredAction]);
-
-    private static string? Normalize(string? value)
-        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
     private static bool Matches(string? value, string? expected)
         => !string.IsNullOrWhiteSpace(value) &&

--- a/src/Meridian.Ui.Shared/Services/TradingOperatorLiveOrderReadinessGate.cs
+++ b/src/Meridian.Ui.Shared/Services/TradingOperatorLiveOrderReadinessGate.cs
@@ -1,3 +1,4 @@
+using Meridian.Contracts.Text;
 using Meridian.Contracts.Workstation;
 using Meridian.Execution.Services;
 using Meridian.Strategies.Models;
@@ -33,7 +34,7 @@ public sealed class TradingOperatorLiveOrderReadinessGate : ILiveOrderReadinessG
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        var requestedRunId = Normalize(request.RunId);
+        var requestedRunId = TextPrimitives.NormalizeOptional(request.RunId);
 
         if (!request.FundAccountId.HasValue)
         {
@@ -43,7 +44,7 @@ public sealed class TradingOperatorLiveOrderReadinessGate : ILiveOrderReadinessG
 
         var readiness = await _readinessProvider.GetAsync(request.FundAccountId.Value, ct).ConfigureAwait(false);
         var promotion = readiness.Promotion;
-        var targetRunId = Normalize(promotion?.TargetRunId);
+        var targetRunId = TextPrimitives.NormalizeOptional(promotion?.TargetRunId);
 
         if (targetRunId is null || !string.Equals(targetRunId, requestedRunId, StringComparison.Ordinal))
         {
@@ -152,9 +153,6 @@ public sealed class TradingOperatorLiveOrderReadinessGate : ILiveOrderReadinessG
             ? summary
             : $"{summary}, and {blockers.Count - maxBlockers} more";
     }
-
-    private static string? Normalize(string? value) =>
-        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
     private static string NormalizeChecklistItem(string? checklistItem) =>
         PromotionApprovalChecklist.Normalize([checklistItem ?? string.Empty]).FirstOrDefault() ?? string.Empty;


### PR DESCRIPTION
## Summary

Seven private helpers named `Normalize`, whose bodies are exactly `TextPrimitives.NormalizeOptional`, now call the shared primitive instead. Net −42 lines, +29.

Two of the nine clones are deliberately left in place, and `NormalizeCurrency` is deliberately **not** consolidated — reasoning below. Partial fix for #2614; should not close it.

## Reason

#2614's remaining named helpers turn out to be mostly *not* duplication. Grouping every same-named declaration by alpha-equivalent body rather than by name:

| Helper | Declarations | Distinct bodies |
| --- | ---: | ---: |
| `Normalize` | 55 | 41 |
| `NormalizeCurrency` | 19 | 9 |
| `FormatBytes` | 15 | 8 |

`Normalize` is a generic name covering 41 genuinely different domain functions — not 55 copies of one. But inside it sits a cluster of **9 declarations with an identical body**:

```csharp
string.IsNullOrWhiteSpace(value) ? null : value.Trim()
```

Those 9 are the interesting find, because **they are invisible to the existing ratchet**. `check-duplicate-helpers.py` tracks names, and a clone that renames itself walks straight past it. The drift #2614 documents is exactly one rename away from detection. Filed as #2702 rather than widened here — tracking the name `Normalize` would fire on all 41 legitimate functions, so the fix is body-based detection, not another name.

### What I left, and why

- **`PrivateCapitalCloseCockpitService`** — 40 call sites across three partial-class files. Removing one declaration in exchange for 40 longer call sites is a bad trade, and a single private helper used only within one class has no cross-file drift surface.
- **`LedgerLineDimensionSetNormalizer`** — `Meridian.Ledger` has no reference to `Meridian.Contracts`. Adding one to reach a one-line helper is a layering change, not a cleanup.

### Why `NormalizeCurrency` is not consolidated

`TextPrimitives`' own doc comment rules it out, and the measurement agrees:

> Currency, symbol, and fund-profile canonicalisation encode real rules and deserve an owner and a test next to the code those rules serve; putting them in a general text bag would repeat the mistake at a larger scale.

The 12 non-validating copies share one expression under **four different blank-policies** — `"USD"`, `"UNSPECIFIED"`, a caller-supplied base currency, and `null`. My grouping only made six look identical because it folds string literals together; that fallback *is* the rule. These want a currency owner, not a text helper. The remaining 8 declarations are `Meridian.Ledger`'s validating canonicaliser, already shared within that project.

`FormatBytes` is likewise mostly done: 7 of its 15 declarations are one-line delegations to `FormatHelpers.FormatBytes`.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [ ] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

**Not compiled locally — this container has no .NET SDK.** CI is the first real compile. No tests added: this is a call-site substitution onto a primitive that already has coverage, with no behaviour change.

Given the edits are mechanical and uncompiled, I verified them three ways rather than one:

1. `TradingOperatorLiveOrderReadinessGate` keeps `PromotionApprovalChecklist.Normalize` untouched — a different method on a different type that a blanket rename would have captured. It was edited by hand for exactly that reason.
2. The clone detector reports **9 → 2**, and the only remaining bare `Normalize(` anywhere in the touched files is that intentional one.
3. Grepped for mangled identifiers (`[A-Za-z_]TextPrimitives\.` and `NormalizeOptional[A-Za-z]`) — none.

Both ratchets exit 0; docs regeneration produced no drift.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed
- [ ] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`