### PR TITLE
Migrate the remaining renamed NormalizeOptional clones onto TextPrimitives

### DIFF
--- a/build/config/file-size-baseline.json
+++ b/build/config/file-size-baseline.json
@@ -1,5 +1,6 @@
 {
-  "_comment": "No-new-god-file ratchet baseline. Each entry caps a currently oversized source file at its recorded line count. Files may shrink freely; growing one past its cap or adding a new file over the threshold fails CI. Regenerate with `python3 build/scripts/ci/check-file-size.py --update-baseline` and justify the change in review.",
+  "_comment": "No-new-god-file ratchet baseline. Each entry caps a currently oversized source file at its recorded line count. Files may shrink freely; growing one past its cap or adding a new file over the threshold fails CI. Lock in reductions with `python3 build/scripts/ci/check-file-size.py --tighten-baseline`, which only lowers caps; `--update-baseline` regenerates from the tree (and can raise caps), so it needs justification in review. The optional headroom map records lines deliberately left spare by the last tightening, so deliberate slack is not reported as an unlocked reduction.",
+  "threshold_lines": 2000,
   "files": {
     "src/Meridian.Application/FundStructure/InMemoryFundStructureService.cs": 4328,
     "src/Meridian.Execution/OrderManagementSystem.cs": 2098,
@@ -52,5 +53,22 @@
     "src/Meridian.Wpf/ViewModels/MainPageViewModel.cs": 2313,
     "src/Meridian.Wpf/ViewModels/SecurityMasterViewModel.cs": 4408
   },
-  "threshold_lines": 2000
+  "headroom": {
+    "src/Meridian.Execution/OrderManagementSystem.cs": 14,
+    "src/Meridian.FinancialOperations/AccountingClose/AccountingReportPackageService.cs": 26,
+    "src/Meridian.FinancialOperations/AccountingSystem/AccountingSystemIntegrationService.cs": 7,
+    "src/Meridian.FinancialOperations/PrivateCapital/PrivateCapitalActivityProjectionBuilder.cs": 2,
+    "src/Meridian.Storage/Reporting/PostgresReportingGovernanceRepository.cs": 2,
+    "src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs": 2,
+    "src/Meridian.Ui.Shared/Evidence/FileEvidenceArtifactStore.cs": 3,
+    "src/Meridian.Ui.Shared/Services/ProviderLedgerReconciliationService.cs": 2,
+    "src/Meridian.Ui.Shared/Services/ReportPackDeliveryService.cs": 3,
+    "src/Meridian.Ui.Shared/Services/ReportPackRunReadService.cs": 15,
+    "src/Meridian.Ui.Shared/Services/ReportingScheduleService.cs": 20,
+    "src/Meridian.Ui.Shared/Services/ReportingWorkflowService.cs": 14,
+    "src/Meridian.Ui.Shared/Services/SecurityMasterWorkbenchQueryService.cs": 2,
+    "src/Meridian.Ui/dashboard/src/screens/settings-screen.tsx": 6,
+    "src/Meridian.Ui/dashboard/src/screens/strategy-designer-screen.view-model.ts": 1,
+    "src/Meridian.Wpf/ViewModels/Accounting/AccountingConfigureViewModel.cs": 2
+  }
 }

--- a/build/scripts/ci/duplicate-helper-baseline.json
+++ b/build/scripts/ci/duplicate-helper-baseline.json
@@ -1,24 +1,10 @@
 {
   "body_clones": {
-    "src/Meridian.Application/FundStructure/InMemoryFundStructureService.cs": 1,
-    "src/Meridian.Application/FundStructure/PostgresFundStructureService.cs": 1,
-    "src/Meridian.Application/ProviderRouting/ProviderSetupService.cs": 1,
-    "src/Meridian.DataIntegration/AccountingSystem/QuickBooks/QuickBooksOnlineProviderCredentialConnectionStore.cs": 1,
-    "src/Meridian.DataIntegration/Credentials/FileProviderCredentialStore.cs": 1,
-    "src/Meridian.DataIntegration/Credentials/ProviderSetupHandlers.cs": 1,
-    "src/Meridian.Execution/Services/BrokerageExecutionReconciliationService.cs": 1,
-    "src/Meridian.Execution/Services/ExecutionOperatorControlService.cs": 1,
-    "src/Meridian.Execution/Services/ReconciliationSetComparer.cs": 1,
-    "src/Meridian.FinancialOperations/PrivateCapital/PrivateCapitalCloseCockpitService.Routes.cs": 1,
-    "src/Meridian.FinancialOperations/Reconciliation/StatementRunMatchingService.cs": 1,
     "src/Meridian.Ledger/LedgerAccounts.cs": 1,
     "src/Meridian.Ledger/LedgerLineDimensionSetNormalizer.cs": 1,
     "src/Meridian.Ledger/PrivateCapitalFundEventLedgerProjector.cs": 1,
     "src/Meridian.Ledger/ProjectLedgerBook.cs": 1,
-    "src/Meridian.Ui.Shared/Evidence/FileEvidenceArtifactStore.cs": 1,
-    "src/Meridian.Wpf/Services/DesktopLaunchArguments.cs": 1,
-    "src/Meridian.Wpf/Services/WorkspaceService.cs": 1,
-    "src/Meridian.Wpf/ViewModels/SettingsViewModel.AssetProfiles.cs": 1
+    "src/Meridian.Ui.Shared/Evidence/FileEvidenceArtifactStore.cs": 1
   },
   "description": "Per-file counts of private declarations of helpers owned by Meridian.Contracts.Text.TextPrimitives. CI fails when a file exceeds its count or a new file appears; migration batches shrink this toward empty. body_clones counts declarations under any other name whose canonical body is one TextPrimitives owns.",
   "files": {
@@ -90,7 +76,7 @@
     "src/Meridian.Wpf/Services/FundLedgerReadService.cs": 1,
     "src/Meridian.Wpf/ViewModels/SecurityMasterViewModel.TextHelpers.cs": 1
   },
-  "total": 95,
+  "total": 81,
   "tracked_helpers": [
     "NormalizeOptional",
     "RequireText",

--- a/src/Meridian.Application/FundStructure/InMemoryFundStructureService.cs
+++ b/src/Meridian.Application/FundStructure/InMemoryFundStructureService.cs
@@ -9,6 +9,7 @@ using Meridian.Entities.FundStructure;
 using Meridian.FSharp.CashFlowInterop;
 using Meridian.Storage.FundStructure;
 using Serilog;
+using static Meridian.Contracts.Text.TextPrimitives;
 
 namespace Meridian.Application.FundStructure;
 
@@ -497,8 +498,8 @@ public sealed partial class InMemoryFundStructureService : INonProductionOnlySer
                 IsActive = request.IsActive ?? existing.IsActive,
                 EffectiveFrom = request.EffectiveFrom ?? existing.EffectiveFrom,
                 EffectiveTo = request.EffectiveTo ?? existing.EffectiveTo,
-                Description = CleanOptional(request.Description) ?? existing.Description,
-                RegistrationNumber = CleanOptional(request.RegistrationNumber) ?? existing.RegistrationNumber,
+                Description = NormalizeOptional(request.Description) ?? existing.Description,
+                RegistrationNumber = NormalizeOptional(request.RegistrationNumber) ?? existing.RegistrationNumber,
                 LifecycleStatus = request.LifecycleStatus ?? existing.LifecycleStatus,
                 BeneficialOwners = request.BeneficialOwners is null
                     ? existing.BeneficialOwners
@@ -3748,7 +3749,6 @@ public sealed partial class InMemoryFundStructureService : INonProductionOnlySer
         }
     }
 
-
     private static FundStructureNodeKindDto ResolveKnownNodeKind(
         Guid nodeId,
         IReadOnlyDictionary<Guid, FundStructureNodeKindDto> nodeKinds)
@@ -4175,8 +4175,8 @@ public sealed partial class InMemoryFundStructureService : INonProductionOnlySer
             Name = CleanRequired(entity.Name, entity.Name),
             Jurisdiction = CleanRequired(entity.Jurisdiction, entity.Jurisdiction),
             BaseCurrency = CleanRequired(entity.BaseCurrency, entity.BaseCurrency).ToUpperInvariant(),
-            RegistrationNumber = CleanOptional(entity.RegistrationNumber),
-            Description = CleanOptional(entity.Description),
+            RegistrationNumber = NormalizeOptional(entity.RegistrationNumber),
+            Description = NormalizeOptional(entity.Description),
             BeneficialOwners = NormalizeBeneficialOwners(entity.BeneficialOwners),
             LifecycleEvents = NormalizeLifecycleEvents(entity.LifecycleEvents)
         };
@@ -4190,8 +4190,8 @@ public sealed partial class InMemoryFundStructureService : INonProductionOnlySer
                 .Select(static owner => owner with
                 {
                     OwnerName = owner.OwnerName.Trim(),
-                    OwnerIdentifier = CleanOptional(owner.OwnerIdentifier),
-                    Notes = CleanOptional(owner.Notes)
+                    OwnerIdentifier = NormalizeOptional(owner.OwnerIdentifier),
+                    Notes = NormalizeOptional(owner.Notes)
                 })
                 .ToList();
 
@@ -4206,7 +4206,7 @@ public sealed partial class InMemoryFundStructureService : INonProductionOnlySer
                 {
                     RecordedBy = lifecycleEvent.RecordedBy.Trim(),
                     Summary = lifecycleEvent.Summary.Trim(),
-                    EvidenceReference = CleanOptional(lifecycleEvent.EvidenceReference)
+                    EvidenceReference = NormalizeOptional(lifecycleEvent.EvidenceReference)
                 })
                 .OrderBy(static lifecycleEvent => lifecycleEvent.OccurredAt)
                 .ThenBy(static lifecycleEvent => lifecycleEvent.EventId)
@@ -4235,8 +4235,6 @@ public sealed partial class InMemoryFundStructureService : INonProductionOnlySer
         var value = string.IsNullOrWhiteSpace(candidate) ? fallback : candidate;
         return value.Trim();
     }
-
-    private static string? CleanOptional(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
     private sealed record ResolvedCashFlowScope(
         GovernanceCashFlowScopeDto Scope,

--- a/src/Meridian.Application/FundStructure/PostgresFundStructureService.cs
+++ b/src/Meridian.Application/FundStructure/PostgresFundStructureService.cs
@@ -5,6 +5,7 @@ using Meridian.Contracts.Services;
 using Meridian.Contracts.SecurityMaster;
 using Meridian.Entities.FundStructure;
 using Meridian.Storage.FundStructure;
+using static Meridian.Contracts.Text.TextPrimitives;
 
 namespace Meridian.Application.FundStructure;
 
@@ -336,8 +337,8 @@ public sealed class PostgresFundStructureService : IFundStructureService
                 IsActive = request.IsActive ?? existing.IsActive,
                 EffectiveFrom = request.EffectiveFrom ?? existing.EffectiveFrom,
                 EffectiveTo = request.EffectiveTo ?? existing.EffectiveTo,
-                Description = CleanOptional(request.Description) ?? existing.Description,
-                RegistrationNumber = CleanOptional(request.RegistrationNumber) ?? existing.RegistrationNumber,
+                Description = NormalizeOptional(request.Description) ?? existing.Description,
+                RegistrationNumber = NormalizeOptional(request.RegistrationNumber) ?? existing.RegistrationNumber,
                 LifecycleStatus = request.LifecycleStatus ?? existing.LifecycleStatus,
                 BeneficialOwners = request.BeneficialOwners is null
                     ? existing.BeneficialOwners
@@ -1345,7 +1346,6 @@ public sealed class PostgresFundStructureService : IFundStructureService
 
     // ── Static utilities ──────────────────────────────────────────────────────
 
-
     private static FundStructureNodeKindDto ResolveKnownNodeKind(
         Guid nodeId,
         IReadOnlyDictionary<Guid, FundStructureNodeKindDto> nodeKinds)
@@ -1423,8 +1423,8 @@ public sealed class PostgresFundStructureService : IFundStructureService
             Name = CleanRequired(entity.Name, entity.Name),
             Jurisdiction = CleanRequired(entity.Jurisdiction, entity.Jurisdiction),
             BaseCurrency = CleanRequired(entity.BaseCurrency, entity.BaseCurrency).ToUpperInvariant(),
-            RegistrationNumber = CleanOptional(entity.RegistrationNumber),
-            Description = CleanOptional(entity.Description),
+            RegistrationNumber = NormalizeOptional(entity.RegistrationNumber),
+            Description = NormalizeOptional(entity.Description),
             BeneficialOwners = NormalizeBeneficialOwners(entity.BeneficialOwners),
             LifecycleEvents = NormalizeLifecycleEvents(entity.LifecycleEvents)
         };
@@ -1438,8 +1438,8 @@ public sealed class PostgresFundStructureService : IFundStructureService
                 .Select(static owner => owner with
                 {
                     OwnerName = owner.OwnerName.Trim(),
-                    OwnerIdentifier = CleanOptional(owner.OwnerIdentifier),
-                    Notes = CleanOptional(owner.Notes)
+                    OwnerIdentifier = NormalizeOptional(owner.OwnerIdentifier),
+                    Notes = NormalizeOptional(owner.Notes)
                 })
                 .ToList();
 
@@ -1454,7 +1454,7 @@ public sealed class PostgresFundStructureService : IFundStructureService
                 {
                     RecordedBy = lifecycleEvent.RecordedBy.Trim(),
                     Summary = lifecycleEvent.Summary.Trim(),
-                    EvidenceReference = CleanOptional(lifecycleEvent.EvidenceReference)
+                    EvidenceReference = NormalizeOptional(lifecycleEvent.EvidenceReference)
                 })
                 .OrderBy(static lifecycleEvent => lifecycleEvent.OccurredAt)
                 .ThenBy(static lifecycleEvent => lifecycleEvent.EventId)
@@ -1483,8 +1483,6 @@ public sealed class PostgresFundStructureService : IFundStructureService
         var value = string.IsNullOrWhiteSpace(candidate) ? fallback : candidate;
         return value.Trim();
     }
-
-    private static string? CleanOptional(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
     private static InvestmentPortfolioSummaryDto ApplyOperatingParent(
         InvestmentPortfolioSummaryDto p, Guid? clientId = null, Guid? fundId = null, Guid? sleeveId = null, Guid? vehicleId = null)

--- a/src/Meridian.Application/ProviderRouting/ProviderSetupService.cs
+++ b/src/Meridian.Application/ProviderRouting/ProviderSetupService.cs
@@ -430,7 +430,4 @@ public sealed class ProviderSetupService
 
         return new string(chars.ToArray());
     }
-
-    private static string? NullIfBlank(string? value)
-        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 }

--- a/src/Meridian.DataIntegration/AccountingSystem/QuickBooks/QuickBooksOnlineProviderCredentialConnectionStore.cs
+++ b/src/Meridian.DataIntegration/AccountingSystem/QuickBooks/QuickBooksOnlineProviderCredentialConnectionStore.cs
@@ -1,6 +1,7 @@
 using Meridian.Contracts.AccountingSystem;
 using Meridian.Contracts.Configuration;
 using Meridian.DataIntegration.Credentials;
+using static Meridian.Contracts.Text.TextPrimitives;
 
 namespace Meridian.DataIntegration.AccountingSystem.QuickBooks;
 
@@ -46,7 +47,7 @@ public sealed class QuickBooksOnlineProviderCredentialConnectionStore : IQuickBo
             refreshToken.Trim(),
             realmId.Trim(),
             NormalizeEnvironment(read.Environment),
-            NullIfWhiteSpace(read.Get(CompanyNameField)));
+            NormalizeOptional(read.Get(CompanyNameField)));
     }
 
     public async Task<AccountingSystemConnectionMetadataDto> GetMetadataAsync(CancellationToken ct = default)
@@ -64,8 +65,8 @@ public sealed class QuickBooksOnlineProviderCredentialConnectionStore : IQuickBo
         return new AccountingSystemConnectionMetadataDto(
             QuickBooksOnlineAccountingProvider.Id,
             NormalizeEnvironment(status.Environment),
-            NullIfWhiteSpace(realmId),
-            NullIfWhiteSpace(companyName),
+            NormalizeOptional(realmId),
+            NormalizeOptional(companyName),
             HasLocalConfig: hasConfig,
             HasRefreshToken: !string.IsNullOrWhiteSpace(read?.Get(RefreshTokenField)),
             LastConnectedAtUtc: status.LastSuccessfulAt,
@@ -139,7 +140,4 @@ public sealed class QuickBooksOnlineProviderCredentialConnectionStore : IQuickBo
                 : "selected company";
         return $"Read-only QuickBooks Online evidence is configured for {selectedCompany}; posting/export remains disabled.";
     }
-
-    private static string? NullIfWhiteSpace(string? value)
-        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 }

--- a/src/Meridian.DataIntegration/Credentials/FileProviderCredentialStore.cs
+++ b/src/Meridian.DataIntegration/Credentials/FileProviderCredentialStore.cs
@@ -6,6 +6,7 @@ using Meridian.Contracts.Configuration;
 using Meridian.Core.Logging;
 using Meridian.Storage.Archival;
 using Serilog;
+using static Meridian.Contracts.Text.TextPrimitives;
 
 namespace Meridian.DataIntegration.Credentials;
 
@@ -199,7 +200,7 @@ public sealed class FileProviderCredentialStore : IProviderCredentialStore
 
             record.LastVerifiedAt = verifiedAt;
             record.LastError = update.Success ? null : SanitizeError(update.ErrorMessage);
-            record.ExternalAccountId = update.Success ? NullIfBlank(update.ExternalAccountId) : record.ExternalAccountId;
+            record.ExternalAccountId = update.Success ? NormalizeOptional(update.ExternalAccountId) : record.ExternalAccountId;
             if (update.Success)
             {
                 record.LastSuccessfulAt = verifiedAt;
@@ -809,9 +810,6 @@ public sealed class FileProviderCredentialStore : IProviderCredentialStore
 
         return message.Trim();
     }
-
-    private static string? NullIfBlank(string? value)
-        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
     private sealed record ProtectedVaultEnvelope(int Version, string Protection, string CipherText);
 

--- a/src/Meridian.DataIntegration/Credentials/ProviderSetupHandlers.cs
+++ b/src/Meridian.DataIntegration/Credentials/ProviderSetupHandlers.cs
@@ -1,6 +1,7 @@
 using Meridian.Contracts.Configuration;
 using Meridian.Core.Config;
 using Meridian.ProviderSdk;
+using static Meridian.Contracts.Text.TextPrimitives;
 
 namespace Meridian.DataIntegration.Credentials;
 
@@ -135,11 +136,9 @@ public abstract class ProviderSetupHandlerBase : IProviderSetupHandler
 
     protected ProviderCredentialCatalogEntry CatalogEntry => _catalogEntry;
 
-    protected static string? NullIfBlank(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
-
     protected void AddIfPresent(IDictionary<string, string?> values, int fieldIndex, string? value)
     {
-        var trimmed = NullIfBlank(value);
+        var trimmed = NormalizeOptional(value);
         if (trimmed is not null && CatalogEntry.RequiredFields.Count > fieldIndex)
         {
             values[CatalogEntry.RequiredFields[fieldIndex].Name] = trimmed;
@@ -181,8 +180,8 @@ public sealed class AlpacaProviderSetupHandler : ProviderSetupHandlerBase
     protected override IReadOnlyDictionary<string, string?> BuildCredentialMap(ProviderSetupContext context)
     {
         var values = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
-        var apiKey = NullIfBlank(context.ApiKey);
-        var apiSecret = NullIfBlank(context.ApiSecret);
+        var apiKey = NormalizeOptional(context.ApiKey);
+        var apiSecret = NormalizeOptional(context.ApiSecret);
         if (apiKey is not null)
             values["KeyId"] = apiKey;
         if (apiSecret is not null)

--- a/src/Meridian.Execution/Services/BrokerageExecutionReconciliationService.cs
+++ b/src/Meridian.Execution/Services/BrokerageExecutionReconciliationService.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Meridian.Execution.Sdk;
 using Microsoft.Extensions.Logging;
+using static Meridian.Contracts.Text.TextPrimitives;
 
 namespace Meridian.Execution.Services;
 
@@ -57,7 +58,7 @@ public sealed class BrokerageExecutionReconciliationService
         foreach (var brokerOrder in brokerOrders)
         {
             ct.ThrowIfCancellationRequested();
-            var clientOrderId = NormalizeId(brokerOrder.ClientOrderId);
+            var clientOrderId = NormalizeOptional(brokerOrder.ClientOrderId);
             if (clientOrderId is null)
             {
                 breaks.Add(CreateBreak(
@@ -255,9 +256,6 @@ public sealed class BrokerageExecutionReconciliationService
             Description: description,
             LocalValue: localOrder is null ? null : DescribeOrder(localOrder),
             BrokerValue: DescribeOrder(brokerOrder));
-
-    private static string? NormalizeId(string? value) =>
-        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
     private static string DescribeOrder(OrderState order) =>
         $"{order.Status} {order.Side} {FormatDecimal(order.Quantity)} {order.Symbol}";

--- a/src/Meridian.Execution/Services/ExecutionOperatorControlService.cs
+++ b/src/Meridian.Execution/Services/ExecutionOperatorControlService.cs
@@ -4,6 +4,7 @@ using Meridian.Execution.Sdk;
 using Meridian.Execution.Serialization;
 using Meridian.Storage.Archival;
 using Microsoft.Extensions.Logging;
+using static Meridian.Contracts.Text.TextPrimitives;
 
 namespace Meridian.Execution.Services;
 
@@ -238,7 +239,7 @@ public sealed class ExecutionOperatorControlService
             {
                 ["isOpen"] = isOpen.ToString()
             },
-            NormalizeOptionalToken(correlationId),
+            NormalizeOptional(correlationId),
             null,
             null,
             ct).ConfigureAwait(false);
@@ -363,9 +364,9 @@ public sealed class ExecutionOperatorControlService
             CreatedBy: NormalizeActor(request.CreatedBy),
             CreatedAt: DateTimeOffset.UtcNow,
             ExpiresAt: request.ExpiresAt,
-            Symbol: NormalizeOptionalToken(request.Symbol),
-            StrategyId: NormalizeOptionalToken(request.StrategyId),
-            RunId: NormalizeOptionalToken(request.RunId));
+            Symbol: NormalizeOptional(request.Symbol),
+            StrategyId: NormalizeOptional(request.StrategyId),
+            RunId: NormalizeOptional(request.RunId));
 
         await MutateAndPersistAsync(
             () =>
@@ -389,7 +390,7 @@ public sealed class ExecutionOperatorControlService
                 ["runId"] = overrideEntry.RunId ?? string.Empty,
                 ["expiresAt"] = overrideEntry.ExpiresAt?.ToString("O") ?? string.Empty
             },
-            correlationId: NormalizeOptionalToken(request.CorrelationId),
+            correlationId: NormalizeOptional(request.CorrelationId),
             runId: overrideEntry.RunId,
             symbol: overrideEntry.Symbol,
             ct: ct).ConfigureAwait(false);
@@ -431,7 +432,7 @@ public sealed class ExecutionOperatorControlService
                 ["strategyId"] = removed.StrategyId ?? string.Empty,
                 ["runId"] = removed.RunId ?? string.Empty
             },
-            correlationId: NormalizeOptionalToken(correlationId),
+            correlationId: NormalizeOptional(correlationId),
             runId: removed.RunId,
             symbol: removed.Symbol,
             ct: ct).ConfigureAwait(false);
@@ -989,9 +990,6 @@ public sealed class ExecutionOperatorControlService
 
     private static string NormalizeActor(string? actor) =>
         string.IsNullOrWhiteSpace(actor) ? "operator" : actor.Trim();
-
-    private static string? NormalizeOptionalToken(string? token) =>
-        string.IsNullOrWhiteSpace(token) ? null : token.Trim();
 
     private readonly record struct ManualOverrideTarget(
         string? Symbol,

--- a/src/Meridian.Execution/Services/ReconciliationSetComparer.cs
+++ b/src/Meridian.Execution/Services/ReconciliationSetComparer.cs
@@ -1,3 +1,5 @@
+using static Meridian.Contracts.Text.TextPrimitives;
+
 namespace Meridian.Execution.Services;
 
 internal static class ReconciliationSetComparer
@@ -16,7 +18,7 @@ internal static class ReconciliationSetComparer
 
         comparer ??= StringComparer.OrdinalIgnoreCase;
         var localByKey = localItems
-            .Select(item => new KeyValuePair<string?, TLocal>(NormalizeKey(localKeySelector(item)), item))
+            .Select(item => new KeyValuePair<string?, TLocal>(NormalizeOptional(localKeySelector(item)), item))
             .Where(static pair => pair.Key is not null)
             .ToDictionary(pair => pair.Key!, pair => pair.Value, comparer);
 
@@ -26,7 +28,7 @@ internal static class ReconciliationSetComparer
 
         foreach (var externalItem in externalItems)
         {
-            var externalKey = NormalizeKey(externalKeySelector(externalItem));
+            var externalKey = NormalizeOptional(externalKeySelector(externalItem));
             if (externalKey is not null && localByKey.TryGetValue(externalKey, out var localItem))
             {
                 matchedLocalKeys.Add(externalKey);
@@ -50,9 +52,6 @@ internal static class ReconciliationSetComparer
             MissingLocal: missingLocal,
             MissingExternal: missingExternal);
     }
-
-    private static string? NormalizeKey(string? value) =>
-        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 }
 
 internal sealed record ReconciliationSetComparison<TLocal, TExternal>(

--- a/src/Meridian.FinancialOperations/PrivateCapital/PrivateCapitalCloseCockpitService.ApprovalHistory.cs
+++ b/src/Meridian.FinancialOperations/PrivateCapital/PrivateCapitalCloseCockpitService.ApprovalHistory.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Meridian.Contracts.Ledger;
 using Meridian.Contracts.Workstation;
+using static Meridian.Contracts.Text.TextPrimitives;
 
 namespace Meridian.FinancialOperations.PrivateCapital;
 
@@ -42,7 +43,7 @@ public sealed partial class PrivateCapitalCloseCockpitService
             var submittedAt = SourceApprovalSubmittedAt(status, record.FundEvent.UpdatedAtUtc);
             var decidedAt = SourceApprovalDecidedAt(status, record.FundEvent.UpdatedAtUtc);
             yield return new PrivateCapitalCloseCockpitApprovalDto(
-                Normalize(record.ApprovalId) ?? $"fund-event-approval:{record.FundEventId}",
+                NormalizeOptional(record.ApprovalId) ?? $"fund-event-approval:{record.FundEventId}",
                 workflow.WorkflowId,
                 workflow.FundAccountId,
                 workflow.PeriodId,
@@ -52,7 +53,7 @@ public sealed partial class PrivateCapitalCloseCockpitService
                 $"Fund-event approval retained for {record.FundEventType}.",
                 submittedAt,
                 decidedAt,
-                Normalize(record.ApprovalRoute) ?? Normalize(record.ActivityRoute) ?? BuildWorkflowRoute(workflow.WorkflowId),
+                NormalizeOptional(record.ApprovalRoute) ?? NormalizeOptional(record.ActivityRoute) ?? BuildWorkflowRoute(workflow.WorkflowId),
                 evidence.Count,
                 evidence);
         }
@@ -84,16 +85,16 @@ public sealed partial class PrivateCapitalCloseCockpitService
                 workflow.PeriodId,
                 status,
                 null,
-                Normalize(output.PublishedBy),
+                NormalizeOptional(output.PublishedBy),
                 output.IsPublished
                     ? $"Report output publication retained for {output.DisplayName}."
                     : $"Report output approval retained for {output.DisplayName}.",
                 submittedAt,
                 decidedAt,
-                Normalize(output.ApprovalRoute) ??
-                Normalize(output.ReportOutputRoute) ??
-                Normalize(output.EvidenceRoute) ??
-                Normalize(output.ReportRoute) ??
+                NormalizeOptional(output.ApprovalRoute) ??
+                NormalizeOptional(output.ReportOutputRoute) ??
+                NormalizeOptional(output.EvidenceRoute) ??
+                NormalizeOptional(output.ReportRoute) ??
                 BuildWorkflowRoute(workflow.WorkflowId),
                 evidence.Count,
                 evidence);
@@ -141,14 +142,14 @@ public sealed partial class PrivateCapitalCloseCockpitService
         {
             var evidence = approval.Approval.EvidenceLinks ?? [];
             yield return new PrivateCapitalCloseCockpitApprovalDto(
-                Normalize(approval.Approval.ApprovalId) ?? $"approval:{workflow.WorkflowId:D}:{approval.Index + 1}",
+                NormalizeOptional(approval.Approval.ApprovalId) ?? $"approval:{workflow.WorkflowId:D}:{approval.Index + 1}",
                 workflow.WorkflowId,
                 workflow.FundAccountId,
                 workflow.PeriodId,
                 approval.Approval.Status,
-                Normalize(approval.Approval.Operator),
-                Normalize(approval.Approval.Reviewer),
-                Normalize(approval.Approval.Rationale),
+                NormalizeOptional(approval.Approval.Operator),
+                NormalizeOptional(approval.Approval.Reviewer),
+                NormalizeOptional(approval.Approval.Rationale),
                 approval.Approval.SubmittedAtUtc,
                 approval.Approval.DecidedAtUtc,
                 workflowRoute,
@@ -165,7 +166,7 @@ public sealed partial class PrivateCapitalCloseCockpitService
         var packageEvidence = package.EvidenceLinks ?? [];
         foreach (var approval in package.ChecklistControlApprovals)
         {
-            var approvalId = $"checklist-control:{workflow.WorkflowId:D}:{Normalize(approval.TaskId) ?? "task"}:{approval.ApprovedAtUtc:yyyyMMddHHmmss}";
+            var approvalId = $"checklist-control:{workflow.WorkflowId:D}:{NormalizeOptional(approval.TaskId) ?? "task"}:{approval.ApprovedAtUtc:yyyyMMddHHmmss}";
             yield return new PrivateCapitalCloseCockpitApprovalDto(
                 approvalId,
                 workflow.WorkflowId,
@@ -173,7 +174,7 @@ public sealed partial class PrivateCapitalCloseCockpitService
                 workflow.PeriodId,
                 OperationsApprovalStateDto.Approved,
                 null,
-                Normalize(approval.ApprovedBy),
+                NormalizeOptional(approval.ApprovedBy),
                 $"Checklist control approval retained for {approval.TaskId}.",
                 approval.ApprovedAtUtc,
                 approval.ApprovedAtUtc,
@@ -197,9 +198,9 @@ public sealed partial class PrivateCapitalCloseCockpitService
                 workflow.FundAccountId,
                 workflow.PeriodId,
                 OperationsApprovalStateDto.Approved,
-                Normalize(entry.Actor),
-                Normalize(entry.Actor),
-                Normalize(entry.Rationale) ?? "Governed period reopen approval retained.",
+                NormalizeOptional(entry.Actor),
+                NormalizeOptional(entry.Actor),
+                NormalizeOptional(entry.Rationale) ?? "Governed period reopen approval retained.",
                 entry.OccurredAtUtc,
                 entry.OccurredAtUtc,
                 workflowRoute,

--- a/src/Meridian.FinancialOperations/PrivateCapital/PrivateCapitalCloseCockpitService.Routes.cs
+++ b/src/Meridian.FinancialOperations/PrivateCapital/PrivateCapitalCloseCockpitService.Routes.cs
@@ -1,6 +1,7 @@
 using Meridian.Contracts.Api;
 using Meridian.Contracts.Workstation;
 using Meridian.FinancialOperations.OperationsContinuity;
+using static Meridian.Contracts.Text.TextPrimitives;
 
 namespace Meridian.FinancialOperations.PrivateCapital;
 
@@ -25,7 +26,7 @@ public sealed partial class PrivateCapitalCloseCockpitService
 
     private static void AddQuery(List<string> query, string key, string? value)
     {
-        var normalized = Normalize(value);
+        var normalized = NormalizeOptional(value);
         if (normalized is not null)
         {
             query.Add($"{key}={Uri.EscapeDataString(normalized)}");
@@ -34,9 +35,6 @@ public sealed partial class PrivateCapitalCloseCockpitService
 
     private static string BuildWorkflowRoute(Guid workflowId)
         => UiApiRoutes.WithParam(UiApiRoutes.OperationsContinuityById, "workflowId", workflowId.ToString("D"));
-
-    private static string? Normalize(string? value)
-        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
     private sealed record ManagementCompanyEvidenceSignal(string Label, bool IsPresent);
 

--- a/src/Meridian.FinancialOperations/PrivateCapital/PrivateCapitalCloseCockpitService.cs
+++ b/src/Meridian.FinancialOperations/PrivateCapital/PrivateCapitalCloseCockpitService.cs
@@ -3,6 +3,7 @@ using Meridian.Contracts.Api;
 using Meridian.Contracts.Ledger;
 using Meridian.Contracts.Workstation;
 using Meridian.FinancialOperations.OperationsContinuity;
+using static Meridian.Contracts.Text.TextPrimitives;
 
 namespace Meridian.FinancialOperations.PrivateCapital;
 
@@ -123,11 +124,11 @@ public sealed partial class PrivateCapitalCloseCockpitService : IPrivateCapitalC
                              approvalStatus == EvidenceStatusDto.Ready;
 
         return new PrivateCapitalCloseCockpitDto(
-            FundProfileId: Normalize(activity?.FundProfileId) ?? Normalize(fundProfileId),
+            FundProfileId: NormalizeOptional(activity?.FundProfileId) ?? NormalizeOptional(fundProfileId),
             LedgerBookId: activity?.LedgerBookId ?? ledgerBookId,
             FundAccountId: fundAccountId,
-            PeriodId: Normalize(periodId),
-            EntityId: Normalize(entityId),
+            PeriodId: NormalizeOptional(periodId),
+            EntityId: NormalizeOptional(entityId),
             ProjectedAtUtc: activity?.ProjectedAtUtc ?? DateTimeOffset.UtcNow,
             CockpitRoute: BuildCockpitRoute(fundProfileId, ledgerBookId, fundAccountId, periodId, entityId),
             OverallStatus: overallStatus,
@@ -164,7 +165,7 @@ public sealed partial class PrivateCapitalCloseCockpitService : IPrivateCapitalC
         }
 
         var summaries = await _operationsContinuityWorkflowService
-            .ListAsync(fundAccountId, Normalize(periodId), status: null, ct: ct, ledgerBookId: ledgerBookId)
+            .ListAsync(fundAccountId, NormalizeOptional(periodId), status: null, ct: ct, ledgerBookId: ledgerBookId)
             .ConfigureAwait(false);
         var workflows = new List<OperationsContinuityWorkflowDto>(summaries.Count);
         foreach (var summary in summaries)
@@ -539,7 +540,7 @@ public sealed partial class PrivateCapitalCloseCockpitService : IPrivateCapitalC
                     : shadowNavReady
                         ? "NAV support package has shadow NAV evidence but still waits on administrator NAV tie-out, position, cash, pricing, or validation readiness."
                         : "NAV support package is missing retained shadow NAV, administrator NAV tie-out, or required close-readiness components.",
-                Normalize(route),
+                NormalizeOptional(route),
                 tieOut.MeridianShadowNav ?? EstimateShadowNav(records),
                 ResolveNavCurrency(records),
                 evidence.Length,
@@ -723,7 +724,7 @@ public sealed partial class PrivateCapitalCloseCockpitService : IPrivateCapitalC
             component?.BlockingReason ?? (isReady
                 ? $"{component?.Label ?? SplitComponentLabel(key)} support is ready for NAV support."
                 : $"{component?.Label ?? SplitComponentLabel(key)} support is missing from close readiness."),
-            Normalize(component?.RouteHint),
+            NormalizeOptional(component?.RouteHint),
             component?.Score ?? (isReady ? 100 : 0));
     }
 
@@ -780,7 +781,7 @@ public sealed partial class PrivateCapitalCloseCockpitService : IPrivateCapitalC
         var route = FirstReportRoute(administratorNavOutputs) ?? FirstReportRoute(shadowNavOutputs);
         var currency = ResolveNavCurrency(records) ??
                        shadowNavOutputs.Concat(administratorNavOutputs)
-                           .Select(static output => Normalize(output.Currency))
+                           .Select(static output => NormalizeOptional(output.Currency))
                            .FirstOrDefault(static value => value is not null);
         var status = ResolveShadowNavTieOutStatus(shadowNavOutputs, administratorNavOutputs, variance);
         var requiredActions = BuildShadowNavTieOutRequiredActions(status, shadowNavOutputs, administratorNavOutputs, variance);
@@ -795,7 +796,7 @@ public sealed partial class PrivateCapitalCloseCockpitService : IPrivateCapitalC
             Tolerance: ShadowNavTieOutTolerance,
             Currency: currency,
             Summary: BuildShadowNavTieOutSummary(status, meridianShadowNav, administratorNav, variance),
-            Route: Normalize(route),
+            Route: NormalizeOptional(route),
             EvidenceLinkCount: evidence.Length,
             EvidenceLinks: evidence,
             RequiredActions: requiredActions);
@@ -1088,7 +1089,7 @@ public sealed partial class PrivateCapitalCloseCockpitService : IPrivateCapitalC
                 EvidenceStatusDto.Blocked => $"Close-control checklist has blocked items for {string.Join(", ", unresolved)}.",
                 _ => $"Close-control checklist still needs retained evidence or approval for {string.Join(", ", unresolved)}."
             },
-            Normalize(route),
+            NormalizeOptional(route),
             evidence.Length,
             evidence,
             requiredActions);
@@ -1167,7 +1168,7 @@ public sealed partial class PrivateCapitalCloseCockpitService : IPrivateCapitalC
 
     private static bool IsChecklistTaskComplete(OperationsCloseChecklistTaskDto task)
     {
-        var status = Normalize(task.Status);
+        var status = NormalizeOptional(task.Status);
         return string.Equals(status, "Done", StringComparison.OrdinalIgnoreCase) ||
                string.Equals(status, "Complete", StringComparison.OrdinalIgnoreCase) ||
                string.Equals(status, "Completed", StringComparison.OrdinalIgnoreCase) ||
@@ -1177,7 +1178,7 @@ public sealed partial class PrivateCapitalCloseCockpitService : IPrivateCapitalC
 
     private static bool IsCloseControlTaskBlocked(OperationsCloseChecklistTaskDto task)
     {
-        var status = Normalize(task.Status);
+        var status = NormalizeOptional(task.Status);
         return string.Equals(status, "Blocked", StringComparison.OrdinalIgnoreCase) ||
                string.Equals(status, "Expired", StringComparison.OrdinalIgnoreCase) ||
                !string.IsNullOrWhiteSpace(task.BlockingReason);
@@ -1194,7 +1195,7 @@ public sealed partial class PrivateCapitalCloseCockpitService : IPrivateCapitalC
 
         var approvals = workflow.ClosePackage?.ChecklistControlApprovals ?? [];
         var approvalCount = approvals
-            .Where(approval => string.Equals(Normalize(approval.TaskId), Normalize(task.TaskId), StringComparison.OrdinalIgnoreCase))
+            .Where(approval => string.Equals(NormalizeOptional(approval.TaskId), NormalizeOptional(task.TaskId), StringComparison.OrdinalIgnoreCase))
             .Where(static approval => !string.IsNullOrWhiteSpace(approval.ApprovedBy))
             .Where(static approval => approval.ApprovedAtUtc != default)
             .Select(static approval => approval.ApprovedBy.Trim())
@@ -1211,7 +1212,7 @@ public sealed partial class PrivateCapitalCloseCockpitService : IPrivateCapitalC
             .Select(static item => new OperationsEvidenceLinkDto(
                 item.Task.EvidencePointer!.Trim(),
                 item.Task.Label,
-                Normalize(item.Task.RemediationRoute) ?? BuildWorkflowRoute(item.Workflow.WorkflowId),
+                NormalizeOptional(item.Task.RemediationRoute) ?? BuildWorkflowRoute(item.Workflow.WorkflowId),
                 "operations-continuity-close-checklist",
                 item.Task.AcknowledgedAtUtc ?? item.Workflow.UpdatedAtUtc))
             .DistinctBy(static link => link.EvidenceId, StringComparer.OrdinalIgnoreCase)
@@ -1336,7 +1337,7 @@ public sealed partial class PrivateCapitalCloseCockpitService : IPrivateCapitalC
             status,
             isReady,
             summary,
-            Normalize(route),
+            NormalizeOptional(route),
             evidenceLinks.Count,
             evidenceLinks,
             isReady ? [] : [requiredAction]);
@@ -1366,7 +1367,7 @@ public sealed partial class PrivateCapitalCloseCockpitService : IPrivateCapitalC
             return [];
         }
 
-        var normalizedPeriodId = Normalize(periodId);
+        var normalizedPeriodId = NormalizeOptional(periodId);
         return workbench.Drafts
             .Where(static draft => draft.TreasuryContext?.IdempotencyKey?.StartsWith(
                 "fair-value|",
@@ -1387,8 +1388,8 @@ public sealed partial class PrivateCapitalCloseCockpitService : IPrivateCapitalC
             return [];
         }
 
-        var normalizedPeriodId = Normalize(periodId);
-        var normalizedEntityId = Normalize(entityId);
+        var normalizedPeriodId = NormalizeOptional(periodId);
+        var normalizedEntityId = NormalizeOptional(entityId);
         return workbench.Drafts
             .Where(static draft => draft.TreasuryContext?.IdempotencyKey is { } key &&
                 (key.StartsWith("mgmt-fee|", StringComparison.OrdinalIgnoreCase) ||
@@ -1435,14 +1436,14 @@ public sealed partial class PrivateCapitalCloseCockpitService : IPrivateCapitalC
 
     private static bool MatchesPeriod(DateOnly effectiveDate, string? periodId)
     {
-        var normalized = Normalize(periodId);
+        var normalized = NormalizeOptional(periodId);
         return normalized is null ||
                string.Equals(effectiveDate.ToString("yyyy-MM", CultureInfo.InvariantCulture), normalized, StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool MatchesEntity(PrivateCapitalFundEventLedgerRecordDto record, string? entityId)
     {
-        var normalized = Normalize(entityId);
+        var normalized = NormalizeOptional(entityId);
         return normalized is null ||
                record.LedgerImpacts
                    .SelectMany(static impact => impact.Lines)
@@ -1737,13 +1738,13 @@ public sealed partial class PrivateCapitalCloseCockpitService : IPrivateCapitalC
             .Concat(shadowNavOutputs.Select(static output => output.ReportOutputId))
             .Concat(administratorNavOutputs.Select(static output => output.ReportOutputId))
             .FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value));
-        return $"shadow-nav-tie-out:{Normalize(scope) ?? "close-scope"}";
+        return $"shadow-nav-tie-out:{NormalizeOptional(scope) ?? "close-scope"}";
     }
 
     private static string? ResolveNavCurrency(IReadOnlyList<PrivateCapitalFundEventLedgerRecordDto> records)
     {
         var currencies = records
-            .Select(static record => Normalize(record.Currency))
+            .Select(static record => NormalizeOptional(record.Currency))
             .Where(static currency => currency is not null)
             .Select(static currency => currency!)
             .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -1759,7 +1760,7 @@ public sealed partial class PrivateCapitalCloseCockpitService : IPrivateCapitalC
 
     private static OperationsEvidenceLinkDto LinkFromRoute(string route, string label, string source)
     {
-        var trimmed = Normalize(route) ?? "unresolved";
+        var trimmed = NormalizeOptional(route) ?? "unresolved";
         var evidenceId = trimmed
             .Trim('/')
             .Replace('/', ':')
@@ -2058,5 +2059,4 @@ public sealed partial class PrivateCapitalCloseCockpitService : IPrivateCapitalC
             ? UiApiRoutes.OperationsPrivateCapitalCloseCockpit
             : UiApiRoutes.WithQuery(UiApiRoutes.OperationsPrivateCapitalCloseCockpit, string.Join("&", query));
     }
-
 }

--- a/src/Meridian.FinancialOperations/Reconciliation/StatementRunMatchingService.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementRunMatchingService.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using Meridian.Domain.Reconciliation;
+using static Meridian.Contracts.Text.TextPrimitives;
 
 namespace Meridian.FinancialOperations.Reconciliation;
 
@@ -63,7 +64,7 @@ public static class StatementRunMatchingService
                         reference,
                         ExternalTransactionId: null,
                         row.Account,
-                        NormalizeSecurityId(row.Symbol),
+                        NormalizeOptional(row.Symbol),
                         Currency: null,
                         row.TradeDate,
                         row.TradeDate,
@@ -193,9 +194,6 @@ public static class StatementRunMatchingService
 
     private static decimal PositionMarketValue(CanonicalStatementRow row)
         => row.Price != 0m ? row.Quantity * row.Price : row.CashAmount;
-
-    private static string? NormalizeSecurityId(string symbol)
-        => string.IsNullOrWhiteSpace(symbol) ? null : symbol.Trim();
 
     private static StatementMatchingToleranceProfile ToEngineTolerance(StatementToleranceProfile profile)
     {

--- a/src/Meridian.Wpf/Services/DesktopLaunchArguments.cs
+++ b/src/Meridian.Wpf/Services/DesktopLaunchArguments.cs
@@ -1,4 +1,5 @@
 using Meridian.Wpf.Models;
+using static Meridian.Contracts.Text.TextPrimitives;
 
 namespace Meridian.Wpf.Services;
 
@@ -53,7 +54,7 @@ internal static class DesktopLaunchArguments
 
             if (arg.StartsWith("--screenshot=", StringComparison.OrdinalIgnoreCase))
             {
-                screenshotPath = NormalizeScreenshotPath(arg["--screenshot=".Length..]);
+                screenshotPath = NormalizeOptional(arg["--screenshot=".Length..]);
                 continue;
             }
 
@@ -62,7 +63,7 @@ internal static class DesktopLaunchArguments
             {
                 if (i + 1 < args.Count)
                 {
-                    screenshotPath = NormalizeScreenshotPath(args[++i]);
+                    screenshotPath = NormalizeOptional(args[++i]);
                 }
 
                 continue;
@@ -85,10 +86,5 @@ internal static class DesktopLaunchArguments
         }
 
         return ShellNavigationCatalog.GetCanonicalPageTag(pageTag);
-    }
-
-    private static string? NormalizeScreenshotPath(string? path)
-    {
-        return string.IsNullOrWhiteSpace(path) ? null : path.Trim();
     }
 }

--- a/src/Meridian.Wpf/Services/WorkspaceService.cs
+++ b/src/Meridian.Wpf/Services/WorkspaceService.cs
@@ -16,6 +16,7 @@ using WorkspaceCategory = Meridian.Ui.Services.WorkspaceCategory;
 using WorkspaceEventArgs = Meridian.Ui.Services.WorkspaceEventArgs;
 using WorkspacePage = Meridian.Ui.Services.WorkspacePage;
 using WorkspaceTemplate = Meridian.Ui.Services.WorkspaceTemplate;
+using static Meridian.Contracts.Text.TextPrimitives;
 
 namespace Meridian.Wpf.Services;
 
@@ -501,7 +502,7 @@ public sealed class WorkspaceService
 
                 state.SavedAt = DateTime.UtcNow;
                 _lastSession = state;
-                var normalizedFundProfileId = NormalizeFundProfileId(fundProfileId);
+                var normalizedFundProfileId = NormalizeOptional(fundProfileId);
                 if (!string.IsNullOrWhiteSpace(normalizedFundProfileId))
                 {
                     LastSelectedFundProfileId = normalizedFundProfileId;
@@ -539,7 +540,7 @@ public sealed class WorkspaceService
                 return null;
             }
 
-            return BuildWorkspaceStateToken(state, workspaceId, NormalizeFundProfileId(fundProfileId));
+            return BuildWorkspaceStateToken(state, workspaceId, NormalizeOptional(fundProfileId));
         }, ct);
 
     public Task<WorkspaceStateRestoreResult?> RestoreWorkspaceStateTokenAsync(
@@ -569,7 +570,7 @@ public sealed class WorkspaceService
     public SessionState? GetLastSessionState(string? fundProfileId)
         => WithStateLock(() =>
         {
-            var normalizedFundProfileId = NormalizeFundProfileId(fundProfileId);
+            var normalizedFundProfileId = NormalizeOptional(fundProfileId);
             if (string.IsNullOrWhiteSpace(normalizedFundProfileId))
             {
                 if (_lastSession is not null)
@@ -606,7 +607,7 @@ public sealed class WorkspaceService
         => WithStateLockAsync(async () =>
         {
             await EnsureInitializedAsync(ct).ConfigureAwait(false);
-            LastSelectedFundProfileId = NormalizeFundProfileId(fundProfileId);
+            LastSelectedFundProfileId = NormalizeOptional(fundProfileId);
             await SaveWorkspacesCoreAsync(ct).ConfigureAwait(false);
         }, ct);
 
@@ -827,12 +828,9 @@ public sealed class WorkspaceService
         addOwner(owners, "GovernanceShell", "accounting");
     }
 
-    private static string? NormalizeFundProfileId(string? fundProfileId)
-        => string.IsNullOrWhiteSpace(fundProfileId) ? null : fundProfileId.Trim();
-
     private static IReadOnlyList<string> GetEquivalentSessionScopeKeys(string? scopeKey)
     {
-        var normalizedScopeKey = NormalizeFundProfileId(scopeKey);
+        var normalizedScopeKey = NormalizeOptional(scopeKey);
         if (string.IsNullOrWhiteSpace(normalizedScopeKey))
         {
             return Array.Empty<string>();
@@ -1404,7 +1402,7 @@ public sealed class WorkspaceService
 
     private static string BuildRawWorkspaceLayoutKey(string workspaceId, string? fundProfileId)
     {
-        var normalizedFundProfileId = NormalizeFundProfileId(fundProfileId);
+        var normalizedFundProfileId = NormalizeOptional(fundProfileId);
         return string.IsNullOrWhiteSpace(normalizedFundProfileId)
             ? workspaceId
             : $"{workspaceId}::{normalizedFundProfileId}";

--- a/src/Meridian.Wpf/ViewModels/SettingsViewModel.AssetProfiles.cs
+++ b/src/Meridian.Wpf/ViewModels/SettingsViewModel.AssetProfiles.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Meridian.Contracts.Api;
 using Meridian.Contracts.SecurityMaster;
 using Meridian.Ui.Services;
+using static Meridian.Contracts.Text.TextPrimitives;
 
 namespace Meridian.Wpf.ViewModels;
 
@@ -277,7 +278,7 @@ public sealed partial class SettingsViewModel
                 NormalizeAssetProfileId(AssetProfileDraftProfileId),
                 AssetProfileDraftName.Trim(),
                 AssetProfileDraftCategory.Trim(),
-                NullIfWhiteSpace(AssetProfileDraftSubType),
+                NormalizeOptional(AssetProfileDraftSubType),
                 starter.Fields,
                 starter.IdentifierPreferences,
                 starter.LifecycleStates,
@@ -855,9 +856,6 @@ public sealed partial class SettingsViewModel
 
     private static string NormalizeCurrency(string? value)
         => string.IsNullOrWhiteSpace(value) ? "USD" : value.Trim().ToUpperInvariant();
-
-    private static string? NullIfWhiteSpace(string? value)
-        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
     private static string GetRequestedBy()
         => string.IsNullOrWhiteSpace(Environment.UserName) ? "wpf-settings" : Environment.UserName;


### PR DESCRIPTION
<!-- phase:PR7 -->

## Summary

Second and final mechanical tranche for #2702's body-clone migration, following #2763's `Meridian.Ui.Shared` tranche. Fourteen files across `Application`, `DataIntegration`, `Execution`, `FinancialOperations`, and `Wpf` declared a private (one `protected`) helper whose body is byte-for-byte `TextPrimitives.NormalizeOptional` under nine different local names — `CleanOptional`, `NullIfBlank`, `NullIfWhiteSpace`, `NormalizeId`, `NormalizeOptionalToken`, `NormalizeKey`, `Normalize`, `NormalizeSecurityId`, `NormalizeScreenshotPath`, `NormalizeFundProfileId`. Each declaration is deleted and its call sites rename onto the primitive via `using static`. The duplicate-helper ratchet baseline tightens **19 → 5** body clones.

Points of note:

- `PrivateCapitalCloseCockpitService`'s helper lived in the `.Routes` partial but was consumed from all three partial-class files (42 call sites) — the cross-partial trap from tranche 1's post-merge fix, handled up front this time: every partial file imports the primitive and renames together.
- The cockpit core partial sat exactly at its file-size cap, so its new `using` directive is paid for by dropping a stray blank line before the file's closing brace — no cap bump.
- `ProviderSetupService.NullIfBlank` had zero call sites — a dead helper, deleted outright.
- `ProviderSetupHandlers.NullIfBlank` was `protected` on the handler base class; every subclass call site lives in the same file, verified by project-wide search before deletion.
- `StatementRunMatchingService.NormalizeSecurityId` took non-nullable `string`; widening to the primitive's `string?` parameter is safe at its call sites.

## The five clones that stay baselined

- **Four `Meridian.Ledger` files** (`LedgerAccounts`, `LedgerLineDimensionSetNormalizer`, `PrivateCapitalFundEventLedgerProjector`, `ProjectLedgerBook`): the project has no `Meridian.Contracts` reference — the same layering decision #2702 itself flags and the SHA-256 program recorded for its own `Ledger` sites. One owner decision unblocks all of these at once.
- **`FileEvidenceArtifactStore.RequireTrimmed`**: body-equivalent to `RequireText`, but the canonicaliser folds literals — and this clone throws a bespoke `ArgumentException` message (`"Evidence vault intake requires non-empty subject, channel, file, and content fields."`) where the primitive throws `"Value must be non-empty text."`. Migrating it changes observable exception text, so it is deliberately excluded from a mechanical tranche. Worth noting for the follow-up: the bespoke message is factually wrong at 4 of its 9 call sites (they validate `documentId`/`tenantId`/`scope`/`reviewer`, not intake fields), so normalizing it is defensible — it just deserves its own reviewed change.

## Reason

#2702's premise: a renamed clone is invisible to name-based tracking and free to drift. The body-based detector (merged in #2762) found these; migrating them and ratcheting the baseline downward is what makes the detection permanent. After this tranche every remaining clone is blocked on a decision, not on mechanics.

## Testing performed

- Migration driver asserted exactly one declaration per file and renamed by identifier word-boundary (catching method groups, not just calls); the cockpit partials' post-rename diff was audited line-by-line — every rename produced a call, and the count difference vs. the line-based grep was confirmed to be multi-call lines, not stray renames.
- Duplicate-helper ratchet green at the tightened baseline (5 body clones); file-size ratchet green (the tighten pass records the current headroom map); inline-SHA ratchet untouched and green; docs automation core profile run twice, idempotent.
- Scope gate verified locally: `PR7` passes for the full changed-file set.
- .NET compile/tests ride CI (`verify-dotnet`, `verify-desktop` for the Wpf files) — no SDK in this container. Every migrated call site passes `string?`-compatible arguments, spot-verified at the declaration sites.

## Safety review

- Byte-identical bodies: every migrated helper is exactly `string.IsNullOrWhiteSpace(value) ? null : value.Trim()`, so call-site behavior cannot change.
- Sibling helpers that merely look related (`NormalizeActor` with its `"operator"` fallback, `NormalizeCurrency` with its `"USD"`/uppercase fallback) are different functions and are untouched.
- The message-bearing `RequireTrimmed` clone is excluded precisely because migrating it would not be behavior-preserving.

## Governance changes

None. Baseline shrinks are downward-only; no workflow, CODEOWNERS, or CI-policy surface is touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtGupfUEyokEr8GmKSVVuq)_