### PR TITLE
Compare typed provenance tags when verifying a posting replay

### DIFF
--- a/src/Meridian.Storage/Ledger/RetainedPostingEquivalence.cs
+++ b/src/Meridian.Storage/Ledger/RetainedPostingEquivalence.cs
@@ -16,9 +16,12 @@ namespace Meridian.Storage.Ledger;
 /// ordinary operator retry into a hard failure.
 /// </para>
 /// <para>
-/// Approval-derived state is excluded for the same reason: approval id, approval state, and
-/// evidence retention stamps are recorded at append time, so a later replay of the same posting
-/// legitimately carries different values. What must not differ is what the books say.
+/// Approval-derived state is excluded for the same reason: approval id, approval state, the
+/// fingerprint computed over the approved command, and evidence retention stamps are all recorded
+/// at append time, so a later replay of the same posting legitimately carries different values.
+/// That exclusion is deliberately narrow — everything else a tag carries, including the
+/// real-versus-simulated provenance mark and the economic-event and projection lineage, is
+/// compared. What must not differ is what the books say, and what the figures claim to be.
 /// </para>
 /// </summary>
 public static class RetainedPostingEquivalence
@@ -127,13 +130,17 @@ public static class RetainedPostingEquivalence
     /// because a retry that keeps the same lines while changing the fund, investor, capital
     /// account, or payment intent it books against is a different posting, not a replay.
     /// <para>
-    /// <see cref="JournalEntryMetadata.Tags"/> and
-    /// <see cref="JournalEntryMetadata.EvidenceReferences"/> are the two deliberate exclusions.
-    /// Both carry approval-time state that a rebuild cannot reproduce: the tag set records the
-    /// approval state, approval id, and a fingerprint computed over the approved command, and the
-    /// evidence list is merged with a clock stamp as the posting is approved. Comparing them
-    /// would reject ordinary retries. Their durable content is largely mirrored by the scalar
-    /// fields above, which are compared.
+    /// Tags participate too, minus a narrow exclusion set. They are not decoration: typed
+    /// provenance — the data-provenance mark separating real figures from simulated ones, the
+    /// economic event's version, domain, entity, and content hash, the projection lineage, and
+    /// the rule pack — is persisted <i>only</i> as tags and is mirrored by none of the scalars
+    /// above. Excluding them wholesale would let a retry that changes what the figures claim to
+    /// be pass as a replay.
+    /// </para>
+    /// <para>
+    /// <see cref="JournalEntryMetadata.EvidenceReferences"/> remains excluded: approval evidence
+    /// is merged with a clock stamp as the posting is approved, so a rebuild carries neither the
+    /// stamp nor the merged entries and comparing the list would reject ordinary retries.
     /// </para>
     /// </summary>
     private static string? MetadataDifference(JournalEntryMetadata retained, JournalEntryMetadata candidate)
@@ -178,9 +185,62 @@ public static class RetainedPostingEquivalence
             return "investor";
         if (!TextMatches(retained.PaymentIntentId, candidate.PaymentIntentId))
             return "payment intent";
-        return TextMatches(retained.SettlementReference, candidate.SettlementReference)
-            ? null
-            : "settlement reference";
+        if (!TextMatches(retained.SettlementReference, candidate.SettlementReference))
+            return "settlement reference";
+        return TagsDifference(retained.Tags, candidate.Tags);
+    }
+
+    /// <summary>
+    /// Tag keys a rebuild cannot reproduce, and the only ones excluded from comparison. The
+    /// approval state and id are stamped as the posting is approved; the fingerprint is computed
+    /// over the whole approved command including its clock-stamped evidence, so it can never
+    /// match across a rebuild. Line-dimension tags are keyed by generated per-line entry ids.
+    /// </summary>
+    private static bool IsRebuildableTag(string key)
+        => !key.StartsWith("lineDimensions.", StringComparison.OrdinalIgnoreCase)
+           && !string.Equals(key, "approvalState", StringComparison.OrdinalIgnoreCase)
+           && !string.Equals(key, "approvalId", StringComparison.OrdinalIgnoreCase)
+           && !string.Equals(
+               key,
+               AccountingPostingCommandValidator.PostingCommandFingerprintTag,
+               StringComparison.OrdinalIgnoreCase);
+
+    private static string? TagsDifference(
+        IReadOnlyDictionary<string, string>? retained,
+        IReadOnlyDictionary<string, string>? candidate)
+    {
+        var retainedTags = ComparableTags(retained);
+        var candidateTags = ComparableTags(candidate);
+
+        foreach (var (key, retainedValue) in retainedTags)
+        {
+            if (!candidateTags.TryGetValue(key, out var candidateValue) || !TextMatches(retainedValue, candidateValue))
+                return $"tag '{key}'";
+        }
+
+        foreach (var key in candidateTags.Keys)
+        {
+            if (!retainedTags.ContainsKey(key))
+                return $"tag '{key}'";
+        }
+
+        return null;
+    }
+
+    private static Dictionary<string, string> ComparableTags(IReadOnlyDictionary<string, string>? tags)
+    {
+        var comparable = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (tags is null)
+            return comparable;
+
+        foreach (var (key, value) in tags)
+        {
+            if (NormalizeOptional(key) is not { } normalizedKey || !IsRebuildableTag(normalizedKey))
+                continue;
+            comparable[normalizedKey] = NormalizeOptional(value) ?? string.Empty;
+        }
+
+        return comparable;
     }
 
     /// <summary>

--- a/tests/Meridian.Tests/Storage/Ledger/RetainedPostingEquivalenceTests.cs
+++ b/tests/Meridian.Tests/Storage/Ledger/RetainedPostingEquivalenceTests.cs
@@ -295,6 +295,55 @@ public sealed class RetainedPostingEquivalenceTests
         difference.Should().Be("line 0 dimensions");
     }
 
+    [Theory]
+    [InlineData("dataProvenance", "Simulated")]
+    [InlineData("sourceEventContentHash", "def456")]
+    [InlineData("projectionModelVersion", "2.0.0")]
+    public void Matches_DifferentTypedProvenanceTag_IsAConflict(string tagKey, string changedValue)
+    {
+        // These live only in tags — no scalar mirrors them — and dataProvenance in particular is
+        // the mark separating real figures from simulated ones.
+        var retained = BuildRecord(BuildEntry(Guid.NewGuid(), Guid.NewGuid()));
+        var candidate = BuildWrite(BuildEntry(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            tags: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["dataProvenance"] = "Real",
+                ["sourceEventContentHash"] = "abc123",
+                ["projectionModelVersion"] = "1.0.0",
+                ["approvalId"] = "approval-original",
+                ["approvalState"] = "Approved",
+                [tagKey] = changedValue
+            }));
+
+        RetainedPostingEquivalence.Matches(retained, candidate, out var difference).Should().BeFalse();
+        difference.Should().Be($"tag '{tagKey}'");
+    }
+
+    [Fact]
+    public void Matches_DifferentApprovalTimeTags_IsStillAnExactReplay()
+    {
+        // Approval id, approval state, and the command fingerprint are stamped at append time and
+        // cannot be reproduced by a rebuild, so they must not turn a retry into a conflict.
+        var retained = BuildRecord(BuildEntry(Guid.NewGuid(), Guid.NewGuid()));
+        var candidate = BuildWrite(BuildEntry(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            tags: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["dataProvenance"] = "Real",
+                ["sourceEventContentHash"] = "abc123",
+                ["projectionModelVersion"] = "1.0.0",
+                ["approvalId"] = "approval-different",
+                ["approvalState"] = "Pending",
+                ["postingCommandFingerprint"] = "sha256:totally-different"
+            }));
+
+        RetainedPostingEquivalence.Matches(retained, candidate, out var difference).Should().BeTrue();
+        difference.Should().BeEmpty();
+    }
+
     private static LedgerEntryCurrency Currency(string transactionCurrency, decimal fxRate, decimal transactionDebit)
         => new(transactionCurrency, "USD", transactionDebit, 0m, fxRate);
 
@@ -317,6 +366,7 @@ public sealed class RetainedPostingEquivalenceTests
         string idempotencyKey = "custodian-interest:2026-05",
         IReadOnlyDictionary<string, string>? externalGlDimensions = null,
         Func<JournalEntryMetadata, JournalEntryMetadata>? metadata = null,
+        IReadOnlyDictionary<string, string>? tags = null,
         DateTimeOffset? timestamp = null,
         string accountName = "Accrued Interest Receivable",
         LedgerEntryCurrency? currency = null)
@@ -354,6 +404,14 @@ public sealed class RetainedPostingEquivalenceTests
                 ActivityType = "interest-accrual",
                 IdempotencyKey = idempotencyKey,
                 EffectiveDate = new DateOnly(2026, 5, 31),
+                Tags = tags ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["dataProvenance"] = "Real",
+                    ["sourceEventContentHash"] = "abc123",
+                    ["projectionModelVersion"] = "1.0.0",
+                    ["approvalId"] = "approval-original",
+                    ["approvalState"] = "Approved"
+                },
                 Symbol = "AAPL",
                 ProjectId = "project-interest-accrual",
                 StrategyId = "strategy-income",


### PR DESCRIPTION
## Summary

Follow-up to the replay verification merged in #2800, closing a gap found in the last review round there after the merge.

That comparer excluded journal tags wholesale, on the stated reasoning that their durable content was "largely mirrored by the scalar fields". That reasoning was too broad. Of what `AccountingPostingCommandValidator.BuildCommandTags` persists, only `sourceEventId`, `securityId`, `selectedRuleId`/`selectedRuleVersion`, and `postingCommandId` are mirrored by compared scalars. Everything else lives in tags alone:

- `dataProvenance` — the real-versus-simulated mark
- `sourceEventType`, `sourceEventVersion`, `sourceEventDomain`, `sourceEventEntityId`, `sourceEventContentHash`
- `bookPositionId`
- `projectionRunId`, `projectionEventId`, `projectionModelKey`, `projectionModelVersion`, `projectionEngineVersion`, `projectionScenario`
- `rulePackId`, `rulePackVersion`

So a retry keeping the same book, source event, rules, and lines while changing **what the figures claim to be** was still reported as an exact replay.

Tags are now compared, minus a narrow exclusion set: `approvalState`, `approvalId`, the posting-command fingerprint, and the generated `lineDimensions.<entryId>.*` keys.

## Reason

`dataProvenance` is the sharpest case. `AccountingPostingCommandDto.Provenance` exists so that, per its own contract, "a simulated figure can never be mistaken for real" — and it was not being compared at all. A resubmission flipping `Real` to `Simulated` under a held identity would have been acknowledged as a replay of the real posting.

The four exclusions are the only values a rebuild genuinely cannot reproduce. Approval state and id are stamped as the posting is approved; the fingerprint is computed over the whole approved command *including its clock-stamped evidence*, so it can never match across a rebuild; line-dimension tags are keyed by generated per-line entry ids. Comparing any of them would reintroduce the false-conflict failure that several rounds of review on #2800 were spent removing.

`EvidenceReferences` stays excluded, and the class comment now says why rather than lumping it in with tags: approval evidence is merged with a clock stamp at approval time, so a rebuild carries neither the stamp nor the merged entries.

## Testing performed

- [x] Relevant unit tests were added or updated
- [ ] `bash scripts/ci.sh` completed successfully
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Guarded from both directions, which is the property that matters here:

- `Matches_DifferentTypedProvenanceTag_IsAConflict` — a theory over `dataProvenance`, `sourceEventContentHash`, and `projectionModelVersion`.
- `Matches_DifferentApprovalTimeTags_IsStillAnExactReplay` — differing approval state, approval id, and fingerprint must remain a replay, so the exclusion set cannot silently widen into a false-conflict source.

Mutation-tested: disabling the tag comparison in isolation fails exactly the three typed-provenance cases and nothing else.

Local validation (`DOTNET_ROOT=/root/.dotnet`):
- `dotnet build Meridian.sln -c Release` — succeeded, 0 errors.
- `dotnet test tests/Meridian.Tests -c Release --filter "FullyQualifiedName~Ledger|FullyQualifiedName~Posting|FullyQualifiedName~Accounting|FullyQualifiedName~Storage"` — **2723 passed, 0 failed**, 116 skipped.
- `python3 build/scripts/ci/check-file-size.py` — ratchet OK.
- `python3 build/scripts/ci/check-duplicate-helpers.py` — baseline satisfied.
- `python3 build/scripts/docs/check-ai-inventory.py --summary` — pass, 0 findings.

The pre-existing service replay tests (treasury and non-treasury) stay green, which is the false-conflict check that matters most: those exercise the full endpoint path where the rebuild is normalized and its tags regenerated.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

## Scope note

This is the tag half of the exclusion I documented in #2800. The evidence half remains open and is deliberately not addressed here — comparing evidence needs a canonical fingerprint that excludes generated ids and timestamps, which is the `DraftFingerprintV1`/`ApprovedPostingFingerprintV1` work #2800's scope note already defers. A hand-maintained tag exclusion list is a stopgap that closes the demonstrable provenance gap; it is not a substitute for a derived fingerprint that fails when the model gains a field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzeZrUtwwf9CnTdrSzALti

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzeZrUtwwf9CnTdrSzALti)_