### PR TITLE
test(ci): serialize env-mutating test classes and raise failover sync deadlines

### DIFF
--- a/tests/Meridian.Tests/Application/Composition/ProductionServiceRegistrationPolicyTests.cs
+++ b/tests/Meridian.Tests/Application/Composition/ProductionServiceRegistrationPolicyTests.cs
@@ -7,6 +7,10 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Meridian.Tests.Application.Composition;
 
+// Mutates process-global posture variables (ASPNETCORE_ENVIRONMENT, MERIDIAN_API_DEPLOYMENT_MODE,
+// MDC_PACKAGED_BUILD, MERIDIAN_CUSTOMER_BUILD) that concurrent compositions read ambiently, so this
+// class must not run in parallel with other collections (#2680).
+[Collection("Sequential")]
 public sealed class ProductionServiceRegistrationPolicyTests
 {
     [Fact]

--- a/tests/Meridian.Tests/Application/Config/ConfigValidatorCliTests.cs
+++ b/tests/Meridian.Tests/Application/Config/ConfigValidatorCliTests.cs
@@ -5,6 +5,9 @@ using Xunit;
 
 namespace Meridian.Tests.Application.Config;
 
+// Mutates process-global environment variables that concurrent compositions read ambiently, so
+// this class must not run in parallel with other collections (#2682).
+[Collection("Sequential")]
 public sealed class ConfigValidatorCliTests
 {
     [Fact]

--- a/tests/Meridian.Tests/Application/Config/ProviderCredentialResolverTests.cs
+++ b/tests/Meridian.Tests/Application/Config/ProviderCredentialResolverTests.cs
@@ -5,6 +5,9 @@ using Xunit;
 
 namespace Meridian.Tests.Application.Config;
 
+// Mutates process-global provider-credential environment variables that concurrent provider
+// composition reads ambiently, so this class must not run in parallel with other collections (#2682).
+[Collection("Sequential")]
 public sealed class ProviderCredentialResolverTests
 {
     [Theory]

--- a/tests/Meridian.Tests/Application/Config/ProviderCredentialStoreTests.cs
+++ b/tests/Meridian.Tests/Application/Config/ProviderCredentialStoreTests.cs
@@ -8,6 +8,9 @@ using Xunit;
 
 namespace Meridian.Tests.Application.Config;
 
+// Mutates process-global provider-credential environment variables that concurrent provider
+// composition reads ambiently, so this class must not run in parallel with other collections (#2682).
+[Collection("Sequential")]
 public sealed class ProviderCredentialStoreTests : IDisposable
 {
     private readonly string _root;

--- a/tests/Meridian.Tests/Application/Services/ConfigurationServiceTests.cs
+++ b/tests/Meridian.Tests/Application/Services/ConfigurationServiceTests.cs
@@ -12,6 +12,12 @@ namespace Meridian.Tests.Application.Services;
 /// Tests for ConfigurationService focusing on self-healing fixes,
 /// credential resolution, validation, and provider filtering.
 /// </summary>
+// Mutates process-global provider-credential variables (ALPACA_KEY_ID/SECRET, POLYGON_API_KEY,
+// TIINGO_API_TOKEN, FINNHUB_API_KEY) that provider constructors and the provider-catalog projection
+// read ambiently at resolve time, so this class must not run in parallel with other collections
+// (#2680/#2682 — key and secret are even set in separate statements, so a concurrent resolve can
+// observe torn credentials).
+[Collection("Sequential")]
 public class ConfigurationServiceTests : IAsyncDisposable
 {
     private readonly ConfigurationService _sut;

--- a/tests/Meridian.Tests/Application/Services/PreflightCheckerTests.cs
+++ b/tests/Meridian.Tests/Application/Services/PreflightCheckerTests.cs
@@ -8,6 +8,9 @@ namespace Meridian.Tests.Application.Services;
 /// Tests for PreflightChecker covering disk space, file permissions,
 /// system time, environment variable checks, and failure modes.
 /// </summary>
+// Mutates process-global environment variables that concurrent compositions read ambiently, so
+// this class must not run in parallel with other collections (#2682).
+[Collection("Sequential")]
 public sealed class PreflightCheckerTests : IDisposable
 {
     private readonly string _tempDir;

--- a/tests/Meridian.Tests/Infrastructure/Providers/FailoverAwareMarketDataClientTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/FailoverAwareMarketDataClientTests.cs
@@ -14,6 +14,12 @@ namespace Meridian.Tests.Providers;
 /// </summary>
 public sealed class FailoverAwareMarketDataClientTests : IAsyncLifetime
 {
+    // Deadline for synchronization waits (event handshakes, thread joins, monitor-block detection).
+    // These waits complete in milliseconds when healthy, so a generous budget does not slow passing
+    // runs — but the previous 2-second budget produced load-induced TimeoutExceptions on busy
+    // parallel CI runners (#2682). A genuine hang still fails, just with a longer fuse.
+    private static readonly TimeSpan SyncTimeout = TimeSpan.FromSeconds(30);
+
     private readonly ConnectionHealthMonitor _healthMonitor;
     private readonly StreamingFailoverService _failoverService;
     private readonly FakeMarketDataClient _primaryClient;
@@ -241,7 +247,7 @@ public sealed class FailoverAwareMarketDataClientTests : IAsyncLifetime
         using var cts = new CancellationTokenSource();
 
         var connectTask = _sut.ConnectAsync(cts.Token);
-        await cancelledBackup.ConnectEntered.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await cancelledBackup.ConnectEntered.Task.WaitAsync(SyncTimeout);
         cts.Cancel();
 
         Func<Task> act = async () => await connectTask;
@@ -314,7 +320,7 @@ public sealed class FailoverAwareMarketDataClientTests : IAsyncLifetime
 
         _failoverService.ForceFailover("test-rule", "backup").Should().BeTrue();
 
-        var switchSnapshot = await switched.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        var switchSnapshot = await switched.Task.WaitAsync(SyncTimeout);
         _sut.ActiveProviderId.Should().Be("backup");
         switchSnapshot.LifecycleState.Should().Be(ProviderConnectionLifecycleState.Connected);
         switchSnapshot.IsReconnecting.Should().BeFalse();
@@ -514,7 +520,7 @@ public sealed class FailoverAwareMarketDataClientTests : IAsyncLifetime
 
         var transitionTask = Task.Run(
             async () => await _failoverService.ForceFailoverAsync("test-rule", "backup"));
-        await _backupClient.TradeSubscribeBlocked.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await _backupClient.TradeSubscribeBlocked.Task.WaitAsync(SyncTimeout);
 
         using var addStarted = new ManualResetEventSlim(initialState: false);
         using var addFinished = new ManualResetEventSlim(initialState: false);
@@ -540,7 +546,7 @@ public sealed class FailoverAwareMarketDataClientTests : IAsyncLifetime
             IsBackground = true
         };
         addThread.Start();
-        addStarted.Wait(TimeSpan.FromSeconds(2)).Should().BeTrue();
+        addStarted.Wait(SyncTimeout).Should().BeTrue();
         try
         {
             WaitUntilBlockedOnMonitor(addThread);
@@ -553,7 +559,7 @@ public sealed class FailoverAwareMarketDataClientTests : IAsyncLifetime
         }
 
         (await transitionTask).Should().BeTrue();
-        addThread.Join(TimeSpan.FromSeconds(2)).Should().BeTrue();
+        addThread.Join(SyncTimeout).Should().BeTrue();
         addException.Should().BeNull();
         addedHandle.Should().BePositive();
         _backupClient.TradeSubscriptions.Keys.Should().BeEquivalentTo(["AAPL", "MSFT"]);
@@ -579,7 +585,7 @@ public sealed class FailoverAwareMarketDataClientTests : IAsyncLifetime
 
         var transitionTask = Task.Run(
             async () => await _failoverService.ForceFailoverAsync("test-rule", "backup"));
-        await _backupClient.TradeSubscribeBlocked.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await _backupClient.TradeSubscribeBlocked.Task.WaitAsync(SyncTimeout);
 
         using var removeStarted = new ManualResetEventSlim(initialState: false);
         using var removeFinished = new ManualResetEventSlim(initialState: false);
@@ -604,7 +610,7 @@ public sealed class FailoverAwareMarketDataClientTests : IAsyncLifetime
             IsBackground = true
         };
         removeThread.Start();
-        removeStarted.Wait(TimeSpan.FromSeconds(2)).Should().BeTrue();
+        removeStarted.Wait(SyncTimeout).Should().BeTrue();
         try
         {
             WaitUntilBlockedOnMonitor(removeThread);
@@ -617,7 +623,7 @@ public sealed class FailoverAwareMarketDataClientTests : IAsyncLifetime
         }
 
         (await transitionTask).Should().BeTrue();
-        removeThread.Join(TimeSpan.FromSeconds(2)).Should().BeTrue();
+        removeThread.Join(SyncTimeout).Should().BeTrue();
         removeException.Should().BeNull();
         _backupClient.TradeSubscriptions.Should().NotContainKey("AAPL");
         _backupClient.TradeSubscriptions.Should().ContainKey("PREEXISTING");
@@ -640,7 +646,7 @@ public sealed class FailoverAwareMarketDataClientTests : IAsyncLifetime
         _backupClient.BlockConnectUntilCancelled = true;
 
         var transition = _failoverService.ForceFailoverAsync("test-rule", "backup");
-        await _backupClient.ConnectEntered.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await _backupClient.ConnectEntered.Task.WaitAsync(SyncTimeout);
 
         await _sut.DisposeAsync();
 
@@ -663,11 +669,11 @@ public sealed class FailoverAwareMarketDataClientTests : IAsyncLifetime
         _backupClient.BlockConnectUntilCancelled = true;
 
         var transition = _failoverService.ForceFailoverAsync("test-rule", "backup");
-        await _backupClient.ConnectEntered.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await _backupClient.ConnectEntered.Task.WaitAsync(SyncTimeout);
 
         _failoverService.Dispose();
 
-        (await transition.WaitAsync(TimeSpan.FromSeconds(2))).Should().BeFalse();
+        (await transition.WaitAsync(SyncTimeout)).Should().BeFalse();
         await WaitUntilAsync(() => _backupClient.ConnectCancellationObserved);
         _sut.ActiveProviderId.Should().Be("primary");
         _failoverService.GetActiveProviderId("test-rule").Should().Be("primary");
@@ -705,7 +711,7 @@ public sealed class FailoverAwareMarketDataClientTests : IAsyncLifetime
 
     private static async Task WaitUntilAsync(Func<bool> condition)
     {
-        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        using var timeout = new CancellationTokenSource(SyncTimeout);
         while (!condition())
             await Task.Delay(10, timeout.Token);
     }
@@ -714,7 +720,7 @@ public sealed class FailoverAwareMarketDataClientTests : IAsyncLifetime
     {
         SpinWait.SpinUntil(
                 () => (thread.ThreadState & ThreadState.WaitSleepJoin) != 0,
-                TimeSpan.FromSeconds(2))
+                SyncTimeout)
             .Should().BeTrue("the subscription mutation should reach the hand-off synchronization gate");
     }
 

--- a/tests/Meridian.Tests/Ui/ProductionStartupPolicySmokeTests.cs
+++ b/tests/Meridian.Tests/Ui/ProductionStartupPolicySmokeTests.cs
@@ -5,6 +5,10 @@ using Microsoft.Extensions.Hosting;
 
 namespace Meridian.Tests.Ui;
 
+// Mutates process-global environment variables (ASPNETCORE_ENVIRONMENT, MDC_AUTH_MODE) that
+// ProductionServiceRegistrationPolicy.IsProductionEnvironment() reads during any concurrent
+// service composition, so this class must not run in parallel with other collections (#2680).
+[Collection("Sequential")]
 public sealed class ProductionStartupPolicySmokeTests
 {
     [Fact]


### PR DESCRIPTION
## Summary

Test-only changes addressing the two diagnosable mechanisms behind the intermittent shard failures in #2680/#2682. No production code is touched.

**1. Serialize seven env-mutating test classes into the existing `"Sequential"` collection** (whose doc comment already names this exact purpose; four sibling posture suites already use it):

- `ProductionStartupPolicySmokeTests` — sets `ASPNETCORE_ENVIRONMENT=Production`, the **confirmed** mechanism behind `SecurityMasterWorkbenchOptionsBindingTests` intermittently failing with *"Production reporting authority requires…"* (#2680): `IsProductionEnvironment()` reads that process-global during any concurrent composition.
- `ProductionServiceRegistrationPolicyTests` — same posture family plus `MERIDIAN_API_DEPLOYMENT_MODE`, `MDC_PACKAGED_BUILD`, `MERIDIAN_CUSTOMER_BUILD`.
- `ConfigurationServiceTests`, `ProviderCredentialResolverTests`, `ProviderCredentialStoreTests`, `ConfigValidatorCliTests`, `PreflightCheckerTests` — mutate provider-credential vars (`ALPACA_KEY_ID`/`SECRET`, `POLYGON_API_KEY`, …) in the same `core-application` shard where `ProviderRoutingServiceTests` intermittently threw while projecting the provider catalog (#2682, flake 5). `AlpacaOptionsChainProvider` reads those vars at resolve time (`AlpacaOptionsChainProvider.cs:93-94`), and `ConfigurationServiceTests` sets key and secret in two separate statements — a concurrent resolve can observe torn credentials. Flagged as strong hypothesis, not proof: the fresh-failure log is gone; serialization is justified regardless by the collection's documented contract.

**2. Raise `FailoverAwareMarketDataClientTests` synchronization deadlines 2s → 30s** (#2682, flake 4): all 13 wait sites (`WaitAsync`/`Wait`/`Join`/CTS/`SpinUntil`) now share one `SyncTimeout` constant. These handshake waits complete in milliseconds when healthy — a generous budget does not slow passing runs, while thread starts + `Task.Run` scheduling on a loaded parallel runner routinely burst a 2-second fuse. A genuine hang still fails. The fake client's 5s deadman release is deliberately unchanged.

## Flake coverage map (of the five in #2682)

| Flake | Addressed here? |
|---|---|
| `SecurityMasterWorkbenchOptionsBindingTests` (env pollution) | ✅ polluter serialized (confirmed mechanism) |
| `ProviderRoutingServiceTests` (catalog projection throw) | ✅ likely — same-shard credential polluters serialized (hypothesis, evidence in commit) |
| `FailoverAwareMarketDataClientTests` (TimeoutException) | ✅ deadlines hardened |
| `PaperFillEnvelopeRegressionTests` (torn quote/trade read) | ❌ product defect — belongs to #2676, must not be masked |
| `PaperSessionRecoveryConcurrencyTests` (cancellation/teardown race) | ❌ undiagnosed, tracked in #2676 |

## Testing performed

- [ ] `bash scripts/ci.sh`
- [x] Verified all 13 replaced sites are wait-deadlines, none configure the SUT
- [x] Verified the `"Sequential"` collection definition (`TestCollections.cs`) documents exactly this use and is already used by 4 posture suites
- [ ] GitHub Actions `quality-gate` — validating on this PR

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled, skipped, or weakened — serialization changes scheduling only; timeout raises affect only the failure path
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

Part of #2680 / #2682.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRdH1FnQmEYt8GLzoQfixJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRdH1FnQmEYt8GLzoQfixJ)_