### PR TITLE
Add --tighten-baseline: downward-only cap locking with retained headroom (#2675)

### DIFF
--- a/build/scripts/ci/check-file-size.py
+++ b/build/scripts/ci/check-file-size.py
@@ -32,6 +32,13 @@ Usage:
     python3 build/scripts/ci/check-file-size.py
     python3 build/scripts/ci/check-file-size.py --update-baseline
     python3 build/scripts/ci/check-file-size.py --threshold 2000
+    python3 build/scripts/ci/check-file-size.py --tighten-baseline [--buffer 50]
+
+--tighten-baseline is the downward-only counterpart to --update-baseline (#2675). It lowers each
+cap to the file's current size plus a working buffer, never raises one, retires an entry only once
+the threshold itself provides at least that buffer of headroom, and records the retained headroom
+in the baseline so the trend does not report deliberate slack as an unlocked reduction. It refuses
+to run at all while the ratchet is failing or while any governed source is unreadable.
 """
 
 from __future__ import annotations
@@ -146,23 +153,47 @@ def _load_baseline(root: Path) -> dict[str, int]:
     return {str(k): int(v) for k, v in data.get("files", {}).items()}
 
 
+def _load_headroom(root: Path) -> dict[str, int]:
+    """Deliberate headroom per file, recorded by --tighten-baseline.
+
+    Distinguishes "room left on purpose so the file can still be edited" from "reduction not yet
+    locked in". Without the distinction, the slack a tightening deliberately retained reads as
+    reclaimable, and the next ordinary run recommends the command that destroys it (#2675 defect 6).
+    Absent for baselines never tightened, which is equivalent to zero everywhere.
+    """
+    path = _baseline_path(root)
+    if not path.exists():
+        return {}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return {str(k): int(v) for k, v in data.get("headroom", {}).items()}
 
 
-def _write_baseline(root: Path, threshold: int, oversized: dict[str, int]) -> None:
+def _write_baseline(
+    root: Path, threshold: int, oversized: dict[str, int], headroom: dict[str, int] | None = None
+) -> None:
     path = _baseline_path(root)
     path.parent.mkdir(parents=True, exist_ok=True)
-    payload = {
+    payload: dict[str, object] = {
         "_comment": (
             "No-new-god-file ratchet baseline. Each entry caps a currently "
             "oversized source file at its recorded line count. Files may shrink "
             "freely; growing one past its cap or adding a new file over the "
-            "threshold fails CI. Regenerate with "
-            "`python3 build/scripts/ci/check-file-size.py --update-baseline` "
-            "and justify the change in review."
+            "threshold fails CI. Lock in reductions with "
+            "`python3 build/scripts/ci/check-file-size.py --tighten-baseline`, "
+            "which only lowers caps; `--update-baseline` regenerates from the "
+            "tree (and can raise caps), so it needs justification in review. "
+            "The optional headroom map records lines deliberately left spare by "
+            "the last tightening, so deliberate slack is not reported as an "
+            "unlocked reduction."
         ),
         "threshold_lines": threshold,
         "files": oversized,
     }
+    # Only entries for files still tracked; --update-baseline passes None and drops the map,
+    # because re-pinning every cap at its exact current size leaves nothing deliberate about
+    # whatever slack later appears.
+    if headroom:
+        payload["headroom"] = {rel: headroom[rel] for rel in sorted(headroom) if rel in oversized}
     path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
 
@@ -209,17 +240,38 @@ def _live_lines(
     return live, unreadable
 
 
-def _report_trend(root: Path, baseline: dict[str, int], current: dict[str, int]) -> None:
-    """Print the burn-down numbers: what is tracked, and how much of it is reclaimable."""
+def _report_trend(
+    root: Path,
+    baseline: dict[str, int],
+    current: dict[str, int],
+    headroom: dict[str, int] | None = None,
+) -> None:
+    """Print the burn-down numbers: what is tracked, and how much of it is reclaimable.
+
+    Reclaimable means "reduction not yet locked in". Headroom a tightening deliberately retained is
+    subtracted per file, because reporting it as reclaimable would recommend destroying it.
+    """
+    headroom = headroom or {}
     live_lines, unreadable = _live_lines(root, baseline, current)
     capped = sum(baseline.values())
     live = sum(live_lines.values())
-    slack = sum(max(0, cap - live_lines[rel]) for rel, cap in baseline.items())
+    slack = sum(
+        max(0, cap - live_lines[rel] - headroom.get(rel, 0)) for rel, cap in baseline.items()
+    )
+    retained = sum(
+        min(headroom.get(rel, 0), max(0, cap - live_lines[rel]))
+        for rel, cap in baseline.items()
+    )
 
     print(
         f"Baseline trend: {len(baseline)} tracked file(s), {capped:,} capped line(s), "
         f"{live:,} current line(s), {slack:,} line(s) reclaimable."
     )
+    if retained:
+        print(
+            f"({retained:,} further line(s) of cap are deliberate working headroom from the last "
+            f"--tighten-baseline and are not counted as reclaimable.)"
+        )
     if unreadable:
         print(
             f"NOTE: {len(unreadable)} baselined file(s) could not be read and are counted at their "
@@ -266,21 +318,116 @@ def _report_trend(root: Path, baseline: dict[str, int], current: dict[str, int])
             print(f"- ... and {len(tight) - 10} more")
     if slack:
         print(
-            "Those lines are not yet locked in: the caps still allow the file to grow back."
+            "Those lines are not yet locked in: the caps still allow the files to grow back. "
+            "Lock them in with --tighten-baseline, which lowers caps and never raises one."
         )
+
+
+# Default working headroom --tighten-baseline leaves above each file's current size. Deliberately
+# larger than TIGHT_HEADROOM_LINES so a freshly tightened baseline does not immediately announce
+# every file as near its cap.
+DEFAULT_TIGHTEN_BUFFER = 50
+
+
+def _load_baseline_threshold(root: Path) -> int:
+    path = _baseline_path(root)
+    if not path.exists():
+        return THRESHOLD_LINES
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return int(data.get("threshold_lines", THRESHOLD_LINES))
+
+
+def _tighten_baseline(
+    root: Path,
+    threshold: int,
+    buffer: int,
+    baseline: dict[str, int],
+    current: dict[str, int],
+) -> tuple[int, dict[str, int], dict[str, int], list[tuple[str, int]], list[str]]:
+    """Compute the tightened baseline. Pure: reads sizes, writes nothing.
+
+    Returns (exit_code, new_files, new_headroom, retired, unreadable_tracked). Only an exit code of
+    0 carries meaningful maps.
+
+    The rules, each the fix for a numbered defect in #2675:
+
+    - A cap only moves down: new cap = min(old cap, lines + buffer).
+    - An entry retires only when the threshold itself supplies the requested headroom
+      (lines + buffer <= threshold). A file one line under the threshold keeps a cap rather than
+      being handed the harder brand-new-god-file failure (defect 2).
+    - A deleted file (line count genuinely zero because it is gone) retires; an unreadable one
+      aborts the whole command, because a file that cannot be read is not a file with zero lines
+      (defects 3 and 4).
+    """
+    new_files: dict[str, int] = {}
+    new_headroom: dict[str, int] = {}
+    retired: list[tuple[str, int]] = []
+    unreadable_tracked: list[str] = []
+
+    for rel, cap in baseline.items():
+        if rel in current:
+            lines: int | None = current[rel]
+        else:
+            lines = _try_count_lines(root / rel)
+        if lines is None:
+            unreadable_tracked.append(rel)
+            continue
+
+        if lines + buffer <= threshold:
+            retired.append((rel, cap))
+            continue
+
+        new_cap = min(cap, lines + buffer)
+        new_files[rel] = new_cap
+        # Only positive headroom is recorded: a zero entry protects nothing and would bloat the
+        # baseline with one line per pinned file.
+        if new_cap > lines:
+            new_headroom[rel] = new_cap - lines
+
+    if unreadable_tracked:
+        return 2, {}, {}, [], sorted(unreadable_tracked)
+    return 0, dict(sorted(new_files.items())), new_headroom, sorted(retired), []
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="check-file-size")
-    parser.add_argument("--threshold", type=int, default=THRESHOLD_LINES)
+    parser.add_argument("--threshold", type=int, default=None)
     parser.add_argument(
         "--update-baseline",
         action="store_true",
         help="Regenerate the baseline from the current tree instead of checking.",
     )
+    parser.add_argument(
+        "--tighten-baseline",
+        action="store_true",
+        help="Lower caps to current size plus --buffer; never raises a cap. "
+             "Retires an entry only once the threshold itself supplies that headroom.",
+    )
+    parser.add_argument(
+        "--buffer",
+        type=int,
+        default=None,
+        help=f"Working headroom --tighten-baseline retains above each file's current size "
+             f"(default {DEFAULT_TIGHTEN_BUFFER}). Only valid with --tighten-baseline.",
+    )
     args = parser.parse_args(argv)
 
-
+    # Contract slips from the withdrawn first attempt (#2675): options that are accepted and
+    # ignored exit 0 while doing something other than what was asked, so both are hard errors.
+    if args.buffer is not None and not args.tighten_baseline:
+        print("ERROR: --buffer is only meaningful with --tighten-baseline.", file=sys.stderr)
+        return 2
+    if args.tighten_baseline and args.threshold is not None:
+        print(
+            "ERROR: --tighten-baseline uses the threshold recorded in the baseline; an explicit "
+            "--threshold would retire entries the baseline still protects.",
+            file=sys.stderr,
+        )
+        return 2
+    if args.tighten_baseline and args.update_baseline:
+        print("ERROR: --tighten-baseline and --update-baseline are mutually exclusive.",
+              file=sys.stderr)
+        return 2
 
     root = _repo_root()
     src_root = root / "src"
@@ -288,7 +435,90 @@ def main(argv: list[str] | None = None) -> int:
         print(f"ERROR: source root not found: {src_root}", file=sys.stderr)
         return 2
 
-    current, unreadable_sources = _scan(root, args.threshold)
+    # Tightening reads its threshold from the baseline it is tightening; everything else takes
+    # the flag or the module default.
+    if args.tighten_baseline:
+        threshold = _load_baseline_threshold(root)
+    else:
+        threshold = args.threshold if args.threshold is not None else THRESHOLD_LINES
+
+    current, unreadable_sources = _scan(root, threshold)
+
+    if args.tighten_baseline:
+        baseline_path = _baseline_path(root)
+        if not baseline_path.exists():
+            print("ERROR: no baseline found. Run with --update-baseline first.", file=sys.stderr)
+            return 2
+        baseline = _load_baseline(root)
+        buffer = args.buffer if args.buffer is not None else DEFAULT_TIGHTEN_BUFFER
+        if buffer < 0:
+            print("ERROR: --buffer must be non-negative.", file=sys.stderr)
+            return 2
+
+        # Fail closed on anything unreadable, tracked or not. An unreadable untracked source is
+        # invisible to the scan, so a new god file could ride through the very command that
+        # rewrites the protections (#2675 defect 4).
+        if unreadable_sources:
+            print(
+                f"ERROR: refusing to tighten. {len(unreadable_sources)} governed source file(s) "
+                f"could not be read:",
+                file=sys.stderr,
+            )
+            for rel in unreadable_sources:
+                print(f"- {rel}", file=sys.stderr)
+            return 2
+
+        # A mutating command must not exit 0 on a tree that fails the documented contract
+        # (#2675 defect 5). Report the violations exactly as the ordinary check would, then stop.
+        failing_new = sorted(rel for rel in current if rel not in baseline)
+        failing_grown = sorted(rel for rel in current if rel in baseline and current[rel] > baseline[rel])
+        if failing_new or failing_grown:
+            print("ERROR: refusing to tighten while the ratchet is failing:", file=sys.stderr)
+            for rel in failing_new:
+                print(f"- NEW god file: {rel} has {current[rel]} lines (> {threshold}).",
+                      file=sys.stderr)
+            for rel in failing_grown:
+                print(f"- GREW past cap: {rel} now {current[rel]} lines "
+                      f"(baseline cap {baseline[rel]}).", file=sys.stderr)
+            print("Fix the violations (or --update-baseline with justification), then tighten.",
+                  file=sys.stderr)
+            return 1
+
+        code, new_files, new_headroom, retired, unreadable_tracked = _tighten_baseline(
+            root, threshold, buffer, baseline, current
+        )
+        if code != 0:
+            print(
+                f"ERROR: refusing to tighten. {len(unreadable_tracked)} baselined file(s) could "
+                f"not be read, and a file that cannot be read is not a file with zero lines:",
+                file=sys.stderr,
+            )
+            for rel in unreadable_tracked:
+                print(f"- {rel}", file=sys.stderr)
+            return 2
+
+        _write_baseline(root, threshold, new_files, new_headroom)
+
+        # Progress accounting counts retired entries (#2675 defect 1). A retired file's future
+        # effective cap is the threshold itself - exceeding it fails as a new god file - so the
+        # locked-in reduction it contributes is cap minus threshold, not zero.
+        locked_kept = sum(baseline[rel] - new_files[rel] for rel in new_files)
+        locked_retired = sum(max(0, cap - threshold) for _, cap in retired)
+        retained_actual = sum(new_headroom.values())
+
+        print(
+            f"Tightened baseline: {len(baseline)} tracked file(s) -> {len(new_files)} kept, "
+            f"{len(retired)} retired."
+        )
+        print(
+            f"Locked in {locked_kept + locked_retired:,} capped line(s) "
+            f"({locked_retired:,} from retired entries); retained {retained_actual:,} line(s) of "
+            f"working headroom (requested {buffer} per file)."
+        )
+        for rel, cap in retired:
+            print(f"- retired: {rel} (cap was {cap}; the {threshold}-line threshold now protects it)")
+        _report_trend(root, new_files, current, new_headroom)
+        return 0
 
     if args.update_baseline:
         # Refuse to write from an incomplete scan. An unreadable source is absent from `current`,
@@ -310,9 +540,9 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"- {rel}", file=sys.stderr)
             return 2
 
-        _write_baseline(root, args.threshold, current)
+        _write_baseline(root, threshold, current)
         print(f"Wrote baseline with {len(current)} tracked file(s) "
-              f"(threshold {args.threshold} lines).")
+              f"(threshold {threshold} lines).")
         # Report against the baseline just written. This is the command run right after a
         # decomposition lands, so it is the one moment an operator most wants the trend - and
         # every file it just re-pinned shows up as TIGHT, which is the cost of the update being
@@ -325,6 +555,7 @@ def main(argv: list[str] | None = None) -> int:
         print("ERROR: no baseline found. Run with --update-baseline first.", file=sys.stderr)
         return 2
     baseline = _load_baseline(root)
+    headroom = _load_headroom(root)
 
     new_god_files: list[tuple[str, int]] = []
     grown_files: list[tuple[str, int, int]] = []
@@ -340,22 +571,22 @@ def main(argv: list[str] | None = None) -> int:
     if new_god_files or grown_files:
         print("File-size ratchet FAILED:", file=sys.stderr)
         for rel, lines in new_god_files:
-            print(f"- NEW god file: {rel} has {lines} lines (> {args.threshold}). "
+            print(f"- NEW god file: {rel} has {lines} lines (> {threshold}). "
                   f"Split it into composed units, or if unavoidable add it to the "
                   f"baseline with justification.", file=sys.stderr)
         for rel, lines, cap in grown_files:
             print(f"- GREW past cap: {rel} now {lines} lines (baseline cap {cap}, "
                   f"exceeded by {lines - cap}). Reduce it, or update the baseline with "
                   f"justification.", file=sys.stderr)
-        _report_trend(root, baseline, current)
+        _report_trend(root, baseline, current, headroom)
         return 1
 
     print(f"File-size ratchet OK: {len(current)} tracked file(s), "
-          f"no new or grown god files (threshold {args.threshold} lines).")
-    _report_trend(root, baseline, current)
+          f"no new or grown god files (threshold {threshold} lines).")
+    _report_trend(root, baseline, current, headroom)
     if stale:
-        print("Notice: baseline entries now under threshold (tighten the ratchet "
-              "by rerunning --update-baseline):")
+        print("Notice: baseline entries now under threshold (lock the reduction in "
+              "with --tighten-baseline, which never raises a cap):")
         for rel in stale:
             print(f"- {rel}")
     return 0

--- a/docs/architecture/module-conventions.md
+++ b/docs/architecture/module-conventions.md
@@ -83,7 +83,10 @@ ratchet**: `build/scripts/ci/check-file-size.py` (invoked from `.github/workflow
 - Any hand-authored production source file over **2000 lines** that is not in
   `build/config/file-size-baseline.json` fails CI.
 - Baselined files are frozen at their recorded line count: they may shrink freely but not grow.
-- Legitimately changing a cap requires `python3 build/scripts/ci/check-file-size.py --update-baseline`
+- After a decomposition, lock the reduction in with
+  `python3 build/scripts/ci/check-file-size.py --tighten-baseline` — it only ever lowers caps and
+  retains a working buffer above each file's current size.
+- Legitimately *raising* a cap requires `python3 build/scripts/ci/check-file-size.py --update-baseline`
   and a justification in review — the diff makes the tracked debt visible.
 
 The intent is directional: every baselined file is a decomposition target, and the ratchet only ever

--- a/docs/development/god-file-burn-down-plan.md
+++ b/docs/development/god-file-burn-down-plan.md
@@ -93,34 +93,32 @@ Reporting only. No enforcement rule is altered, so nothing that passes today sta
    visible before a contributor hits it, and the report names decomposition candidates by urgency
    rather than by size.
 
-## The missing mechanism
+## Locking in a reduction
 
-Reporting makes the problem visible. It does not fix it, and the gap is specific:
+After a decomposition lands, lock the reclaimed lines in with the downward-only tightener (#2675):
 
-**There is no safe way to lock in a reduction.** `--update-baseline` regenerates from the tree, so
-it can raise a cap as easily as lower one — which is why it is the escape hatch that should surface
-in review as tracked debt. Nothing lowers caps only. Until that exists, lines reclaimed by a
-decomposition sit unprotected: the old cap still permits the file to grow straight back.
+```bash
+python3 build/scripts/ci/check-file-size.py --tighten-baseline           # default 50-line buffer
+python3 build/scripts/ci/check-file-size.py --tighten-baseline --buffer 25
+```
 
-**Nothing creates working headroom.** Any mechanism that lowers a cap to the current count re-pins
-the file, which is the state this plan exists to escape. A useful tool has to lock in most of a
-reduction while deliberately leaving room to edit.
+Its contract, shaped by the six defects review found in a withdrawn first attempt:
 
-A first attempt at both — a downward-only `--tighten-baseline` with a `--buffer N` option — was
-drafted alongside this plan and **withdrawn**. Review found six distinct defects in it across five
-rounds: retired files dropped out of the reclaimed total, retirement discarded a cap while the file
-was still within the buffer of the threshold, an unreadable file was counted as empty and had its
-cap written away, the command returned success while the ratchet was failing, `--buffer` was
-accepted and ignored outside tightening, and the resulting slack made the tool recommend a command
-that destroyed the headroom it had just created.
+- **A cap only moves down** — each becomes `min(old cap, current lines + buffer)`. Raising a cap
+  still requires `--update-baseline` plus justification in review.
+- **The buffer is working headroom, not slack.** It is recorded in the baseline's `headroom` map,
+  so the trend report does not count it as reclaimable and nothing recommends re-pinning it away.
+- **An entry retires only when the threshold itself supplies the requested headroom**
+  (`lines + buffer <= threshold`). A file one line under the threshold keeps a lowered cap rather
+  than being handed the harder brand-new-god-file failure.
+- **It refuses to run while the ratchet is failing**, and **fails closed on any unreadable governed
+  source**, tracked or not — a file that cannot be read is not a file with zero lines. A genuinely
+  deleted file retires and its reduction is counted.
+- `--buffer` outside tightening, or `--tighten-baseline` with an explicit `--threshold`, are hard
+  errors rather than accepted-and-ignored options.
 
-Every one of those lived in the same seam: the interaction between *file below threshold*, *file
-still in baseline*, and *tree currently failing*. A read-only check never has to reason about it. A
-mutating one does, on every path. That is the design work the mechanism needs, and it belongs in its
-own change with its own review rather than riding along with a reporting improvement.
-
-Until then, lock in a reduction with `--update-baseline` and justify the diff in review, as the
-ratchet's own documentation already directs.
+The reclaimable figure in the trend report is therefore exactly the reduction not yet locked in;
+run the tightener whenever it is non-zero and the tree is green.
 
 ## Targets
 
@@ -225,8 +223,9 @@ python3 build/scripts/ci/check-file-size.py
 After a decomposition lands, lock in the reduction:
 
 ```bash
-python3 build/scripts/ci/check-file-size.py --update-baseline
+python3 build/scripts/ci/check-file-size.py --tighten-baseline
 ```
 
-Review the diff carefully — this command can raise a cap as well as lower one, which is why a
-downward-only alternative is the missing mechanism described above. Caps should only ever fall.
+This only ever lowers caps and retains a working buffer above each file's current size (see
+"Locking in a reduction" above). `--update-baseline` remains the escape hatch for deliberately
+*raising* a cap, and its diff should be justified in review — caps should only ever fall.

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 648,
-  "total_lines": 128500,
+  "total_lines": 128502,
   "orphaned_count": 254,
   "no_heading_count": 148,
   "stale_count": 0,
@@ -1521,7 +1521,7 @@
     },
     {
       "path": "docs/architecture/module-conventions.md",
-      "line_count": 99,
+      "line_count": 102,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -1849,7 +1849,7 @@
     },
     {
       "path": "docs/development/god-file-burn-down-plan.md",
-      "line_count": 232,
+      "line_count": 231,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 648 |
-| Total lines | 128,500 |
+| Total lines | 128,502 |
 | Average file size (lines) | 198.3 |
 | Orphaned files | 254 |
 | Files without headings | 148 |

--- a/docs/status/example-validation.md
+++ b/docs/status/example-validation.md
@@ -8,8 +8,8 @@
 
 | Metric | Count |
 |--------|------:|
-| Total code blocks | 999 |
-| Valid | 577 |
+| Total code blocks | 1000 |
+| Valid | 578 |
 | Invalid | 0 |
 | Skipped | 422 |
 
@@ -18,7 +18,7 @@
 | Language | Total | Valid | Invalid | Skipped |
 |----------|------:|------:|--------:|--------:|
 | `(none)` | 104 | 0 | 0 | 104 |
-| `bash` | 162 | 162 | 0 | 0 |
+| `bash` | 163 | 163 | 0 | 0 |
 | `cmd` | 1 | 0 | 0 | 1 |
 | `cpp` | 1 | 0 | 0 | 1 |
 | `csharp` | 322 | 322 | 0 | 0 |
@@ -100,7 +100,7 @@ No invalid code examples found.
 | `docs/development/documentation-contribution-guide.md` | 7 |
 | `docs/development/expanding-scripts.md` | 8 |
 | `docs/development/git-hooks.md` | 4 |
-| `docs/development/god-file-burn-down-plan.md` | 3 |
+| `docs/development/god-file-burn-down-plan.md` | 4 |
 | `docs/development/otlp-trace-visualization.md` | 5 |
 | `docs/development/provider-implementation.md` | 23 |
 | `docs/development/repository-organization-guide.md` | 8 |

--- a/tests/scripts/test_check_file_size_ratchet.py
+++ b/tests/scripts/test_check_file_size_ratchet.py
@@ -251,5 +251,172 @@ class TrendReportingTests(unittest.TestCase):
             self.assertIn("NEW god file", output)
 
 
+def read_payload(root: Path) -> dict:
+    return json.loads((root / "build" / "config" / "file-size-baseline.json").read_text())
+
+
+class TightenBaselineTests(unittest.TestCase):
+    """--tighten-baseline against the numbered defects of #2675's withdrawn first attempt.
+
+    All fixtures use threshold 10 (written into the baseline by fake_repo); tighten reads the
+    threshold from the baseline rather than the command line, so none of these pass --threshold.
+    """
+
+    def test_never_raises_a_cap_and_reports_actual_headroom(self):
+        # Requirements 1 and 7. 29 lines with a buffer of 50 targets a cap of 79, but the old cap
+        # is 30 - so the cap stays 30, and the headroom reported is the 1 line actually retained,
+        # not the 50 requested.
+        with fake_repo({"src/a.cs": 29}, {"src/a.cs": 30}) as root:
+            code, output = run(["--tighten-baseline", "--buffer", "50"])
+
+            self.assertEqual(code, 0, output)
+            self.assertEqual(read_baseline(root), {"src/a.cs": 30})
+            self.assertIn("retained 1 line(s) of working headroom (requested 50 per file)", output)
+
+    def test_lowers_a_cap_to_lines_plus_buffer(self):
+        with fake_repo({"src/a.cs": 20}, {"src/a.cs": 90}) as root:
+            code, output = run(["--tighten-baseline", "--buffer", "5"])
+
+            self.assertEqual(code, 0, output)
+            self.assertEqual(read_baseline(root), {"src/a.cs": 25})
+            self.assertEqual(read_payload(root)["headroom"], {"src/a.cs": 5})
+
+    # Defect 1: a retired entry's reduction vanished from the progress figure at exactly the
+    # moment a decomposition achieved the headline goal.
+    def test_counts_a_retired_entry_in_the_locked_in_figure(self):
+        # 5 lines + buffer 5 = 10 <= threshold 10, so the entry retires. Its future effective cap
+        # is the threshold, so the locked-in reduction is 30 - 10 = 20.
+        with fake_repo({"src/small.cs": 5}, {"src/small.cs": 30}) as root:
+            code, output = run(["--tighten-baseline", "--buffer", "5"])
+
+            self.assertEqual(code, 0, output)
+            self.assertEqual(read_baseline(root), {})
+            self.assertIn("1 retired", output)
+            self.assertIn("Locked in 20 capped line(s) (20 from retired entries)", output)
+
+    # Defect 2: a file one line under the threshold was retired by the buffer, so its next added
+    # line failed as a brand-new god file - a harder failure than the cap it just lost.
+    def test_keeps_an_entry_until_the_threshold_supplies_the_headroom(self):
+        # 9 lines + buffer 5 = 14 > threshold 10: the threshold alone cannot supply the requested
+        # headroom, so the entry is kept, capped at 14.
+        with fake_repo({"src/edge.cs": 9}, {"src/edge.cs": 21}) as root:
+            code, output = run(["--tighten-baseline", "--buffer", "5"])
+
+            self.assertEqual(code, 0, output)
+            self.assertEqual(read_baseline(root), {"src/edge.cs": 14})
+            self.assertIn("0 retired", output)
+
+    # Defect 3: an unreadable tracked file counted as empty and had its cap written away.
+    def test_refuses_when_a_tracked_file_is_unreadable(self):
+        with fake_repo({"src/locked.cs": 8}, {"src/locked.cs": 30}) as root:
+            with unreadable("locked.cs"):
+                code, output = run(["--tighten-baseline", "--buffer", "5"])
+
+            self.assertEqual(code, 2)
+            self.assertIn("refusing to tighten", output)
+            self.assertIn("src/locked.cs", output)
+            self.assertEqual(read_baseline(root), {"src/locked.cs": 30})
+
+    # Defect 4: an unreadable *untracked* source was silently skipped, so tightening could
+    # rewrite the baseline while missing a new god file entirely.
+    def test_refuses_when_an_untracked_source_is_unreadable(self):
+        with fake_repo({"src/ok.cs": 20, "src/mystery.cs": 40}, {"src/ok.cs": 30}) as root:
+            with unreadable("mystery.cs"):
+                code, output = run(["--tighten-baseline", "--buffer", "5"])
+
+            self.assertEqual(code, 2)
+            self.assertIn("refusing to tighten", output)
+            self.assertIn("src/mystery.cs", output)
+            self.assertEqual(read_baseline(root), {"src/ok.cs": 30})
+
+    # Defect 5: tightening wrote the baseline and returned 0 while the ratchet was failing.
+    def test_refuses_while_the_ratchet_is_failing(self):
+        with fake_repo({"src/grown.cs": 40, "src/fresh.cs": 50},
+                       {"src/grown.cs": 30}) as root:
+            code, output = run(["--tighten-baseline", "--buffer", "5"])
+
+            self.assertEqual(code, 1)
+            self.assertIn("refusing to tighten while the ratchet is failing", output)
+            self.assertIn("NEW god file: src/fresh.cs", output)
+            self.assertIn("GREW past cap: src/grown.cs", output)
+            self.assertEqual(read_baseline(root), {"src/grown.cs": 30})
+
+    # Defect 6: retained buffer read as reclaimable slack, so the next ordinary run recommended
+    # the command that destroys the headroom the buffer just created.
+    def test_retained_headroom_is_not_reported_as_reclaimable(self):
+        with fake_repo({"src/a.cs": 20}, {"src/a.cs": 90}):
+            code, output = run(["--tighten-baseline", "--buffer", "5"])
+            self.assertEqual(code, 0, output)
+
+            code, output = run(["--threshold", "10"])
+            self.assertEqual(code, 0, output)
+            self.assertIn("0 line(s) reclaimable", output)
+            self.assertIn("5 further line(s) of cap are deliberate working headroom", output)
+            self.assertNotIn("not yet locked in", output)
+
+    def test_a_further_reduction_beyond_the_headroom_is_reclaimable_again(self):
+        with fake_repo({"src/a.cs": 20}, {"src/a.cs": 90}) as root:
+            code, output = run(["--tighten-baseline", "--buffer", "5"])
+            self.assertEqual(code, 0, output)
+
+            # The file shrinks by another 12 lines after the tightening.
+            (root / "src" / "a.cs").write_text("\n".join("x" for _ in range(8)) + "\n")
+            code, output = run(["--threshold", "10"])
+
+            self.assertEqual(code, 0, output)
+            self.assertIn("12 line(s) reclaimable", output)
+            self.assertIn("not yet locked in", output)
+            self.assertIn("--tighten-baseline", output)
+
+    def test_a_deleted_file_retires(self):
+        # Deleted and unreadable are different answers: gone really is zero lines.
+        with fake_repo({"src/kept.cs": 20}, {"src/kept.cs": 30, "src/gone.cs": 40}) as root:
+            code, output = run(["--tighten-baseline", "--buffer", "5"])
+
+            self.assertEqual(code, 0, output)
+            self.assertEqual(read_baseline(root), {"src/kept.cs": 25})
+            self.assertIn("1 retired", output)
+            self.assertIn("src/gone.cs", output)
+
+    # Contract slip 1: --buffer accepted and ignored outside tightening, so
+    # `--update-baseline --buffer 25` exited 0 while pinning every cap.
+    def test_buffer_without_tighten_is_an_error(self):
+        with fake_repo({"src/a.cs": 20}, {"src/a.cs": 30}) as root:
+            code, output = run(["--update-baseline", "--buffer", "25"])
+
+            self.assertEqual(code, 2)
+            self.assertIn("--buffer is only meaningful with --tighten-baseline", output)
+            self.assertEqual(read_baseline(root), {"src/a.cs": 30})
+
+    # Contract slip 2: an explicit --threshold retired files the baseline still protected.
+    def test_tighten_with_explicit_threshold_is_an_error(self):
+        with fake_repo({"src/a.cs": 20}, {"src/a.cs": 30}) as root:
+            code, output = run(["--tighten-baseline", "--threshold", "50"])
+
+            self.assertEqual(code, 2)
+            self.assertIn("threshold recorded in the baseline", output)
+            self.assertEqual(read_baseline(root), {"src/a.cs": 30})
+
+    def test_tighten_uses_the_baseline_threshold_not_the_default(self):
+        # fake_repo records threshold 10 in the baseline; the module default is 2000. If tighten
+        # used the default, every fixture entry would retire (lines + buffer << 2000).
+        with fake_repo({"src/a.cs": 20}, {"src/a.cs": 90}) as root:
+            code, output = run(["--tighten-baseline", "--buffer", "5"])
+
+            self.assertEqual(code, 0, output)
+            self.assertEqual(read_baseline(root), {"src/a.cs": 25})
+
+    def test_update_baseline_drops_recorded_headroom(self):
+        # Re-pinning every cap at its exact size leaves nothing deliberate about later slack.
+        with fake_repo({"src/a.cs": 20}, {"src/a.cs": 90}) as root:
+            run(["--tighten-baseline", "--buffer", "5"])
+            self.assertIn("headroom", read_payload(root))
+
+            code, output = run(["--threshold", "10", "--update-baseline"])
+
+            self.assertEqual(code, 0, output)
+            self.assertNotIn("headroom", read_payload(root))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- phase:PR6 -->

## Summary

`check-file-size.py --tighten-baseline [--buffer N]` — the downward-only counterpart to `--update-baseline`. It lowers each cap to `min(old cap, current lines + buffer)`, never raises one, retires an entry only once the threshold itself supplies the requested headroom, persists the retained headroom in the baseline, and refuses to run on a failing tree or past any unreadable governed source.

Fixes #2675.

## Reason

#2675 is unusual in that it *is* the specification: six numbered defects from a withdrawn first attempt, plus eight requirements distilled from them. This implementation treats the defects as the test plan — each has a named test — and the requirements as the contract:

| # | Defect in the withdrawn attempt | Rule here |
| --- | --- | --- |
| 1 | Retired files vanished from the reclaimed total | A retired entry's reduction is counted at `cap − threshold` — the threshold is its future effective cap |
| 2 | Retirement stranded a file one line under the threshold | Retire only when `lines + buffer ≤ threshold`, so the threshold itself provides the headroom being requested |
| 3 | Unreadable tracked file counted as empty, cap written away | Exit 2 before anything is written |
| 4 | Unreadable *untracked* source silently skipped | Same — an invisible source could hide a new god file from the very command rewriting the protections |
| 5 | Returned 0 while the ratchet was failing | Exit 1 with the ordinary failure report; a mutating command must not exit 0 on a tree failing the documented contract |
| 6 | Retained buffer read as reclaimable slack | Actual retained headroom (`min(slack, buffer)` per file) is persisted in a new optional `headroom` map, and the trend subtracts it from the reclaimable figure |

Both contract slips are hard errors: `--buffer` without `--tighten-baseline`, and `--tighten-baseline` with an explicit `--threshold` (tightening reads the threshold from the baseline it is tightening, so it cannot retire entries the baseline still protects).

### The issue's design concern, answered

The issue flags requirement 8 as "probably persisted metadata rather than an inference" — a baseline schema question. Resolved as an **optional** `headroom` map alongside `files`: absent for never-tightened baselines (equivalent to zero everywhere), entries only for positive headroom, dropped by `--update-baseline` since re-pinning leaves nothing deliberate about later slack. Every existing consumer of `files` is untouched.

### Reporting alignment

The trend's "not yet locked in" footer and the stale-entry notice now recommend `--tighten-baseline`. The stale notice previously recommended `--update-baseline` — the command that can *raise* caps — as the way to tighten the ratchet. Default buffer is 50, deliberately above the 25-line TIGHT threshold so a fresh tightening doesn't announce every file as near its cap.

### The live baseline is deliberately untouched

Current slack is 79 lines spread across 11 files, all under the default buffer — so tightening today is a no-op *by design* (`min(cap, lines+50)` changes nothing where slack < 50). The tool earns its keep on the next real decomposition. That also keeps this PR mechanism-only: no policy change to the 50 live caps rides along.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Python, verified locally end to end. 14 new tests (29 in the suite): one per numbered defect, both contract slips, the never-raises property with actual-vs-requested headroom reporting (a 50-line request against 1 line of slack reports 1, not 50), the baseline-threshold rule, headroom expiry under `--update-baseline`, deleted-vs-unreadable divergence, and that a further reduction *beyond* retained headroom reads as reclaimable again.

Also verified beyond the unit under change: live ratchet still exits 0 against the real tree; full script lane green at 856; docs regeneration idempotent on the post-#2710 base. For this generator there is only one test location (`tests/scripts/test_check_file_size_ratchet.py`) — checked, after being burned by a second one on the last PR.

Docs updated where this mechanism was documented as missing: `god-file-burn-down-plan.md`'s "missing mechanism" section is now the tool's contract, its command appendix recommends tighten, and `module-conventions.md` distinguishes locking in a reduction from raising a cap.

## Scope note

Declared `phase:PR6` (the diff touches `build/**`, `tests/**`, and `docs/**`, all within PR6's cumulative scope). Verified locally: `enforce_phase_scope.py --phase PR6` passes against this diff.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed
- [ ] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`