### PR TITLE
fix(reconciliation): align remaining SourceFileHash producers with canonical encoding (fixes red main)

### DIFF
--- a/build/scripts/ci/inline-sha256-baseline.json
+++ b/build/scripts/ci/inline-sha256-baseline.json
@@ -55,9 +55,7 @@
     "src/Meridian.FinancialOperations/Reconciliation/Connectors/Ofx/OfxStatementConnector.cs": 1,
     "src/Meridian.FinancialOperations/Reconciliation/Connectors/StatementImportService.cs": 1,
     "src/Meridian.FinancialOperations/Reconciliation/ReconciliationMatchKernel.cs": 1,
-    "src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationOrchestrator.cs": 1,
     "src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs": 1,
-    "src/Meridian.FinancialOperations/Reconciliation/StatementRunCreateRequest.cs": 1,
     "src/Meridian.FinancialOperations/Reconciliation/StatementRunMatcher.cs": 1,
     "src/Meridian.FinancialOperations/Reconciliation/StatementRunWorkflowService.cs": 1,
     "src/Meridian.FinancialOperations/Reconciliation/StatementValidationService.cs": 1,
@@ -172,6 +170,6 @@
     "src/Meridian.Workflow/Runbooks/RunbookExecutor.cs": 4,
     "src/Meridian.Wpf/ViewModels/Accounting/AccountingConfigureViewModel.cs": 1
   },
-  "total": 260,
+  "total": 258,
   "tracked_call": "SHA256.HashData"
 }

--- a/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationOrchestrator.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationOrchestrator.cs
@@ -1,5 +1,5 @@
 using System.Collections.Concurrent;
-using System.Security.Cryptography;
+using Meridian.Contracts.Integrity;
 
 namespace Meridian.FinancialOperations.Reconciliation;
 
@@ -220,7 +220,8 @@ public sealed class StatementReconciliationOrchestrator(
     private static async Task<string> ComputeSourceFileHashAsync(string sourcePath, CancellationToken ct)
     {
         await using var stream = File.OpenRead(sourcePath);
-        var hashBytes = await SHA256.HashDataAsync(stream, ct).ConfigureAwait(false);
-        return Convert.ToHexString(hashBytes);
+        // Same SourceFileHash family as the statement-import producers — canonical encoding keeps
+        // the value consistent across every producer of this field (#2691).
+        return await Sha256Digest.ComputeAsync(stream, ct).ConfigureAwait(false);
     }
 }

--- a/src/Meridian.FinancialOperations/Reconciliation/StatementRunCreateRequest.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementRunCreateRequest.cs
@@ -1,4 +1,4 @@
-using System.Security.Cryptography;
+using Meridian.Contracts.Integrity;
 using Meridian.Domain.Reconciliation;
 
 namespace Meridian.FinancialOperations.Reconciliation;
@@ -65,8 +65,10 @@ public sealed record StatementRunCreateRequest(
             throw new ArgumentException("Statement period end must be on or after statement period start.", nameof(statementPeriodEnd));
 
         await using var stream = File.OpenRead(sourcePath);
-        var hashBytes = await SHA256.HashDataAsync(stream, ct).ConfigureAwait(false);
-        var sourceFileHash = Convert.ToHexString(hashBytes);
+        // Same SourceFileHash family as BrokerStatementInfrastructure.CaptureFileAsync and
+        // StatementRunWorkflowService.ComputeFileHashAsync — all three producers must emit the
+        // canonical encoding so the value is consistent wherever it is recorded (#2691).
+        var sourceFileHash = await Sha256Digest.ComputeAsync(stream, ct).ConfigureAwait(false);
 
         return new StatementRunCreateRequest(
             broker.Trim(),

--- a/tests/Meridian.Tests/Reconciliation/Connectors/StatementImportServiceTests.cs
+++ b/tests/Meridian.Tests/Reconciliation/Connectors/StatementImportServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using System.Text;
 using FluentAssertions;
+using Meridian.Contracts.Integrity;
 using Meridian.Contracts.Workstation;
 using Meridian.Domain.Reconciliation;
 using Meridian.FinancialOperations.Reconciliation;
@@ -165,10 +166,10 @@ public sealed class StatementImportServiceTests : IDisposable
         var rawPath = Path.Combine(_root, result.RetainedSourcePath);
         var canonicalPath = Path.Combine(_root, result.RetainedCanonicalPath);
         run.Import.SourceFileHash.Should().Be(
-            Convert.ToHexString(SHA256.HashData(await File.ReadAllBytesAsync(rawPath))),
+            Sha256Digest.Compute(await File.ReadAllBytesAsync(rawPath)),
             "the retained source hash is authoritative evidence for the original upload bytes");
         run.Import.CanonicalArtifactHash.Should().Be(
-            Convert.ToHexString(SHA256.HashData(await File.ReadAllBytesAsync(canonicalPath))),
+            Sha256Digest.Compute(await File.ReadAllBytesAsync(canonicalPath)),
             "the parse artifact hash is retained separately from the original upload hash");
         run.Cases.Should().HaveCount(6);
         run.Cases.Should().OnlyContain(reconciliationCase => reconciliationCase.Status == "Open");
@@ -352,7 +353,7 @@ public sealed class StatementImportServiceTests : IDisposable
         var run = await _workflow.GetAsync(result.RunId);
         run.Should().NotBeNull();
         run!.Import.SourceFileHash.Should().Be(
-            Convert.ToHexString(SHA256.HashData(expectedSource)));
+            Sha256Digest.Compute(expectedSource));
     }
 
     [Fact]

--- a/tests/Meridian.Tests/Reconciliation/StatementImportAndMatchingTests.cs
+++ b/tests/Meridian.Tests/Reconciliation/StatementImportAndMatchingTests.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using System.Text;
 using FluentAssertions;
+using Meridian.Contracts.Integrity;
 using Meridian.FinancialOperations.Reconciliation;
 using Meridian.Domain.Reconciliation;
 using Meridian.Infrastructure.Reconciliation;
@@ -191,7 +192,7 @@ public sealed class StatementImportAndMatchingTests
             });
 
         imported.Import.SourceFileHash.Should().Be(
-            Convert.ToHexString(SHA256.HashData(await File.ReadAllBytesAsync(path))));
+            Sha256Digest.Compute(await File.ReadAllBytesAsync(path)));
         imported.Rows.Should().ContainSingle();
         imported.Rows[0].Symbol.Should().Be("BRK,B");
         imported.Rows[0].ActivityType.Should().Be("OTHER \"SPECIAL\"");


### PR DESCRIPTION
## Summary

**Fixes the red `verify-dotnet` on `main`** introduced by the #2724 merge (run [31929756186](https://github.com/rodoHasArrived/Meridian-main/actions/runs/31929756186): 4 failures in `core-platform-domain-root`, all statement-import hash assertions).

Investigating exposed a real gap, not just stale assertions: **`SourceFileHash` has three producers and #2724 canonicalized only two.** `StatementRunCreateRequest.FromFileAsync` and `StatementReconciliationOrchestrator.ComputeSourceFileHashAsync` still emitted uppercase because they split the hash and hex-encode across two statements — the exact shape the uppercase classifier couldn't see (it analyzes single statements). One failing test (`Import_detects_duplicates_by_fund_account_period_and_source_file_hash`) compared two producers' values directly and caught the inconsistency.

## Changes

- **Both remaining producers → `Sha256Digest.ComputeAsync`**, so every producer of this field family emits the canonical encoding. Safety unchanged from #2724's analysis: all production comparators decode hex bytes (`StatementDurabilityHashing.FixedTimeEquals` / `AssertHash`) and `StatementDuplicateKey` normalizes inputs, so previously persisted uppercase values still verify.
- **Four test assertions → `Sha256Digest.Compute`** — the intended-behavior assertion. Deliberately-legacy seeds (pre-upgrade record, stale-hash mismatch case) untouched.
- Ratchet baseline locked downward again: 260 → 258 sites (170 → 168 files).

Also noted for the batch migration: the split-compute/encode shape exists at ~14 more sites repo-wide (found by sweeping `Convert.ToHexString(` over variables); those are pre-existing self-consistent families — several identity-bearing (`StatementDuplicateKey` output, DirectLending/Backtest ids) — and get the same per-site trace discipline in the step-2 batches, not a blanket change here.

## Testing performed

- [ ] `bash scripts/ci.sh`
- [x] Ratchet green on refreshed baseline; brace balance verified
- [x] Producer consistency: all three `SourceFileHash` producers now route through the canonical primitive
- [ ] GitHub Actions `quality-gate` — validating on this PR

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] Legacy/pre-upgrade test seeds deliberately untouched

## Governance changes

- [x] No governance files changed

Part of #2691.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRdH1FnQmEYt8GLzoQfixJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRdH1FnQmEYt8GLzoQfixJ)_