### PR TITLE
Retire deleted files unconditionally and fail closed on unenumerable directories in the ratchet

### DIFF
--- a/build/scripts/ci/check-file-size.py
+++ b/build/scripts/ci/check-file-size.py
@@ -36,9 +36,10 @@ Usage:
 
 --tighten-baseline is the downward-only counterpart to --update-baseline (#2675). It lowers each
 cap to the file's current size plus a working buffer, never raises one, retires an entry only once
-the threshold itself provides at least that buffer of headroom, and records the retained headroom
-in the baseline so the trend does not report deliberate slack as an unlocked reduction. It refuses
-to run at all while the ratchet is failing or while any governed source is unreadable.
+the threshold itself provides at least that buffer of headroom (a deleted file always retires —
+there is nothing left to protect), and records the retained headroom in the baseline so the trend
+does not report deliberate slack as an unlocked reduction. It refuses to run at all while the
+ratchet is failing or while any governed source is unreadable.
 """
 
 from __future__ import annotations
@@ -111,6 +112,21 @@ def _try_count_lines(path: Path) -> int | None:
         return None
 
 
+def _is_gone(path: Path) -> bool | None:
+    """True if the file is genuinely absent, False if present, None if unknowable.
+
+    Probed with open() rather than Path.exists(), which re-raises OSErrors outside ENOENT —
+    EACCES on an untraversable parent among them — instead of returning False.
+    """
+    try:
+        with path.open("rb"):
+            return False
+    except FileNotFoundError:
+        return True
+    except OSError:
+        return None
+
+
 def _iter_source_files(src_root: Path) -> tuple[list[Path], list[Path]]:
     """Every governed source file, plus any directory the walk could not enumerate.
 
@@ -150,7 +166,13 @@ def _scan(root: Path, threshold: int) -> tuple[dict[str, int], list[str]]:
     unreadable: list[str] = []
     files, failed_dirs = _iter_source_files(src_root)
     for directory in failed_dirs:
-        unreadable.append(_relativize(directory, root))
+        rel = _relativize(directory, root)
+        # A directory that is itself an excluded prefix holds only excluded files, so failing to
+        # enumerate it hides nothing this check governs. The trailing slash makes the directory
+        # match the same prefix patterns its files would.
+        if _is_excluded(rel + "/"):
+            continue
+        unreadable.append(rel)
     for path in files:
         rel = path.relative_to(root).as_posix()
         if _is_excluded(rel):
@@ -381,10 +403,13 @@ def _tighten_baseline(
     - An entry retires only when the threshold itself supplies the requested headroom
       (lines + buffer <= threshold). A file one line under the threshold keeps a cap rather than
       being handed the harder brand-new-god-file failure (defect 2).
-    - A deleted file (line count genuinely zero because it is gone) retires unconditionally —
-      before the buffer rule, which a buffer larger than the threshold would otherwise fail it
-      against. An unreadable one aborts the whole command, because a file that cannot be read is
-      not a file with zero lines (defects 3 and 4).
+    - A deleted file retires unconditionally — before the buffer rule, which a buffer larger
+      than the threshold would otherwise fail it against. Deletion is confirmed by probing the
+      path, because a zero line count alone also describes a file that exists but is empty; an
+      empty file follows the ordinary rules, so an oversized buffer keeps its cap rather than
+      handing a later rebuild the brand-new-god-file failure. An unreadable file aborts the
+      whole command, because a file that cannot be read is not a file with zero lines
+      (defects 3 and 4).
     """
     new_files: dict[str, int] = {}
     new_headroom: dict[str, int] = {}
@@ -400,10 +425,21 @@ def _tighten_baseline(
             unreadable_tracked.append(rel)
             continue
 
-        # Deleted (or emptied) first: zero lines means there is nothing left to protect, and the
-        # buffer rule below would keep the entry whenever the buffer exceeds the threshold -
-        # recording the whole cap of a nonexistent file as deliberate headroom.
-        if lines == 0 or lines + buffer <= threshold:
+        # Deleted first: nothing is left to protect, and the buffer rule below would keep the
+        # entry whenever the buffer exceeds the threshold - recording the whole cap of a
+        # nonexistent file as deliberate headroom. Zero lines alone does not prove deletion
+        # (an existing file can be empty), so absence is confirmed by a probe; a probe that
+        # cannot tell is an unreadable source, not a retirement.
+        if lines == 0:
+            gone = _is_gone(root / rel)
+            if gone is None:
+                unreadable_tracked.append(rel)
+                continue
+            if gone:
+                retired.append((rel, cap))
+                continue
+
+        if lines + buffer <= threshold:
             retired.append((rel, cap))
             continue
 
@@ -431,7 +467,8 @@ def main(argv: list[str] | None = None) -> int:
         "--tighten-baseline",
         action="store_true",
         help="Lower caps to current size plus --buffer; never raises a cap. "
-             "Retires an entry only once the threshold itself supplies that headroom.",
+             "Retires an entry only once the threshold itself supplies that headroom; "
+             "a deleted file always retires.",
     )
     parser.add_argument(
         "--buffer",

--- a/build/scripts/ci/check-file-size.py
+++ b/build/scripts/ci/check-file-size.py
@@ -111,14 +111,30 @@ def _try_count_lines(path: Path) -> int | None:
         return None
 
 
-def _iter_source_files(src_root: Path) -> list[Path]:
+def _iter_source_files(src_root: Path) -> tuple[list[Path], list[Path]]:
+    """Every governed source file, plus any directory the walk could not enumerate.
+
+    os.walk ignores scandir errors by default, which silently prunes the whole subtree from the
+    scan. A pruned subtree hides its files exactly the way one unreadable file hides itself, so
+    the failed directory is surfaced for the caller's unreadable set instead of dropped. A
+    directory deleted mid-walk is the one exception: gone is not unreadable, matching how
+    _try_count_lines treats a deleted file.
+    """
     files: list[Path] = []
-    for dirpath, dirnames, filenames in os.walk(src_root, topdown=True, followlinks=False):
+    failed_dirs: list[Path] = []
+
+    def record(error: OSError) -> None:
+        if isinstance(error, FileNotFoundError):
+            return
+        failed_dirs.append(Path(error.filename) if error.filename else src_root)
+
+    for dirpath, dirnames, filenames in os.walk(
+            src_root, topdown=True, onerror=record, followlinks=False):
         dirnames[:] = [d for d in dirnames if d.lower() not in _SKIP_DIR_NAMES]
         for filename in filenames:
             if filename.endswith(SOURCE_SUFFIXES):
                 files.append(Path(dirpath) / filename)
-    return files
+    return files, failed_dirs
 
 
 def _scan(root: Path, threshold: int) -> tuple[dict[str, int], list[str]]:
@@ -132,7 +148,10 @@ def _scan(root: Path, threshold: int) -> tuple[dict[str, int], list[str]]:
     src_root = root / "src"
     oversized: dict[str, int] = {}
     unreadable: list[str] = []
-    for path in _iter_source_files(src_root):
+    files, failed_dirs = _iter_source_files(src_root)
+    for directory in failed_dirs:
+        unreadable.append(_relativize(directory, root))
+    for path in files:
         rel = path.relative_to(root).as_posix()
         if _is_excluded(rel):
             continue
@@ -143,6 +162,13 @@ def _scan(root: Path, threshold: int) -> tuple[dict[str, int], list[str]]:
         if lines > threshold:
             oversized[rel] = lines
     return dict(sorted(oversized.items())), sorted(unreadable)
+
+
+def _relativize(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
 
 
 def _load_baseline(root: Path) -> dict[str, int]:
@@ -355,9 +381,10 @@ def _tighten_baseline(
     - An entry retires only when the threshold itself supplies the requested headroom
       (lines + buffer <= threshold). A file one line under the threshold keeps a cap rather than
       being handed the harder brand-new-god-file failure (defect 2).
-    - A deleted file (line count genuinely zero because it is gone) retires; an unreadable one
-      aborts the whole command, because a file that cannot be read is not a file with zero lines
-      (defects 3 and 4).
+    - A deleted file (line count genuinely zero because it is gone) retires unconditionally —
+      before the buffer rule, which a buffer larger than the threshold would otherwise fail it
+      against. An unreadable one aborts the whole command, because a file that cannot be read is
+      not a file with zero lines (defects 3 and 4).
     """
     new_files: dict[str, int] = {}
     new_headroom: dict[str, int] = {}
@@ -373,7 +400,10 @@ def _tighten_baseline(
             unreadable_tracked.append(rel)
             continue
 
-        if lines + buffer <= threshold:
+        # Deleted (or emptied) first: zero lines means there is nothing left to protect, and the
+        # buffer rule below would keep the entry whenever the buffer exceeds the threshold -
+        # recording the whole cap of a nonexistent file as deliberate headroom.
+        if lines == 0 or lines + buffer <= threshold:
             retired.append((rel, cap))
             continue
 
@@ -460,7 +490,7 @@ def main(argv: list[str] | None = None) -> int:
         # rewrites the protections (#2675 defect 4).
         if unreadable_sources:
             print(
-                f"ERROR: refusing to tighten. {len(unreadable_sources)} governed source file(s) "
+                f"ERROR: refusing to tighten. {len(unreadable_sources)} governed source path(s) "
                 f"could not be read:",
                 file=sys.stderr,
             )
@@ -533,7 +563,7 @@ def main(argv: list[str] | None = None) -> int:
         if unreadable_sources:
             print(
                 f"ERROR: refusing to rewrite the baseline. {len(unreadable_sources)} governed "
-                f"source file(s) could not be read, and writing now would drop their caps:",
+                f"source path(s) could not be read, and writing now would drop their caps:",
                 file=sys.stderr,
             )
             for rel in unreadable_sources:

--- a/docs/development/god-file-burn-down-plan.md
+++ b/docs/development/god-file-burn-down-plan.md
@@ -110,10 +110,13 @@ Its contract, shaped by the six defects review found in a withdrawn first attemp
   so the trend report does not count it as reclaimable and nothing recommends re-pinning it away.
 - **An entry retires only when the threshold itself supplies the requested headroom**
   (`lines + buffer <= threshold`). A file one line under the threshold keeps a lowered cap rather
-  than being handed the harder brand-new-god-file failure.
+  than being handed the harder brand-new-god-file failure. The one exception is a genuinely
+  deleted file, which always retires — there is nothing left to protect, whatever the buffer —
+  while a file that merely became empty follows the ordinary rules.
 - **It refuses to run while the ratchet is failing**, and **fails closed on any unreadable governed
-  source**, tracked or not — a file that cannot be read is not a file with zero lines. A genuinely
-  deleted file retires and its reduction is counted.
+  source**, tracked or not — a file that cannot be read is not a file with zero lines, and a
+  directory that cannot be enumerated hides every governed file under it. Deleted-file
+  reductions are counted when the entry retires.
 - `--buffer` outside tightening, or `--tighten-baseline` with an explicit `--threshold`, are hard
   errors rather than accepted-and-ignored options.
 

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 648,
-  "total_lines": 128502,
+  "total_lines": 128505,
   "orphaned_count": 254,
   "no_heading_count": 148,
   "stale_count": 0,
@@ -1849,7 +1849,7 @@
     },
     {
       "path": "docs/development/god-file-burn-down-plan.md",
-      "line_count": 231,
+      "line_count": 234,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 648 |
-| Total lines | 128,502 |
+| Total lines | 128,505 |
 | Average file size (lines) | 198.3 |
 | Orphaned files | 254 |
 | Files without headings | 148 |

--- a/tests/scripts/test_check_file_size_ratchet.py
+++ b/tests/scripts/test_check_file_size_ratchet.py
@@ -432,6 +432,18 @@ class TightenBaselineTests(unittest.TestCase):
             self.assertIn("src/gone.cs", output)
             self.assertNotIn("src/gone.cs", read_payload(root).get("headroom", {}))
 
+    # Zero lines alone does not prove deletion: an existing file can be empty. Retiring it under
+    # an oversized buffer would hand a later rebuild the brand-new-god-file failure instead of
+    # the cap the operator asked to keep.
+    def test_an_emptied_file_is_not_retired_as_deleted_when_the_buffer_exceeds_the_threshold(self):
+        with fake_repo({"src/kept.cs": 20}, {"src/kept.cs": 30, "src/emptied.cs": 40}) as root:
+            (root / "src" / "emptied.cs").write_text("", encoding="utf-8")
+            code, output = run(["--tighten-baseline", "--buffer", "25"])
+
+            self.assertEqual(code, 0, output)
+            self.assertEqual(read_baseline(root), {"src/kept.cs": 30, "src/emptied.cs": 25})
+            self.assertIn("0 retired", output)
+
     # os.walk ignores scandir errors unless given an onerror callback, so an unenumerable
     # subtree used to vanish from the scan entirely — and tightening would rewrite the baseline
     # having never seen whatever that subtree holds.
@@ -446,6 +458,17 @@ class TightenBaselineTests(unittest.TestCase):
             self.assertIn("src/vault", output)
             self.assertEqual(read_baseline(root),
                              {"src/ok.cs": 30, "src/vault/secret.cs": 40})
+
+    # An excluded subtree holds only files the ratchet never governs, so failing to enumerate it
+    # hides nothing and must not veto a rewrite the way a governed subtree does.
+    def test_an_unenumerable_excluded_directory_does_not_block_tightening(self):
+        with fake_repo({"src/ok.cs": 20, "src/generated/big.cs": 40},
+                       {"src/ok.cs": 30}) as root:
+            with unenumerable("generated"):
+                code, output = run(["--tighten-baseline", "--buffer", "5"])
+
+            self.assertEqual(code, 0, output)
+            self.assertEqual(read_baseline(root), {"src/ok.cs": 25})
 
     # Contract slip 1: --buffer accepted and ignored outside tightening, so
     # `--update-baseline --buffer 25` exited 0 while pinning every cap.

--- a/tests/scripts/test_check_file_size_ratchet.py
+++ b/tests/scripts/test_check_file_size_ratchet.py
@@ -65,6 +65,34 @@ def unreadable(*file_names: str):
         ratchet._try_count_lines = original
 
 
+@contextlib.contextmanager
+def unenumerable(dir_name: str):
+    """Make the named directory fail enumeration, as an EACCES during os.walk would.
+
+    Simulated by wrapping os.walk rather than by chmod, for the same reason `unreadable` patches a
+    helper: these tests may run as root, where a permission fixture silently passes. The wrapper
+    reproduces what the real walk does on a scandir failure — it reports the directory to the
+    onerror callback it was given (None if the caller wired none, which is the defect this fixture
+    exists to catch) and yields nothing from that subtree.
+    """
+    original = ratchet.os.walk
+
+    def failing(top, topdown=True, onerror=None, followlinks=False):
+        for entry in original(top, topdown=topdown, onerror=onerror, followlinks=followlinks):
+            dirpath = Path(entry[0])
+            if dir_name in dirpath.parts:
+                if dirpath.name == dir_name and onerror is not None:
+                    onerror(PermissionError(13, "Permission denied", str(dirpath)))
+                continue
+            yield entry
+
+    ratchet.os.walk = failing
+    try:
+        yield
+    finally:
+        ratchet.os.walk = original
+
+
 def run(argv: list[str]) -> tuple[int, str]:
     out, err = io.StringIO(), io.StringIO()
     with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
@@ -233,6 +261,19 @@ class TrendReportingTests(unittest.TestCase):
             # The cap it could not verify must survive the refusal.
             self.assertEqual(read_baseline(root), {"src/ok.cs": 40, "src/flaky.cs": 30})
 
+    # The same fail-closed rule covers a directory the walk could not enumerate: every file under
+    # it is invisible, which is worse than one unreadable file, not better.
+    def test_refuses_to_update_the_baseline_when_a_directory_cannot_be_enumerated(self):
+        with fake_repo({"src/ok.cs": 40, "src/vault/hidden.cs": 30},
+                       {"src/ok.cs": 40, "src/vault/hidden.cs": 30}) as root:
+            with unenumerable("vault"):
+                code, output = run(["--threshold", "10", "--update-baseline"])
+
+            self.assertEqual(code, 2)
+            self.assertIn("refusing to rewrite the baseline", output)
+            self.assertIn("src/vault", output)
+            self.assertEqual(read_baseline(root), {"src/ok.cs": 40, "src/vault/hidden.cs": 30})
+
     # The read-only path keeps reporting rather than failing: a check that cannot see a file should
     # not invent a verdict about it, and a transient error must not redden an unrelated PR.
     def test_an_unreadable_source_does_not_fail_the_ordinary_check(self):
@@ -377,6 +418,34 @@ class TightenBaselineTests(unittest.TestCase):
             self.assertEqual(read_baseline(root), {"src/kept.cs": 25})
             self.assertIn("1 retired", output)
             self.assertIn("src/gone.cs", output)
+
+    # A deleted file used to retire only via the buffer rule, which a buffer larger than the
+    # threshold fails: 0 + buffer > threshold kept the entry and recorded the whole cap of a
+    # nonexistent file as deliberate working headroom.
+    def test_a_deleted_file_retires_even_when_the_buffer_exceeds_the_threshold(self):
+        with fake_repo({"src/kept.cs": 20}, {"src/kept.cs": 30, "src/gone.cs": 40}) as root:
+            code, output = run(["--tighten-baseline", "--buffer", "25"])
+
+            self.assertEqual(code, 0, output)
+            self.assertEqual(read_baseline(root), {"src/kept.cs": 30})
+            self.assertIn("1 retired", output)
+            self.assertIn("src/gone.cs", output)
+            self.assertNotIn("src/gone.cs", read_payload(root).get("headroom", {}))
+
+    # os.walk ignores scandir errors unless given an onerror callback, so an unenumerable
+    # subtree used to vanish from the scan entirely — and tightening would rewrite the baseline
+    # having never seen whatever that subtree holds.
+    def test_refuses_to_tighten_when_a_directory_cannot_be_enumerated(self):
+        with fake_repo({"src/ok.cs": 20, "src/vault/secret.cs": 40},
+                       {"src/ok.cs": 30, "src/vault/secret.cs": 40}) as root:
+            with unenumerable("vault"):
+                code, output = run(["--tighten-baseline", "--buffer", "5"])
+
+            self.assertEqual(code, 2)
+            self.assertIn("refusing to tighten", output)
+            self.assertIn("src/vault", output)
+            self.assertEqual(read_baseline(root),
+                             {"src/ok.cs": 30, "src/vault/secret.cs": 40})
 
     # Contract slip 1: --buffer accepted and ignored outside tightening, so
     # `--update-baseline --buffer 25` exited 0 while pinning every cap.


### PR DESCRIPTION
<!-- phase:PR6 -->

## Summary

Fixes the two post-merge Codex review findings on PR #2714's `--tighten-baseline` mechanism (`build/scripts/ci/check-file-size.py`), both verified against the merged code, plus three findings from this PR's own review round:

1. **Deleted files now retire unconditionally — with deletion confirmed by a probe.** A deleted tracked file previously retired only through the buffer rule (`lines + buffer <= threshold`), so a `--buffer` larger than the threshold (e.g. `--buffer 2500` against the 2000-line baseline) kept the nonexistent entry and recorded its entire cap as deliberate working headroom. Zero lines now retires before the buffer rule — but only after an absence probe confirms the file is genuinely gone, because an existing file can be empty: an emptied file follows the ordinary rules (an oversized buffer keeps its cap rather than handing a later rebuild the brand-new-god-file failure), and a probe that cannot tell is treated as an unreadable source.
2. **Unenumerable directories now fail the mutating commands closed.** `os.walk` ignores scandir errors unless given an `onerror` callback, so an `EACCES` on a subdirectory silently pruned that whole subtree from the scan — `--tighten-baseline` and `--update-baseline` could rewrite the baseline having never seen whatever the subtree holds. The walk now surfaces failed directories into the unreadable set: both mutating commands refuse (exit 2), while the read-only check keeps reporting and passing, consistent with the existing unreadable-file policy. Two carve-outs keep the refusal honest: a directory deleted mid-walk is gone, not unreadable (matching `_try_count_lines`), and a directory that is itself an excluded prefix (a generated tree) holds no governed files, so its failure vetoes nothing.
3. **The published retirement contract is aligned.** The module docstring, the `--tighten-baseline` help text, and `docs/development/god-file-burn-down-plan.md` now state the deleted-file exception alongside the buffer rule instead of contradicting it.

## Reason

Post-merge review on #2714 (issue #2675) found both original defects in the tighten path's fail-closed seam — the same *file below threshold / file still in baseline / scan incomplete* interaction the burn-down plan calls out as where every prior defect in this mechanism lived. This PR's own review round then found the empty-vs-deleted conflation, the excluded-subtree false refusal, and the doc drift, all fixed here.

## Testing performed

- `python3 -m unittest tests.scripts.test_check_file_size_ratchet` — 34 tests, all passing (5 new across both rounds: deleted-file-retires-despite-oversized-buffer, emptied-file-is-not-retired-as-deleted, tighten-refuses-unenumerable-directory, update-refuses-unenumerable-directory, excluded-unenumerable-directory-does-not-block).
- Negative verification: every new test fails against the unfixed script and passes with the fix.
- `python3 build/scripts/ci/check-file-size.py` against the live tree — exit 0, output unchanged.
- Full script-test lane: 861 tests, 0 failures, 0 errors.
- Docs automation pipeline run twice (idempotent) after the plan edit; regenerated doc-health dashboard committed.

## Safety review

- The read-only CI check's pass/fail behavior is unchanged — a transient traversal error still cannot redden an unrelated PR; only the baseline-writing commands (`--tighten-baseline`, `--update-baseline`) gain the new refusals.
- The new `unenumerable` test fixture wraps `os.walk` rather than using chmod, because these tests can run as root where a permission fixture passes without exercising anything (same rationale as the existing `unreadable` fixture); the deletion probe uses `open()` rather than `Path.exists()`, which re-raises `EACCES` on an untraversable parent.

## Governance changes

None. No governed workflow, CODEOWNERS, or CI-policy surface is touched; the diff is the ratchet script, its test suite, the burn-down plan's contract text, and the regenerated doc-health dashboard.