### PR TITLE
Stop the manual-journal normalizer discarding seven dimension fields (#2672)

### DIFF
--- a/src/Meridian.Contracts/Ledger/LedgerDimensionTags.cs
+++ b/src/Meridian.Contracts/Ledger/LedgerDimensionTags.cs
@@ -43,7 +43,12 @@ public static class LedgerDimensionTags
                || !string.IsNullOrWhiteSpace(dimensions.TaxLotId)
                || !string.IsNullOrWhiteSpace(dimensions.CostCenterId)
                || !string.IsNullOrWhiteSpace(dimensions.CounterpartyId)
-               || dimensions.ExternalGlDimensions.Count > 0
+               // A blank key or value is not a dimension. ExtractExternalGlDimensions never emits
+               // one, so this only bites on a caller-supplied dictionary -- where the close path
+               // already answered "not dimensioned" and everyone else answered "dimensioned".
+               // Holding that rule here keeps the two from disagreeing (#2672).
+               || dimensions.ExternalGlDimensions.Any(static pair =>
+                      !string.IsNullOrWhiteSpace(pair.Key) && !string.IsNullOrWhiteSpace(pair.Value))
                || !string.IsNullOrWhiteSpace(dimensions.OrganizationId)
                || !string.IsNullOrWhiteSpace(dimensions.PortfolioId)
                || !string.IsNullOrWhiteSpace(dimensions.BookId)

--- a/src/Meridian.FinancialOperations/AccountingClose/AccountingCloseServices.cs
+++ b/src/Meridian.FinancialOperations/AccountingClose/AccountingCloseServices.cs
@@ -569,7 +569,7 @@ public sealed class TrialBalanceProjectionService
 
         if (actual is null)
         {
-            return !HasAnyDimension(expected);
+            return !LedgerDimensionTags.HasAnyDimension(expected);
         }
 
         return Matches(expected.FundId, actual.FundId) &&
@@ -632,7 +632,7 @@ public sealed class TrialBalanceProjectionService
 
     private static string BuildDimensionSignature(LedgerDimensionSetDto? dimensions)
     {
-        if (dimensions is null || !HasAnyDimension(dimensions))
+        if (dimensions is null || !LedgerDimensionTags.HasAnyDimension(dimensions))
         {
             return "dimension:none";
         }
@@ -666,27 +666,6 @@ public sealed class TrialBalanceProjectionService
             ? $"{signature}|positionId={dimensions.PositionId.Value:D}"
             : signature;
     }
-
-    private static bool HasAnyDimension(LedgerDimensionSetDto dimensions)
-        => !string.IsNullOrWhiteSpace(dimensions.FundId) ||
-            !string.IsNullOrWhiteSpace(dimensions.EntityId) ||
-            !string.IsNullOrWhiteSpace(dimensions.SleeveId) ||
-            !string.IsNullOrWhiteSpace(dimensions.StrategyId) ||
-            !string.IsNullOrWhiteSpace(dimensions.InvestorId) ||
-            !string.IsNullOrWhiteSpace(dimensions.CapitalAccountId) ||
-            dimensions.InstrumentId.HasValue ||
-            dimensions.PositionId.HasValue ||
-            !string.IsNullOrWhiteSpace(dimensions.TaxLotId) ||
-            !string.IsNullOrWhiteSpace(dimensions.CostCenterId) ||
-            !string.IsNullOrWhiteSpace(dimensions.CounterpartyId) ||
-            !string.IsNullOrWhiteSpace(dimensions.OrganizationId) ||
-            !string.IsNullOrWhiteSpace(dimensions.PortfolioId) ||
-            !string.IsNullOrWhiteSpace(dimensions.BookId) ||
-            !string.IsNullOrWhiteSpace(dimensions.AccountId) ||
-            !string.IsNullOrWhiteSpace(dimensions.CustomerId) ||
-            !string.IsNullOrWhiteSpace(dimensions.VendorId) ||
-            !string.IsNullOrWhiteSpace(dimensions.ProjectId) ||
-            dimensions.ExternalGlDimensions.Any(static pair => !string.IsNullOrWhiteSpace(pair.Key) && !string.IsNullOrWhiteSpace(pair.Value));
 
     private static string NormalizeToken(string? value)
         => string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim().ToUpperInvariant();

--- a/src/Meridian.Ui.Shared/Services/ManualJournalEntryWorkbenchService.Lifecycle.cs
+++ b/src/Meridian.Ui.Shared/Services/ManualJournalEntryWorkbenchService.Lifecycle.cs
@@ -970,27 +970,25 @@ public sealed partial class ManualJournalEntryWorkbenchService
             CounterpartyId: NormalizeOptional(dimensions?.CounterpartyId) ?? NormalizeOptional(counterpartyId),
             ExternalGlDimensions: externalDimensions
                 .OrderBy(item => item.Key, StringComparer.OrdinalIgnoreCase)
-                .ToDictionary(item => item.Key, item => item.Value, StringComparer.OrdinalIgnoreCase))
+                .ToDictionary(item => item.Key, item => item.Value, StringComparer.OrdinalIgnoreCase),
+            // Carried through rather than dropped. These seven are constructor parameters that
+            // default to null, so omitting them silently discarded any organization, portfolio,
+            // book, account, customer, vendor, or project dimension the caller supplied -- even
+            // when another field kept the set alive. AccountingReportPackageService's
+            // same-named normalizer already carries all nineteen.
+            OrganizationId: NormalizeOptional(dimensions?.OrganizationId),
+            PortfolioId: NormalizeOptional(dimensions?.PortfolioId),
+            BookId: NormalizeOptional(dimensions?.BookId),
+            AccountId: NormalizeOptional(dimensions?.AccountId),
+            CustomerId: NormalizeOptional(dimensions?.CustomerId),
+            VendorId: NormalizeOptional(dimensions?.VendorId),
+            ProjectId: NormalizeOptional(dimensions?.ProjectId))
         {
             PositionId = dimensions?.PositionId
         };
 
-        return HasAnyDimension(normalized) ? normalized : null;
+        return LedgerDimensionTags.HasAnyDimension(normalized) ? normalized : null;
     }
-
-    private static bool HasAnyDimension(LedgerDimensionSetDto dimensions)
-        => !string.IsNullOrWhiteSpace(dimensions.FundId) ||
-           !string.IsNullOrWhiteSpace(dimensions.EntityId) ||
-           !string.IsNullOrWhiteSpace(dimensions.SleeveId) ||
-           !string.IsNullOrWhiteSpace(dimensions.StrategyId) ||
-           !string.IsNullOrWhiteSpace(dimensions.InvestorId) ||
-           !string.IsNullOrWhiteSpace(dimensions.CapitalAccountId) ||
-           dimensions.InstrumentId.HasValue ||
-           dimensions.PositionId.HasValue ||
-           !string.IsNullOrWhiteSpace(dimensions.TaxLotId) ||
-           !string.IsNullOrWhiteSpace(dimensions.CostCenterId) ||
-           !string.IsNullOrWhiteSpace(dimensions.CounterpartyId) ||
-           dimensions.ExternalGlDimensions.Count > 0;
 
     private static void ValidateRequiredDimensions(
         LedgerDimensionSetDto? dimensions,

--- a/tests/Meridian.Tests/Contracts/Ledger/LedgerDimensionTagsTests.cs
+++ b/tests/Meridian.Tests/Contracts/Ledger/LedgerDimensionTagsTests.cs
@@ -37,6 +37,42 @@ public sealed class LedgerDimensionTagsTests
             .Should()
             .BeTrue();
 
+    [Fact]
+    public void HasAnyDimension_TreatsABlankExternalGlEntryAsAbsent()
+    {
+        // A pair with a blank key or value is not a dimension. ExtractExternalGlDimensions never
+        // emits one, so this only arises from a caller-supplied dictionary -- where the close path
+        // answered "not dimensioned" and every other caller answered "dimensioned" (#2672). The
+        // stricter reading now lives here so the two cannot disagree.
+        LedgerDimensionTags.HasAnyDimension(new LedgerDimensionSetDto(
+            ExternalGlDimensions: new Dictionary<string, string> { ["  "] = "100" }))
+            .Should()
+            .BeFalse();
+
+        LedgerDimensionTags.HasAnyDimension(new LedgerDimensionSetDto(
+            ExternalGlDimensions: new Dictionary<string, string> { ["costCentre"] = "  " }))
+            .Should()
+            .BeFalse();
+    }
+
+    [Fact]
+    public void HasAnyDimension_CountsAnExternalGlEntryWithBothSidesPopulated() =>
+        LedgerDimensionTags.HasAnyDimension(new LedgerDimensionSetDto(
+            ExternalGlDimensions: new Dictionary<string, string> { ["costCentre"] = "100" }))
+            .Should()
+            .BeTrue();
+
+    [Fact]
+    public void HasAnyDimension_CountsAPopulatedEntryAlongsideABlankOne() =>
+        LedgerDimensionTags.HasAnyDimension(new LedgerDimensionSetDto(
+            ExternalGlDimensions: new Dictionary<string, string>
+            {
+                ["  "] = "100",
+                ["costCentre"] = "200"
+            }))
+            .Should()
+            .BeTrue();
+
     // Guards against a copy that silently covers only part of the dimension set: every field on
     // LedgerDimensionSetDto must, on its own, be enough to make the set "dimensioned". One of the
     // predicate copies this consolidation replaced checked only 11 of the 19 fields.

--- a/tests/Meridian.Tests/Ui/AccountingConfigurationServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/AccountingConfigurationServiceTests.cs
@@ -2208,6 +2208,70 @@ public sealed class AccountingConfigurationServiceTests
     }
 
     [Fact]
+    public async Task Scenario_ManualJournalEntry_CarriesEveryDimensionFieldThroughNormalization()
+    {
+        // NormalizeDimensionSet rebuilds the DTO from named arguments. Seven of the nineteen
+        // constructor parameters were omitted, and because they default to null the caller's
+        // organization, portfolio, book, account, customer, vendor, and project dimensions were
+        // silently discarded -- even here, where FundId keeps the set alive so the loss is not
+        // visible as "no dimensions". AccountingReportPackageService's same-named normalizer
+        // already carried all nineteen, so the two disagreed on what survives (#2672).
+        var configuration = CreateService();
+        await SeedBalancedConfigurationAsync(configuration);
+        var service = CreateManualJournalEntryWorkbenchService(configuration);
+        var draft = BalancedManualJournalEntry() with
+        {
+            Dimensions = new LedgerDimensionSetDto(
+                FundId: "fund-alpha",
+                OrganizationId: "org-1",
+                PortfolioId: "portfolio-1",
+                BookId: "book-1",
+                AccountId: "account-1",
+                CustomerId: "customer-1",
+                VendorId: "vendor-1",
+                ProjectId: "project-1")
+        };
+
+        var validated = await service.ValidateDraftAsync(new ValidateManualJournalEntryDraftRequest(
+            draft,
+            "controller"));
+
+        validated.Dimensions.Should().NotBeNull();
+        validated.Dimensions!.OrganizationId.Should().Be("org-1");
+        validated.Dimensions.PortfolioId.Should().Be("portfolio-1");
+        validated.Dimensions.BookId.Should().Be("book-1");
+        validated.Dimensions.AccountId.Should().Be("account-1");
+        validated.Dimensions.CustomerId.Should().Be("customer-1");
+        validated.Dimensions.VendorId.Should().Be("vendor-1");
+        validated.Dimensions.ProjectId.Should().Be("project-1");
+    }
+
+    [Fact]
+    public async Task Scenario_ManualJournalEntry_KeepsADimensionSetCarriedOnlyByBook()
+    {
+        // A caller supplying only a book dimension. Note the set is never dropped wholesale on
+        // this path -- NormalizeDimensionSet is called with `fundId: draft.FundNodeId ??
+        // fundProfileId`, so FundId is always populated and the predicate always says
+        // "dimensioned". That is why the local predicate's 11-of-19 gap was unreachable, and why
+        // the real defect is the discarded fields rather than the misclassification.
+        var configuration = CreateService();
+        await SeedBalancedConfigurationAsync(configuration);
+        var service = CreateManualJournalEntryWorkbenchService(configuration);
+        var draft = BalancedManualJournalEntry() with
+        {
+            FundNodeId = null,
+            Dimensions = new LedgerDimensionSetDto(BookId: "book-only")
+        };
+
+        var validated = await service.ValidateDraftAsync(new ValidateManualJournalEntryDraftRequest(
+            draft,
+            "controller"));
+
+        validated.Dimensions.Should().NotBeNull();
+        validated.Dimensions!.BookId.Should().Be("book-only");
+    }
+
+    [Fact]
     public async Task Scenario_ManualJournalEntry_PeriodLockBlocksMutationsAndValidatesAsCritical()
     {
         var configuration = CreateService();


### PR DESCRIPTION
## Summary

Closes the two divergent dimension predicates left open by #2611 — and corrects what #2672 said the first one was.

Six copies of `HasAnyDimension` are now one.

## Reason

### The manual-journal defect is data loss, not misclassification

#2672 (which I filed) reported that `ManualJournalEntryWorkbenchService`'s private `HasAnyDimension` checks 11 of 19 fields, so a set carrying only a `BookId` would be classified "not dimensioned" and dropped.

**That isn't reachable.** `NormalizeDimensionSet` is called with `fundId: draft.FundNodeId ?? fundProfileId`, so `FundId` is always populated and the predicate always answers "dimensioned".

The real defect sits upstream of the predicate:

```csharp
var normalized = new LedgerDimensionSetDto(
    FundId: …, EntityId: …, /* …twelve in total… */)
{
    PositionId = dimensions?.PositionId
};
```

The other seven — `OrganizationId`, `PortfolioId`, `BookId`, `AccountId`, `CustomerId`, `VendorId`, `ProjectId` — are constructor parameters defaulting to `null`, so a caller's dimensions on those axes were **silently discarded**. The local predicate then agreed with itself, because it only checked the fields the normalizer could still produce.

That is worse than the reported symptom, not milder: the set survives, so nothing looks wrong, and the dimensions are gone.

`AccountingReportPackageService.NormalizeDimensionSet` — same method name, same DTO — already carried all nineteen. Two normalizers sharing a name disagreed about what survives normalization.

### The external-GL divergence

`AccountingCloseServices` required a non-blank key *and* value; the shared predicate took `Count > 0`. They agree for anything `ExtractExternalGlDimensions` produces, which never emits a blank, and diverge only on a caller-supplied dictionary with a blank entry — where the close path said "not dimensioned" and everyone else said "dimensioned".

The stricter reading is the right one and now lives in `LedgerDimensionTags`, so the two cannot disagree. **This is a behaviour change for every caller of the shared predicate**, but only for dictionaries containing a blank key or value.

### Consolidation

Both local copies are deleted; both files call `LedgerDimensionTags.HasAnyDimension` and both already imported `Meridian.Contracts.Ledger`. The three other callers — `AccountingReportPackageService`, `ReportGenerationService`, `PostgresLedgerBookService` — already reached it via `using static` and pick up the tightened rule automatically. `LedgerJournalConstruction` is left alone as before: it operates on `LedgerLineDimensionSet`, a different type.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Five tests: three on the shared predicate (blank, populated, and mixed external-GL entries) and two on the manual-journal path asserting all seven fields survive `ValidateDraftAsync`. Both of the latter fail before this change, since the fields came back `null`.

**Not compiled or run locally — no .NET SDK in this container**, so the two new C# tests reach CI unexecuted. What keeps that risk small is that they reuse the fixture helpers (`CreateService`, `SeedBalancedConfigurationAsync`, `CreateManualJournalEntryWorkbenchService`, `BalancedManualJournalEntry`) that an existing `ValidateDraftAsync` test in the same file already relies on, rather than inventing a new one.

Ratchets exit 0, script lane green at 834, docs regenerated and confirmed idempotent on a second pass.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed
- [ ] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtGupfUEyokEr8GmKSVVuq)_