### PR TITLE
Fix web screenshot capture timeouts caused by the first-run activation gate

### DIFF
--- a/scripts/dev/capture-web-screenshots.mjs
+++ b/scripts/dev/capture-web-screenshots.mjs
@@ -624,8 +624,20 @@ async function captureRoute(page, pageErrors, capture, outputDir, baseUrl, defau
     capture.name,
     "loading the route"
   );
+  // Label the frame timeout explicitly: the raw Playwright message ("page.waitForSelector:
+  // Timeout ... exceeded.") does not say which wait failed, and this is the one wait that
+  // fails when the app shell itself never mounts (e.g. the first-run activation gate has no
+  // fixture and blocks every route).
   await waitForCaptureStep(
-    page.waitForSelector(".workstation-frame", { timeout: timeoutMs }),
+    page.waitForSelector(".workstation-frame", { timeout: timeoutMs }).catch((cause) => {
+      if (cause?.name === "TimeoutError") {
+        throw new Error(
+          `App shell failed to mount: .workstation-frame did not render within ${timeoutMs}ms. `
+          + "Check shell-level screenshot fixtures (e.g. /api/workstation/first-run/) and the dev server logs."
+        );
+      }
+      throw cause;
+    }),
     pageErrors,
     capture.name,
     "waiting for the workstation frame"
@@ -940,6 +952,24 @@ async function main() {
         };
         results.push(failed);
         console.error(`::warning::Skipped ${capture.name} (${capture.path}): ${message.split(/\r?\n/)[0]}`);
+
+        // Systemic-failure circuit breaker: per-route fault isolation exists so one broken
+        // screen never blocks the rest of the catalog, but when the shared app shell itself
+        // never mounts, every remaining route is guaranteed to fail the same slow way
+        // (2 x timeoutMs each) until the CI job ceiling cancels the run. If the first few
+        // routes ALL failed to mount the shell, abort now with a pointed error instead.
+        const shellMountFailureLimit = 3;
+        if (
+          results.length >= shellMountFailureLimit
+          && results.every((result) => result.status === "failed"
+            && /App shell failed to mount/.test(String(result.error)))
+        ) {
+          throw new Error(
+            `Aborting capture run: the app shell failed to mount on the first ${results.length} route(s). `
+            + "This is a shell-level failure (activation gate, missing shell fixtures, or a dev server "
+            + "compile error), so every remaining route would fail the same way. See the manifest logs."
+          );
+        }
       }
     }
 

--- a/scripts/dev/web-screenshot-fixtures.json
+++ b/scripts/dev/web-screenshot-fixtures.json
@@ -2,6 +2,121 @@
   "version": 1,
   "description": "Static fixture responses served by Playwright page.route() during web screenshot capture. Keeps screenshots independent of a running Meridian API backend. Update when API response shapes change.",
   "routes": {
+    "/api/workstation/first-run/": {
+      "isComplete": true,
+      "goal": "operate-fund",
+      "starterKitId": "fund-operations",
+      "dataChoice": "provider",
+      "workspace": {
+        "id": "primary",
+        "name": "Meridian Workspace",
+        "isSample": false,
+        "badge": "LOCAL",
+        "safetyMessage": "Local workspace data.",
+        "samplePackVersion": ""
+      },
+      "starterKits": [
+        {
+          "id": "personal-portfolio",
+          "name": "Personal Portfolio Desk",
+          "goal": "monitor-investments",
+          "description": "Track holdings, watchlists, and portfolio changes.",
+          "defaultRoute": "/portfolio"
+        },
+        {
+          "id": "fund-operations",
+          "name": "Fund Operations Desk",
+          "goal": "operate-fund",
+          "description": "Run daily controls, approvals, and operational evidence.",
+          "defaultRoute": "/accounting/operations-continuity"
+        },
+        {
+          "id": "accounting-reconciliation",
+          "name": "Accounting and Reconciliation Desk",
+          "goal": "reconcile-accounts",
+          "description": "Import statements, investigate breaks, and close with evidence.",
+          "defaultRoute": "/accounting/statement-import"
+        },
+        {
+          "id": "strategy-research",
+          "name": "Strategy Research Desk",
+          "goal": "research-strategies",
+          "description": "Research, backtest, and paper-trade governed strategies.",
+          "defaultRoute": "/strategy"
+        },
+        {
+          "id": "market-data",
+          "name": "Market Data Desk",
+          "goal": "collect-market-data",
+          "description": "Connect, validate, and monitor trusted market data.",
+          "defaultRoute": "/data"
+        }
+      ],
+      "outcomes": [
+        {
+          "key": "workspace-opened",
+          "label": "Open or create a workspace",
+          "actionLabel": "Open workspace",
+          "route": "/portfolio",
+          "isComplete": true,
+          "completedAtUtc": "2026-07-13T17:50:00Z"
+        },
+        {
+          "key": "data-imported",
+          "label": "Import sample or real data",
+          "actionLabel": "Import data",
+          "route": "/accounting/statement-import",
+          "isComplete": true,
+          "completedAtUtc": "2026-07-13T17:52:00Z"
+        },
+        {
+          "key": "validation-resolved",
+          "label": "Resolve one validation issue",
+          "actionLabel": "Review breaks",
+          "route": "/accounting/reconciliation/match",
+          "isComplete": true,
+          "completedAtUtc": "2026-07-13T17:54:00Z"
+        },
+        {
+          "key": "report-run",
+          "label": "Run one report",
+          "actionLabel": "Run report",
+          "route": "/reporting/run",
+          "isComplete": true,
+          "completedAtUtc": "2026-07-13T17:56:00Z"
+        },
+        {
+          "key": "result-saved",
+          "label": "Save or export one useful result",
+          "actionLabel": "Review results",
+          "route": "/reporting/library",
+          "isComplete": true,
+          "completedAtUtc": "2026-07-13T17:58:00Z"
+        }
+      ],
+      "recommendedActions": [
+        {
+          "label": "Open your desk",
+          "route": "/accounting/operations-continuity",
+          "description": "See the workspace configured for your goal."
+        },
+        {
+          "label": "Add starting data",
+          "route": "/accounting/statement-import",
+          "description": "Import and validate a statement or holdings file."
+        },
+        {
+          "label": "Run a report",
+          "route": "/reporting/run",
+          "description": "Produce a useful result and keep the evidence."
+        }
+      ],
+      "sampleWorkspace": null
+    },
+    "/api/demo/mode": {
+      "enabled": true,
+      "provenance": "seeded"
+    },
     "/api/workstation/session": {
       "displayName": "Ops Desk",
       "role": "Operator",

--- a/scripts/dev/web-screenshot-routes.json
+++ b/scripts/dev/web-screenshot-routes.json
@@ -14,6 +14,8 @@
       "docLabel": "Daily Control Tower",
       "waitForText": "Daily Control Tower Workstation",
       "requiredApiRoutes": [
+        "/api/workstation/first-run/",
+        "/api/demo/mode",
         "/api/workstation/session",
         "/api/status",
         "/api/workstation/workflow-summary"

--- a/tests/scripts/test_refresh_screenshots_workflow.py
+++ b/tests/scripts/test_refresh_screenshots_workflow.py
@@ -151,6 +151,29 @@ class RefreshScreenshotsWorkflowTests(unittest.TestCase):
         missing_paths = sorted(explicit_pages - captured_paths)
         self.assertEqual([], missing_paths, f"Missing explicit app route screenshots: {missing_paths}")
 
+    def test_first_run_activation_gate_passes_during_capture(self) -> None:
+        """The app shell blocks every route behind /api/workstation/first-run/ until it
+        reports a completed activation. Without these fixtures the Playwright mock answers
+        404, the shell renders the activation gate instead of .workstation-frame, and every
+        capture times out (two 120s waits per route until the job ceiling)."""
+        fixture_routes = self.web_screenshot_fixtures.get("routes", {})
+
+        self.assertIn("/api/workstation/first-run/", fixture_routes)
+        first_run = fixture_routes["/api/workstation/first-run/"]
+        self.assertIs(True, first_run.get("isComplete"))
+        self.assertFalse(first_run.get("workspace", {}).get("isSample"))
+
+        self.assertIn("/api/demo/mode", fixture_routes)
+        self.assertIn("enabled", fixture_routes["/api/demo/mode"])
+
+    def test_capture_script_fails_fast_on_systemic_shell_mount_failures(self) -> None:
+        """A shell that never mounts fails every route at the full navigation timeout
+        (twice per route) until the CI job ceiling cancels the run. The capture script
+        must label the frame-mount timeout and abort early when the failure is systemic."""
+        self.assertIn("App shell failed to mount", self.web_screenshot_capture_script)
+        self.assertIn("shellMountFailureLimit", self.web_screenshot_capture_script)
+        self.assertIn("Aborting capture run", self.web_screenshot_capture_script)
+
     def test_strategy_designer_screenshot_route_has_fixture_evidence(self) -> None:
         captures = self.web_screenshot_routes.get("captures", [])
         designer_capture = next(


### PR DESCRIPTION
## Summary

Fixes the Web Screenshot Capture workflow, where every route timed out on `page.waitForSelector('.workstation-frame')` (120 s, twice per route) until the 50-minute job ceiling canceled the run with zero screenshots.

Root cause: the app shell now blocks every route behind the first-run activation gate (`/api/workstation/first-run/`, introduced in `ffeb200a`). The capture harness's Playwright mock answered that endpoint with 404, `apiGetJson` found no dev fixture for the path, and `AppRoot` rendered the "Activation status unavailable" gate instead of the workstation frame — so `.workstation-frame` never mounted on any route.

Changes:

- **`scripts/dev/web-screenshot-fixtures.json`** — add a completed, non-sample `/api/workstation/first-run/` fixture mirroring `FirstRunExperienceService.ToDto`, so the activation gate passes during capture; add an `/api/demo/mode` fixture declaring a seeded demo host (matching the W9-TRUTH-001 posture pinned in `UiServer.cs`), so the shell's provenance label is deterministic rather than depending on which endpoint first falls back to dev fixtures.
- **`scripts/dev/web-screenshot-routes.json`** — list both routes in the daily-control-tower capture's `requiredApiRoutes`, so the existing fixture-coverage test permanently guards the fixtures.
- **`scripts/dev/capture-web-screenshots.mjs`** — label the frame-mount timeout with a pointed diagnosis (the raw Playwright message `page.waitForSelector: Timeout 120000ms exceeded.` never said which wait failed), and abort the run when the first three routes all fail to mount the shell: that is a shell-level failure, and continuing would fail every remaining route the same slow way until the job is canceled. Per-route fault isolation for individual broken screens is unchanged.
- **`tests/scripts/test_refresh_screenshots_workflow.py`** — regression tests for the gate fixtures and the fail-fast behavior.

## Reason

The 2026-08-17 Web Screenshot Capture run skipped all routes with `page.waitForSelector: Timeout 120000ms exceeded.` and was canceled at the job timeout, producing no screenshots and no actionable diagnosis.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Local validation of the touched area:
- Full catalog capture run: **77/77 routes captured successfully** (previously 0), CI validator invoked against the output.
- `python3 -m unittest tests.scripts.test_refresh_screenshots_workflow`: 37/37 pass, including the two new regression tests.
- Fail-fast behavior verified by re-running the capture against the old fixtures: first three routes fail with the labeled `App shell failed to mount` error, then the run aborts with exit code 1 instead of grinding through the catalog.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed
- [ ] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DJKYVVy2XWWYeyviKb9we

---
_Generated by [Claude Code](https://claude.ai/code/session_016DJKYVVy2XWWYeyviKb9we)_