### PR TITLE
Fix the Docker template dry-run, MDC_SYMBOLS duplicates, and credential-gated historical defaults

### DIFF
--- a/build/scripts/ci/check-sample-config-datasources.py
+++ b/build/scripts/ci/check-sample-config-datasources.py
@@ -117,8 +117,14 @@ def streaming_source_ids() -> frozenset[str]:
 CATALOG_ALIASES = {"ib": "ibkr"}
 
 
-def backfill_activation() -> dict[str, str]:
-    """Map each backfill family to the activation rule its factory actually applies.
+def _backfill_factory_bodies() -> dict[str, str]:
+    """Return each backfill factory's member body, keyed by folded family name.
+
+    Shared by the activation and credential-gating readers so the member-shape parsing —
+    braced bodies and expression-bodied ``=> CreateKeyedProvider(...)`` alike — lives in one
+    place rather than being duplicated and drifting.
+
+    Historic note on why the rule is read rather than assumed:
 
     ``ProviderFactory`` has two, and they invert each other for an unset value:
 
@@ -133,12 +139,12 @@ def backfill_activation() -> dict[str, str]:
     that matches neither helper (TwelveData passes a hardcoded ``enabled: true``) is deliberately
     left out of the map so the caller stays silent rather than guessing.
     """
+    bodies: dict[str, str] = {}
     try:
         text = PROVIDER_FACTORY_SOURCE.read_text(encoding="utf-8")
     except OSError:
-        return {}
+        return bodies
 
-    activation: dict[str, str] = {}
     for match in re.finditer(
         r"private\s+IHistoricalDataProvider\?\s+Create(\w+)BackfillProvider\s*\(", text
     ):
@@ -174,11 +180,43 @@ def backfill_activation() -> dict[str, str]:
         else:
             continue
 
+        bodies[match.group(1).casefold()] = body
+    return bodies
+
+
+def backfill_activation() -> dict[str, str]:
+    """Map each backfill family to the activation rule its factory applies."""
+    activation: dict[str, str] = {}
+    for family, body in _backfill_factory_bodies().items():
         if "EnabledWhenOptedIn" in body:
-            activation[match.group(1).casefold()] = "opt-in"
+            activation[family] = "opt-in"
         elif "EnabledByDefault" in body:
-            activation[match.group(1).casefold()] = "default-on"
+            activation[family] = "default-on"
     return activation
+
+
+def credential_gated_families() -> frozenset[str]:
+    """Families whose backfill factory resolves through the credential-gated helper.
+
+    ``CreateCredentialGatedBackfillProvider`` returns null when its named credential is absent
+    from both config and environment, so passing the ``Enabled`` check is not sufficient for
+    these. The sample is required to be credential-free — this guard rejects secret-shaped keys
+    outright — so a historical default pointing at one of them can never register a provider from
+    the sample alone, however its ``Enabled`` flag reads.
+
+    Two shapes carry the same meaning and both must be matched. Most families delegate to the
+    helper, but Alpaca resolves credentials inline and returns null on a blank key:
+
+    ``if (string.IsNullOrWhiteSpace(keyId) || string.IsNullOrWhiteSpace(secretKey)) return null;``
+
+    Matching only the helper name would call Alpaca credential-free and let exactly the default
+    this check exists to reject pass.
+    """
+    return frozenset(
+        family
+        for family, body in _backfill_factory_bodies().items()
+        if "CreateCredentialGated" in body or "CreateCredentialContext" in body
+    )
 
 
 def historical_capable_families() -> frozenset[str]:
@@ -632,6 +670,21 @@ def main() -> int:
         # started this. When the rule cannot be read, no verdict is issued.
         enabled = gate.get("Enabled") if isinstance(gate, dict) else None
         activation = backfill_activation().get(name.casefold())
+
+        # Enabled is necessary but not sufficient. A credential-gated factory returns null when
+        # its key is absent, and this sample must never carry one — the secret-key scan below
+        # rejects exactly that. So an out-of-box historical default has to name a provider that
+        # registers without credentials; anything else synthesizes a binding with nothing behind
+        # it for every operator who has not yet exported a key.
+        if name.casefold() in credential_gated_families():
+            errors.append(
+                f"DataSources.{field} = {default_id!r} resolves to {name}, whose backfill factory "
+                f"returns null when its credentials are absent. This sample is required to be "
+                f"credential-free, so the synthesized historical binding would have no registered "
+                f"provider for a fresh checkout. Point the out-of-box default at a provider that "
+                f"registers without credentials."
+            )
+            continue
 
         if enabled is False:
             errors.append(

--- a/src/Meridian.Core/Config/ConfigEnvironmentOverride.cs
+++ b/src/Meridian.Core/Config/ConfigEnvironmentOverride.cs
@@ -425,10 +425,18 @@ public sealed class ConfigEnvironmentOverride
         // SymbolConfigValidator matches ^[A-Z0-9\-\.\/]+$, so a lowercase ticker typed into the
         // environment would otherwise fail validation rather than subscribe. Character validity
         // is deliberately left to that validator instead of being restated here.
+        // Deduplicated case-insensitively because uppercasing merges spellings the operator wrote
+        // as distinct: "SPY,spy" becomes two identical entries, and per-symbol validation accepts
+        // both. SubscriptionOrchestrator.ApplyAsync then builds its desired set with
+        // ToDictionary(..., StringComparer.OrdinalIgnoreCase), which throws on the duplicate key
+        // and aborts collector startup. Dropping the repeat is the reading that matches intent —
+        // naming a ticker twice means subscribing to it, not failing to start.
         var symbols = value
             .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(symbol => symbol.ToUpperInvariant())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
             .Select(symbol => new SymbolConfig(
-                symbol.ToUpperInvariant(),
+                symbol,
                 SubscribeTrades: subscribeTrades,
                 SubscribeDepth: subscribeDepth,
                 DepthLevels: depthLevels))

--- a/src/Meridian.Core/Config/ConfigTemplateGenerator.cs
+++ b/src/Meridian.Core/Config/ConfigTemplateGenerator.cs
@@ -303,6 +303,14 @@ public sealed class ConfigTemplateGenerator
             // offline without keys, and MDC_DATASOURCE still overrides it through the normal
             // environment path.
             DataSource = "Synthetic",
+            // DataSource: Synthetic without this section is a template that loads but fails its
+            // own documented validation. DryRunService.ValidateProvidersAsync asserts
+            // `config.Synthetic?.Enabled == true` and reports "Synthetic dataset disabled" for a
+            // null section, so `--generate-config --template docker` followed by the `--dry-run`
+            // the docs prescribe would fail out of the box. SyntheticMarketDataClient treats a
+            // null config as enabled, so this only ever tripped the validator — which is exactly
+            // the kind of gap an operator reads as "the tool is broken".
+            Synthetic = new { Enabled = true },
             Alpaca = new
             {
                 // The credential placeholders stay in "${...}" form because ConfigValidationHelper

--- a/tests/Meridian.Tests/Core/Config/ConfigEnvironmentOverrideTests.cs
+++ b/tests/Meridian.Tests/Core/Config/ConfigEnvironmentOverrideTests.cs
@@ -80,6 +80,26 @@ public sealed class ConfigEnvironmentOverrideTests
     }
 
     [Fact]
+    public void ApplyOverrides_Symbols_DeduplicatesCaseInsensitively()
+    {
+        // Uppercasing merges spellings the operator wrote as distinct, and per-symbol validation
+        // accepts both copies. SubscriptionOrchestrator.ApplyAsync then keys its desired set with
+        // ToDictionary(..., StringComparer.OrdinalIgnoreCase), which throws on the duplicate and
+        // aborts collector startup — so the repeat has to be dropped here, before orchestration.
+        using var symbolsVar = new EnvironmentVariableScope("MDC_SYMBOLS", "SPY,spy, QQQ ,Spy,qqq");
+
+        var sut = new ConfigEnvironmentOverride();
+        var result = sut.ApplyOverrides(new AppConfig());
+
+        result.Symbols.Should().NotBeNull();
+        result.Symbols!.Select(s => s.Symbol).Should().Equal("SPY", "QQQ");
+
+        // The same key the orchestrator builds must not throw.
+        var act = () => result.Symbols!.ToDictionary(s => s.Symbol.Trim(), s => s, StringComparer.OrdinalIgnoreCase);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
     public void ApplyOverrides_Symbols_InheritCollectionTogglesWithoutContractIdentity()
     {
         // MDC_SYMBOLS changes which symbols are collected, not how. A configuration that

--- a/tests/Meridian.Tests/Core/Config/ConfigTemplateGeneratorTests.cs
+++ b/tests/Meridian.Tests/Core/Config/ConfigTemplateGeneratorTests.cs
@@ -34,6 +34,24 @@ public sealed class ConfigTemplateGeneratorTests
     }
 
     [Fact]
+    public void GenerateDocker_EmitsAnEnabledSyntheticSectionForItsOwnDefault()
+    {
+        // The template selects DataSource: Synthetic so a container starts without keys, but it
+        // emitted no Synthetic section. DryRunService.ValidateProvidersAsync asserts exactly
+        // `config.Synthetic?.Enabled == true` and reports "Synthetic dataset disabled" otherwise,
+        // so generating this template and running the documented --dry-run failed out of the box
+        // even though SyntheticMarketDataClient treats a null config as enabled. This pins the
+        // validator's predicate, not the client's leniency.
+        var template = new ConfigTemplateGenerator().GenerateDocker();
+        var config = JsonSerializer.Deserialize<AppConfig>(template.Json, AppConfigJsonOptions.Read);
+
+        config.Should().NotBeNull();
+        config!.DataSource.Should().Be(DataSourceKind.Synthetic);
+        (config.Synthetic?.Enabled == true).Should().BeTrue(
+            "DryRunService gates the Synthetic provider check on this exact expression");
+    }
+
+    [Fact]
     public void GenerateDocker_EmitsParseableLiteralsForValidatedFields()
     {
         var template = new ConfigTemplateGenerator().GenerateDocker();


### PR DESCRIPTION
## Summary

Three defects found by review on #2599 after its final push, which merged before the fixes were pushed. All three are live on `main` now. This is a new pull request, not a continuation of the merged one.

**1. The Docker config template fails its own documented validation.**
`GenerateDocker` selects `DataSource: Synthetic` so a container starts without keys, but emitted no `Synthetic` section at all. `DryRunService.ValidateProvidersAsync` gates its provider check on `config.Synthetic?.Enabled == true` and records "Synthetic dataset disabled" for a null section, so `--generate-config --template docker` followed by the `--dry-run` the docs prescribe fails out of the box. `SyntheticMarketDataClient` treats a null configuration as enabled, so only the validator ever tripped — which an operator reads as the tool being broken. The template now emits `Synthetic: { Enabled: true }`.

**2. `MDC_SYMBOLS` can abort collector startup.**
The override uppercases each entry, which merges spellings the operator wrote as distinct: `SPY,spy` produced two identical `SymbolConfig` entries, and per-symbol validation accepted both. `SubscriptionOrchestrator.ApplyAsync` then builds its desired set with `ToDictionary(..., StringComparer.OrdinalIgnoreCase)`, which throws on the duplicate key. Entries are now deduplicated case-insensitively, first spelling wins — naming a ticker twice means subscribing to it, not failing to start.

**3. The sample-config guard passed historical defaults that cannot register.**
`check-sample-config-datasources.py` modelled the `Enabled` helper but not credentials, so a `DefaultHistoricalSourceId` pointing at Alpaca or Polygon passed even though `ProviderFactory` returns null for both when keys are absent — and this sample is required to be credential-free, since the guard itself rejects secret-shaped keys. Credential gating is now read from the factory in both shapes it takes: the `CreateCredentialGated*` helper, and Alpaca's inline `if (string.IsNullOrWhiteSpace(keyId) || ...) return null`. Matching only the helper name would have classified Alpaca as credential-free and admitted exactly the default this check exists to reject. The activation and credential readers now share one member-body parser rather than duplicating the shape handling.

## Reason

Review findings on #2599 arrived after its last push and the PR merged before they were addressed, so the fixes need their own change.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Two new tests, both of which need CI to run:

- `GenerateDocker_EmitsAnEnabledSyntheticSectionForItsOwnDefault` pins `DryRunService`'s exact predicate rather than the client's leniency, so a future template edit that drops the section fails here instead of in an operator's terminal.
- `ApplyOverrides_Symbols_DeduplicatesCaseInsensitively` asserts the orchestrator's own `ToDictionary(..., OrdinalIgnoreCase)` construction does not throw, rather than only checking the deduplicated list.

Run locally: the sample-config guard's mutation matrix (Alpaca and Polygon historical defaults must fail; Yahoo, Synthetic, and the unmodified sample must pass; the real-time default path unaffected), plus the `verify-docs` and `verify-workflows` lanes. Re-run after rebasing onto current `main`.

**The C# edits are not verified locally — this environment has no .NET SDK**, so `verify-dotnet` is the first thing to actually compile them. That gap is why the two changes are deliberately small and each carries a test.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

Check every governance file modified:

- [x] No governance files changed
- [ ] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeGYVgbZ5EWtCnuaqGGr7z)_