### PR TITLE
Carry data provenance from fabricated marks into valuation evidence

### DIFF
--- a/database/manifest/contracts.json
+++ b/database/manifest/contracts.json
@@ -3520,7 +3520,7 @@
       ]
     }
   ],
-  "fingerprint": "a80a3bde0dd1878103b12bc427558fd84d042e9236532076a9ff350bd62e14bf",
+  "fingerprint": "329f3b3176cd4c62c53f6873b68210f68879968253d1ab08bf7e6d13e8b34713",
   "mapping_policy": {
     "level": "module",
     "note": "Schema associations are module-level only; no DTO-to-table or member-to-column structural equivalence is claimed.",
@@ -5171,7 +5171,7 @@
       "contract_sets": [
         "all-contracts"
       ],
-      "fingerprint": "b460f75f4bec7cb7de25c6a8dc77463436ade550deef5116c0302e81f8a6373c",
+      "fingerprint": "e1143092823992e4e3b98f796096b60f15d70e7ca9923a21c32832a235f360a7",
       "mapped_schemas": [],
       "namespace": "Meridian.Contracts.Operations",
       "object_ids": [
@@ -183700,7 +183700,7 @@
       "diagram": false,
       "diagram_contract_sets": [],
       "enum_members": [],
-      "fingerprint": "65df64cbfb4d5e3d0e44e0bdd4b34107de3d640754ea41dc333282fa9fa478cb",
+      "fingerprint": "1d3ee837f73109e2913aba089ef319f5b39b3d0bd4be664a7731bc458a7a3d0c",
       "full_name": "Meridian.Contracts.Operations.DataProvenanceBadge",
       "id": "Meridian.Contracts.Operations.DataProvenanceBadge",
       "kind": "record",
@@ -183717,7 +183717,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 130,
+          "source_line": 162,
           "type": "string"
         },
         {
@@ -183731,7 +183731,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 129,
+          "source_line": 161,
           "type": "string"
         },
         {
@@ -183745,7 +183745,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "DataProvenance",
-          "source_line": 128,
+          "source_line": 160,
           "type": "DataProvenance"
         }
       ],
@@ -183757,12 +183757,12 @@
         "Meridian.Contracts.Operations.DataProvenance"
       ],
       "source": {
-        "line": 127,
+        "line": 159,
         "path": "src/Meridian.Contracts/Operations/DataProvenance.cs"
       },
       "sources": [
         {
-          "line": 127,
+          "line": 159,
           "path": "src/Meridian.Contracts/Operations/DataProvenance.cs"
         }
       ],

--- a/src/Meridian.Application/Accounting/DailyMarkToMarketService.cs
+++ b/src/Meridian.Application/Accounting/DailyMarkToMarketService.cs
@@ -1,4 +1,5 @@
 using System.Threading;
+using Meridian.Contracts.Operations;
 using Meridian.Core.Logging;
 using Meridian.Ledger;
 using Serilog;
@@ -21,13 +22,20 @@ public sealed record MarkToMarketPosition(
 /// the ASC 820 fair-value classification of the price and <see cref="PriceAsOf"/> the date the
 /// price was observed, so downstream valuation can assess defensibility and freshness.
 /// </summary>
+/// <param name="Provenance">
+/// Where the price actually came from. A source that fabricates prices — a synthetic provider, a
+/// seeded demo feed — must declare a non-real value here so the mark, the valuation draft, and
+/// every report built on it carry the origin outward instead of presenting a model output as an
+/// observed market price.
+/// </param>
 public sealed record MarkPriceQuote(
     decimal Price,
     string Source,
     string EvidenceReference,
     FairValueLevel Level = FairValueLevel.Unclassified,
     DateOnly? PriceAsOf = null,
-    DailyPortfolioPriceConfidence Confidence = DailyPortfolioPriceConfidence.High)
+    DailyPortfolioPriceConfidence Confidence = DailyPortfolioPriceConfidence.High,
+    DataProvenance Provenance = DataProvenance.Real)
 {
     /// <summary>
     /// Compatibility constructor for callers introduced with the confidence-aware mark contract.
@@ -392,9 +400,20 @@ public sealed class DailyMarkToMarketService
                     position.Symbol, assessment.AgeDays, stalePricePolicy.MaxAgeDays);
             }
 
-            var fairValueLevel = quote.Level == FairValueLevel.Unclassified
-                ? request.Policy.DefaultFairValueLevel
-                : quote.Level;
+            // Clamped against the quote's origin so neither an optimistic source assertion nor the
+            // fund's default level can present a fabricated price as an observable market input.
+            var fairValueLevel = FairValueLevelPolicy.Resolve(
+                quote.Level,
+                request.Policy.DefaultFairValueLevel,
+                quote.Provenance);
+
+            if (quote.Provenance.IsNonReal())
+            {
+                _log.Warning(
+                    "Mark price for {Symbol} as of {AsOfDate} originates from {Provenance} source {PriceSource}; " +
+                    "retained as a {FairValueLevel} unobservable mark and marked non-real on the valuation draft",
+                    position.Symbol, asOfDate, quote.Provenance.Token(), quote.Source, fairValueLevel);
+            }
 
             marks.Add(new DailyPortfolioPriceMark(
                 position.Symbol,
@@ -413,7 +432,8 @@ public sealed class DailyMarkToMarketService
                 PriorCarryingValue: carryingValue.Amount,
                 CarryingValueSource: carryingValue.Source,
                 CarryingValueCapturedAtUtc: carryingValue.CapturedAtUtc,
-                CarryingValueEvidenceReference: carryingValue.EvidenceReference));
+                CarryingValueEvidenceReference: carryingValue.EvidenceReference,
+                Provenance: quote.Provenance));
         }
 
         var unpriced = rejected

--- a/src/Meridian.Application/Accounting/HistoricalCloseMarkPriceSource.cs
+++ b/src/Meridian.Application/Accounting/HistoricalCloseMarkPriceSource.cs
@@ -1,4 +1,5 @@
 using System.Threading;
+using Meridian.Contracts.Operations;
 using Meridian.Core.Logging;
 using Meridian.Infrastructure.Adapters.Core;
 using Meridian.Ledger;
@@ -44,13 +45,17 @@ public sealed class HistoricalCloseMarkPriceSource : IMarkPriceSource
             }
 
             var source = string.IsNullOrWhiteSpace(bar.Source) ? _provider.Name : bar.Source;
+            var provenance = ResolveProvenance(source);
             return new MarkPriceQuote(
                 bar.Close,
                 source,
                 FormattableString.Invariant($"daily-close:{symbol}:{bar.SessionDate:yyyy-MM-dd}:{source}"),
                 // A quoted exchange close for the identical instrument is an ASC 820 Level 1 input.
-                FairValueLevel.Level1,
-                bar.SessionDate);
+                // A fabricated close is not an observation of anything, so it is classified at the
+                // unobservable tier instead of inheriting Level 1 from the shape of the request.
+                provenance.IsNonReal() ? FairValueLevel.Level3 : FairValueLevel.Level1,
+                bar.SessionDate,
+                Provenance: provenance);
         }
         catch (OperationCanceledException)
         {
@@ -62,4 +67,17 @@ public sealed class HistoricalCloseMarkPriceSource : IMarkPriceSource
             return null;
         }
     }
+
+    /// <summary>
+    /// Classifies where a close actually came from. The provider's own
+    /// <see cref="IHistoricalDataProvider.IsSimulated"/> declaration is the primary gate; the bar's
+    /// <c>Source</c> tag is the second, and is what catches an aggregator such as
+    /// <see cref="CompositeHistoricalDataProvider"/> — not simulated itself — serving a fabricated
+    /// bar from a constituent provider. Both use the shared structured token table, so a real
+    /// vendor named "Sample Custodian" is not mistaken for a simulated origin.
+    /// </summary>
+    private DataProvenance ResolveProvenance(string source)
+        => _provider.IsSimulated || DataProvenanceExtensions.IsSimulatedOriginToken(source)
+            ? DataProvenance.Simulated
+            : DataProvenance.Real;
 }

--- a/src/Meridian.Application/Accounting/WaterfallMarkPriceSource.cs
+++ b/src/Meridian.Application/Accounting/WaterfallMarkPriceSource.cs
@@ -1,4 +1,5 @@
 using System.Threading;
+using Meridian.Contracts.Operations;
 using Meridian.Core.Logging;
 using Meridian.Ledger;
 using Serilog;
@@ -48,10 +49,12 @@ public sealed class WaterfallMarkPriceSource : IMarkPriceSource
             if (quote is null)
                 continue;
 
-            var level = quote.Level == FairValueLevel.Unclassified ? tier.Level : quote.Level;
+            // The tier's level classifies an unclassified quote, but never raises a fabricated one:
+            // a tier labelled "exchange-close" must not lend Level 1 standing to a simulated price.
+            var level = FairValueLevelPolicy.Resolve(quote.Level, tier.Level, quote.Provenance);
             _log.Debug(
-                "Priced {Symbol} as of {AsOf} from tier {Tier} at fair-value {Level}",
-                symbol, asOf, tier.Label, level);
+                "Priced {Symbol} as of {AsOf} from tier {Tier} at fair-value {Level} (origin {Provenance})",
+                symbol, asOf, tier.Label, level, quote.Provenance.Token());
             return quote with { Level = level };
         }
 

--- a/src/Meridian.Contracts/Operations/DataProvenance.cs
+++ b/src/Meridian.Contracts/Operations/DataProvenance.cs
@@ -81,6 +81,38 @@ public static class DataProvenanceExtensions
     };
 
     /// <summary>
+    /// Folds many origins into the one a derived figure must carry: the strongest non-real
+    /// provenance among the inputs, or <see cref="DataProvenance.Real"/> only when every input is
+    /// real. A derived figure — a valuation draft, a NAV, a report pack — is never more real than
+    /// its least-real input, so this is the single rule every derivation uses.
+    /// </summary>
+    /// <remarks>
+    /// "Strongest" follows the <see cref="DataProvenance"/> ordering, where a lower value is the
+    /// stronger claim: <see cref="DataProvenance.Simulated"/> outranks
+    /// <see cref="DataProvenance.Seeded"/>, which outranks <see cref="DataProvenance.Sample"/>.
+    /// </remarks>
+    public static DataProvenance Strongest(IEnumerable<DataProvenance> provenances)
+    {
+        ArgumentNullException.ThrowIfNull(provenances);
+
+        var strongest = DataProvenance.Real;
+        foreach (var provenance in provenances)
+        {
+            if (!provenance.IsNonReal())
+            {
+                continue;
+            }
+
+            if (strongest == DataProvenance.Real || provenance < strongest)
+            {
+                strongest = provenance;
+            }
+        }
+
+        return strongest;
+    }
+
+    /// <summary>
     /// Unambiguous, structured simulated-origin markers, matched by exact (trimmed,
     /// case-insensitive) equality — never by substring — so legitimate values like
     /// "Sample Custodian" or "fixture-bank" are not mistaken for a simulated origin. An explicit

--- a/src/Meridian.Infrastructure/Adapters/Core/IHistoricalDataProvider.cs
+++ b/src/Meridian.Infrastructure/Adapters/Core/IHistoricalDataProvider.cs
@@ -46,6 +46,21 @@ public interface IHistoricalDataProvider : IProviderMetadata, IDisposable
 
 
     /// <summary>
+    /// True when this provider fabricates bars instead of returning real observed market data.
+    /// Mirrors <see cref="Meridian.ProviderSdk.IMarketDataClient.IsSimulated"/> for the historical
+    /// lane, which feeds backfill and daily fair-value valuation. Valuation, ledger, and reporting
+    /// surfaces use it to classify derived figures, so a fabricated price is never presented as an
+    /// observable market input.
+    /// </summary>
+    /// <remarks>
+    /// This is the primary, explicit signal. Consumers should also treat a bar whose own
+    /// <c>Source</c> tag is a structured simulated-origin token as non-real, because an aggregator
+    /// such as <see cref="CompositeHistoricalDataProvider"/> is not itself simulated yet can serve
+    /// a fabricated bar from a constituent provider.
+    /// </remarks>
+    bool IsSimulated => false;
+
+    /// <summary>
     /// Priority for fallback ordering (lower = higher priority, tried first).
     /// Default: 100 for basic providers.
     /// </summary>

--- a/src/Meridian.Infrastructure/Adapters/Synthetic/SyntheticHistoricalDataProvider.cs
+++ b/src/Meridian.Infrastructure/Adapters/Synthetic/SyntheticHistoricalDataProvider.cs
@@ -18,6 +18,12 @@ public sealed class SyntheticHistoricalDataProvider : IHistoricalDataProvider, I
         _config = config ?? new SyntheticMarketDataConfig(Enabled: true);
     }
 
+    /// <summary>
+    /// Every bar this provider returns is a deterministic seeded walk, not an observed market
+    /// price. Declared so valuation and reporting can mark derived figures as non-real.
+    /// </summary>
+    public bool IsSimulated => true;
+
     public string Name => "synthetic";
     public string DisplayName => "Synthetic Historical Provider";
     public string Description => "Deterministic historical bars, quotes, trades, auctions, and corporate actions for offline development.";

--- a/src/Meridian.Ledger/DailyPortfolioPriceMark.cs
+++ b/src/Meridian.Ledger/DailyPortfolioPriceMark.cs
@@ -1,3 +1,5 @@
+using Meridian.Contracts.Operations;
+
 namespace Meridian.Ledger;
 
 /// <summary>
@@ -33,7 +35,8 @@ public sealed record DailyPortfolioPriceMark
         decimal? PriorCarryingValue = null,
         string? CarryingValueSource = null,
         DateTimeOffset? CarryingValueCapturedAtUtc = null,
-        string? CarryingValueEvidenceReference = null)
+        string? CarryingValueEvidenceReference = null,
+        DataProvenance Provenance = DataProvenance.Real)
     {
         if (string.IsNullOrWhiteSpace(Symbol))
             throw new ArgumentException("Symbol must not be null or whitespace.", nameof(Symbol));
@@ -75,6 +78,7 @@ public sealed record DailyPortfolioPriceMark
         this.CarryingValueEvidenceReference = string.IsNullOrWhiteSpace(CarryingValueEvidenceReference)
             ? null
             : CarryingValueEvidenceReference.Trim();
+        this.Provenance = Provenance;
     }
 
     public string Symbol { get; }
@@ -118,4 +122,12 @@ public sealed record DailyPortfolioPriceMark
     public DateTimeOffset? CarryingValueCapturedAtUtc { get; }
 
     public string? CarryingValueEvidenceReference { get; }
+
+    /// <summary>
+    /// Origin of the mark price. Anything other than <see cref="DataProvenance.Real"/> means the
+    /// figure was fabricated rather than observed, and must be carried outward — onto the valuation
+    /// line, the journal draft, and every report that cites it — so it is never mistaken for a real
+    /// market price.
+    /// </summary>
+    public DataProvenance Provenance { get; }
 }

--- a/src/Meridian.Ledger/DailyPortfolioPricingDraftBuilder.cs
+++ b/src/Meridian.Ledger/DailyPortfolioPricingDraftBuilder.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
+using Meridian.Contracts.Operations;
 
 namespace Meridian.Ledger;
 
@@ -124,6 +125,9 @@ public static class DailyPortfolioPricingDraftBuilder
                 .OrderBy(static level => level)
                 .Select(static level => level.ToString()));
         var stalePricedCount = pricingLines.Count(static line => line.IsStalePriced);
+        // A draft that mixes real and fabricated marks is never reported as entirely real.
+        var draftProvenance = DataProvenanceExtensions.Strongest(
+            pricingLines.Select(static line => line.Provenance));
 
         var tags = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
@@ -143,6 +147,7 @@ public static class DailyPortfolioPricingDraftBuilder
             ["valuation.markAdjustment"] = Format(markAdjustment),
             ["valuation.markFingerprintSha256"] = fingerprint,
             ["valuation.fairValueLevels"] = fairValueLevels,
+            [ValuationProvenanceTag.Key] = draftProvenance.Token(),
             ["valuation.stalePricedCount"] = stalePricedCount.ToString(CultureInfo.InvariantCulture),
             ["valuation.carryingValueSources"] = string.Join(",", pricingLines
                 .Select(static line => line.CarryingValueSource)
@@ -184,7 +189,7 @@ public static class DailyPortfolioPricingDraftBuilder
                 RetainedBy: input.Policy.ApprovedBy,
                 SubjectId: scope.SecurityId?.ToString("D") ?? line.Symbol,
                 Description: FormattableString.Invariant(
-                    $"{line.Symbol} marked at {Format(line.MarkPrice)} via {line.PriceSource}; observed {(line.PriceObservedOn.HasValue ? line.PriceObservedOn.Value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) : "unknown")}; confidence {line.Confidence}")).Normalize());
+                    $"{line.Symbol} marked at {Format(line.MarkPrice)} via {line.PriceSource}; observed {(line.PriceObservedOn.HasValue ? line.PriceObservedOn.Value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) : "unknown")}; confidence {line.Confidence}; origin {line.Provenance.Token()}")).Normalize());
 
             if (!string.IsNullOrWhiteSpace(line.CarryingValueEvidenceReference))
             {
@@ -240,7 +245,10 @@ public static class DailyPortfolioPricingDraftBuilder
                 .Append('|').Append(line.FairValueLevel)
                 .Append('|').Append(line.IsStalePriced ? "stale" : "current")
                 .Append('|').Append(line.CarryingValueSource ?? "unknown")
-                .Append('|').Append(line.CarryingValueEvidenceReference ?? "none");
+                .Append('|').Append(line.CarryingValueEvidenceReference ?? "none")
+                // Origin participates in the fingerprint so a simulated valuation run can never
+                // share an idempotency key with the real run for the same scope and period.
+                .Append('|').Append(line.Provenance.Token());
         }
 
         return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical.ToString())))

--- a/src/Meridian.Ledger/DailyPortfolioPricingLine.cs
+++ b/src/Meridian.Ledger/DailyPortfolioPricingLine.cs
@@ -1,8 +1,15 @@
+using Meridian.Contracts.Operations;
+
 namespace Meridian.Ledger;
 
 /// <summary>
 /// Valuation and audit evidence for one daily-priced portfolio position.
 /// </summary>
+/// <param name="Provenance">
+/// Origin of the mark price behind this line. Anything other than <see cref="DataProvenance.Real"/>
+/// means the figure was fabricated rather than observed, and stays marked on every draft, journal
+/// tag, and report that cites it.
+/// </param>
 public sealed record DailyPortfolioPricingLine(
     string Symbol,
     decimal Quantity,
@@ -27,4 +34,5 @@ public sealed record DailyPortfolioPricingLine(
     Guid? SecurityId = null,
     string? CarryingValueSource = null,
     DateTimeOffset? CarryingValueCapturedAtUtc = null,
-    string? CarryingValueEvidenceReference = null);
+    string? CarryingValueEvidenceReference = null,
+    DataProvenance Provenance = DataProvenance.Real);

--- a/src/Meridian.Ledger/DailyPortfolioPricingProjector.cs
+++ b/src/Meridian.Ledger/DailyPortfolioPricingProjector.cs
@@ -49,16 +49,20 @@ public static class DailyPortfolioPricingProjector
             input.Policy.ValuationMethod,
             mark.FinancialAccountId,
             mark.InstrumentType,
-            FairValueLevel: mark.FairValueLevel == FairValueLevel.Unclassified
-                ? input.Policy.DefaultFairValueLevel
-                : mark.FairValueLevel,
+            // Clamped against the mark's origin: the fund's default level may classify an
+            // unclassified real mark, but can never raise a fabricated one to an observable tier.
+            FairValueLevel: FairValueLevelPolicy.Resolve(
+                mark.FairValueLevel,
+                input.Policy.DefaultFairValueLevel,
+                mark.Provenance),
             IsStalePriced: mark.IsStalePriced,
             PriceObservedOn: mark.PriceObservedOn,
             Confidence: mark.Confidence,
             SecurityId: mark.SecurityId,
             CarryingValueSource: mark.CarryingValueSource,
             CarryingValueCapturedAtUtc: mark.CarryingValueCapturedAtUtc,
-            CarryingValueEvidenceReference: mark.CarryingValueEvidenceReference);
+            CarryingValueEvidenceReference: mark.CarryingValueEvidenceReference,
+            Provenance: mark.Provenance);
     }
 
     private static IReadOnlyList<DailyPortfolioPricingJournalLine> BuildJournalLines(

--- a/src/Meridian.Ledger/FairValueLevel.cs
+++ b/src/Meridian.Ledger/FairValueLevel.cs
@@ -1,3 +1,5 @@
+using Meridian.Contracts.Operations;
+
 namespace Meridian.Ledger;
 
 /// <summary>
@@ -18,4 +20,37 @@ public enum FairValueLevel
 
     /// <summary>Level 3 — unobservable inputs, typically a model or manual mark for illiquid or private holdings.</summary>
     Level3,
+}
+
+/// <summary>
+/// Resolves the ASC 820 classification a daily mark may carry, given what the price source
+/// asserted, what the fund's valuation policy defaults to, and where the figure actually came
+/// from.
+/// </summary>
+/// <remarks>
+/// The observability hierarchy describes inputs observed in a market. A simulated, seeded, or
+/// sample price is not an observation of anything: it is a model output whose inputs are, by
+/// construction, unobservable. So a non-real mark is classified <see cref="FairValueLevel.Level3"/>
+/// and neither the price source nor the fund policy may raise it. Without this clamp a fabricated
+/// price inherits <see cref="DailyPortfolioPricingPolicy.DefaultFairValueLevel"/> — or an
+/// optimistic source assertion — and enters valuation evidence as an observable market input.
+/// </remarks>
+public static class FairValueLevelPolicy
+{
+    /// <summary>
+    /// Applies the fund's policy default when the price source left the mark unclassified, then
+    /// clamps the result to the ceiling implied by the mark's origin.
+    /// </summary>
+    public static FairValueLevel Resolve(
+        FairValueLevel quoted,
+        FairValueLevel policyDefault,
+        DataProvenance provenance)
+    {
+        if (provenance.IsNonReal())
+        {
+            return FairValueLevel.Level3;
+        }
+
+        return quoted == FairValueLevel.Unclassified ? policyDefault : quoted;
+    }
 }

--- a/src/Meridian.Ledger/ValuationProvenanceTag.cs
+++ b/src/Meridian.Ledger/ValuationProvenanceTag.cs
@@ -1,0 +1,47 @@
+using Meridian.Contracts.Operations;
+
+namespace Meridian.Ledger;
+
+/// <summary>
+/// The journal tag that carries a fair-value draft's data provenance, and the reader that recovers
+/// it from posted entries.
+/// </summary>
+/// <remarks>
+/// Valuation is where fabricated market data enters the books: a daily mark priced off a synthetic
+/// provider becomes a posted journal entry, and every figure derived from that entry — carrying
+/// value, NAV, a report pack — inherits the fabrication without inheriting the disclosure. Tagging
+/// the draft and reading the tag back is what lets a derived figure state its true origin instead
+/// of defaulting to real.
+/// </remarks>
+public static class ValuationProvenanceTag
+{
+    /// <summary>Journal metadata tag key written by <see cref="DailyPortfolioPricingDraftBuilder"/>.</summary>
+    public const string Key = "valuation.dataProvenance";
+
+    /// <summary>
+    /// Origin declared by one journal entry's valuation tag. An entry with no tag is not a
+    /// valuation entry and contributes <see cref="DataProvenance.Real"/>; an entry carrying an
+    /// unrecognized token degrades to <see cref="DataProvenance.Simulated"/> rather than to real.
+    /// </summary>
+    public static DataProvenance Read(JournalEntryMetadata? metadata)
+    {
+        if (metadata?.Tags is not { } tags ||
+            !tags.TryGetValue(Key, out var token) ||
+            string.IsNullOrWhiteSpace(token))
+        {
+            return DataProvenance.Real;
+        }
+
+        return DataProvenanceExtensions.ParseTokenOrSimulated(token);
+    }
+
+    /// <summary>
+    /// Strongest non-real origin declared across a set of posted entries — the mark any figure
+    /// derived from them must carry.
+    /// </summary>
+    public static DataProvenance Strongest(IEnumerable<JournalEntry> entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        return DataProvenanceExtensions.Strongest(entries.Select(static entry => Read(entry.Metadata)));
+    }
+}

--- a/src/Meridian.Ui.Shared/Services/FundOperationsWorkspaceReadService.cs
+++ b/src/Meridian.Ui.Shared/Services/FundOperationsWorkspaceReadService.cs
@@ -600,7 +600,12 @@ public sealed partial class FundOperationsWorkspaceReadService
             report,
             auditActor,
             ct).ConfigureAwait(false);
-        var derivedProvenanceToken = ReportPackProvenanceResolver.ResolveDerivedToken(runs);
+        // Posted valuation entries are consulted alongside the cited runs: a pack can be built
+        // entirely from fabricated marks while citing no simulated run at all, and deriving the mark
+        // from runs alone would report that pack as real.
+        var derivedProvenanceToken = ReportPackProvenanceResolver.ResolveDerivedToken(
+            runs,
+            ledgerBook.ConsolidatedJournalEntries());
         var validationIssues = _reportPackValidationService.Validate(new ReportPackValidationContext(
             ReportId: report.ReportId,
             AsOf: asOf,

--- a/src/Meridian.Ui.Shared/Services/FundOperationsWorkspaceReadService.cs
+++ b/src/Meridian.Ui.Shared/Services/FundOperationsWorkspaceReadService.cs
@@ -600,12 +600,7 @@ public sealed partial class FundOperationsWorkspaceReadService
             report,
             auditActor,
             ct).ConfigureAwait(false);
-        // Posted valuation entries are consulted alongside the cited runs: a pack can be built
-        // entirely from fabricated marks while citing no simulated run at all, and deriving the mark
-        // from runs alone would report that pack as real.
-        var derivedProvenanceToken = ReportPackProvenanceResolver.ResolveDerivedToken(
-            runs,
-            ledgerBook.ConsolidatedJournalEntries());
+        var derivedProvenanceToken = ReportPackProvenanceResolver.ResolveDerivedToken(runs, ledgerBook.ConsolidatedJournalEntries());
         var validationIssues = _reportPackValidationService.Validate(new ReportPackValidationContext(
             ReportId: report.ReportId,
             AsOf: asOf,

--- a/src/Meridian.Ui.Shared/Services/ReportPackProvenanceResolver.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportPackProvenanceResolver.cs
@@ -1,45 +1,49 @@
 using Meridian.Contracts.Operations;
+using Meridian.Ledger;
 using Meridian.Strategies.Models;
 
 namespace Meridian.Ui.Shared.Services;
 
 /// <summary>
-/// W9-TRUTH-001: derives the data-provenance mark a report pack must carry from the strategy runs
-/// it cites. A pack that cites any simulated, seeded, or sample run inherits the strongest
-/// non-real provenance of its inputs, so the derived figure can never enter report-pack evidence
-/// without the blocking mark. Unknown tokens degrade to "simulated", never to real.
+/// W9-TRUTH-001: derives the data-provenance mark a report pack must carry from the evidence it
+/// cites — the strategy runs behind its figures and the posted valuation entries behind its
+/// balances. A pack citing any simulated, seeded, or sample input inherits the strongest non-real
+/// provenance of those inputs, so a derived figure can never enter report-pack evidence without the
+/// blocking mark. Unknown tokens degrade to "simulated", never to real.
 /// </summary>
+/// <remarks>
+/// Valuation entries are consulted because a pack can be built entirely from fabricated marks while
+/// citing no simulated strategy run at all: a NAV priced off a synthetic provider posts real-looking
+/// journal entries, and deriving provenance from runs alone would report that pack as real.
+/// </remarks>
 public static class ReportPackProvenanceResolver
 {
     public static string? ResolveDerivedToken(IReadOnlyList<StrategyRunEntry> runs)
+        => ResolveDerivedToken(runs, []);
+
+    /// <summary>
+    /// Derives the pack's mark from both evidence lanes.
+    /// </summary>
+    /// <param name="runs">Strategy runs the pack cites.</param>
+    /// <param name="valuationEntries">
+    /// Posted journal entries backing the pack's balances. Their
+    /// <see cref="ValuationProvenanceTag"/> declares whether the marks behind them were observed or
+    /// fabricated.
+    /// </param>
+    /// <returns>The provenance token to carry, or <c>null</c> when every input is real.</returns>
+    public static string? ResolveDerivedToken(
+        IReadOnlyList<StrategyRunEntry> runs,
+        IReadOnlyList<JournalEntry> valuationEntries)
     {
         ArgumentNullException.ThrowIfNull(runs);
+        ArgumentNullException.ThrowIfNull(valuationEntries);
 
-        DataProvenance? strongest = null;
-        foreach (var run in runs)
-        {
-            if (string.IsNullOrWhiteSpace(run.DataProvenanceToken))
-            {
-                continue;
-            }
+        var strongest = DataProvenanceExtensions.Strongest(
+            runs
+                .Where(static run => !string.IsNullOrWhiteSpace(run.DataProvenanceToken))
+                .Select(static run => DataProvenanceExtensions.ParseTokenOrSimulated(run.DataProvenanceToken))
+                .Append(ValuationProvenanceTag.Strongest(valuationEntries)));
 
-            var declared = DataProvenanceExtensions.ParseTokenOrSimulated(run.DataProvenanceToken);
-            if (!declared.IsNonReal())
-            {
-                continue;
-            }
-
-            if (declared == DataProvenance.Simulated)
-            {
-                return declared.Token();
-            }
-
-            if (strongest is null || declared < strongest)
-            {
-                strongest = declared;
-            }
-        }
-
-        return strongest?.Token();
+        return strongest.IsNonReal() ? strongest.Token() : null;
     }
 }

--- a/tests/Meridian.Tests/Application/Accounting/SyntheticMarkProvenanceTests.cs
+++ b/tests/Meridian.Tests/Application/Accounting/SyntheticMarkProvenanceTests.cs
@@ -1,0 +1,214 @@
+using FluentAssertions;
+using Meridian.Application.Accounting;
+using Meridian.Contracts.Domain.Models;
+using Meridian.Contracts.Operations;
+using Meridian.Infrastructure.Adapters.Core;
+using Meridian.Infrastructure.Adapters.Synthetic;
+using Meridian.Ledger;
+using Xunit;
+
+namespace Meridian.Tests.Application.Accounting;
+
+/// <summary>
+/// Guards the honesty boundary between fabricated market data and governed valuation evidence.
+///
+/// The failure these cover is not that Meridian prices positions off a synthetic provider — an
+/// offline or demo deployment legitimately does — but that it used to do so silently: a seeded
+/// random walk was stamped as an ASC 820 Level 1 observable input, carried no origin mark, and a
+/// NAV derived from it validated as an approvable deliverable. A fabricated number that announces
+/// itself is a feature; one that presents as an exchange close is the product's core promise
+/// inverted.
+/// </summary>
+public sealed class SyntheticMarkProvenanceTests
+{
+    private static readonly DateOnly AsOf = new(2026, 7, 3);
+    private static readonly DateTimeOffset AsOfUtc = new(2026, 7, 3, 21, 0, 0, TimeSpan.Zero);
+
+    private static HistoricalBar Bar(string source, decimal close = 187.42m)
+        => new("AAPL", AsOf, 186m, 188m, 185m, close, 1_000_000, Source: source);
+
+    [Fact]
+    public async Task SyntheticProvider_MarkIsNeverStampedLevel1()
+    {
+        var source = new HistoricalCloseMarkPriceSource(new StubProvider("synthetic", Bar("synthetic"), isSimulated: true));
+
+        var quote = await source.GetMarkPriceAsync("AAPL", AsOf);
+
+        quote.Should().NotBeNull();
+        quote!.Provenance.Should().Be(DataProvenance.Simulated);
+        quote.Level.Should().Be(
+            FairValueLevel.Level3,
+            "a seeded walk is a model output with unobservable inputs, not a quoted price in an active market");
+    }
+
+    [Fact]
+    public async Task RealProvider_StillMarksAtLevel1()
+    {
+        var source = new HistoricalCloseMarkPriceSource(new StubProvider("polygon", Bar("polygon")));
+
+        var quote = await source.GetMarkPriceAsync("AAPL", AsOf);
+
+        quote.Should().NotBeNull();
+        quote!.Provenance.Should().Be(DataProvenance.Real);
+        quote.Level.Should().Be(FairValueLevel.Level1, "a genuine exchange close is an observable Level 1 input");
+    }
+
+    [Fact]
+    public async Task AggregatorServingSyntheticBar_IsClassifiedFromTheBarNotTheAggregator()
+    {
+        // The composite provider is not itself simulated, so the provider-level flag says nothing.
+        // The bar's own source tag is what betrays the fabrication.
+        var source = new HistoricalCloseMarkPriceSource(new StubProvider("composite", Bar("synthetic")));
+
+        var quote = await source.GetMarkPriceAsync("AAPL", AsOf);
+
+        quote.Should().NotBeNull();
+        quote!.Provenance.Should().Be(DataProvenance.Simulated);
+        quote.Level.Should().Be(FairValueLevel.Level3);
+    }
+
+    [Fact]
+    public async Task RealVendorWhoseNameContainsASimulatedWord_IsNotMisclassified()
+    {
+        // Token matching is exact, never substring: a real custodian must not be branded simulated.
+        var source = new HistoricalCloseMarkPriceSource(new StubProvider("sample-custodian", Bar("Sample Custodian")));
+
+        var quote = await source.GetMarkPriceAsync("AAPL", AsOf);
+
+        quote.Should().NotBeNull();
+        quote!.Provenance.Should().Be(DataProvenance.Real);
+        quote.Level.Should().Be(FairValueLevel.Level1);
+    }
+
+    [Fact]
+    public async Task RealSyntheticHistoricalProvider_DeclaresItselfSimulated()
+    {
+        // Exercises the shipped provider rather than a stub, so the declaration cannot rot.
+        using var provider = new SyntheticHistoricalDataProvider();
+        provider.IsSimulated.Should().BeTrue();
+
+        var quote = await new HistoricalCloseMarkPriceSource(provider).GetMarkPriceAsync("AAPL", AsOf);
+
+        quote.Should().NotBeNull();
+        quote!.Provenance.Should().Be(DataProvenance.Simulated);
+        quote.Level.Should().Be(FairValueLevel.Level3);
+        quote.EvidenceReference.Should().Contain("synthetic");
+    }
+
+    [Fact]
+    public async Task FundPolicyDefault_CannotUpgradeASimulatedMarkToLevel1()
+    {
+        // A fund whose policy defaults to Level 1 must not launder a fabricated mark through it.
+        var policy = new DailyPortfolioPricingPolicy(
+            fundId: "fund-alpha",
+            policyId: "vp-1",
+            policyName: "Daily fair value",
+            valuationMethod: "market-close",
+            approvedBy: "cfo",
+            approvedAtUtc: AsOfUtc.AddDays(-30),
+            defaultFairValueLevel: FairValueLevel.Level1);
+
+        var run = await new DailyMarkToMarketService(new FixedQuoteSource(new MarkPriceQuote(
+                Price: 160m,
+                Source: "synthetic",
+                EvidenceReference: "daily-close:AAPL:2026-07-03:synthetic",
+                Level: FairValueLevel.Unclassified,
+                PriceAsOf: AsOf,
+                Confidence: DailyPortfolioPriceConfidence.High,
+                Provenance: DataProvenance.Simulated)))
+            .PrepareAsync(new DailyMarkToMarketRequest(
+                policy,
+                PeriodId: "2026-07",
+                AsOfUtc,
+                BaseCurrency: "USD",
+                Positions: [new MarkToMarketPosition("AAPL", Quantity: 100m, CostPrice: 150m)],
+                Actor: "ops",
+                Reason: "daily close marks"));
+
+        var line = run.Projection!.Lines.Should().ContainSingle().Subject;
+        line.Provenance.Should().Be(DataProvenance.Simulated, "the origin must survive the projection");
+        line.FairValueLevel.Should().Be(
+            FairValueLevel.Level3,
+            "the fund's default level classifies unclassified real marks, not fabricated ones");
+    }
+
+    [Fact]
+    public async Task SimulatedValuationDraft_CarriesTheOriginAndADistinctIdempotencyKey()
+    {
+        var simulated = await BuildDraftAsync(DataProvenance.Simulated);
+        var real = await BuildDraftAsync(DataProvenance.Real);
+
+        simulated.Metadata.Tags![ValuationProvenanceTag.Key].Should().Be("simulated");
+        real.Metadata.Tags![ValuationProvenanceTag.Key].Should().Be("real");
+
+        simulated.Metadata.IdempotencyKey.Should().NotBe(
+            real.Metadata.IdempotencyKey,
+            "a simulated valuation run must never collide with the real run for the same scope and period");
+
+        ValuationProvenanceTag.Read(simulated.Metadata).Should().Be(DataProvenance.Simulated);
+        ValuationProvenanceTag.Read(real.Metadata).Should().Be(DataProvenance.Real);
+    }
+
+    private static async Task<AutomatedJournalDraft> BuildDraftAsync(DataProvenance provenance)
+    {
+        var policy = new DailyPortfolioPricingPolicy(
+            fundId: "fund-alpha",
+            policyId: "vp-1",
+            policyName: "Daily fair value",
+            valuationMethod: "market-close",
+            approvedBy: "cfo",
+            approvedAtUtc: AsOfUtc.AddDays(-30));
+
+        var run = await new DailyMarkToMarketService(new FixedQuoteSource(new MarkPriceQuote(
+                Price: 160m,
+                // Identical price, source, and evidence in both runs: origin is the only declared
+                // difference, so a colliding key would mean provenance is absent from the key.
+                Source: "daily-close-provider",
+                EvidenceReference: "daily-close:AAPL:2026-07-03",
+                Level: FairValueLevel.Level1,
+                PriceAsOf: AsOf,
+                Confidence: DailyPortfolioPriceConfidence.High,
+                Provenance: provenance)))
+            .PrepareAsync(new DailyMarkToMarketRequest(
+                policy,
+                PeriodId: "2026-07",
+                AsOfUtc,
+                BaseCurrency: "USD",
+                Positions: [new MarkToMarketPosition("AAPL", Quantity: 100m, CostPrice: 150m)],
+                Actor: "ops",
+                Reason: "daily close marks"));
+
+        return run.Approvals.Should().ContainSingle().Subject.Draft;
+    }
+
+    private sealed class FixedQuoteSource : IMarkPriceSource
+    {
+        private readonly MarkPriceQuote _quote;
+
+        public FixedQuoteSource(MarkPriceQuote quote) => _quote = quote;
+
+        public Task<MarkPriceQuote?> GetMarkPriceAsync(string symbol, DateOnly asOf, CancellationToken ct = default)
+            => Task.FromResult<MarkPriceQuote?>(_quote);
+    }
+
+    private sealed class StubProvider : IHistoricalDataProvider
+    {
+        private readonly HistoricalBar _bar;
+
+        public StubProvider(string name, HistoricalBar bar, bool isSimulated = false)
+        {
+            Name = DisplayName = name;
+            _bar = bar;
+            IsSimulated = isSimulated;
+        }
+
+        public string Name { get; }
+        public string DisplayName { get; }
+        public string Description => string.Empty;
+        public bool IsSimulated { get; }
+
+        public Task<IReadOnlyList<HistoricalBar>> GetDailyBarsAsync(
+            string symbol, DateOnly? from, DateOnly? to, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<HistoricalBar>>([_bar]);
+    }
+}

--- a/tests/Meridian.Tests/Ui/ReportPackProvenanceResolverTests.cs
+++ b/tests/Meridian.Tests/Ui/ReportPackProvenanceResolverTests.cs
@@ -1,0 +1,100 @@
+using FluentAssertions;
+using Meridian.Contracts.Operations;
+using Meridian.Ledger;
+using Meridian.Strategies.Models;
+using Meridian.Ui.Shared.Services;
+using Xunit;
+
+namespace Meridian.Tests.Ui;
+
+/// <summary>
+/// A report pack states its own trustworthiness. These cover the case that used to slip through:
+/// a NAV priced entirely off fabricated marks, citing no simulated strategy run at all, deriving
+/// provenance "real" and validating as an approvable deliverable. Provenance is derived from every
+/// evidence lane a pack rests on, not just the one that happened to be wired first.
+/// </summary>
+public sealed class ReportPackProvenanceResolverTests
+{
+    private static readonly DateTimeOffset AsOf = new(2026, 7, 3, 21, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void NavBuiltOnSyntheticMarks_DerivesSimulatedEvenWithNoSimulatedRuns()
+    {
+        var token = ReportPackProvenanceResolver.ResolveDerivedToken(
+            [Run(provenanceToken: "real")],
+            ValuationEntries(DataProvenance.Simulated));
+
+        token.Should().Be(
+            "simulated",
+            "a pack whose balances rest on fabricated marks is not real, however its strategy runs are marked");
+    }
+
+    [Fact]
+    public void PackBuiltEntirelyOnRealEvidence_StaysReal()
+    {
+        var token = ReportPackProvenanceResolver.ResolveDerivedToken(
+            [Run(provenanceToken: "real")],
+            ValuationEntries(DataProvenance.Real));
+
+        token.Should().BeNull("a null token is how this surface says \"real\"");
+    }
+
+    [Fact]
+    public void SimulatedRunOutranksSeededValuation()
+    {
+        var token = ReportPackProvenanceResolver.ResolveDerivedToken(
+            [Run(provenanceToken: "simulated")],
+            ValuationEntries(DataProvenance.Seeded));
+
+        token.Should().Be("simulated", "the pack inherits the strongest non-real claim among its inputs");
+    }
+
+    [Fact]
+    public void UntaggedValuationEntries_DoNotFabricateANonRealMark()
+    {
+        // Entries that are not valuation drafts carry no tag and must not be read as simulated.
+        var ledger = new Meridian.Ledger.Ledger();
+        ledger.PostLines(AsOf, "Buy 100 AAPL @ 150",
+        [
+            (LedgerAccounts.Securities("AAPL"), 15_000m, 0m),
+            (LedgerAccounts.Cash, 0m, 15_000m)
+        ]);
+
+        ReportPackProvenanceResolver
+            .ResolveDerivedToken([Run(provenanceToken: "real")], ledger.GetJournalEntries(new LedgerQuery()))
+            .Should().BeNull();
+    }
+
+    private static IReadOnlyList<JournalEntry> ValuationEntries(DataProvenance provenance)
+    {
+        var ledger = new Meridian.Ledger.Ledger();
+        ledger.PostLines(
+            AsOf,
+            "Daily fair-value mark for AAPL",
+            [
+                (LedgerAccounts.Securities("AAPL"), 1_000m, 0m),
+                (LedgerAccounts.UnrealizedGain, 0m, 1_000m)
+            ],
+            new JournalEntryMetadata(
+                ActivityType: "fair-value-mark",
+                Symbol: "AAPL",
+                Tags: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    [ValuationProvenanceTag.Key] = provenance.Token()
+                }));
+
+        return ledger.GetJournalEntries(new LedgerQuery());
+    }
+
+    private static StrategyRunEntry Run(string provenanceToken) => new(
+        RunId: "run-1",
+        StrategyId: "strategy-1",
+        StrategyName: "Strategy One",
+        RunType: RunType.Backtest,
+        StartedAt: AsOf.AddHours(-1),
+        EndedAt: AsOf,
+        Metrics: null)
+    {
+        DataProvenanceToken = provenanceToken
+    };
+}


### PR DESCRIPTION
## Summary

Fabricated market data can no longer present itself as observed market fact on the daily fair-value path.

- **`IHistoricalDataProvider.IsSimulated`** — new default interface member mirroring `IMarketDataClient.IsSimulated`, declared `true` on `SyntheticHistoricalDataProvider`. The historical lane (which feeds backfill and valuation) previously had no simulated signal at all. The provider flag is the primary gate; a bar's own `Source` tag, matched against the shared structured token table, is the second, and catches an aggregator serving a fabricated bar from a constituent provider.
- **Provenance on the valuation chain** — `MarkPriceQuote`, `DailyPortfolioPriceMark`, and `DailyPortfolioPricingLine` now carry `DataProvenance`, propagated through `DailyMarkToMarketService` and `DailyPortfolioPricingProjector`.
- **`FairValueLevelPolicy.Resolve`** — a non-real mark is classified ASC 820 Level 3 (unobservable), and neither an optimistic source assertion, nor a `WaterfallMarkPriceSource` tier, nor the fund's `DefaultFairValueLevel` may raise it. Real marks keep their existing classification byte-for-byte.
- **Valuation drafts state their origin** — new `valuation.dataProvenance` journal tag (`ValuationProvenanceTag`), origin named in evidence descriptions, and provenance folded into the mark fingerprint so a simulated run cannot share an idempotency key with the real run for the same scope and period.
- **Report-pack derivation** — `ReportPackProvenanceResolver` now derives from posted valuation entries as well as cited strategy runs, via one shared `DataProvenanceExtensions.Strongest` fold that replaces duplicated per-site logic.

## Reason

The live-order path is well defended — nine independent flags, two on-disk artifacts, a per-order readiness gate. The exposure ran the other way: the system would show fabricated numbers and, outside the browser's red banner, not say so.

Three defects, all verified against source before changing anything:

1. `HistoricalCloseMarkPriceSource` stamped **every** daily close `FairValueLevel.Level1` with the comment "a quoted exchange close for the identical instrument is an ASC 820 Level 1 input". Bars from `SyntheticHistoricalDataProvider` are a deterministic seeded walk (`Noise(profile.Symbol, i, ...)`) tagged `Source: "synthetic"` — a model output with no observable input behind it, entering valuation evidence as a quoted price in an active market.
2. `MarkPriceQuote` carried no origin field, so nothing downstream could state where a price came from. The ledger's simulated-origin gate in `AccountingPostingCommandValidator` matches exact structured tokens on a posting's source system — that rule is correct and unchanged; it simply had no provenance to act on for this path.
3. `ReportPackProvenanceResolver.ResolveDerivedToken` consulted only `StrategyRunEntry.DataProvenanceToken`. A NAV built entirely on synthetic marks cites no simulated run, so it derived `real` and resolved to `Validated`. `ReportPackValidationService` was already fail-closed on a non-null token — only the derivation was blind.

For a product whose stated promise is "Meridian does not just show the number, Meridian proves the number," that was the finding that mattered most.

Behavior for real data is unchanged: every existing quote defaults to `DataProvenance.Real`, for which `FairValueLevelPolicy.Resolve` is equivalent to the code it replaces.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [x] GitHub Actions `quality-gate` passed

No .NET SDK was available in the authoring environment, so nothing was compiled locally; CI was the validating run. On head `ad5693c6` every check is green — `quality-gate`, `verify-dotnet` ("All 19 .NET test projects passed", zero failures and zero skips), `verify-desktop (build/test WPF)`, `Analyze csharp`, `verify-browser`, `verify-docs`, `verify-workflows`, `schema-control`, Secret Scan, both route validations, WPF W4 Acceptance, Browser W4 Parity, and Pilot Acceptance Evidence.

New coverage:

`tests/Meridian.Tests/Application/Accounting/SyntheticMarkProvenanceTests.cs`
- a synthetic bar never classifies Level 1
- a real provider still classifies Level 1
- an aggregator serving a synthetic-tagged bar is classified from the bar, not the aggregator
- a real vendor named `Sample Custodian` is **not** misclassified (exact-token matching, never substring)
- the shipped `SyntheticHistoricalDataProvider` declares itself simulated (so the declaration cannot rot)
- a fund policy defaulting to Level 1 cannot upgrade a fabricated mark
- a simulated draft carries the origin tag and a distinct idempotency key

`tests/Meridian.Tests/Ui/ReportPackProvenanceResolverTests.cs`
- a NAV on synthetic marks derives `simulated` with no simulated run cited
- an all-real pack stays real
- the strongest non-real claim wins across lanes
- untagged (non-valuation) entries do not fabricate a non-real mark

Two CI guardrails also fired on the first push and were fixed in `ad5693c6`: the no-new-god-file ratchet (the added comment pushed `FundOperationsWorkspaceReadService.cs` 5 lines past its 4646-line cap — the call is now one line, with the reasoning kept in `ReportPackProvenanceResolver`'s class remarks), and stale schema-control manifests (adding `DataProvenanceExtensions.Strongest` shifted `DataProvenanceBadge` down; `database/manifest/contracts.json` was regenerated, with the delta limited to source-line positions and fingerprints — no structural contract change, and dependencies plus generated docs re-render byte-identical).

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed