### PR TITLE
refactor(security-master): use named schema-version constants for the last literal writes

### DIFF
--- a/src/Meridian.Application/SecurityMaster/EdgarIngestOrchestrator.cs
+++ b/src/Meridian.Application/SecurityMaster/EdgarIngestOrchestrator.cs
@@ -397,7 +397,7 @@ public sealed class EdgarIngestOrchestrator : IEdgarIngestOrchestrator
             ? JsonSerializer.SerializeToElement(
                 new Dictionary<string, object?>
                 {
-                    ["schemaVersion"] = 1,
+                    ["schemaVersion"] = SecurityMasterSchemaVersions.LegacyAssetSpecificTerms,
                     ["category"] = "MutualFund",
                     ["subType"] = association.SecurityType,
                     ["issuerName"] = association.Name ?? filer?.Name
@@ -406,7 +406,7 @@ public sealed class EdgarIngestOrchestrator : IEdgarIngestOrchestrator
             : JsonSerializer.SerializeToElement(
                 new Dictionary<string, object?>
                 {
-                    ["schemaVersion"] = 1,
+                    ["schemaVersion"] = SecurityMasterSchemaVersions.LegacyAssetSpecificTerms,
                     ["classification"] = "Common",
                     ["shareClass"] = snapshot?.Security12bTitle?.RawValue
                 },

--- a/src/Meridian.Application/SecurityMaster/SecurityMasterMapping.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityMasterMapping.cs
@@ -98,7 +98,7 @@ internal static class SecurityMasterMapping
             {
                 ["sourceSystem"] = sourceSystem,
                 ["reason"] = reason,
-                ["schemaVersion"] = 2,
+                ["schemaVersion"] = SecurityMasterSchemaVersions.EconomicTerms,
                 ["payloadType"] = "SecurityEconomicDefinition"
             },
             SecurityMasterJsonContext.Default.DictionaryStringObject);


### PR DESCRIPTION
## Summary

`SecurityMasterSchemaVersions` already owns the security-master schema version numbers, and most write sites use it (`SecurityEconomicDefinitionAdapter.cs:93`, `SecurityMasterEditViewModel.cs:284`, `SettingsViewModel.AssetProfiles.cs:500`). Three sites still wrote bare integers — these were the last ones in `src/`:

- `EdgarIngestOrchestrator.cs:400,409` stamped asset-specific term payloads with `1` → `SecurityMasterSchemaVersions.LegacyAssetSpecificTerms`
- `SecurityMasterMapping.cs:101` stamped the `SecurityEconomicDefinition` envelope with `2` → `SecurityMasterSchemaVersions.EconomicTerms`

## Reason

Removes the last magic numbers so a future schema bump has a single owner rather than needing a grep for stray literals. Found while verifying the security-master area against current `main`.

**No behavior change:** the constants resolve to exactly the values being replaced (`AssetSpecificTermsSchema.Legacy = 1`, `EconomicTermsSchema.Current = 2`), so no persisted payload changes and no reader is affected. Both files already import `Meridian.Contracts.SecurityMaster`, so no new usings.

Semantics were checked per site rather than assumed: both Edgar sites serialize asset-specific term payloads (`category`/`subType`/`issuerName` and `classification`/`shareClass`), and the mapping site serializes the economic-definition envelope (`payloadType = "SecurityEconomicDefinition"`).

## Testing performed

- [ ] `bash scripts/ci.sh`
- [x] Verified no remaining `["schemaVersion"] = <literal>` sites in `src/`
- [ ] Relevant unit tests were added or updated — none needed; values are unchanged, existing coverage applies
- [ ] GitHub Actions `quality-gate` passed — validating on this PR

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRdH1FnQmEYt8GLzoQfixJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRdH1FnQmEYt8GLzoQfixJ)_