### PR TITLE
Fix two kill-switch defects left on main, and record two that remain (W9-SAFETY-007)

### DIFF
--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -1099,6 +1099,7 @@ Meridian-main
 │       │   ├── check-duplicate-helpers.py
 │       │   ├── check-endpoint-cancellation.py
 │       │   ├── check-file-size.py
+│       │   ├── check-inline-sha256.py
 │       │   ├── check-lane-manifest.py
 │       │   ├── check-sample-config-datasources.py
 │       │   ├── check-test-skip-register.py
@@ -1107,6 +1108,7 @@ Meridian-main
 │       │   ├── dispatch-targeted-test.py
 │       │   ├── duplicate-helper-baseline.json
 │       │   ├── generate-release-evidence-manifest.py
+│       │   ├── inline-sha256-baseline.json
 │       │   ├── run-dotnet-ci-tests.py
 │       │   ├── run-script-tests.py
 │       │   ├── script-test-quarantine.json
@@ -10272,6 +10274,7 @@ Meridian-main
 │   │   ├── test_check_duplicate_helpers.py
 │   │   ├── test_check_endpoint_cancellation.py
 │   │   ├── test_check_file_size_ratchet.py
+│   │   ├── test_check_inline_sha256.py
 │   │   ├── test_check_program_state_consistency.py
 │   │   ├── test_check_status_delivery_claims.py
 │   │   ├── test_check_test_skip_register.py

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 648,
-  "total_lines": 128505,
+  "total_lines": 128511,
   "orphaned_count": 254,
   "no_heading_count": 148,
   "stale_count": 0,
@@ -2609,7 +2609,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 10455,
+      "line_count": 10458,
       "has_heading": true,
       "todo_count": 8,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 648 |
-| Total lines | 128,505 |
+| Total lines | 128,511 |
 | Average file size (lines) | 198.3 |
 | Orphaned files | 254 |
 | Files without headings | 148 |

--- a/docs/status/workflow-drift-report.md
+++ b/docs/status/workflow-drift-report.md
@@ -68,8 +68,8 @@
 - `build/scripts/ci/check-duplicate-helpers.py`
 - `build/scripts/ci/check-endpoint-cancellation.py`
 - `build/scripts/ci/check-file-size.py`
+- `build/scripts/ci/check-inline-sha256.py`
 - `build/scripts/ci/check-lane-manifest.py`
 - `build/scripts/ci/check-sample-config-datasources.py`
 - `build/scripts/ci/check-test-skip-register.py`
 - `build/scripts/ci/check-warning-suppressions.py`
-- `build/scripts/ci/check-workflow-hygiene.py`

--- a/src/Meridian.Execution/OrderManagementSystem.KillSwitch.cs
+++ b/src/Meridian.Execution/OrderManagementSystem.KillSwitch.cs
@@ -188,19 +188,22 @@ public sealed partial class OrderManagementSystem
     /// </summary>
     private decimal ResolveWorkingReductionQuantity(string symbol, Guid? fundAccountId)
     {
-        var held = 0m;
-        if (_portfolioState?.Positions.TryGetValue(symbol, out var position) == true)
+        if (_portfolioState?.Positions.TryGetValue(symbol, out var position) != true)
         {
-            held = position.ExactQuantity;
+            return 0m;
         }
 
+        // The same fund-owned quantity the admission check measures, not the netted aggregate. A
+        // fund can hold the opposite sign to the book: with fund A long 100 and fund B short 10 the
+        // aggregate is long 90, so taking the side from it would look for B's reductions among
+        // sells while B reduces by buying — leaving its working buy-to-close uncounted and letting
+        // a second buy cross B through flat into a long.
+        var held = Services.ExecutionOperatorControlService.ResolveOwnedQuantity(position!, fundAccountId);
         if (held == 0m)
         {
             return 0m;
         }
 
-        // The side that moves this position toward flat. Orders on the other side increase it and
-        // are not reductions to be counted against the closable quantity.
         var reducingSide = held > 0m ? OrderSide.Sell : OrderSide.Buy;
 
         return _orders.Values

--- a/src/Meridian.Execution/Services/ExecutionOperatorControlService.cs
+++ b/src/Meridian.Execution/Services/ExecutionOperatorControlService.cs
@@ -570,7 +570,7 @@ public sealed class ExecutionOperatorControlService
             return false;
         }
 
-        var held = ResolveHeldQuantity(position, request.FundAccountId);
+        var held = ResolveOwnedQuantity(position, request.FundAccountId);
         if (held == 0m)
         {
             return false;
@@ -622,7 +622,7 @@ public sealed class ExecutionOperatorControlService
     /// number that would be wrong.
     /// </para>
     /// </summary>
-    private static decimal ResolveHeldQuantity(IPosition position, Guid? fundAccountId)
+    internal static decimal ResolveOwnedQuantity(IPosition position, Guid? fundAccountId)
     {
         // Unrounded, for the reason the position-limit gate gives: a fractional holding rounded to
         // zero would read as flat and refuse a legitimate close.

--- a/src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs
@@ -519,7 +519,9 @@ public static class ExecutionEndpoints
             // book emptied or orders were still working, and could only discover the difference by
             // separately querying the audit trail.
             return Results.Json(
-                sweepOutcome is null ? snapshot : new ExecutionCircuitBreakerActivationResponse(snapshot, sweepOutcome),
+                sweepOutcome is null
+                    ? snapshot
+                    : (object)ExecutionCircuitBreakerActivationResponse.From(snapshot, sweepOutcome),
                 jsonOptions);
         })
         .WithName("UpdateExecutionCircuitBreaker")
@@ -1835,10 +1837,34 @@ public sealed record CreatePaperSessionRequest(
 /// Circuit-breaker activation result: the control state, plus what the coupled kill-switch sweep
 /// achieved. The two travel together so opening the breaker cannot report success over a book that
 /// still has working orders.
+/// <para>
+/// The snapshot's members are repeated at the top level rather than nested under a wrapper
+/// property, so every existing consumer of this route — the browser workstation and the WPF halt
+/// client among them — keeps deserializing the shape it already expects and simply ignores the
+/// added sweep. Nesting them would have reported "Stop did not take effect" on a breaker the server
+/// had just opened.
+/// </para>
 /// </summary>
 public sealed record ExecutionCircuitBreakerActivationResponse(
-    ExecutionControlSnapshot Controls,
-    KillSwitchSweepResult Sweep);
+    ExecutionCircuitBreakerState CircuitBreaker,
+    decimal? DefaultMaxPositionSize,
+    IReadOnlyDictionary<string, decimal> SymbolPositionLimits,
+    IReadOnlyList<ExecutionManualOverride> ManualOverrides,
+    DateTimeOffset AsOf,
+    long Version,
+    KillSwitchSweepResult Sweep)
+{
+    public static ExecutionCircuitBreakerActivationResponse From(
+        ExecutionControlSnapshot snapshot,
+        KillSwitchSweepResult sweep) => new(
+            snapshot.CircuitBreaker,
+            snapshot.DefaultMaxPositionSize,
+            snapshot.SymbolPositionLimits,
+            snapshot.ManualOverrides,
+            snapshot.AsOf,
+            snapshot.Version,
+            sweep);
+}
 
 public sealed record TradingActionResult(
     string ActionId,

--- a/tests/Meridian.Tests/Execution/KillSwitchCloseOnlyTests.cs
+++ b/tests/Meridian.Tests/Execution/KillSwitchCloseOnlyTests.cs
@@ -245,6 +245,32 @@ public sealed class KillSwitchCloseOnlyTests : IDisposable
             .IsApproved.Should().BeFalse("fund B holds nothing here, so this sell opens a short");
     }
 
+
+    /// <summary>
+    /// A fund can hold the opposite sign to the netted book. With fund A long 100 and fund B short
+    /// 10 the aggregate is long 90, so deriving the reducing side from it looks for B's reductions
+    /// among sells while B reduces by buying — leaving B's working buy-to-close uncounted and
+    /// admitting a second buy that crosses B through flat into a long.
+    /// </summary>
+    [Fact]
+    public async Task FundHoldingTheOppositeSignToTheBook_HasItsOwnReductionsCounted()
+    {
+        var fundShort = Guid.NewGuid();
+        var (controls, overrideId) = await HaltedDeskWithOverrideAsync();
+
+        // Aggregate long 90; this fund is short 10 and already has 6 working buys against it.
+        controls.WorkingReductionQuantityProbe = (_, fund) => fund == fundShort ? 6m : 0m;
+
+        var portfolio = new StubPortfolioState(
+            [("AAPL", 90m)],
+            owners: new Dictionary<string, decimal> { [fundShort.ToString("D")] = -10m });
+
+        controls.EvaluateOrder(Order(OrderSide.Buy, 4m, overrideId) with { FundAccountId = fundShort }, portfolio)
+            .IsApproved.Should().BeTrue("6 working plus 4 exactly closes the 10-share short");
+        controls.EvaluateOrder(Order(OrderSide.Buy, 5m, overrideId) with { FundAccountId = fundShort }, portfolio)
+            .IsApproved.Should().BeFalse("6 working plus 5 would leave this fund long 1");
+    }
+
     private async Task<(ExecutionOperatorControlService Controls, string OverrideId)> HaltedDeskWithOverrideAsync(
         decimal alreadyWorking = 0m)
     {


### PR DESCRIPTION
<!-- phase:PR7 -->

## Summary

Review found four more defects in #2711 after it merged. Two are fixed here; two are design-level and are described below rather than half-done.

**The breaker activation response broke its own consumers.** #2711 nested the control snapshot under a wrapper property to carry the sweep outcome. Every existing consumer of that route deserializes the snapshot at the *top level* — including the WPF Stop command merged in #2712, which reads `CircuitBreaker.IsOpen` to confirm the halt actually took. Nesting made it report **"Stop did NOT take effect"** on a breaker the server had just opened: precisely the false negative that client exists to prevent. The sweep is now an added top-level member, so older consumers ignore it and keep working.

**The working-reduction probe mixed scopes.** It filtered orders by `FundAccountId` but derived the *reducing side* from the netted aggregate. A fund can hold the opposite sign to the book: with fund A long 100 and fund B short 10 the aggregate is long 90, so the probe looked for B's reductions among sells while B reduces by buying — leaving B's working buy-to-close uncounted and admitting a second buy that crosses B through flat into a long. Both sides of the arithmetic now read the same fund-owned quantity.

## Two that remain, and why they are not in this PR

**The close-only exception is unreachable on the live path.** `OrderManagementSystem.cs:315` reads `controlRequest = requiresLiveOrderReadinessGate ? safeRequest : request`, and `manualOverrideId` is in `ExecutionOrderMetadataPolicy`'s stripped-key list. So on live production routing `bypassOverride` is always null, the gate returns `CIRCUIT_BREAKER_OPEN`, and close-only is never consulted.

This matters beyond the defect: the intended semantics were *close-only* over *revoke-on-trip*, and on the live path the shipped behaviour is revoke-on-trip — the alternative that was explicitly not chosen. Closing it needs a **trusted server-side channel** for an authorized override to reach the gate, because the key is stripped precisely so a caller cannot supply one. That is a new seam with authorization consequences, not an edit, and it wants its own change and its own review.

**Close-only admission is not atomic with reservation.** The probe observes orders already registered in `_orders`, but two concurrent `PlaceOrderAsync` calls both evaluate the gate before either registers, so both can see zero working reductions and two 10-share sells can pass against one 10-share long. #2711 fixed the sequential case; the concurrent one needs the evaluation moved inside the registration critical section, or the approved reduction reserved atomically — a change to the placement path's locking, which is worth doing deliberately.

Neither is a regression introduced by this PR; both are recorded so they are not mistaken for closed.

## Reason

`W9-SAFETY-007` criterion one. #2711 merged with these outstanding, and two of them are live defects on `main` — one of which makes a merged safety control report failure when it succeeded.

## Testing performed

- [x] Relevant unit tests were added or updated
- [ ] `bash scripts/ci.sh` completed successfully — not run in full
- [ ] GitHub Actions `quality-gate` passed — pending, and authoritative

| Check | Result |
| --- | --- |
| execution / kill-switch / risk suites | 1,040 passed, 0 failed |
| `KillSwitchCloseOnlyTests` | 16 passed |
| WPF test project compile (`-p:IsWindows=true -p:EnableFullWpfBuild=true`) | 0 errors |
| `dotnet format whitespace --verify-no-changes` | no changes |
| route-contract / docs / diagram / tracker regeneration | current |
| `check-file-size.py` | passes |

New coverage: a fund holding the opposite sign to the netted book has its own working reductions counted — 6 working plus 4 closes its 10-share short, 6 plus 5 is refused because it would leave the fund long 1.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01GrqST8GCLa8rKGhxyELqPW)_