### PR TITLE
Stop ETL source retention from overwriting what it retains

### DIFF
--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -4875,6 +4875,7 @@ Meridian-main
 │   │   │   │   ├── SftpCredentialResolver.cs
 │   │   │   │   └── SftpRemoteLocation.cs
 │   │   │   ├── CsvPartnerFileParser.cs
+│   │   │   ├── EtlArchiveNaming.cs
 │   │   │   ├── LocalFileSourceReader.cs
 │   │   │   ├── SftpFilePublisher.cs
 │   │   │   └── SftpFileSourceReader.cs
@@ -9187,6 +9188,7 @@ Meridian-main
 │   │   │   │   └── CredentialConfigTests.cs
 │   │   │   ├── Etl
 │   │   │   │   ├── CsvPartnerFileParserTests.cs
+│   │   │   │   ├── LocalFileSourceReaderPostProcessingTests.cs
 │   │   │   │   ├── SftpCapabilityServiceTests.cs
 │   │   │   │   └── SftpInfrastructureTests.cs
 │   │   │   ├── Http

--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -5113,6 +5113,7 @@ Meridian-main
 │   │   ├── ShareClassUnitRegisterProjector.cs
 │   │   ├── StalePricePolicy.cs
 │   │   ├── TaxCharacter.cs
+│   │   ├── ValuationProvenanceTag.cs
 │   │   ├── WashSale.cs
 │   │   └── YearEndClose.cs
 │   ├── Meridian.LifecycleSupervisor
@@ -8734,7 +8735,8 @@ Meridian-main
 │   │   ├── Application
 │   │   │   ├── Accounting
 │   │   │   │   ├── DailyMarkToMarketServiceTests.cs
-│   │   │   │   └── DailyValuationPolicyTests.cs
+│   │   │   │   ├── DailyValuationPolicyTests.cs
+│   │   │   │   └── SyntheticMarkProvenanceTests.cs
 │   │   │   ├── Auth
 │   │   │   │   ├── RolePermissionsTests.cs
 │   │   │   │   └── ScopedAccessServiceTests.cs
@@ -9886,6 +9888,7 @@ Meridian-main
 │   │   │   ├── ReportingRunStoreManifestHashTests.cs
 │   │   │   ├── ReportingRunStreamEndpointTests.cs
 │   │   │   ├── ReportingTenantIsolationTests.cs
+│   │   │   ├── ReportPackProvenanceResolverTests.cs
 │   │   │   ├── ReportPackValidationServiceTests.cs
 │   │   │   ├── ReportPackWorkflowServiceTests.cs
 │   │   │   ├── RiskEndpointsTests.cs

--- a/docs/operators/failover-and-recovery.md
+++ b/docs/operators/failover-and-recovery.md
@@ -202,6 +202,31 @@ Treat a conflict here as a reconciliation signal, not a transient error: two dif
 have been approved against one source event, and an operator has to decide which one the books
 should carry.
 
+## ETL Source Retention Semantics
+
+An ETL source's archive and error locations are single directories shared by every run of that
+source, and sources are enumerated by file pattern with no cross-run name dedupe. A scheduled drop
+that always lands the same well-known name resolves to the same retention path forever.
+
+- Retention never overwrites. A free destination name is used as-is, so ordinary runs keep the
+  original file name.
+- A destination already holding **identical** content means the move completed on an earlier
+  attempt. The source is consumed and no second copy is written, so a retried or resumed run
+  converges rather than accumulating duplicates.
+- A destination already holding **different** content is never replaced. The incoming source is
+  retained beside it under a deterministic content-addressed name,
+  `<name>.sha256-<first 16 hex of the content hash><extension>`. Both sources survive, and the
+  same content always resolves to the same name, so replay stays idempotent.
+- If that content-addressed path is somehow occupied by different content, post-processing fails
+  closed and leaves the source in place rather than overwriting. Resolve the retained file before
+  retrying.
+- SFTP verifies destination contents before removing anything, and only pays for the transfer when
+  a name actually collides; the ordinary path costs one existence check.
+
+Expect `positions.sha256-….csv` style names in a retention directory to mean two genuinely
+different sources arrived under one name — normally a re-sent or corrected file. Reconcile which
+one the books should reflect rather than deleting either.
+
 ## Recovery Decision Matrix
 
 1. Detect symptom and scope (single provider, module, or full workflow surface).

--- a/docs/status/coverage-report.md
+++ b/docs/status/coverage-report.md
@@ -5,7 +5,7 @@
 
 ## Overall Coverage
 
-**1237 / 8802** items documented (**14.1%**) &mdash; Grade: **F**
+**1237 / 8804** items documented (**14.1%**) &mdash; Grade: **F**
 
 ```text
 [===-----------------] 14.1%
@@ -15,7 +15,7 @@
 
 | Category | Documented | Total | Coverage | Grade |
 | ---------- | ----------- | ------- | ---------- | ------- |
-| Public Classes / Interfaces | 1140 | 8333 | 13.7% | F |
+| Public Classes / Interfaces | 1140 | 8335 | 13.7% | F |
 | API Endpoints | 85 | 329 | 25.8% | F |
 | Configuration Options | 1 | 129 | 0.8% | F |
 | Provider Implementations | 0 | 0 | 100.0% | A |
@@ -23,26 +23,26 @@
 
 ## Undocumented Items
 
-### Public Classes / Interfaces (7193 undocumented)
+### Public Classes / Interfaces (7195 undocumented)
 
 | Item | Location |
 | ------ | ---------- |
-| `MarkToMarketPosition` | `src/Meridian.Application/Accounting/DailyMarkToMarketService.cs:11` |
-| `MarkPriceQuote` | `src/Meridian.Application/Accounting/DailyMarkToMarketService.cs:24` |
-| `MarkPriceQualityPolicy` | `src/Meridian.Application/Accounting/DailyMarkToMarketService.cs:60` |
-| `MarkPriceRejection` | `src/Meridian.Application/Accounting/DailyMarkToMarketService.cs:93` |
-| `IMarkPriceSource` | `src/Meridian.Application/Accounting/DailyMarkToMarketService.cs:105` |
-| `MarkToMarketCarryingValueKey` | `src/Meridian.Application/Accounting/DailyMarkToMarketService.cs:115` |
-| `MarkToMarketCarryingValue` | `src/Meridian.Application/Accounting/DailyMarkToMarketService.cs:149` |
-| `MarkToMarketCarryingValueRequest` | `src/Meridian.Application/Accounting/DailyMarkToMarketService.cs:178` |
-| `IMarkToMarketCarryingValueSource` | `src/Meridian.Application/Accounting/DailyMarkToMarketService.cs:190` |
-| `DailyMarkToMarketRequest` | `src/Meridian.Application/Accounting/DailyMarkToMarketService.cs:200` |
-| `DailyMarkToMarketRun` | `src/Meridian.Application/Accounting/DailyMarkToMarketService.cs:216` |
-| `DailyMarkToMarketService` | `src/Meridian.Application/Accounting/DailyMarkToMarketService.cs:253` |
-| `HistoricalCloseMarkPriceSource` | `src/Meridian.Application/Accounting/HistoricalCloseMarkPriceSource.cs:14` |
+| `MarkToMarketPosition` | `src/Meridian.Application/Accounting/DailyMarkToMarketService.cs:12` |
+| `MarkPriceQuote` | `src/Meridian.Application/Accounting/DailyMarkToMarketService.cs:31` |
+| `MarkPriceQualityPolicy` | `src/Meridian.Application/Accounting/DailyMarkToMarketService.cs:68` |
+| `MarkPriceRejection` | `src/Meridian.Application/Accounting/DailyMarkToMarketService.cs:101` |
+| `IMarkPriceSource` | `src/Meridian.Application/Accounting/DailyMarkToMarketService.cs:113` |
+| `MarkToMarketCarryingValueKey` | `src/Meridian.Application/Accounting/DailyMarkToMarketService.cs:123` |
+| `MarkToMarketCarryingValue` | `src/Meridian.Application/Accounting/DailyMarkToMarketService.cs:157` |
+| `MarkToMarketCarryingValueRequest` | `src/Meridian.Application/Accounting/DailyMarkToMarketService.cs:186` |
+| `IMarkToMarketCarryingValueSource` | `src/Meridian.Application/Accounting/DailyMarkToMarketService.cs:198` |
+| `DailyMarkToMarketRequest` | `src/Meridian.Application/Accounting/DailyMarkToMarketService.cs:208` |
+| `DailyMarkToMarketRun` | `src/Meridian.Application/Accounting/DailyMarkToMarketService.cs:224` |
+| `DailyMarkToMarketService` | `src/Meridian.Application/Accounting/DailyMarkToMarketService.cs:261` |
+| `HistoricalCloseMarkPriceSource` | `src/Meridian.Application/Accounting/HistoricalCloseMarkPriceSource.cs:15` |
 | `RegisteredHistoricalCloseMarkPriceSource` | `src/Meridian.Application/Accounting/RegisteredHistoricalCloseMarkPriceSource.cs:10` |
-| `PriceSourceTier` | `src/Meridian.Application/Accounting/WaterfallMarkPriceSource.cs:15` |
-| `WaterfallMarkPriceSource` | `src/Meridian.Application/Accounting/WaterfallMarkPriceSource.cs:24` |
+| `PriceSourceTier` | `src/Meridian.Application/Accounting/WaterfallMarkPriceSource.cs:16` |
+| `WaterfallMarkPriceSource` | `src/Meridian.Application/Accounting/WaterfallMarkPriceSource.cs:25` |
 | `AutoRemediationOutcome` | `src/Meridian.Application/Backfill/AutoGapRemediationService.cs:14` |
 | `AutoRemediationTriggerSource` | `src/Meridian.Application/Backfill/AutoGapRemediationService.cs:24` |
 | `IDataQualityGapRemediationService` | `src/Meridian.Application/Backfill/AutoGapRemediationService.cs:36` |
@@ -77,7 +77,7 @@
 | `CrossSourceBackfillClosureDecision` | `src/Meridian.Application/Backfill/CrossSourceBackfillReconciliationService.cs:533` |
 | `CrossSourceBackfillDiscrepancy` | `src/Meridian.Application/Backfill/CrossSourceBackfillReconciliationService.cs:605` |
 | `CrossSourceBackfillProviderError` | `src/Meridian.Application/Backfill/CrossSourceBackfillReconciliationService.cs:618` |
-| ... and 7143 more | |
+| ... and 7145 more | |
 
 ### API Endpoints (244 undocumented)
 
@@ -193,7 +193,7 @@
 
 ## Recommendations
 
-1. **Public Classes / Interfaces**: 7193 undocumented types. Add reference entries under `docs/reference/` for the types that carry contracts. Running DocFX does not move this metric: it emits browsable output from XML doc comments into `docs/docfx/api/*.yml`, which is gitignored and so is not part of the scanned corpus.
+1. **Public Classes / Interfaces**: 7195 undocumented types. Add reference entries under `docs/reference/` for the types that carry contracts. Running DocFX does not move this metric: it emits browsable output from XML doc comments into `docs/docfx/api/*.yml`, which is gitignored and so is not part of the scanned corpus.
 2. **API Endpoints**: 244 endpoint(s) missing from `docs/reference/api-reference.md`. Run the endpoint audit and update the API reference table.
 3. **Configuration Options**: 128 config key(s) not found in `docs/generated/configuration-schema.md`. Re-run the configuration schema generator to synchronise.
 

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 653,
-  "total_lines": 130662,
+  "total_lines": 130689,
   "orphaned_count": 254,
   "no_heading_count": 148,
   "stale_count": 0,
@@ -2617,7 +2617,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 10483,
+      "line_count": 10488,
       "has_heading": true,
       "todo_count": 8,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -2745,7 +2745,7 @@
     },
     {
       "path": "docs/operators/failover-and-recovery.md",
-      "line_count": 261,
+      "line_count": 283,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 653,
-  "total_lines": 130659,
+  "total_lines": 130662,
   "orphaned_count": 254,
   "no_heading_count": 148,
   "stale_count": 0,
@@ -2745,7 +2745,7 @@
     },
     {
       "path": "docs/operators/failover-and-recovery.md",
-      "line_count": 258,
+      "line_count": 261,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 653 |
-| Total lines | 130,662 |
+| Total lines | 130,689 |
 | Average file size (lines) | 200.1 |
 | Orphaned files | 254 |
 | Files without headings | 148 |

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 653 |
-| Total lines | 130,659 |
+| Total lines | 130,662 |
 | Average file size (lines) | 200.1 |
 | Orphaned files | 254 |
 | Files without headings | 148 |

--- a/src/Meridian.Infrastructure/Etl/EtlArchiveNaming.cs
+++ b/src/Meridian.Infrastructure/Etl/EtlArchiveNaming.cs
@@ -1,0 +1,57 @@
+using System.Security.Cryptography;
+
+namespace Meridian.Infrastructure.Etl;
+
+/// <summary>
+/// Collision-safe naming for ETL source post-processing moves.
+/// <para>
+/// An archive or error location is a single configured directory shared by every run of a source,
+/// and sources are enumerated by pattern with no cross-run name dedupe. A scheduled drop that
+/// always lands the same well-known name — <c>positions.csv</c> each morning — therefore resolves
+/// to one destination path forever. Overwriting it destroys the previously retained source with no
+/// record that it existed, so a name that is already taken by *different* content is disambiguated
+/// by that content's hash instead.
+/// </para>
+/// </summary>
+internal static class EtlArchiveNaming
+{
+    /// <summary>
+    /// Deterministic sibling name for <paramref name="fileName"/> carrying content
+    /// <paramref name="contentHashSha256"/>. Deterministic by construction: identical content
+    /// always resolves to the same name, so a retried move is idempotent rather than duplicating.
+    /// The extension is preserved last so downstream pattern matching still selects the file.
+    /// </summary>
+    public static string BuildCollisionSafeName(string fileName, string contentHashSha256)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(contentHashSha256);
+
+        var stem = Path.GetFileNameWithoutExtension(fileName);
+        var extension = Path.GetExtension(fileName);
+        return $"{stem}.sha256-{contentHashSha256[..16]}{extension}";
+    }
+
+    public static async Task<string> ComputeFileHashAsync(string path, CancellationToken ct = default)
+    {
+        await using var stream = new FileStream(
+            path, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, useAsync: true);
+        return Convert.ToHexStringLower(await SHA256.HashDataAsync(stream, ct).ConfigureAwait(false));
+    }
+
+    /// <summary>
+    /// Hashes what <paramref name="download"/> writes without buffering it. The transform is the
+    /// sink, so a remote file is verified as it streams rather than being materialized first.
+    /// </summary>
+    public static string ComputeStreamedHash(Action<Stream> download)
+    {
+        ArgumentNullException.ThrowIfNull(download);
+
+        using var sha = SHA256.Create();
+        using (var hashing = new CryptoStream(Stream.Null, sha, CryptoStreamMode.Write, leaveOpen: true))
+        {
+            download(hashing);
+        }
+
+        return Convert.ToHexStringLower(sha.Hash!);
+    }
+}

--- a/src/Meridian.Infrastructure/Etl/EtlArchiveNaming.cs
+++ b/src/Meridian.Infrastructure/Etl/EtlArchiveNaming.cs
@@ -1,5 +1,3 @@
-using System.Security.Cryptography;
-
 namespace Meridian.Infrastructure.Etl;
 
 /// <summary>
@@ -29,29 +27,5 @@ internal static class EtlArchiveNaming
         var stem = Path.GetFileNameWithoutExtension(fileName);
         var extension = Path.GetExtension(fileName);
         return $"{stem}.sha256-{contentHashSha256[..16]}{extension}";
-    }
-
-    public static async Task<string> ComputeFileHashAsync(string path, CancellationToken ct = default)
-    {
-        await using var stream = new FileStream(
-            path, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, useAsync: true);
-        return Convert.ToHexStringLower(await SHA256.HashDataAsync(stream, ct).ConfigureAwait(false));
-    }
-
-    /// <summary>
-    /// Hashes what <paramref name="download"/> writes without buffering it. The transform is the
-    /// sink, so a remote file is verified as it streams rather than being materialized first.
-    /// </summary>
-    public static string ComputeStreamedHash(Action<Stream> download)
-    {
-        ArgumentNullException.ThrowIfNull(download);
-
-        using var sha = SHA256.Create();
-        using (var hashing = new CryptoStream(Stream.Null, sha, CryptoStreamMode.Write, leaveOpen: true))
-        {
-            download(hashing);
-        }
-
-        return Convert.ToHexStringLower(sha.Hash!);
     }
 }

--- a/src/Meridian.Infrastructure/Etl/LocalFileSourceReader.cs
+++ b/src/Meridian.Infrastructure/Etl/LocalFileSourceReader.cs
@@ -1,4 +1,5 @@
 using Meridian.Contracts.Etl;
+using Meridian.Contracts.Integrity;
 using Meridian.Storage.Etl;
 
 namespace Meridian.Infrastructure.Etl;
@@ -87,8 +88,8 @@ public sealed class LocalFileSourceReader : IEtlSourceReader
             return;
         }
 
-        var sourceHash = await EtlArchiveNaming.ComputeFileHashAsync(path, ct).ConfigureAwait(false);
-        var retainedHash = await EtlArchiveNaming.ComputeFileHashAsync(destination, ct).ConfigureAwait(false);
+        var sourceHash = await ComputeFileHashAsync(path, ct).ConfigureAwait(false);
+        var retainedHash = await ComputeFileHashAsync(destination, ct).ConfigureAwait(false);
         if (string.Equals(sourceHash, retainedHash, StringComparison.Ordinal))
         {
             // Already retained by an earlier attempt; completing the move is the idempotent result.
@@ -104,7 +105,7 @@ public sealed class LocalFileSourceReader : IEtlSourceReader
             // The name is derived from this content, so an occupant should carry it. Verify rather
             // than assume: the name uses a hash prefix, and overwriting on an unverified match is
             // the very loss this path exists to prevent.
-            var disambiguatedHash = await EtlArchiveNaming.ComputeFileHashAsync(disambiguated, ct).ConfigureAwait(false);
+            var disambiguatedHash = await ComputeFileHashAsync(disambiguated, ct).ConfigureAwait(false);
             if (!string.Equals(sourceHash, disambiguatedHash, StringComparison.Ordinal))
             {
                 throw new InvalidOperationException(
@@ -117,6 +118,13 @@ public sealed class LocalFileSourceReader : IEtlSourceReader
         }
 
         File.Move(path, disambiguated);
+    }
+
+    private static async Task<string> ComputeFileHashAsync(string path, CancellationToken ct)
+    {
+        await using var stream = new FileStream(
+            path, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, useAsync: true);
+        return await Sha256Digest.ComputeAsync(stream, ct).ConfigureAwait(false);
     }
 
     private static IEnumerable<string> ExpandPatterns(string pattern)

--- a/src/Meridian.Infrastructure/Etl/LocalFileSourceReader.cs
+++ b/src/Meridian.Infrastructure/Etl/LocalFileSourceReader.cs
@@ -43,14 +43,14 @@ public sealed class LocalFileSourceReader : IEtlSourceReader
         return await _stagingStore.StageAsync(jobId, file, stream, ct).ConfigureAwait(false);
     }
 
-    public Task PostProcessFileAsync(EtlSourceDefinition source, EtlRemoteFile file, bool succeeded, CancellationToken ct = default)
+    public async Task PostProcessFileAsync(EtlSourceDefinition source, EtlRemoteFile file, bool succeeded, CancellationToken ct = default)
     {
         var action = source.DeleteAfterSuccess ? EtlSourcePostProcessingAction.Delete : source.PostProcessingAction;
         if (action == EtlSourcePostProcessingAction.LeaveInPlace ||
             (succeeded && action == EtlSourcePostProcessingAction.MoveToError) ||
             (!succeeded && action != EtlSourcePostProcessingAction.MoveToError))
         {
-            return Task.CompletedTask;
+            return;
         }
 
         switch (action)
@@ -59,26 +59,64 @@ public sealed class LocalFileSourceReader : IEtlSourceReader
                 File.Delete(file.Path);
                 break;
             case EtlSourcePostProcessingAction.MoveToArchive when !string.IsNullOrWhiteSpace(source.ArchiveLocation):
-                MoveLocalFile(file.Path, source.ArchiveLocation);
+                await MoveLocalFileAsync(file.Path, source.ArchiveLocation, ct).ConfigureAwait(false);
                 break;
             case EtlSourcePostProcessingAction.MoveToError when !string.IsNullOrWhiteSpace(source.ErrorLocation):
-                MoveLocalFile(file.Path, source.ErrorLocation);
+                await MoveLocalFileAsync(file.Path, source.ErrorLocation, ct).ConfigureAwait(false);
                 break;
             case EtlSourcePostProcessingAction.WriteDoneMarker:
-                File.WriteAllText(file.Path + ".done", DateTimeOffset.UtcNow.ToString("O"));
+                await File.WriteAllTextAsync(file.Path + ".done", DateTimeOffset.UtcNow.ToString("O"), ct)
+                    .ConfigureAwait(false);
                 break;
         }
-
-        return Task.CompletedTask;
     }
 
-    private static void MoveLocalFile(string path, string directory)
+    /// <summary>
+    /// Moves a processed source into its retention directory without ever destroying what is
+    /// already there. A free name is used as-is; a name held by identical content means the move
+    /// already ran, so the source is simply dropped; a name held by different content resolves to
+    /// a deterministic content-addressed sibling so both sources survive.
+    /// </summary>
+    private static async Task MoveLocalFileAsync(string path, string directory, CancellationToken ct)
     {
         Directory.CreateDirectory(directory);
         var destination = Path.Combine(directory, Path.GetFileName(path));
-        if (File.Exists(destination))
-            File.Delete(destination);
-        File.Move(path, destination);
+        if (!File.Exists(destination))
+        {
+            File.Move(path, destination);
+            return;
+        }
+
+        var sourceHash = await EtlArchiveNaming.ComputeFileHashAsync(path, ct).ConfigureAwait(false);
+        var retainedHash = await EtlArchiveNaming.ComputeFileHashAsync(destination, ct).ConfigureAwait(false);
+        if (string.Equals(sourceHash, retainedHash, StringComparison.Ordinal))
+        {
+            // Already retained by an earlier attempt; completing the move is the idempotent result.
+            File.Delete(path);
+            return;
+        }
+
+        var disambiguated = Path.Combine(
+            directory,
+            EtlArchiveNaming.BuildCollisionSafeName(Path.GetFileName(path), sourceHash));
+        if (File.Exists(disambiguated))
+        {
+            // The name is derived from this content, so an occupant should carry it. Verify rather
+            // than assume: the name uses a hash prefix, and overwriting on an unverified match is
+            // the very loss this path exists to prevent.
+            var disambiguatedHash = await EtlArchiveNaming.ComputeFileHashAsync(disambiguated, ct).ConfigureAwait(false);
+            if (!string.Equals(sourceHash, disambiguatedHash, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"ETL retention path '{disambiguated}' already holds different content than source '{path}'. " +
+                    "The source was left in place; resolve the retained file before retrying.");
+            }
+
+            File.Delete(path);
+            return;
+        }
+
+        File.Move(path, disambiguated);
     }
 
     private static IEnumerable<string> ExpandPatterns(string pattern)

--- a/src/Meridian.Infrastructure/Etl/SftpFileSourceReader.cs
+++ b/src/Meridian.Infrastructure/Etl/SftpFileSourceReader.cs
@@ -1,4 +1,5 @@
 using Meridian.Contracts.Etl;
+using Meridian.Contracts.Integrity;
 using Meridian.Infrastructure.Etl.Sftp;
 using Meridian.Storage.Etl;
 
@@ -194,8 +195,28 @@ public sealed class SftpFileSourceReader : IEtlSourceReader
         client.RenameFile(file.Path, disambiguated, canOverwrite: false);
     }
 
+    /// <summary>
+    /// Hashes a remote file through a temporary spill rather than buffering it in memory, the same
+    /// shape <see cref="StageFileAsync"/> already uses for downloads. Only a name collision pays
+    /// for this.
+    /// </summary>
     private static string ComputeRemoteHash(ISftpClient client, string path)
-        => EtlArchiveNaming.ComputeStreamedHash(sink => client.DownloadFile(path, sink));
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), "meridian-sftp-hash-" + Guid.NewGuid().ToString("N") + ".tmp");
+        try
+        {
+            using var temp = new FileStream(
+                tempPath, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 81920, FileOptions.DeleteOnClose);
+            client.DownloadFile(path, temp);
+            temp.Position = 0;
+            return Sha256Digest.Compute(temp);
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+                File.Delete(tempPath);
+        }
+    }
 
     private static void EnsureRemoteDirectory(ISftpClient client, string normalizedDirectory)
     {

--- a/src/Meridian.Infrastructure/Etl/SftpFileSourceReader.cs
+++ b/src/Meridian.Infrastructure/Etl/SftpFileSourceReader.cs
@@ -144,6 +144,12 @@ public sealed class SftpFileSourceReader : IEtlSourceReader
         }
     }
 
+    /// <summary>
+    /// Moves a processed remote source into its retention directory, verifying the destination
+    /// contents before anything is removed. A free name is renamed into directly; a name holding
+    /// identical content means the move already ran, so the source is dropped; a name holding
+    /// different content resolves to a deterministic content-addressed sibling so both survive.
+    /// </summary>
     private static void MoveRemoteFile(ISftpClient client, EtlRemoteFile file, string? remoteDirectory)
     {
         if (string.IsNullOrWhiteSpace(remoteDirectory))
@@ -152,8 +158,44 @@ public sealed class SftpFileSourceReader : IEtlSourceReader
         var normalizedDirectory = SftpRemoteLocation.NormalizePath(remoteDirectory.TrimEnd('/'));
         EnsureRemoteDirectory(client, normalizedDirectory);
 
-        client.RenameFile(file.Path, SftpRemoteLocation.Combine(normalizedDirectory, file.Name), canOverwrite: true);
+        var destination = SftpRemoteLocation.Combine(normalizedDirectory, file.Name);
+        if (!client.Exists(destination))
+        {
+            // Existence was just checked, so overwriting is never the intent here.
+            client.RenameFile(file.Path, destination, canOverwrite: false);
+            return;
+        }
+
+        // Only a collision pays for the content comparison; the ordinary path above adds one
+        // existence check and no transfers.
+        var sourceHash = ComputeRemoteHash(client, file.Path);
+        if (string.Equals(sourceHash, ComputeRemoteHash(client, destination), StringComparison.Ordinal))
+        {
+            client.DeleteFile(file.Path);
+            return;
+        }
+
+        var disambiguated = SftpRemoteLocation.Combine(
+            normalizedDirectory,
+            EtlArchiveNaming.BuildCollisionSafeName(file.Name, sourceHash));
+        if (client.Exists(disambiguated))
+        {
+            if (!string.Equals(sourceHash, ComputeRemoteHash(client, disambiguated), StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"ETL retention path '{disambiguated}' already holds different content than source '{file.Path}'. " +
+                    "The source was left in place; resolve the retained file before retrying.");
+            }
+
+            client.DeleteFile(file.Path);
+            return;
+        }
+
+        client.RenameFile(file.Path, disambiguated, canOverwrite: false);
     }
+
+    private static string ComputeRemoteHash(ISftpClient client, string path)
+        => EtlArchiveNaming.ComputeStreamedHash(sink => client.DownloadFile(path, sink));
 
     private static void EnsureRemoteDirectory(ISftpClient client, string normalizedDirectory)
     {

--- a/tests/Meridian.Tests/Infrastructure/Etl/LocalFileSourceReaderPostProcessingTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Etl/LocalFileSourceReaderPostProcessingTests.cs
@@ -1,0 +1,124 @@
+using FluentAssertions;
+using Meridian.Contracts.Etl;
+using Meridian.Infrastructure.Etl;
+using Meridian.Storage.Etl;
+
+namespace Meridian.Tests.Infrastructure.Etl;
+
+/// <summary>
+/// Guards ETL source retention. An archive or error location is one directory shared by every run
+/// of a source, so a scheduled drop under a fixed name resolves to the same destination forever.
+/// Retention that overwrites is retention that silently loses what it was asked to keep.
+/// </summary>
+public sealed class LocalFileSourceReaderPostProcessingTests : IDisposable
+{
+    private const string MondayContent = "symbol,qty\nAAPL,100\n";
+    private const string TuesdayContent = "symbol,qty\nMSFT,250\n";
+
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(),
+        "meridian-etl-postprocess-" + Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public async Task PostProcessFileAsync_WhenArchiveNameHoldsDifferentContent_RetainsBothSources()
+    {
+        var (sourceDir, archiveDir) = CreateDirectories();
+        var archived = Path.Combine(archiveDir, "positions.csv");
+        await File.WriteAllTextAsync(archived, MondayContent);
+        var incoming = await DropAsync(sourceDir, "positions.csv", TuesdayContent);
+
+        await ArchiveAsync(sourceDir, archiveDir, incoming);
+
+        // Monday's archived source is untouched, and Tuesday's is retained alongside it.
+        (await File.ReadAllTextAsync(archived)).Should().Be(MondayContent);
+        var retained = Directory.GetFiles(archiveDir);
+        retained.Should().HaveCount(2);
+        var sibling = retained.Single(path => path != archived);
+        (await File.ReadAllTextAsync(sibling)).Should().Be(TuesdayContent);
+        Path.GetFileName(sibling).Should().StartWith("positions.sha256-").And.EndWith(".csv");
+        File.Exists(incoming).Should().BeFalse("the source is consumed once it is retained");
+    }
+
+    [Fact]
+    public async Task PostProcessFileAsync_WhenArchiveNameIsFree_KeepsTheOriginalName()
+    {
+        var (sourceDir, archiveDir) = CreateDirectories();
+        var incoming = await DropAsync(sourceDir, "positions.csv", TuesdayContent);
+
+        await ArchiveAsync(sourceDir, archiveDir, incoming);
+
+        Directory.GetFiles(archiveDir).Should().ContainSingle()
+            .Which.Should().Be(Path.Combine(archiveDir, "positions.csv"));
+        File.Exists(incoming).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task PostProcessFileAsync_WhenArchiveNameHoldsIdenticalContent_IsAnIdempotentReplay()
+    {
+        var (sourceDir, archiveDir) = CreateDirectories();
+        var archived = Path.Combine(archiveDir, "positions.csv");
+        await File.WriteAllTextAsync(archived, TuesdayContent);
+        var incoming = await DropAsync(sourceDir, "positions.csv", TuesdayContent);
+
+        await ArchiveAsync(sourceDir, archiveDir, incoming);
+
+        Directory.GetFiles(archiveDir).Should().ContainSingle();
+        (await File.ReadAllTextAsync(archived)).Should().Be(TuesdayContent);
+        File.Exists(incoming).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task PostProcessFileAsync_RepeatedForTheSameContent_DoesNotAccumulateCopies()
+    {
+        var (sourceDir, archiveDir) = CreateDirectories();
+        await File.WriteAllTextAsync(Path.Combine(archiveDir, "positions.csv"), MondayContent);
+
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            var incoming = await DropAsync(sourceDir, "positions.csv", TuesdayContent);
+            await ArchiveAsync(sourceDir, archiveDir, incoming);
+        }
+
+        // Deterministic naming means the retry resolves onto the same sibling every time.
+        Directory.GetFiles(archiveDir).Should().HaveCount(2);
+    }
+
+    private (string SourceDir, string ArchiveDir) CreateDirectories()
+    {
+        var sourceDir = Path.Combine(_root, "drop");
+        var archiveDir = Path.Combine(_root, "archive");
+        Directory.CreateDirectory(sourceDir);
+        Directory.CreateDirectory(archiveDir);
+        return (sourceDir, archiveDir);
+    }
+
+    private static async Task<string> DropAsync(string sourceDir, string name, string content)
+    {
+        var path = Path.Combine(sourceDir, name);
+        await File.WriteAllTextAsync(path, content);
+        return path;
+    }
+
+    private Task ArchiveAsync(string sourceDir, string archiveDir, string incoming)
+    {
+        var reader = new LocalFileSourceReader(new EtlStagingStore(_root));
+        var source = new EtlSourceDefinition
+        {
+            Kind = EtlSourceKind.Local,
+            Location = sourceDir,
+            PostProcessingAction = EtlSourcePostProcessingAction.MoveToArchive,
+            ArchiveLocation = archiveDir
+        };
+
+        return reader.PostProcessFileAsync(
+            source,
+            new EtlRemoteFile { Path = incoming, Name = Path.GetFileName(incoming), SizeBytes = 0 },
+            succeeded: true);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+    }
+}

--- a/tests/Meridian.Tests/Infrastructure/Etl/SftpInfrastructureTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Etl/SftpInfrastructureTests.cs
@@ -242,8 +242,49 @@ public sealed class SftpInfrastructureTests : IDisposable
         client.RenameCalls.Should().ContainSingle(call =>
             call.OldPath == "/inbound/positions.csv" &&
             call.NewPath == "/archive/2026/06/positions.csv" &&
-            call.CanOverwrite);
+            !call.CanOverwrite);
         client.DisconnectCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task PostProcessFileAsync_WhenArchiveNameHoldsDifferentContent_RetainsBothRemoteSources()
+    {
+        var client = new RecordingSftpClient { DownloadPayload = "symbol,qty\nMSFT,250\n" };
+        client.SeedRemoteFile("/archive/positions.csv", "symbol,qty\nAAPL,100\n");
+        var reader = new SftpFileSourceReader(new EtlStagingStore(_root), new RecordingSftpClientFactory(client), new EnvironmentSftpCredentialResolver(), ReadySftp);
+        var source = CreateSource(
+            postProcessingAction: EtlSourcePostProcessingAction.MoveToArchive,
+            archiveLocation: "/archive");
+        var file = new EtlRemoteFile { Path = "/inbound/positions.csv", Name = "positions.csv" };
+
+        await reader.PostProcessFileAsync(source, file, succeeded: true);
+
+        // The occupied name is never renamed over, and the source is not deleted: it is renamed
+        // to a deterministic content-addressed sibling so both remote sources survive.
+        client.RenameCalls.Should().ContainSingle(call =>
+            call.OldPath == "/inbound/positions.csv" &&
+            call.NewPath.StartsWith("/archive/positions.sha256-", StringComparison.Ordinal) &&
+            call.NewPath.EndsWith(".csv", StringComparison.Ordinal) &&
+            !call.CanOverwrite);
+        client.DeletedPaths.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task PostProcessFileAsync_WhenArchiveNameHoldsIdenticalContent_IsAnIdempotentReplay()
+    {
+        var client = new RecordingSftpClient { DownloadPayload = "symbol,qty\nMSFT,250\n" };
+        client.SeedRemoteFile("/archive/positions.csv", "symbol,qty\nMSFT,250\n");
+        var reader = new SftpFileSourceReader(new EtlStagingStore(_root), new RecordingSftpClientFactory(client), new EnvironmentSftpCredentialResolver(), ReadySftp);
+        var source = CreateSource(
+            postProcessingAction: EtlSourcePostProcessingAction.MoveToArchive,
+            archiveLocation: "/archive");
+        var file = new EtlRemoteFile { Path = "/inbound/positions.csv", Name = "positions.csv" };
+
+        await reader.PostProcessFileAsync(source, file, succeeded: true);
+
+        // The move already happened; finishing it means consuming the source, not renaming again.
+        client.RenameCalls.Should().BeEmpty();
+        client.DeletedPaths.Should().Equal("/inbound/positions.csv");
     }
 
     [Fact]
@@ -266,7 +307,7 @@ public sealed class SftpInfrastructureTests : IDisposable
         client.RenameCalls.Should().ContainSingle(call =>
             call.OldPath == "/inbound/positions.csv" &&
             call.NewPath == "/error/positions.csv" &&
-            call.CanOverwrite);
+            !call.CanOverwrite);
     }
 
     public void Dispose()
@@ -367,6 +408,7 @@ public sealed class SftpInfrastructureTests : IDisposable
 
         public IReadOnlyList<ISftpFileEntry> Entries { get; init; } = [];
         public string DownloadPayload { get; init; } = string.Empty;
+        public Dictionary<string, string> PayloadsByPath { get; } = new(StringComparer.Ordinal);
         public bool ThrowOnUpload { get; init; }
         public bool ThrowOnRename { get; init; }
         public int ConnectCalls { get; private set; }
@@ -390,8 +432,15 @@ public sealed class SftpInfrastructureTests : IDisposable
         public void DownloadFile(string path, Stream output)
         {
             DownloadPaths.Add(path);
-            var bytes = Encoding.UTF8.GetBytes(DownloadPayload);
+            var payload = PayloadsByPath.TryGetValue(path, out var scoped) ? scoped : DownloadPayload;
+            var bytes = Encoding.UTF8.GetBytes(payload);
             output.Write(bytes);
+        }
+
+        public void SeedRemoteFile(string path, string payload)
+        {
+            _remoteFiles.Add(path);
+            PayloadsByPath[path] = payload;
         }
 
         public void UploadFile(Stream input, string path, bool canOverwrite)


### PR DESCRIPTION
## Summary

An ETL source's archive and error locations are single directories shared by every run of that source, and `ListFilesAsync` enumerates by pattern with no cross-run name dedupe. A scheduled drop under a fixed name therefore resolves to one destination path forever.

Both readers overwrote it unconditionally — `LocalFileSourceReader` deleted the destination before `File.Move`, and `SftpFileSourceReader` renamed with `canOverwrite: true`. Tuesday's `positions.csv` replaced Monday's: different content, same name, no record that the earlier source existed.

Retention now never destroys what is already there:

- a **free** destination name is used as-is, so ordinary runs are unchanged;
- a name holding **identical** content means the move already ran, so the source is consumed without writing a second copy, and a retried or resumed run converges instead of accumulating duplicates;
- a name holding **different** content resolves to a deterministic content-addressed sibling, `<name>.sha256-<16 hex><ext>`, so both sources survive and identical content always lands on the same name;
- a content-addressed path occupied by different content fails closed and leaves the source in place. The name carries only a hash prefix, so the occupant is verified rather than assumed.

SFTP verifies destination contents before removing anything, and only a name collision pays for the transfer — the ordinary path adds one existence check. Hashing goes through `Meridian.Contracts.Integrity.Sha256Digest`; the remote file spills to a temporary `FileStream` with `DeleteOnClose` and is hashed from there, the same shape `StageFileAsync` already uses in that class, so memory stays bounded without a bespoke mechanism.

## Reason

Fifth in the ordered "repair irreversible correctness boundaries" series, after #2526, #2794, #2800, and #2802. The governing invariant is at-least-once recovery: prefer a detectable, idempotent replay over silent loss.

**Demonstrated before it was fixed.** A test seeded an archive with Monday's `positions.csv`, dropped a different Tuesday file at the same name, and ran post-processing. It passed against unmodified `main` showing Monday's content destroyed and a single file remaining — that is what established the defect. It was then flipped to require both sources retained.

Reachability was established end-to-end first:
1. `MoveToArchive`/`MoveToError` are configurable `EtlSourcePostProcessingAction` values with configured `ArchiveLocation`/`ErrorLocation`.
2. Destinations are `location + original filename` (`MoveLocalFile`, `MoveRemoteFile`) with nothing to disambiguate.
3. `ListFilesAsync` enumerates by pattern from the source directory with no cross-run name dedupe, so a recurring fixed name is the normal case for a scheduled drop.
4. The orchestrator invokes post-processing with `succeeded: true` on the success path (`EtlServices.cs:422`).

**Severity, stated honestly.** `EtlStagingStore` has no purge path, so a per-job staged copy of the bytes survives under `_etl/staging/<jobId>/`. The overwritten bytes are therefore not unrecoverable in practice today. What is lost is the operator-facing archive — the surface someone points at to answer "what did we ingest on Monday?" — and it is lost silently, with nothing recording that it happened. Real and worth fixing; smaller than the losses in #2526, #2794, and #2800.

## Testing performed

- [x] Relevant unit tests were added or updated
- [x] GitHub Actions `quality-gate` passed
- [ ] `bash scripts/ci.sh` completed successfully
- [ ] Relevant integration tests were added or updated

`LocalFileSourceReaderPostProcessingTests` (4 cases): different content retains both under a content-addressed sibling; a free name keeps the original name; identical content is an idempotent replay; repeated retention of the same content does not accumulate copies.

`SftpInfrastructureTests` gains two remote cases: a colliding name with different content renames to the content-addressed sibling **and deletes nothing**, and a colliding name with identical content deletes the source without renaming.

Mutation-tested: reverting `MoveLocalFileAsync` to the original overwrite fails the retained-source test with Monday's content replaced by Tuesday's, and fails the repeat-retention test with one file instead of two.

Two pre-existing SFTP assertions required `canOverwrite: true`. They encoded the overwrite this change removes, so they now require `canOverwrite: false` — updated deliberately, not incidentally.

Local validation (`DOTNET_ROOT=/root/.dotnet`):
- `dotnet build Meridian.sln -c Release` — succeeded, 0 errors.
- `dotnet test tests/Meridian.Tests -c Release --filter "FullyQualifiedName~Etl|FullyQualifiedName~Sftp|FullyQualifiedName~DataIntegration|FullyQualifiedName~Infrastructure"` — **1634 passed, 0 failed**, 3 skipped.
- `python3 build/scripts/ci/run-script-tests.py` — **915 passed, 0 failures**, 9 modules quarantined (the suite `verify-workflows` runs).
- All eleven ratchets under `build/scripts/ci/` — pass. An earlier revision of this branch failed `verify-dotnet` and `verify-workflows` on the inline SHA-256 ratchet because the hashing was open-coded; that is what the `Sha256Digest` change above resolves.
- `python3 build/scripts/docs/check-ai-inventory.py --summary` — pass, 0 findings.
- Docs regenerated (`run-docs-automation.py --profile core`), since new files make `repository-structure.md` stale.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

## Scope note

The brief's fifth section describes two full resumable sagas. Most of what it asks for the **statement** side already exists and is not rebuilt here: `StatementRunWorkflowService` carries a staged recovery checkpoint matching the proposed stages, and `ReconciliationCaseInfrastructure.MaterializeRunProjectionAsync:237` throws when a retained case falls outside its immutable match/source-commit authority chain — which is the brief's "replays must never overwrite operator-assigned, commented, or resolved cases" protection, already shipped. I found no demonstrable defect there and did not manufacture one.

Two further ETL observations, deliberately not addressed:

- Source post-processing runs before the terminal receipt is retained (`EtlServices.cs:422` versus `:461`), which reads like the brief's "retain the staged source until the terminal receipt exists". It is an ordering smell rather than a loss, because staging retains the bytes and has no purge, so it is left alone.
- The remaining ETL bullets — `IEtlRunStateStore`, `ResumeAsync`, `--etl-resume`, delivery receipts, `Finalizing` status — are a large additive surface, left out rather than half-built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzeZrUtwwf9CnTdrSzALti